### PR TITLE
MULTIARCH-6267 MTO 1.3.2 release notes

### DIFF
--- a/modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-3-2_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.3.2
+
+Issued: 13 July 2026
+
+[id="multi-arch-tuning-operator-1-3-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, when deleting a `ClusterPodPlacementConfig` with the `execFormatErrorMonitor` plugin enabled, the MTO could get stuck in a `Deleting` state because some resources were not deleted. With this update, all relevant resources are removed so that the deletion is successful. link:https://redhat.atlassian.net/browse/MULTIARCH-6186[(*MULTIARCH-6186*)]
+
+* Previously, a race condition between the eNoExecEvent daemon and the handler controller caused the `ENoExecEvent` CR to be rolled back before its status could be set, preventing any exec format errors from being recorded. This update resolves the conflict so events are captured successfully. link:https://redhat.atlassian.net/browse/MULTIARCH-6207[(*MULTIARCH-6207*)]
+
+* Previously, deleting a `ClusterPodPlacementConfig` object could tear down the webhook and operand resources while `PodPlacementConfigs` still existed, orphaning them without the resources they depend on. The deletion is now properly gated and blocks if any `PodPlacementConfig` objects remain. link:https://redhat.atlassian.net/browse/MULTIARCH-6236[(*MULTIARCH-6236*)]
+
+[id="multi-arch-tuning-operator-1-3-2-enhancements_{context}"]
+== Enhancements
+
+* MTO has been updated to use `go` version 1.26.3.
+
+* When the MTO is unable to connect to an image registry, the resulting error message has been improved to better explain the error. link:https://redhat.atlassian.net/browse/MULTIARCH-5541[(*MULTIARCH-5541*)]
+
+* The MTO API has been updated to use `runtime.NewSchemeBuilder` instead of the deprecated `scheme.Builder`. link:https://redhat.atlassian.net/browse/MULTIARCH-6272[(*MULTIARCH-6272*)]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -11,6 +11,8 @@ The Multiarch Tuning Operator (MTO) optimizes workload management within multi-a
 
 For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
 
+include::modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc[leveloffset=+1]
+
 include::modules/multi-arch-tuning-operator-release-notes-1-3-1.adoc[leveloffset=+1]
 
 include::modules/multi-arch-tuning-operator-release-notes-1-3-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/MULTIARCH-6267

Link to docs preview:
https://115221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html#multi-arch-tuning-operator-release-notes-1-3-2_multi-arch-tuning-operator-release-notes

QE review:
Engineering provided the review
