### PR TITLE
Post-GA 3.4 release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ commercial_package
 .vale/styles/RedHat
 migrating/JIRA-9894-dns-capture-documentation-plan.md
 migrating/modules/ossm-migrating-a-multitenant-deployment.html
+analysis/
 artifacts/
 update/ossm-preparing-for-rhel-10-migration.adoc
 modules/ossm-migrate-to-nftables-rhel10-ambient.adoc

--- a/modules/ossm-release-notes-3-4-fixed-issues.adoc
+++ b/modules/ossm-release-notes-3-4-fixed-issues.adoc
@@ -13,3 +13,9 @@ Istiod containers include termination message policy for easier debugging::
 Before this update, istiod containers did not specify a `terminationMessagePolicy`. As a consequence, when an istiod container failed, you had to retrieve log information from log storage systems for troubleshooting. This release sets the `terminationMessagePolicy` to `FallbackToLogsOnError`. As a result, when a container fails, the last chunk of log output is captured in the pod status and accessible with `oc describe pod`, making initial debugging easier without requiring log storage access.
 +
 link:https://issues.redhat.com/browse/OSSM-13701[OSSM-13701]
+
+
+Kiali correctly validates Istio configuration for multiple meshes in a cluster::
+Before this update, when multiple Istio control planes ran in the same {ocp-short-name} cluster, Kiali used only one control plane's `MeshConfig` properties to validate all Istio configurations. As a consequence, Kiali reported incorrect `KIA1101` (`VirtualService`) and `KIA0203` (`DestinationRule`) validation errors. This release validates Istio resources within the context of each control plane's managed namespace, using each control plane's own `MeshConfig` properties. As a result, resources belonging to one mesh are validated independently, and false validation errors no longer appear.
++
+link:https://redhat.atlassian.net/browse/OSSM-12562[OSSM-12562]

--- a/modules/ossm-release-notes-3-4-new-features-enhancements.adoc
+++ b/modules/ossm-release-notes-3-4-new-features-enhancements.adoc
@@ -30,7 +30,7 @@ On FIPS-enabled {ocp-product-title} clusters, {SMProductShortName} supports FIPS
 link:https://issues.redhat.com/browse/OSSM-12531[OSSM-12531]
 
 
-{SMProduct} supports the coexistence of sidecar and ambient mode workloads:: 
+{SMProduct} supports the coexistence of sidecar and ambient mode workloads::
 {SMProductShortName} supports running sidecar proxy and ambient mode workloads simultaneously in separate namespaces within the same mesh (with limitations noted in the documentation). This coexistence enables an incremental migration to ambient mode. You can also maintain specific workloads in sidecar mode if they require features that ambient mode does not yet support.
 +
 For more information, see xref:../install/ossm-ambient-sidecar-coexistence.adoc#ossm-ambient-sidecar-coexistence[Coexistence of ambient and sidecar modes].
@@ -54,6 +54,39 @@ Kiali supports stricter namespace access control for multi-tenancy environments:
 This release introduces a new configuration attribute, `KialiFeatureFlags.Authz.RequireNamespaceGet`, to improve multi-tenancy support in Kiali. By default, when Kiali runs in cluster-wide mode, it treats users with List permission to a namespace as also having Get permission, and displays all List namespaces in the Namespace dropdown. In environments where List and Get permissions differ, this can expose namespaces that users should not access. When you set `KialiFeatureFlags.Authz.RequireNamespaceGet=true`, Kiali limits the Namespace dropdown to only those namespaces for which users have Get permission, ensuring stricter access control. The default value is `false`, so existing deployments are not affected.
 +
 link:https://issues.redhat.com/browse/OSSM-13288[OSSM-13288]
+
+
+Kiali Overview page redesigned for performance and multi-cluster awareness::
+This release replaces the Kiali Overview page with a compact, multi-cluster-aware dashboard that provides a high-level view of mesh health at a glance. The redesigned page uses pre-computed and cached data to ensure fast rendering independent of mesh size.
++
+The Overview page displays summary cards for:
++
+* Cluster health
+* Istio configuration validation
+* Control plane status
+* Namespace mesh participation (Ambient, Sidecar, or Out of mesh)
+* An interactive application health donut chart
+* Workload insights such as missing sidecars, high error rates, or failing probes
++
+This release also adds a dedicated Namespaces page.
++
+link:https://redhat.atlassian.net/browse/OSSM-11833[OSSM-11833]
+
+
+Kiali Namespace detail page provides a comprehensive namespace view::
+Clicking a namespace in the Kiali Namespaces list opens a detail page with a split-panel layout showing namespace metadata, health, and traffic.
++
+The left panel displays:
++
+* Namespace attributes such as cluster, revision, status, mesh mode, and mTLS status
+* Links to applications, services, workloads, and Istio configuration with health breakdowns
+* Editable labels and annotations with click-to-filter navigation
++
+The right panel displays a namespace-scoped traffic minigraph.
++
+Additionally, an Actions menu lists options such as traffic policies. The page also supports breadcrumb navigation, view-only mode, and kiosk mode.
++
+link:https://redhat.atlassian.net/browse/OSSM-13271[OSSM-13271]
 
 
 {SMProduct} supports Gateway API 1.5.1, in which the following features are now stable::

--- a/modules/ossm-release-notes-3-4-technology-preview-features.adoc
+++ b/modules/ossm-release-notes-3-4-technology-preview-features.adoc
@@ -20,7 +20,7 @@ While {SMProduct} already supports workload identity creation and management thr
 * *Deep workload attestation* - Verifies workload identity based on configurable criteria backed by hardware or cloud environment verification
 * *Trust domain federation* - Enables workloads from different trust domains to authenticate and communicate securely
 +
-SPIRE is supported as part of the Open Shift Zero Trust Workload Identity Manager. Integration with {SMProduct} is a Technology Preview feature.
+SPIRE is supported as part of the OpenShift Zero Trust Workload Identity Manager. Integration with {SMProduct} is a Technology Preview feature.
 +
 For more information, see xref:../install/ossm-SPIRE.adoc#ossm-SPIRE[SPIRE integration for mesh security].
 +


### PR DESCRIPTION
[OSSM-14936](https://redhat.atlassian.net/browse/OSSM-14936): [DOC] 3.4 release notes submitted past freeze date

Version(s):
service-mesh-docs-3.4 (no cherry-pics necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14936

Link to docs preview:
Please see the three new release notes on the "Files changed" tab.