### PR TITLE
OSDOCS-17040: platform agnostic CQA

### DIFF
--- a/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
@@ -150,6 +150,11 @@ include::modules/installation-generate-ignition-configs.adoc[leveloffset=+1]
 
 include::modules/creating-machines-bare-metal.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/[coreos-installer image mirror]
+
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
@@ -167,7 +172,7 @@ include::modules/installation-user-infra-machines-advanced-ignition.adoc[levelof
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli] 
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmtui_configuring-and-managing-networking[Getting started with nmtui]
 
 include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]

--- a/installing/installing_bare_metal/upi/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-bare-metal.adoc
@@ -176,6 +176,11 @@ include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[lev
 
 include::modules/creating-machines-bare-metal.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/[coreos-installer image mirror]
+
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
@@ -193,7 +198,7 @@ include::modules/installation-user-infra-machines-advanced-ignition.adoc[levelof
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli] 
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmtui_configuring-and-managing-networking[Getting started with nmtui]
 
 include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]

--- a/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
@@ -166,6 +166,11 @@ include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
 include::modules/creating-machines-bare-metal.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/[coreos-installer image mirror]
+
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
@@ -183,7 +188,7 @@ include::modules/installation-user-infra-machines-advanced-ignition.adoc[levelof
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli] 
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmcli_configuring-and-managing-networking[Getting started with nmcli]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#getting-started-with-nmtui_configuring-and-managing-networking[Getting started with nmtui]
 
 include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]

--- a/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+++ b/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
@@ -6,34 +6,26 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-any infrastructure that you provision, including virtualization and cloud environments.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on any infrastructure that you provision, including virtualization and cloud environments.
 
 [IMPORTANT]
 ====
-Review the information in the link:https://access.redhat.com/articles/4207611[guidelines for deploying {product-title} on non-tested platforms] before you attempt to install an {product-title} cluster in virtualized or cloud environments.
+See "Deploying OpenShift 4.x on non-tested platforms using the bare metal install method" before you try to install an {product-title} cluster in virtualized or cloud environments.
 ====
 
-== Prerequisites
+include::modules/installing-ocp-agnostic-prereqs.adoc[leveloffset=+1]
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-+
-[NOTE]
-====
-Be sure to also review this site list if you are configuring a proxy.
-====
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[Configuring your firewall]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
+include::modules/installation-upi-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 
@@ -84,6 +76,11 @@ include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/creating-machines-bare-metal.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/[coreos-installer image mirror]
 
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
@@ -141,11 +138,13 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-== Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* xref:../../registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc#configuring-registry-storage-baremetal[Set up your registry and configure registry storage].
+* link:https://access.redhat.com/articles/4207611[Deploying OpenShift 4.x on non-tested platforms using the bare metal install method]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Available cluster customizations]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc#configuring-registry-storage-baremetal[Configuring the registry for bare metal]

--- a/modules/creating-machines-bare-metal.adoc
+++ b/modules/creating-machines-bare-metal.adoc
@@ -30,7 +30,7 @@ You can configure {op-system} during ISO and PXE installations by using the foll
 +
 [NOTE]
 ====
-As of version `0.17.0-3`, `coreos-installer` requires {op-system-base} 9 or later to run the program. You can still use older versions of `coreos-installer` to customize {op-system} artifacts of newer {product-title} releases and install metal images to disk. You can download older versions of the `coreos-installer` binary from the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/[`coreos-installer` image mirror] page.
+As of version `0.17.0-3`, `coreos-installer` requires {op-system-base} 9 or later to run the program. You can still use older versions of `coreos-installer` to customize {op-system} artifacts of newer {product-title} releases and install metal images to disk. See "coreos-installer image mirror" to download older versions of the `coreos-installer` binary.
 ====
 
 Whether to use an ISO or PXE install depends on your situation. A PXE install requires an available DHCP service and more preparation, but can make the installation process more automated. An ISO install is a more manual process and can be inconvenient if you are setting up more than a few machines.

--- a/modules/installation-upi-requirements.adoc
+++ b/modules/installation-upi-requirements.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: CONCEPT
+[id="installation-requirements-user-infra_{context}"]
+= Requirements for a cluster with user-provisioned infrastructure
+
+[role="_abstract"]
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
+
+This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.

--- a/modules/installing-ocp-agnostic-prereqs.adoc
+++ b/modules/installing-ocp-agnostic-prereqs.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: REFERENCE
+[id="prerequisites_{context}"]
+= Prerequisites for installing a cluster on any platform
+
+[role="_abstract"]
+Before beginning your cluster installation, you must complete prerequisite tasks that prepare your environment.
+
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read "Selecting a cluster installation method and preparing it for users".
+* If you use a firewall or proxy, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall".
++
+[NOTE]
+====
+Be sure to also review this site list if you are configuring a proxy.
+====

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -32,6 +32,7 @@ endif::[]
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Disabling the default software catalog sources
 
+[role="_abstract"]
 Operator catalogs that source content provided by Red Hat and community projects are configured for the software catalog by default during an {product-title} installation.
 ifndef::olm-managing-custom-catalogs[]
 In a restricted network environment, you must disable the default catalogs as a cluster administrator.
@@ -52,7 +53,7 @@ endif::[]
 $ oc patch OperatorHub cluster --type json \
     -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 ----
-
++
 [TIP]
 ====
 Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.


### PR DESCRIPTION
[OSDOCS-17040](https://redhat.atlassian.net/browse/OSDOCS-17040)

Version(s): 4.20+

CQA for platform agnostic install docs

QE review: QE review not required IMO, let me know if you see anything that makes you disagree.

Previews: 
- [Installing a cluster on any platform](https://115208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic)
- [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://115208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations#creating-machines-bare-metal_installing-bare-metal-network-customizations) (bare metal UPI network customizations)
- [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://115208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal) (bare metal UPI)
- [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://115208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal#creating-machines-bare-metal_installing-restricted-networks-bare-metal) (bare metal UPI disconnected env)

