### PR TITLE
CNV-92974: Removed IPv6 TP admonition

### DIFF
--- a/modules/virt-important-considerations.adoc
+++ b/modules/virt-important-considerations.adoc
@@ -17,10 +17,6 @@ If you deploy {VirtProductName} with {rh-storage-first}, you must create a dedic
 
 IPv6::
 {VirtProductName} support for single-stack IPv6 clusters is limited to the OVN-Kubernetes localnet and Linux bridge Container Network Interface (CNI) plugins.
-+
-:FeatureName: Deploying {VirtProductName} on a single-stack IPv6 cluster
-include::snippets/technology-preview.adoc[]
-:!FeatureName:
 
 FIPS mode::
 If you install your cluster in FIPS mode, no additional setup is required for {VirtProductName}. For more information, see "Installing a FIPS-compliant cluster" in the Additional resources section.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: CNV-92974
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://115192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
