### PR TITLE
[OSDOCS-20641]: CQA: HCP authentication and authorization (2 of 2)

### DIFF
--- a/modules/hcp-cco-verify-aws-sts.adoc
+++ b/modules/hcp-cco-verify-aws-sts.adoc
@@ -7,6 +7,7 @@
 [id="hcp-cco-verify-aws-sts_{context}"]
 = Verifying the CCO installation in a hosted cluster on {aws-short}
 
+[role="_abstract"]
 You can verify that the Cloud Credential Operator (CCO) is running correctly in your hosted control plane.
 
 .Prerequisites

--- a/modules/hcp-configuring-oauth-console.adoc
+++ b/modules/hcp-configuring-oauth-console.adoc
@@ -6,6 +6,7 @@
 [id="hcp-configuring-oauth-console_{context}"]
 = Configuring the OAuth server for a hosted cluster by using the web console
 
+[role="_abstract"]
 You can configure the internal OAuth server for your hosted cluster by using the {product-title} web console.
 
 You can configure OAuth for the following supported identity providers:
@@ -34,7 +35,7 @@ When you configure identity providers, you must configure at least one `NodePool
 
 .Procedure
 
-. Navigate to *Home* -> *API Explorer*.
+. Go to *Home* -> *API Explorer*.
 
 . Use the *Filter by kind* box to search for your `HostedCluster` resource.
 
@@ -48,33 +49,38 @@ When you configure identity providers, you must configure at least one `NodePool
 +
 [source,yaml]
 ----
+apiVersion: hypershift.openshift.io/v1alpha1
+kind: HostedCluster
+metadata:
+  #...
 spec:
   configuration:
     oauth:
       identityProviders:
-      - openID: <1>
+      - openID:
           claims:
-            email: <2>
+            email:
               - <email_address>
-            name: <3>
+            name:
               - <display_name>
-            preferredUsername: <4>
+            preferredUsername:
               - <preferred_username>
-          clientID: <client_id> <5>
+          clientID: <client_id>
           clientSecret:
-            name: <client_id_secret_name> <6>
-          issuer: https://example.com/identity <7>
-        mappingMethod: lookup <8>
+            name: <client_id_secret_name>
+          issuer: https://example.com/identity
+        mappingMethod: lookup
         name: IAM
         type: OpenID
 ----
-<1> This provider name is prefixed to the value of the identity claim to form an identity name. The provider name is also used to build the redirect URL.
-<2> Defines a list of attributes to use as the email address.
-<3> Defines a list of attributes to use as a display name.
-<4> Defines a list of attributes to use as a preferred user name.
-<5> Defines the ID of a client registered with the OpenID provider. You must allow the client to redirect to the `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>` URL.
-<6> Defines a secret of a client registered with the OpenID provider.
-<7> The link:https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier[Issuer Identifier] described in the OpenID spec. You must use `https` without query or fragment component.
-<8> Defines a mapping method that controls how mappings are established between identities of this provider and `User` objects.
++
+* `spec.configuration.oauth.identityProviders.openID` specifies the provider name that is prefixed to the value of the identity claim to form an identity name. The provider name is also used to build the redirect URL.
+* `spec.configuration.oauth.identityProviders.openID.claims.email` defines a list of attributes to use as the email address.
+* `spec.configuration.oauth.identityProviders.openID.claims.name` defines a list of attributes to use as a display name.
+* `spec.configuration.oauth.identityProviders.openID.claims.preferredUsername` defines a list of attributes to use as a preferred user name.
+* `spec.configuration.oauth.identityProviders.openID.clientID` defines the ID of a client registered with the OpenID provider. You must allow the client to redirect to the `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>` URL.
+* `spec.configuration.oauth.identityProviders.openID.clientSecret.name` defines a secret of a client registered with the OpenID provider.
+* `spec.configuration.oauth.identityProviders.openID.issuer` specifies the Issuer Identifier described in the OpenID spec. You must use `https` without query or fragment component. For more information, see "Issuer Identifier".
+* `spec.configuration.oauth.identityProviders.mappingMethod` defines a mapping method that controls how mappings are established between identities of this provider and `User` objects.
 
 . Click *Save*.

--- a/modules/hcp-configuring-oauth.adoc
+++ b/modules/hcp-configuring-oauth.adoc
@@ -79,7 +79,7 @@ spec:
 * `spec.configuration.oauth.identityProviders.openID.claims.preferredUsername` defines a list of attributes to use as a preferred user name.
 * `spec.configuration.oauth.identityProviders.openID.clientID` defines the ID of a client registered with the OpenID provider. You must allow the client to redirect to the `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>` URL.
 * `spec.configuration.oauth.identityProviders.openID.clientSecret.name` defines a secret of a client registered with the OpenID provider.
-* `spec.configuration.oauth.identityProviders.openID.issuer` specifies the Issuer Identifier described in the OpenID spec. You must use `https` without query or fragment component. For more information about Issuer Identifiers, see "Issuer Identifier" in the _Additional resources_ section.
+* `spec.configuration.oauth.identityProviders.openID.issuer` specifies the Issuer Identifier described in the OpenID spec. You must use `https` without query or fragment component. For more information about Issuer Identifiers, see "Issuer Identifier".
 * `spec.configuration.oauth.identityProviders.mappingMethod` defines a mapping method that controls how mappings are established between identities of this provider and `User` objects.
 
 . Save the file to apply the changes.

--- a/modules/osdk-cco-aws-sts-enabling.adoc
+++ b/modules/osdk-cco-aws-sts-enabling.adoc
@@ -7,6 +7,7 @@
 [id="osdk-cco-aws-sts-enabling_{context}"]
 = Enabling Operators to support CCO-based workflows with AWS STS
 
+[role="_abstract"]
 As an Operator author designing your project to run on Operator Lifecycle Manager (OLM), you can enable your Operator to authenticate against AWS on STS-enabled {product-title} clusters by customizing your project to support the Cloud Credential Operator (CCO).
 
 With this method, the Operator is responsible for and requires RBAC permissions for creating the `CredentialsRequest` object and reading the resulting `Secret` object.
@@ -29,8 +30,6 @@ By default, pods related to the Operator deployment mount a `serviceAccountToken
 .. Ensure your Operator has RBAC permission to create `CredentialsRequests` objects:
 +
 .Example `clusterPermissions` list
-[%collapsible]
-====
 [source,yaml]
 ----
 # ...
@@ -51,7 +50,6 @@ install:
         - update
         - watch
 ----
-====
 
 .. Add the following annotation to claim support for this method of CCO-based workflow with AWS STS:
 +
@@ -78,8 +76,6 @@ webIdentityTokenPath := "/var/run/secrets/openshift/serviceaccount/token"
 .. Ensure you have a `CredentialsRequest` object ready to be patched and applied. For example:
 +
 .Example `CredentialsRequest` object creation
-[%collapsible]
-====
 [source,go]
 ----
 import (
@@ -127,13 +123,10 @@ var CredentialsRequestTemplate = &minterv1.CredentialsRequest{
    },
 }
 ----
-====
 +
 Alternatively, if you are starting from a `CredentialsRequest` object in YAML form (for example, as part of your Operator project code), you can handle it differently:
 +
 .Example `CredentialsRequest` object creation in YAML form
-[%collapsible]
-====
 [source,go]
 ----
 // CredentialsRequest is a struct that represents a request for credentials
@@ -192,7 +185,6 @@ func ConsumeCredsRequestAddingTokenInfo(fileName, tokenString, tokenPath string)
   return cr, nil
 }
 ----
-====
 +
 [NOTE]
 ====
@@ -202,8 +194,6 @@ Adding a `CredentialsRequest` object to the Operator bundle is not currently sup
 .. Add the role ARN and web identity token path to the credentials request and apply it during Operator initialization:
 +
 .Example applying `CredentialsRequest` object during Operator initialization
-[%collapsible]
-====
 [source,go]
 ----
 // apply CredentialsRequest on install
@@ -218,13 +208,10 @@ if err := c.Create(context.TODO(), credReq); err != nil {
    }
 }
 ----
-====
 
 .. Ensure your Operator can wait for a `Secret` object to show up from the CCO, as shown in the following example, which is called along with the other items you are reconciling in your Operator:
 +
 .Example wait for `Secret` object
-[%collapsible]
-====
 [source,go]
 ----
 // WaitForSecret is a function that takes a Kubernetes client, a namespace, and a v1 "k8s.io/api/core/v1" name as arguments
@@ -232,7 +219,7 @@ if err := c.Create(context.TODO(), credReq); err != nil {
 // It returns the secret object or an error if the timeout is exceeded
 func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Secret, error) {
   // set a timeout of 10 minutes
-  timeout := time.After(10 * time.Minute) <1>
+  timeout := time.After(10 * time.Minute)
 
   // set a polling interval of 10 seconds
   ticker := time.NewTicker(10 * time.Second)
@@ -263,14 +250,12 @@ func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Sec
   }
 }
 ----
-<1> The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
-====
++
+The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
 
 .. Set up the AWS configuration by reading the secret created by the CCO from the credentials request and creating the AWS config file containing the data from that secret:
 +
 .Example AWS configuration creation
-[%collapsible]
-====
 [source,go]
 ----
 func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
@@ -294,7 +279,6 @@ func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
    return f.Name(), nil
 }
 ----
-====
 +
 [IMPORTANT]
 ====
@@ -306,8 +290,6 @@ Additionally, the wait period should eventually time out and warn users that the
 .. Configure the AWS SDK session, for example:
 +
 .Example AWS SDK session configuration
-[%collapsible]
-====
 [source,go]
 ----
 sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
@@ -319,4 +301,3 @@ options := session.Options{
    SharedConfigFiles: []string{sharedCredentialsFile},
 }
 ----
-====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20641
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Configuring the OAuth server for a hosted cluster by using the console: https://115202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-configuring-oauth-console_hcp-authentication-authorization
- Verifying the CCO installation in a hosted cluster on AWS: https://115202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-cco-verify-aws-sts_hcp-authentication-authorization
- Enabling Operators to support CCO-based workflows with AWS STS (in HCP book): https://115202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#osdk-cco-aws-sts-enabling_hcp-authentication-authorization
- Enabling Operators to support CCO-based workflows with AWS STS (in Operators book): https://115202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-aws-sts.html#osdk-cco-aws-sts-enabling_osdk-cco-aws-sts
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Do not merge until https://github.com/openshift/openshift-docs/pull/115187 is merged
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
