### PR TITLE
OSDOCS-17037: SNO Install CQA pt 3

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -44,23 +44,28 @@ include::modules/install-sno-okd-assisted-service.adoc[leveloffset=+1]
 
 endif::openshift-origin[]
 
+ifdef::openshift-origin[]
 [role="_additional-resources"]
 .Additional resources
 
-ifdef::openshift-origin[]
 * link:https://github.com/openshift/assisted-service/tree/master/deploy/podman#okd-configuration[Install OKD using Assisted Service]
-endif::openshift-origin[]
 
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
 
+* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
+endif::openshift-origin[]
+
 ifndef::openshift-origin[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
+
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
+
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 endif::openshift-origin[]
 
-ifdef::openshift-origin[]
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
-endif::openshift-origin[]
 
 ifndef::openshift-origin[]
 include::modules/install-sno-manual.adoc[leveloffset=+1]
@@ -94,10 +99,11 @@ include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffs
 .Additional resources
 
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
-ifndef::openshift-origin[]
-* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
+ifdef::openshift-origin[]
+* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
 endif::openshift-origin[]
 ifndef::openshift-origin[]
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
 include::modules/install-sno-agent.adoc[leveloffset=+1]
@@ -108,10 +114,6 @@ include::modules/install-sno-agent.adoc[leveloffset=+1]
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
 
 include::modules/install-sno-installing-with-agent-based-installer.adoc[leveloffset=+2]
-endif::openshift-origin[]
-
-ifdef::openshift-origin[]
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
 endif::openshift-origin[]
 
 include::modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17037](https://redhat.atlassian.net/browse/OSDOCS-17037)

Version(s): 4.20+

PR trying to untangle some very conditionalized AR sections for the enterprise and OKD docs.

QE review: QE not needed

Previews (should be zero detectable change from live doc):
1. [Installing single-node OKD using the Assisted Service](https://file.corp.redhat.com/skopacz/OSDOCS-17037_3/installing/installing_sno/install-sno-installing-sno.html#installing-sno-assisted-installer_install-sno-installing-sno-with-the-assisted-installer) (OKD, VPN required)
2. [Monitoring the cluster installation using openshift-install](https://file.corp.redhat.com/skopacz/OSDOCS-17037_3/installing/installing_sno/install-sno-installing-sno.html#install-sno-monitoring-the-installation-manually_install-sno-installing-sno-with-the-assisted-installer) (OKD, VPN required)
3. [Installing single-node OpenShift using the Assisted Installer](https://115231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#installing-sno-assisted-installer_install-sno-installing-sno-with-the-assisted-installer) (enterprise)
4. [Monitoring the cluster installation using openshift-install](https://115231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#install-sno-monitoring-the-installation-manually_install-sno-installing-sno-with-the-assisted-installer) (enterprise)

Existing docs, for comparison:
1. [Installing single-node OKD using the Assisted Service](https://docs.okd.io/latest/installing/installing_sno/install-sno-installing-sno.html#installing-sno-assisted-installer_install-sno-installing-sno-with-the-assisted-installer) (OKD)
2. [Monitoring the cluster installation using openshift-install](https://docs.okd.io/latest/installing/installing_sno/install-sno-installing-sno.html#install-sno-monitoring-the-installation-manually_install-sno-installing-sno-with-the-assisted-installer) (OKD)
3. [Installing single-node OpenShift using the Assisted Installer](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/installing_on_a_single_node/install-sno-installing-sno#installing-sno-assisted-installer_install-sno-installing-sno-with-the-assisted-installer) (enterprise)
4. [Monitoring the cluster installation using openshift-install](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/installing_on_a_single_node/install-sno-installing-sno#install-sno-monitoring-the-installation-manually_install-sno-installing-sno-with-the-assisted-installer) (enterprise)
