### PR TITLE
OSDOCS-17014-1: INSTALL-8: OpenStack

### DIFF
--- a/installing/installing_openstack/installation-config-parameters-openstack.adoc
+++ b/installing/installing_openstack/installation-config-parameters-openstack.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you deploy an {product-title} cluster on {rh-openstack-first}, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+[role="_abstract"]
+Before you deploy an {product-title} cluster on {rh-openstack-first}, provide parameters to customize your environment. Provide required parameters through the CLI when generating the `install-config.yaml` file. You can then further customize the file.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
+++ b/installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
@@ -6,6 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+The reference guide provides a comprehensive overview of the {rh-openstack-first} Cloud Controller Manager (CCM) config map parameters, specifically detailing load balancer options and properties automatically managed by the Operator.
+
 include::modules/nw-openstack-external-ccm.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Cloud Controller Manager (Kubernetes documentation)]
+
 include::modules/cluster-cloud-controller-config-osp.adoc[leveloffset=+1]
+
+include::modules/ccm-config-lb-options.adoc[leveloffset=+2]
+
+include::modules/cluster-cloud-controller-config-overrides.adoc[leveloffset=+2]

--- a/installing/installing_openstack/uninstalling-openstack-user.adoc
+++ b/installing/installing_openstack/uninstalling-openstack-user.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can remove a cluster that you deployed to {rh-openstack-first} on user-provisioned infrastructure.
 
 // include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/ccm-config-lb-options.adoc
+++ b/modules/ccm-config-lb-options.adoc
@@ -1,0 +1,145 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ccm-config-lb-options_{context}"]
+= Load balancer options
+
+[role="_abstract"]
+You can configure load balancer options to control how the Cloud Controller Manager (CCM) creates and manages {rh-openstack} Octavia load balancers for services in your cluster.
+
+[NOTE]
+====
+Neutron-LBaaS support is deprecated.
+====
+
+|===
+| Option | Description
+
+| `enabled`
+| Enables the `LoadBalancer` service type integration. The default value is `true`.
+
+| `floating-network-id`
+| Optional. The external network used to create floating IP addresses for load balancer virtual IP addresses (VIPs). If there are multiple external networks in the cloud, you must set this option or specify the `loadbalancer.openstack.org/floating-network-id` label in the service annotation.
+
+| `floating-subnet-id`
+| Optional. The external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet-id`.
+
+| `floating-subnet`
+| Optional. A name pattern (glob or regular expression if starting with `~`) for the external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the pattern, the first one with available IP addresses is used.
+
+| `floating-subnet-tags`
+| Optional. Tags for the external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet-tags`. If multiple subnets match these tags, the first one with available IP addresses is used.
+
+If the {rh-openstack} network is configured with sharing disabled, for example, with the `--no-share` flag used during creation, this option is unsupported. Set the network to share to use this option.
+
+| `lb-method`
+| The load balancing algorithm used to create the load balancer pool.
+For the Amphora provider the value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. The default value is `ROUND_ROBIN`.
+
+For the OVN provider, only the `SOURCE_IP_PORT` algorithm is supported.
+
+For the Amphora provider, if using the `LEAST_CONNECTIONS` or `SOURCE_IP` methods, configure the `create-monitor` option as `true` in the `cloud-provider-config` config map on the `openshift-config` namespace and `ETP:Local` on the load-balancer type service to allow balancing algorithm enforcement in the client to service endpoint connections.
+
+| `lb-provider`
+| Optional. Used to specify the provider of the load balancer, for example, `amphora` or `octavia`. Only the Amphora and Octavia providers are supported.
+
+| `lb-version`
+| Optional. The load balancer API version. Only `"v2"` is supported.
+
+| `subnet-id`
+| The ID of the Networking service subnet on which load balancer VIPs are created. For dual stack deployments, leave this option unset. The OpenStack cloud provider automatically selects which subnet to use for a load balancer.
+
+// This ID is also used to create pool members if `member-subnet-id` is not set.
+
+// | `member-subnet-id`
+// | ID of the Neutron network on which to create the members of the load balancer. The load balancer gets another network port on this subnet. Defaults to `subnet-id` if not set.
+
+| `network-id`
+| The ID of the Networking service network on which load balancer VIPs are created. Unnecessary if `subnet-id` is set. If this property is not set, the network is automatically selected based on the network that cluster nodes use.
+
+// | `manage-security-groups`
+// | If the Neutron security groups should be managed separately. Default: false
+
+| `create-monitor`
+| Creates a health monitor for the service load balancer. A health monitor is required for services that declare `externalTrafficPolicy: Local`. The default value is `false`.
+
+This option is unsupported if you use {rh-openstack} earlier than version 17 with the `ovn` provider.
+
+| `monitor-delay`
+| The interval in seconds by which probes are sent to members of the load balancer. The default value is `5`.
+
+| `monitor-max-retries`
+| The number of successful checks that are required to change the operating status of a load balancer member to `ONLINE`. The valid range is `1` to `10`, and the default value is `1`.
+
+| `monitor-timeout`
+| The time in seconds that a monitor waits to connect to the back end before it times out. The default value is `3`.
+
+| `internal-lb`
+| Whether or not to create an internal load balancer without floating IP addresses. The default value is `false`.
+
+// | `cascade-delete`
+// | Determines whether or not to perform cascade deletion of load balancers. Default: true.
+
+// | `flavor-id`
+// | The id of the loadbalancer flavor to use. Uses octavia default if not set.
+
+// | `availability-zone`
+// | The name of the loadbalancer availability zone to use. The Octavia availability zone capabilities will not be used if it is not set. The parameter will be ignored if the Octavia version does not support availability zones yet.
+
+| `LoadBalancerClass "ClassName"`
+a| This is a config section that comprises a set of options:
+
+ * `floating-network-id`
+ * `floating-subnet-id`
+ * `floating-subnet`
+ * `floating-subnet-tags`
+ * `network-id`
+ * `subnet-id`
+
+//  * `member-subnet-id`
+
+The behavior of these options is the same as that of the identically named options in the load balancer section of the CCM config file.
+
+You can set the `ClassName` value by specifying the service annotation `loadbalancer.openstack.org/class`.
+
+// | `enable-ingress-hostname`
+// | Used with proxy protocol (set by annotation `loadbalancer.openstack.org/proxy-protocol: "true"`) by adding a dns suffix (nip.io) to the load balancer IP address. Default false.
+
+//  This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
+
+// | `ingress-hostname-suffix`
+// | The dns suffix to the load balancer IP address when using proxy protocol. Default nip.io
+
+//  This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
+
+// | `default-tls-container-ref`
+// | Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
+
+//  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+//  Check `container-store` parameter if you want to disable validation.
+
+// | `container-store`
+// | Optional. Used to specify the store of the tls-container-ref, e.g. "barbican" or "external" - other store will cause a warning log. Default value - `barbican` - existence of tls container ref would always be performed. If set to `external` format for tls container ref will not be validated.
+
+| `max-shared-lb`
+| The maximum number of services that can share a load balancer. The default value is `2`.
+|===
+
+// [id="ccm-config-metadata-options"]
+// == Metadata options
+
+// |===
+// | Option | Description
+
+// | `search-order`
+// | This configuration key affects the way that the provider retrieves metadata that relates to the instances in which it runs. The default value of `configDrive,metadataService` results in the provider retrieving metadata that relates to the instance from, if available, the config drive first,and then the metadata service. Alternative values are:
+//  * `configDrive`: Only retrieve instance metadata from the configuration drive.
+//  * `metadataService`: Only retrieve instance metadata from the metadata service.
+//  * `metadataService,configDrive`: Retrieve instance metadata from the metadata service first if available, and then retrieve instance metadata from the configuration drive.
+// |===
+
+// ### Multi region support (alpha)
+
+// | environment variable `OS_CCM_REGIONAL` is set to `true` - allow CCM to set ProviderID with region name `${ProviderName}://${REGION}/${instance-id}`. Default: false.

--- a/modules/cluster-cloud-controller-config-osp.adoc
+++ b/modules/cluster-cloud-controller-config-osp.adoc
@@ -6,7 +6,8 @@
 [id="cluster-cloud-controller-config_{context}"]
 = The OpenStack Cloud Controller Manager (CCM) config map
 
-An OpenStack CCM config map defines how your cluster interacts with your {rh-openstack} cloud. By default, this configuration is stored under the `cloud.conf` key in the `cloud-conf` config map in the `openshift-cloud-controller-manager` namespace.
+[role="_abstract"]
+An {rh-openstack} CCM config map defines how your cluster interacts with your {rh-openstack} cloud. By default, the configuration is stored under the `cloud.conf` key in the `cloud-conf` config map in the `openshift-cloud-controller-manager` namespace.
 
 [IMPORTANT]
 ====
@@ -25,7 +26,7 @@ For example:
 apiVersion: v1
 data:
   cloud.conf: |
-    [Global] <1>
+    [Global]
     secret-name = openstack-credentials
     secret-namespace = kube-system
     region = regionOne
@@ -39,7 +40,7 @@ metadata:
   resourceVersion: "2519"
   uid: cbbeedaf-41ed-41c2-9f37-4885732d3677
 ----
-<1> Set global options by using a `clouds.yaml` file rather than modifying the config map.
+`apiVersion.data.cloud.conf`: Specifies global options by using a `clouds.yaml` file rather than modifying the config map.
 
 The following options are present in the config map. Except when indicated otherwise, they are mandatory for clusters that run on {rh-openstack}.
 
@@ -108,217 +109,3 @@ The following options are present in the config map. Except when indicated other
 
 // This option can be useful if you have multiple or dual-stack interfaces attached to a node that need a user-controlled, deterministic way of sorting addresses.
 // |===
-
-[id="ccm-config-lb-options"]
-== Load balancer options
-
-CCM supports several load balancer options for deployments that use Octavia.
-
-[NOTE]
-====
-Neutron-LBaaS support is deprecated.
-====
-
-|===
-| Option | Description
-
-| `enabled`
-| Whether or not to enable the `LoadBalancer` type of services integration. The default value is `true`.
-
-| `floating-network-id`
-| Optional. The external network used to create floating IP addresses for load balancer virtual IP addresses (VIPs). If there are multiple external networks in the cloud, this option must be set or the user must specify `loadbalancer.openstack.org/floating-network-id` in the service annotation.
-
-| `floating-subnet-id`
-| Optional. The external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet-id`.
-
-| `floating-subnet`
-| Optional. A name pattern (glob or regular expression if starting with `~`) for the external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the pattern, the first one with available IP addresses is used.
-
-| `floating-subnet-tags`
-| Optional. Tags for the external network subnet used to create floating IP addresses for the load balancer VIP. Can be overridden by the service annotation `loadbalancer.openstack.org/floating-subnet-tags`. If multiple subnets match these tags, the first one with available IP addresses is used.
-
-If the {rh-openstack} network is configured with sharing disabled, for example, with the `--no-share` flag used during creation, this option is unsupported. Set the network to share to use this option.
-
-| `lb-method`
-| The load balancing algorithm used to create the load balancer pool.
-For the Amphora provider the value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. The default value is `ROUND_ROBIN`.
-
-For the OVN provider, only the `SOURCE_IP_PORT` algorithm is supported.
-
-For the Amphora provider, if using the `LEAST_CONNECTIONS` or `SOURCE_IP` methods, configure the `create-monitor` option as `true`  in the `cloud-provider-config` config map on the `openshift-config` namespace and `ETP:Local` on the load-balancer type service to allow balancing algorithm enforcement in the client to service endpoint connections.
-
-| `lb-provider`
-| Optional. Used to specify the provider of the load balancer, for example, `amphora` or `octavia`. Only the Amphora and Octavia providers are supported.
-
-| `lb-version`
-| Optional. The load balancer API version. Only `"v2"` is supported.
-
-| `subnet-id`
-| The ID of the Networking service subnet on which load balancer VIPs are created. For dual stack deployments, leave this option unset. The OpenStack cloud provider automatically selects which subnet to use for a load balancer.
-
-// This ID is also used to create pool members if `member-subnet-id` is not set.
-
-// | `member-subnet-id`
-// | ID of the Neutron network on which to create the members of the load balancer. The load balancer gets another network port on this subnet. Defaults to `subnet-id` if not set.
-
-| `network-id`
-| The ID of the Networking service network on which load balancer VIPs are created. Unnecessary if `subnet-id` is set. If this property is not set, the network is automatically selected based on the network that cluster nodes use.
-
-// | `manage-security-groups`
-// | If the Neutron security groups should be managed separately. Default: false
-
-| `create-monitor`
-| Whether or not to create a health monitor for the service load balancer. A health monitor is required for services that declare `externalTrafficPolicy: Local`. The default value is `false`.
-
-This option is unsupported if you use {rh-openstack} earlier than version 17 with the `ovn` provider.
-
-| `monitor-delay`
-| The interval in seconds by which probes are sent to members of the load balancer. The default value is `5`.
-
-| `monitor-max-retries`
-| The number of successful checks that are required to change the operating status of a load balancer member to `ONLINE`. The valid range is `1` to `10`, and the default value is `1`.
-
-| `monitor-timeout`
-| The time in seconds that a monitor waits to connect to the back end before it times out. The default value is `3`.
-
-| `internal-lb`
-| Whether or not to create an internal load balancer without floating IP addresses. The default value is `false`.
-
-// | `cascade-delete`
-// | Determines whether or not to perform cascade deletion of load balancers. Default: true.
-
-// | `flavor-id`
-// | The id of the loadbalancer flavor to use. Uses octavia default if not set.
-
-// | `availability-zone`
-// | The name of the loadbalancer availability zone to use. The Octavia availability zone capabilities will not be used if it is not set. The parameter will be ignored if the Octavia version does not support availability zones yet.
-
-| `LoadBalancerClass "ClassName"`
-a| This is a config section that comprises a set of options:
-
- * `floating-network-id`
- * `floating-subnet-id`
- * `floating-subnet`
- * `floating-subnet-tags`
- * `network-id`
- * `subnet-id`
-
-//  * `member-subnet-id`
-
-The behavior of these options is the same as that of the identically named options in the load balancer section of the CCM config file.
-
-You can set the `ClassName` value by specifying the service annotation `loadbalancer.openstack.org/class`.
-
-// | `enable-ingress-hostname`
-// | Used with proxy protocol (set by annotation `loadbalancer.openstack.org/proxy-protocol: "true"`) by adding a dns suffix (nip.io) to the load balancer IP address. Default false.
-
-//  This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
-
-// | `ingress-hostname-suffix`
-// | The dns suffix to the load balancer IP address when using proxy protocol. Default nip.io
-
-//  This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
-
-// | `default-tls-container-ref`
-// | Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
-
-//  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
-//  Check `container-store` parameter if you want to disable validation.
-
-// | `container-store`
-// | Optional. Used to specify the store of the tls-container-ref, e.g. "barbican" or "external" - other store will cause a warning log. Default value - `barbican` - existence of tls container ref would always be performed. If set to `external` format for tls container ref will not be validated.
-
-| `max-shared-lb`
-| The maximum number of services that can share a load balancer. The default value is `2`.
-|===
-
-// [id="ccm-config-metadata-options"]
-// == Metadata options
-
-// |===
-// | Option | Description
-
-// | `search-order`
-// | This configuration key affects the way that the provider retrieves metadata that relates to the instances in which it runs. The default value of `configDrive,metadataService` results in the provider retrieving metadata that relates to the instance from, if available, the config drive first,and then the metadata service. Alternative values are:
-//  * `configDrive`: Only retrieve instance metadata from the configuration drive.
-//  * `metadataService`: Only retrieve instance metadata from the metadata service.
-//  * `metadataService,configDrive`: Retrieve instance metadata from the metadata service first if available, and then retrieve instance metadata from the configuration drive.
-// |===
-
-// ### Multi region support (alpha)
-
-// | environment variable `OS_CCM_REGIONAL` is set to `true` - allow CCM to set ProviderID with region name `${ProviderName}://${REGION}/${instance-id}`. Default: false.
-
-[id="cluster-cloud-controller-config-overrides"]
-== Options that the Operator overrides
-
-The CCM Operator overrides the following options, which you might recognize from configuring {rh-openstack}. Do not configure them yourself. They are included in this document for informational purposes only.
-
-|===
-| Option | Description
-
-| `auth-url`
-| The {rh-openstack} Identity service URL. For example, `http://128.110.154.166/identity`.
-
-| `os-endpoint-type`
-| The type of endpoint to use from the service catalog.
-
-// If unset, public endpoints are used.
-
-| `username`
-| The Identity service user name.
-
-// Leave this option unset if you are using Identity service application credentials.
-
-| `password`
-| The Identity service user password.
-
-// Leave this option unset if you are using Identity service application credentials.
-
-| `domain-id`
-| The Identity service user domain ID.
-
-// Leave this option unset if you are using Identity service application credentials.
-
-| `domain-name`
-| The Identity service user domain name.
-
-// This option is not required if you set `domain-id`.
-
-| `tenant-id`
-| The Identity service project ID. Leave this option unset if you are using Identity service application credentials.
-
-In version 3 of the Identity API, which changed the identifier `tenant` to `project`, the value of `tenant-id` is automatically mapped to the project construct in the API.
-
-| `tenant-name`
-| The Identity service project name.
-
-| `tenant-domain-id`
-| The Identity service project domain ID.
-
-| `tenant-domain-name`
-| The Identity service project domain name.
-
-| `user-domain-id`
-| The Identity service user domain ID.
-
-| `user-domain-name`
-| The Identity service user domain name.
-
-| `use-clouds`
-a| Whether or not to fetch authorization credentials from a `clouds.yaml` file. Options set in this section are prioritized over values read from the `clouds.yaml` file.
-
-CCM searches for the file in the following places:
-
-. The value of the `clouds-file` option.
-. A file path stored in the environment variable `OS_CLIENT_CONFIG_FILE`.
-. The directory `pkg/openstack`.
-. The directory `~/.config/openstack`.
-. The directory `/etc/openstack`.
-
-| `clouds-file`
-| The file path of a `clouds.yaml` file. It is used if the `use-clouds` option is set to `true`.
-
-| `cloud`
-| The named cloud in the `clouds.yaml` file that you want to use. It is used if the `use-clouds` option is set to `true`.
-|===

--- a/modules/cluster-cloud-controller-config-overrides.adoc
+++ b/modules/cluster-cloud-controller-config-overrides.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cluster-cloud-controller-config-overrides_{context}"]
+= Options that the Operator overrides
+
+[role="_abstract"]
+The CCM Operator overrides specific options, which you might recognize from configuring {rh-openstack}. Do not configure these options. The options are for informational purposes only.
+
+.Options overridden by the CCM Operator
+|===
+| Option | Description
+
+| `auth-url`
+| The {rh-openstack} Identity service URL. For example, `http://128.110.154.166/identity`.
+
+| `os-endpoint-type`
+| The type of endpoint to use from the service catalog.
+
+// If unset, public endpoints are used.
+
+| `username`
+| The Identity service user name.
+
+// Leave this option unset if you are using Identity service application credentials.
+
+| `password`
+| The Identity service user password.
+
+// Leave this option unset if you are using Identity service application credentials.
+
+| `domain-id`
+| The Identity service user domain ID.
+
+// Leave this option unset if you are using Identity service application credentials.
+
+| `domain-name`
+| The Identity service user domain name.
+
+// This option is not required if you set `domain-id`.
+
+| `tenant-id`
+| The Identity service project ID. Leave this option unset if you are using Identity service application credentials.
+
+In version 3 of the Identity API, which changed the identifier `tenant` to `project`, the value of `tenant-id` is automatically mapped to the project construct in the API.
+
+| `tenant-name`
+| The Identity service project name.
+
+| `tenant-domain-id`
+| The Identity service project domain ID.
+
+| `tenant-domain-name`
+| The Identity service project domain name.
+
+| `user-domain-id`
+| The Identity service user domain ID.
+
+| `user-domain-name`
+| The Identity service user domain name.
+
+| `use-clouds`
+a| Whether to fetch authorization credentials from a `clouds.yaml` file. Options set in this section are prioritized over values read from the `clouds.yaml` file.
+
+The CCM Operator searches for the file in the following places:
+
+. The value of the `clouds-file` option.
+. A file path stored in the environment variable `OS_CLIENT_CONFIG_FILE`.
+. The directory `pkg/openstack`.
+. The directory `~/.config/openstack`.
+. The directory `/etc/openstack`.
+
+| `clouds-file`
+| The file path of a `clouds.yaml` file. It is used if the `use-clouds` option is set to `true`.
+
+| `cloud`
+| The named cloud in the `clouds.yaml` file that you want to use. It is used if the `use-clouds` option is set to `true`.
+|===

--- a/modules/insights-operator-manual-upload.adoc
+++ b/modules/insights-operator-manual-upload.adoc
@@ -72,5 +72,5 @@ If the operation is successful, the command returns a `"request_id"` and `"accou
 If the upload was successful, the tab displays one of the following:
 +
 * *Your cluster passed all recommendations*, if the {red-hat-lightspeed} advisor service did not identify any issues.
-
++
 * A list of issues that the {red-hat-lightspeed} advisor service has detected, prioritized by risk (low, moderate, important, and critical).

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -69,7 +69,7 @@ ifndef::agent,generic[]
 = Available installation configuration parameters for {platform}
 
 [role="_abstract"]
-To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
+To customize your cluster installation, you can use configuration parameters in the `install-config.yaml` file.
 
 The following tables specify the required, optional, and {platform}-specific installation configuration parameters that you can set as part of the installation process.
 
@@ -83,7 +83,7 @@ ifdef::generic[]
 = Available installation configuration parameters
 
 [role="_abstract"]
-To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
+To customize your cluster installation, you can use configuration parameters in the `install-config.yaml` file.
 
 The following tables specify the required, network, and optional installation configuration parameters that you can set as part of the installation process.
 
@@ -93,7 +93,7 @@ ifdef::agent[]
 = Available installation configuration parameters
 
 [role="_abstract"]
-To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
+To customize your cluster installation, you can use configuration parameters in the `install-config.yaml` file.
 
 The following tables specify the required and optional installation configuration parameters that you can set as part of the Agent-based installation process.
 
@@ -228,7 +228,7 @@ Additional {ibm-power-vc-name} configuration parameters are described in the fol
     cloud:
 |The name of the {ibm-power-vc-name} cloud to use from the list of clouds in the `clouds.yaml` file.
 
-In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
+In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propagation that follow user name and password rotation.
 
 *Value:* String, for example `MyCloud`.
 
@@ -1373,7 +1373,7 @@ You can enable BYOIP only for customized installations that do not have any netw
 |platform:
   aws:
     ipFamily:
-|The IP address family for networks used by the cluster. Specify `IPv4`` for IPv4-only networking, `DualStackIPv4Primary` for dual-stack networking with IPv4 as the primary address family, or `DualStackIPv6Primary` for dual-stack networking with IPv6 as the primary address family. When using dual-stack, the VPC and subnets must be configured with both IPv4 and IPv6 CIDR blocks.
+|The IP address family for networks used by the cluster. Specify `IPv4` for IPv4-only networking, `DualStackIPv4Primary` for dual-stack networking with IPv4 as the primary address family, or `DualStackIPv6Primary` for dual-stack networking with IPv6 as the primary address family. When using dual-stack, the VPC and subnets must be configured with both IPv4 and IPv6 CIDR blocks.
 
 Consider the following requirements if you use dual-stack networking:
 
@@ -1520,7 +1520,7 @@ Additional {rh-openstack} configuration parameters are described in the followin
     cloud:
 |The name of the {rh-openstack} cloud to use from the list of clouds in the `clouds.yaml` file.
 
-In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
+In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propagation that follow user name and password rotation.
 
 *Value:* String, for example `MyCloud`.
 
@@ -1807,7 +1807,7 @@ The following values are associated with the boot diagnostics type:
   platform:
     azure:
       encryptionAtHost:
-|Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
+|Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached, and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
 
 *Value:* `true` or `false`. The default is `false`.
 
@@ -2518,7 +2518,7 @@ Supplying more than one user-assigned identity is an experimental feature, which
   platform:
     azure:
       encryptionAtHost:
-|Enables host-level encryption for control plane machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
+|Enables host-level encryption for control plane machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached, and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
 
 *Value:* `true` or `false`. The default is `false`.
 

--- a/modules/installation-osp-configuring-sr-iov.adoc
+++ b/modules/installation-osp-configuring-sr-iov.adoc
@@ -1,8 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
 // * installing/installing_openstack/installing-openstack-nfv-preparing.adoc
-// * installing/installing_openstack/installing-openstack-user-sr-iov.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-osp-configuring-sr-iov_{context}"]

--- a/modules/installation-osp-downloading-modules.adoc
+++ b/modules/installation-osp-downloading-modules.adoc
@@ -21,6 +21,7 @@ endif::[]
 [id="installation-osp-downloading-modules_{context}"]
 = Downloading playbook dependencies
 
+[role="_abstract"]
 ifdef::osp-user[]
 The Ansible playbooks that simplify the installation process on user-provisioned infrastructure require several ansible collections and Python modules. On the machine where you will run the installation program, add the {rh-openstack-first} repositories and then install the packages.
 
@@ -35,9 +36,7 @@ The following dependencies are required:
 ** `ansible-collections-openstack`, which installs Ansible Core
 ** `ansible-collection-community-general`
 ** `ansible-collection-ansible-netcommon`
-
 endif::osp-user[]
-
 ifdef::osp-user-uninstall[]
 The Ansible playbooks that simplify the removal process on user-provisioned
 infrastructure require several Python modules. On the machine where you will run the process,
@@ -45,7 +44,9 @@ add the modules' repositories and then download them.
 endif::osp-user-uninstall[]
 
 [NOTE]
+====
 These instructions assume that you are using {op-system-base-full} 8.
+====
 
 .Prerequisites
 
@@ -53,29 +54,29 @@ These instructions assume that you are using {op-system-base-full} 8.
 
 .Procedure
 
-. On a command line, add the repositories:
-
+. On a command line, add the following repositories:
++
 .. Register with Red Hat Subscription Manager:
 +
 [source,terminal]
 ----
 $ sudo subscription-manager register # If not done already
 ----
-
++
 .. Pull the latest subscription data:
 +
 [source,terminal]
 ----
 $ sudo subscription-manager attach --pool=$YOUR_POOLID # If not done already
 ----
-
++
 .. Disable the current repositories:
 +
 [source,terminal]
 ----
 $ sudo subscription-manager repos --disable=* # If not done already
 ----
-
++
 .. Add the required repositories:
 +
 [source,terminal]

--- a/modules/installation-uninstall-infra.adoc
+++ b/modules/installation-uninstall-infra.adoc
@@ -6,6 +6,7 @@
 [id="installation-uninstall-infra_{context}"]
 = Removing a cluster from {rh-openstack} that uses your own infrastructure
 
+[role="_abstract"]
 You can remove an {product-title} cluster on {rh-openstack-first} that uses your own infrastructure. To complete the removal process quickly, run several Ansible playbooks.
 
 .Prerequisites
@@ -18,7 +19,7 @@ You can remove an {product-title} cluster on {rh-openstack-first} that uses your
 
 .Procedure
 
-. On a command line, run the playbooks that you downloaded:
+. On a command line, run the playbooks that you downloaded by entering the following command:
 +
 [source,terminal]
 ----
@@ -32,5 +33,5 @@ $ ansible-playbook -i inventory.yaml  \
 ----
 
 . Remove any DNS record changes you made for the {product-title} installation.
-
++
 {product-title} is removed from your infrastructure.

--- a/modules/nw-openstack-external-ccm.adoc
+++ b/modules/nw-openstack-external-ccm.adoc
@@ -7,11 +7,17 @@
 [id="nw-openstack-external-ccm_{context}"]
 = The OpenStack Cloud Controller Manager
 
-Beginning with {product-title} 4.12, clusters that run on {rh-openstack-first} were switched from the legacy OpenStack cloud provider to the external OpenStack Cloud Controller Manager (CCM). This change follows the move in Kubernetes from in-tree, legacy cloud providers to external cloud providers that are implemented by using the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Cloud Controller Manager].
+[role="_abstract"]
+Beginning with {product-title} 4.12, clusters that run on {rh-openstack-first} were switched from the legacy {rh-openstack} cloud provider to the external OpenStack Cloud Controller Manager (CCM). 
 
-To preserve user-defined configurations for the legacy cloud provider, existing configurations are mapped to new ones as part of the migration process. It searches for a configuration called `cloud-provider-config` in the `openshift-config` namespace.
+This change follows the move in Kubernetes from in-tree, legacy cloud providers to external cloud providers that are implemented by using the CCM.
 
-NOTE: The config map name `cloud-provider-config` is not statically configured. It is derived from the `spec.cloudConfig.name` value in the `infrastructure/cluster` CRD.
+To preserve user-defined configurations for the legacy cloud provider, existing configurations are mapped to new ones as part of the migration process. The OpenStack CCM searches for a configuration called `cloud-provider-config` in the `openshift-config` namespace.
+
+[NOTE]
+====
+The config map name `cloud-provider-config` is not statically configured. The name is derived from the `spec.cloudConfig.name` value in the `infrastructure/cluster` CRD.
+====
 
 Found configurations are synchronized to the `cloud-conf` config map in the `openshift-cloud-controller-manager` namespace.
 


### PR DESCRIPTION
Key Changes:
  
  1. Created two new REFERENCE modules by extracting content from a single monolithic module:
    - modules/ccm-config-lb-options.adoc (145 lines) — Load balancer configuration options
    - modules/cluster-cloud-controller-config-overrides.adoc (80 lines) — Options the CCM
  Operator overrides
  2. Updated parent assembly (installing-openstack-cloud-config-reference.adoc):
    - Added abstract paragraph describing the reference guide's scope
    - Added external link to Kubernetes CCM documentation
    - Included the two new modules at leveloffset=+2 (nested under existing content)
  3. Refactored existing CCM config module (cluster-cloud-controller-config-osp.adoc):
    - Added abstract paragraph
    - Removed 214 lines of load balancer and override options content (now in separate modules)
    - Changed callout format from numbered to descriptive (line 43)
    - Kept only the core config map structure and global options
  4. Added abstract paragraphs to three assembly files:
    - installation-config-parameters-openstack.adoc — Minor wording improvement ("provide"
  instead of "you provide")
    - uninstalling-openstack-user.adoc — Added missing abstract attribute

Version(s):
4.20+

Issue:
[OSDOCS-17014](https://redhat.atlassian.net/browse/OSDOCS-17014)

Link to docs preview:

* https://115190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack.html
* https://115190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-cloud-config-reference.html
* https://115190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-user.html
* https://115190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/uninstalling-openstack-user.html
