### PR TITLE
OSDOCS-17034: two node OCP CQA

### DIFF
--- a/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
+++ b/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
@@ -4,7 +4,9 @@
 :context: about-two-node-arbiter-installation
 
 [role="_abstract"]
-An {product-title} cluster with two control plane nodes and one local arbiter node is a compact, cost-effective {product-title} topology. The arbiter node stores the full etcd data, maintaining an etcd quorum and preventing split brain. The arbiter node does not run the additional control plane components `kube-apiserver` and `kube-controller-manager`, nor does it run workloads.
+An {product-title} cluster with two control plane nodes and one local arbiter node is a compact, cost-effective {product-title} topology.
+
+The arbiter node stores the full etcd data, maintaining an etcd quorum and preventing split brain. The arbiter node does not run the additional control plane components `kube-apiserver` and `kube-controller-manager`, nor does it run workloads.
 
 To install a cluster with two control plane nodes and one local arbiter node, assign an arbiter role to at least one of the nodes and set the control plane node count for the cluster to 2. Although {product-title} does not currently impose a limit on the number of arbiter nodes, the typical deployment includes only one to minimize the use of hardware resources.
 
@@ -12,8 +14,8 @@ After installation, you can add additional worker nodes to a cluster with two co
 
 [NOTE]
 ====
-Do not add more than two worker nodes to the {product-title} cluster. 
-For a cluster with an arbiter, the same networking requirements as a regular cluster for connectivity between machines apply. 
+Do not add more than two worker nodes to the {product-title} cluster.
+For a cluster with an arbiter, the same networking requirements as a regular cluster for connectivity between machines apply.
 ====
 
 [role="_additional-resources"]

--- a/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
@@ -15,7 +15,7 @@ include::modules/installation-manual-recovering-when-auto-recovery-is-unavail.ad
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd-restoring_backing-up-etcd[Restoring etcd from a backup].
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd-restoring_backing-up-etcd[Restoring etcd from a backup]
 
 * xref:../installing_tnf/install-post-tnf.adoc#installation-verifying-etcd-health_install-post-tnf[Verifying etcd health in a two-node OpenShift cluster with fencing]
 

--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -55,12 +55,13 @@ include::modules/installation-dns-installer-infra.adoc[leveloffset=+1]
 include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
 
 * xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest file for a customized br-ex bridge]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL].
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL]
 
 

--- a/modules/installation-dns-installer-infra.adoc
+++ b/modules/installation-dns-installer-infra.adoc
@@ -4,4 +4,9 @@
 [id="installation-installer-user-infra_{context}"]
 = Installer-provisioned DNS requirements
 
+[role="_abstract"]
+In {product-title} deployments, you must ensure that cluster components meet certain DNS name resolution criteria for internal communication, certificate validation, and automated node discovery purposes.
+
 include::snippets/dns-requirements.adoc[leveloffset=+1]
+
+//abstract copied from modules/installation-dns-user-infra.adoc, the User-provisioned version of this section

--- a/modules/installation-replacing-control-plane-nodes.adoc
+++ b/modules/installation-replacing-control-plane-nodes.adoc
@@ -6,11 +6,12 @@
 [id="installation-replacing-control-plane-nodes_{context}"]
 = Replacing control plane nodes in a two-node OpenShift cluster with fencing
 
+[role="_abstract"]
 You can replace a failed control plane node in a two-node OpenShift cluster. The replacement node must use the same host name and IP address as the failed node.
 
 .Prerequisites
 
-* You have a functioning survivor control plane node.  
+* You have a functioning survivor control plane node.
 * You have verified that either the machine is not running or the node is not ready.
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You know the host name and IP address of the failed node.
@@ -46,8 +47,8 @@ Votequorum information
 Expected votes:   2
 Highest expected: 2
 Total votes:      2
-Quorum:           1  
-Flags:            2Node Quorate WaitForAll 
+Quorum:           1
+Flags:            2Node Quorate WaitForAll
 
 Membership information
 ----------------------
@@ -150,7 +151,7 @@ $ oc get machines.machine.openshift.io -n openshift-machine-api
 +
 [source,terminal]
 ----
-$ oc get machines.machine.openshift.io/<machine_name> -n openshift-machine-api \ 
+$ oc get machines.machine.openshift.io/<machine_name> -n openshift-machine-api \
   -o jsonpath='Machine hash label: {.metadata.labels.machine\.openshift\.io/cluster-api-cluster}{"\n"}'
 ----
 +
@@ -163,7 +164,7 @@ You need this label to provision a new `Machine` object.
 [source,terminal]
 ----
 $ oc delete machines.machine.openshift.io/<machine_name>-<failed nodename> -n openshift-machine-api
----- 
+----
 +
 [NOTE]
 ====
@@ -174,7 +175,7 @@ The node object is deleted automatically after deleting the `Machine` object.
 +
 [IMPORTANT]
 ====
-You must perform this step only if you are using installer-provisioned infrastructure or the Machine API to create the original node.  
+You must perform this step only if you are using installer-provisioned infrastructure or the Machine API to create the original node.
 For information about replacing a failed bare-metal control plane node, see "Replacing an unhealthy etcd member on bare metal".
 ====
 
@@ -217,8 +218,8 @@ spec:
         name: master-user-data-managed
 ----
 +
-* `metadata.annotations.metal3.io/BareMetalHost`: Replace `{bmh_name}` with the name of the BMH object that is associated with the host that you are replacing. 
-* `labels.machine.openshift.io/cluster-api-cluster`: Replace `{machine_hash_label}` with the label that you fetched from the machine you deleted. 
+* `metadata.annotations.metal3.io/BareMetalHost`: Replace `{bmh_name}` with the name of the BMH object that is associated with the host that you are replacing.
+* `labels.machine.openshift.io/cluster-api-cluster`: Replace `{machine_hash_label}` with the label that you fetched from the machine you deleted.
 * `metadata.name`: Replace `{machine_name}` with the name of the machine you deleted.
 
 .. Create the new BMH object and the secret to store the BMC credentials by running the following command:
@@ -262,7 +263,7 @@ EOF
 * `metadata.name`: Specify the name of the secret.
 * `metadata.name`: Replace `{bmh_name}` with the name of the BMH object that you deleted.
 * `bmc.address`: Replace `{uuid}` with the UUID of the node that you created.
-* `bmc.credentialsName`: Replace `name` with the name of the secret that you created. 
+* `bmc.credentialsName`: Replace `name` with the name of the secret that you created.
 * `bootMACAddress`: Specify the MAC address of the provisioning network interface. This is the MAC address the node uses to identify itself when communicating with Ironic during provisioning.
 
 . Verify that the new node has reached the `Provisioned` state by running the following command:

--- a/modules/installation-two-node-cluster-min-resource-reqs.adoc
+++ b/modules/installation-two-node-cluster-min-resource-reqs.adoc
@@ -1,7 +1,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-two-node-fencing-minimum-resource-requirements_{context}"]
-= Minimum resource requirements for installing the two-node OpenShift cluster with fencing
+= Minimum resource requirements for installing a two-node OpenShift cluster with fencing
+
+[role="_abstract"]
+Each cluster must meet minimum requirements so that the cluster runs as expected.
 
 Each cluster machine must meet the following minimum requirements:
 

--- a/modules/installation-two-node-creating-manifest-custom-br-ex.adoc
+++ b/modules/installation-two-node-creating-manifest-custom-br-ex.adoc
@@ -1,7 +1,8 @@
 :_mod-docs-content-type: CONCEPT
-[id="creating-manifest-custom-br-ex_{context}"] 
-= Creating a manifest object for a customized br-ex bridge 
+[id="creating-manifest-custom-br-ex_{context}"]
+= Creating a manifest object for a customized br-ex bridge
 
-You must create a manifest object to modify the cluster’s network configuration after installation. The manifest configures the br-ex bridge, which manages external network connectivity for the cluster. 
+[role="_abstract"]
+You must create a manifest object to modify the cluster's network configuration after installation. The manifest configures the br-ex bridge, which manages external network connectivity for the cluster.
 
-For instructions on creating this manifest, "Creating a manifest file for a customized br-ex bridge".
+For instructions on creating this manifest, see "Creating a manifest file for a customized br-ex bridge".

--- a/modules/installation-verifying-etcd-health.adoc
+++ b/modules/installation-verifying-etcd-health.adoc
@@ -2,6 +2,7 @@
 [id="installation-verifying-etcd-health_{context}"]
 = Verifying etcd health in a two-node OpenShift cluster with fencing
 
+[role="_abstract"]
 After completing node recovery or maintenance procedures, verify that both control plane nodes and etcd are operating correctly.
 
 .Prerequisites

--- a/modules/sample-install-config-two-node-fencing-abi.adoc
+++ b/modules/sample-install-config-two-node-fencing-abi.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
 //
 //* installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="sample-install-config-two-node-fencing-abi_{context}"]
 = Sample install-config.yaml file for a two-node cluster with fencing for Agent-based Installer
 
-[role="abstract"]
+[role="_abstract"]
 You can use the following `install-config.yaml` configuration file as a template for deploying a two-node {product-title} cluster with fencing (TNF) by using the Agent-based Installer method.
 
 See the following sample `install-config.yaml` configuration file for bare-metal:
@@ -53,13 +53,13 @@ pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
 
-* `platform.baremetal.apiVIPs` and `ingressVIPs`: Specifies virtual IPs for the API and Ingress endpoints. Required for bare-metal platform; not applicable for none.
+* `platform.baremetal.apiVIPs` and `ingressVIPs`: Specifies virtual IPs for the API and Ingress endpoints. Required for bare-metal platform; not applicable for `none`.
 
 For other bare metal specific fields, see "Installation configuration parameters for the Agent-based Installer".
 
 The following sample `install-config.yaml` configuration file is for the attribute platform with value `none`.
 
-You must provide DNS name resolution and load balancing infrastructure. 
+You must provide DNS name resolution and load balancing infrastructure.
 
 [source,yaml]
 ----
@@ -100,11 +100,11 @@ pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
 
-* `controlPlane.replicas`: Must be `2` for a two-node {product-title} cluster with fencing (TNF).  
-* `compute[0].replicas`: Must be `0`. A two-node {product-title} cluster with fencing does not support compute nodes.  
-* `controlPlane.fencing.credentials`: Exactly 2 entries required, one per control plane node. 
+* `controlPlane.replicas`: Must be `2` for a two-node {product-title} cluster with fencing (TNF).
+* `compute[0].replicas`: Must be `0`. A two-node {product-title} cluster with fencing does not support compute nodes.
+* `controlPlane.fencing.credentials`: Exactly 2 entries required, one per control plane node.
 * `fencing.credentials[].hostname`: The hostname of the control plane node. Must be unique across credentials.
-* `fencing.credentials[].address`: The Redfish BMC URL. Must use the `redfish+https://` scheme (for example, `redfish+[\https://192.168.1.10:443/redfish/v1/Systems/1](\https://192.168.1.10:443/redfish/v1/Systems/1))`. IPMI addresses are not supported. Vendor-specific Redfish schemes such as `idrac-redfish+https://` and `ilo5-redfish+https://` are also accepted.  
-* `fencing.credentials[].username`: BMC username for the node.  
+* `fencing.credentials[].address`: The Redfish BMC URL. Must use the `redfish+https://` scheme (for example, `redfish+[\https://192.168.1.10:443/redfish/v1/Systems/1](\https://192.168.1.10:443/redfish/v1/Systems/1))`. IPMI addresses are not supported. Vendor-specific Redfish schemes such as `idrac-redfish+https://` and `ilo5-redfish+https://` are also accepted.
+* `fencing.credentials[].username`: BMC username for the node.
 * `fencing.credentials[].password`: BMC password for the node.
 * `fencing.credentials[].certificateVerification`: Optional. Set to Disabled if your BMC uses self-signed certificates (common for internally-hosted endpoints). Set to Enabled (default) for BMCs with valid CA-signed certificates.


### PR DESCRIPTION
[OSDOCS-17034](https://redhat.atlassian.net/browse/OSDOCS-17034)

Version(s): 4.20+

CQA for two node cluster install docs.

QE review: not required IMO but let me know if you see anything that makes you disagree.

Previews:
- [Post-installation troubleshooting and recovery](https://115222--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-post-tnf)
- [Preparing to install a two-node OpenShift cluster with fencing](https://115222--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing)
- [Two-Node with Arbiter](https://115222--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/about-two-node-arbiter-installation)
- [Installing a two-node OpenShift cluster with fencing](https://115222--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-tnf)
