### PR TITLE
CNV-63300: Add installation methods to OVE overview

### DIFF
--- a/modules/ove-installation.adoc
+++ b/modules/ove-installation.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * overview/ove-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ove-installation_{context}"]
+= {product-title} installation
+
+[role="_abstract"]
+You can install {product-title} by using the Assisted Installer. The Assisted Installer provides an Operator bundle for {virt} that includes essential supporting Operators, so you do not need to install them individually.

--- a/overview/ove-overview.adoc
+++ b/overview/ove-overview.adoc
@@ -7,14 +7,21 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title}, an edition of Red{nbsp}Hat OpenShift, is an enterprise-grade virtualization solution for organizations that need a scalable, reliable platform for running and managing virtual machines (VMs). It integrates with your existing IT infrastructure to support VM-exclusive workloads, including those requiring consistent VM performance.
+{product-title}, an edition of Red{nbsp}Hat OpenShift, is an enterprise-grade virtualization solution for running and managing virtual machines (VMs). You can integrate {product-title} with your existing IT infrastructure to support VM-exclusive workloads, including those requiring consistent VM performance.
 
 include::modules/ove-about.adoc[leveloffset=+1]
+
+include::modules/ove-installation.adoc[leveloffset=+1]
+
 include::modules/ove-support.adoc[leveloffset=+1]
 
 [id="additional-resources_{context}"]
 [role="_additional-resources"]
 == Additional resources
+
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/about-ai[Assisted Installer for {ocp}]
+
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/installing-with-ui#installing-operators-and-bundles-ui_installing-with-ui[Installing Operators and bundles with the Assisted Installer]
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/virtualization/index[{virt} documentation]
 
@@ -32,4 +39,4 @@ include::modules/ove-support.adoc[leveloffset=+1]
 
 * link:https://app.arcade.software/share/PIbyWf2YD2A6BqwXp6hz[Demo: Manage and monitor VMs on OpenShift with {rh-rhacm}]
 
-* link:https://access.redhat.com/support/cases/#/case/list?query=%20orderBy%20lastModifiedDate%20desc&p=1&size=10&searchType=basic[Red{nbsp}Hat customer support portal]
+* link:https://access.redhat.com/support/cases/[Red{nbsp}Hat customer support portal]


### PR DESCRIPTION
Version(s):
main

Issue:
[CNV-63300](https://redhat.atlassian.net/browse/CNV-63300)

Link to docs preview:
https://115191--ocpdocs-pr.netlify.app/openshift-ove/latest/overview/ove-overview.html

QE review:
- [x] QE has approved this change.

Additional information:
- Adds a new concept module (`ove-installation.adoc`) to the OVE overview highlighting the Assisted Installer as the recommended installation method for OVE
- Notes that the Assisted Installer provides an Operator bundle for OpenShift Virtualization that includes essential supporting Operators, so they do not need to be installed individually
- Adds links to the Assisted Installer landing page and the Operators and bundles installation guide in the Additional Resources section