### PR TITLE
added FedRamp Guide to ROSA HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -175,6 +175,8 @@ Topics:
   File: rosa-govcloud-account-management
 - Name: Installing a Red Hat OpenShift Service on AWS cluster in AWS GovCloud
   File: rosa-install-govcloud-cluster
+- Name: Red Hat OpenShift Service on AWS FedRAMP Rev5 Secure Configuration Guidance
+  File: rosa-fedramp-security-config
 ---
 Name: Install clusters
 Dir: rosa_hcp


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+ 

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18533
This PR is to add the guide into ROSA HCP. See the follow PR for the actual content work (already merged into ROSA Classic): https://github.com/openshift/openshift-docs/pull/113973

Link to docs preview:
https://115188--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_govcloud/rosa-fedramp-security-config

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
