### PR TITLE
OSDOCS-16939: DITA split-modules — olm-packaging-format

### DIFF
--- a/modules/olm-bundle-format-annotations.adoc
+++ b/modules/olm-bundle-format-annotations.adoc
@@ -6,25 +6,31 @@
 [id="olm-bundle-format-annotations_{context}"]
 = Annotations
 
+[role="_abstract"]
+Operator bundle annotations in `annotations.yaml` define aggregate metadata that describes how a bundle is indexed in {product-title}. These annotations specify media type, manifest paths, package name, channels, and the default channel for catalog registration.
+
 A bundle also includes an `annotations.yaml` file in its `/metadata` directory. This file defines higher level aggregate data that helps describe the format and package information about how the bundle should be added into an index of bundles:
 
 .Example `annotations.yaml`
 [source,yaml]
 ----
 annotations:
-  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1" <1>
-  operators.operatorframework.io.bundle.manifests.v1: "manifests/" <2>
-  operators.operatorframework.io.bundle.metadata.v1: "metadata/" <3>
-  operators.operatorframework.io.bundle.package.v1: "test-operator" <4>
-  operators.operatorframework.io.bundle.channels.v1: "beta,stable" <5>
-  operators.operatorframework.io.bundle.channel.default.v1: "stable" <6>
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "test-operator"
+  operators.operatorframework.io.bundle.channels.v1: "beta,stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"
 ----
-<1> The media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
-<2> The path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
-<3> The path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
-<4> The package name of the bundle.
-<5> The list of channels the bundle is subscribing to when added into an Operator Registry.
-<6> The default channel an Operator should be subscribed to when installed from a registry.
++
+where:
+
+`annotations.operators.operatorframework.io.bundle.mediatype.v1`:: Specifies the media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
+`annotations.operators.operatorframework.io.bundle.manifests.v1`:: Specifies the path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
+`annotations.operators.operatorframework.io.bundle.metadata.v1`:: Specifies the path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
+`annotations.operators.operatorframework.io.bundle.package.v1`:: Specifies the package name of the bundle.
+`annotations.operators.operatorframework.io.bundle.channels.v1`:: Specifies the list of channels the bundle is subscribing to when added into an Operator Registry.
+`annotations.operators.operatorframework.io.bundle.channel.default.v1`:: Specifies the default channel an Operator should be subscribed to when installed from a registry.
 
 [NOTE]
 ====

--- a/modules/olm-bundle-format-annotations.adoc
+++ b/modules/olm-bundle-format-annotations.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-bundle-format-annotations_{context}"]
+= Annotations
+
+A bundle also includes an `annotations.yaml` file in its `/metadata` directory. This file defines higher level aggregate data that helps describe the format and package information about how the bundle should be added into an index of bundles:
+
+.Example `annotations.yaml`
+[source,yaml]
+----
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1" <1>
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/" <2>
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/" <3>
+  operators.operatorframework.io.bundle.package.v1: "test-operator" <4>
+  operators.operatorframework.io.bundle.channels.v1: "beta,stable" <5>
+  operators.operatorframework.io.bundle.channel.default.v1: "stable" <6>
+----
+<1> The media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
+<2> The path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
+<3> The path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
+<4> The package name of the bundle.
+<5> The list of channels the bundle is subscribing to when added into an Operator Registry.
+<6> The default channel an Operator should be subscribed to when installed from a registry.
+
+[NOTE]
+====
+In case of a mismatch, the `annotations.yaml` file is authoritative because the on-cluster Operator Registry that relies on these annotations only has access to this file.
+====

--- a/modules/olm-bundle-format-manifests-optional.adoc
+++ b/modules/olm-bundle-format-manifests-optional.adoc
@@ -6,9 +6,12 @@
 [id="olm-bundle-format-manifests-optional_{context}"]
 = Additionally supported objects
 
+[role="_abstract"]
+Operator bundles can optionally include additional Kubernetes object types in the `/manifests` directory for deployment with a cluster service version (CSV) in {product-title}. When included, Operator Lifecycle Manager (OLM) creates and manages the lifecycle of these objects alongside the CSV.
+
 The following object types can also be optionally included in the `/manifests` directory of a bundle:
 
-.Supported optional object types
+== Supported optional object types
 [.small]
 * `ClusterRole`
 * `ClusterRoleBinding`
@@ -30,7 +33,7 @@ The following object types can also be optionally included in the `/manifests` d
 
 When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
 
-.Lifecycle for optional objects
+== Lifecycle for optional objects
 * When the CSV is deleted, OLM deletes the optional object.
 * When the CSV is upgraded:
 ** If the name of the optional object is the same, OLM updates it in place.

--- a/modules/olm-bundle-format-manifests-optional.adoc
+++ b/modules/olm-bundle-format-manifests-optional.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="olm-bundle-format-manifests-optional_{context}"]
+= Additionally supported objects
+
+The following object types can also be optionally included in the `/manifests` directory of a bundle:
+
+.Supported optional object types
+[.small]
+* `ClusterRole`
+* `ClusterRoleBinding`
+* `ConfigMap`
+* `ConsoleCLIDownload`
+* `ConsoleLink`
+* `ConsoleQuickStart`
+* `ConsoleYamlSample`
+* `PodDisruptionBudget`
+* `PriorityClass`
+* `PrometheusRule`
+* `Role`
+* `RoleBinding`
+* `Secret`
+* `Service`
+* `ServiceAccount`
+* `ServiceMonitor`
+* `VerticalPodAutoscaler`
+
+When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
+
+.Lifecycle for optional objects
+* When the CSV is deleted, OLM deletes the optional object.
+* When the CSV is upgraded:
+** If the name of the optional object is the same, OLM updates it in place.
+** If the name of the optional object has changed between versions, OLM deletes and recreates it.

--- a/modules/olm-bundle-format-manifests.adoc
+++ b/modules/olm-bundle-format-manifests.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-bundle-format-manifests_{context}"]
+= Manifests
+
+Bundle manifests refer to a set of Kubernetes manifests that define the deployment and RBAC model of the Operator.
+
+A bundle includes one CSV per directory and typically the CRDs that define the owned APIs of the CSV in its `/manifests` directory.
+
+.Example bundle format layout
+[source,terminal]
+----
+etcd
+├── manifests
+│   ├── etcdcluster.crd.yaml
+│   └── etcdoperator.clusterserviceversion.yaml
+│   └── secret.yaml
+│   └── configmap.yaml
+└── metadata
+    └── annotations.yaml
+    └── dependencies.yaml
+----

--- a/modules/olm-bundle-format-manifests.adoc
+++ b/modules/olm-bundle-format-manifests.adoc
@@ -6,6 +6,9 @@
 [id="olm-bundle-format-manifests_{context}"]
 = Manifests
 
+[role="_abstract"]
+Bundle manifests are Kubernetes objects in an Operator bundle that define the deployment and RBAC model for an Operator in {product-title}. A bundle includes one CSV and typically the CRDs for APIs owned by that CSV in its `/manifests` directory.
+
 Bundle manifests refer to a set of Kubernetes manifests that define the deployment and RBAC model of the Operator.
 
 A bundle includes one CSV per directory and typically the CRDs that define the owned APIs of the CSV in its `/manifests` directory.

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-bundle-format_{context}"]
 = Bundle format
 
@@ -21,86 +22,3 @@ When loading manifests into the Operator Registry database, the following requir
 * The bundle must have at least one channel defined in the annotations.
 * Every bundle has exactly one cluster service version (CSV).
 * If a CSV owns a custom resource definition (CRD), that CRD must exist in the bundle.
-
-[id="olm-bundle-format-manifests_{context}"]
-== Manifests
-
-Bundle manifests refer to a set of Kubernetes manifests that define the deployment and RBAC model of the Operator.
-
-A bundle includes one CSV per directory and typically the CRDs that define the owned APIs of the CSV in its `/manifests` directory.
-
-.Example bundle format layout
-[source,terminal]
-----
-etcd
-├── manifests
-│   ├── etcdcluster.crd.yaml
-│   └── etcdoperator.clusterserviceversion.yaml
-│   └── secret.yaml
-│   └── configmap.yaml
-└── metadata
-    └── annotations.yaml
-    └── dependencies.yaml
-----
-
-
-[id="olm-bundle-format-manifests-optional_{context}"]
-=== Additionally supported objects
-
-The following object types can also be optionally included in the `/manifests` directory of a bundle:
-
-.Supported optional object types
-[.small]
-* `ClusterRole`
-* `ClusterRoleBinding`
-* `ConfigMap`
-* `ConsoleCLIDownload`
-* `ConsoleLink`
-* `ConsoleQuickStart`
-* `ConsoleYamlSample`
-* `PodDisruptionBudget`
-* `PriorityClass`
-* `PrometheusRule`
-* `Role`
-* `RoleBinding`
-* `Secret`
-* `Service`
-* `ServiceAccount`
-* `ServiceMonitor`
-* `VerticalPodAutoscaler`
-
-When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
-
-.Lifecycle for optional objects
-* When the CSV is deleted, OLM deletes the optional object.
-* When the CSV is upgraded:
-** If the name of the optional object is the same, OLM updates it in place.
-** If the name of the optional object has changed between versions, OLM deletes and recreates it.
-
-[id="olm-bundle-format-annotations_{context}"]
-== Annotations
-
-A bundle also includes an `annotations.yaml` file in its `/metadata` directory. This file defines higher level aggregate data that helps describe the format and package information about how the bundle should be added into an index of bundles:
-
-.Example `annotations.yaml`
-[source,yaml]
-----
-annotations:
-  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1" <1>
-  operators.operatorframework.io.bundle.manifests.v1: "manifests/" <2>
-  operators.operatorframework.io.bundle.metadata.v1: "metadata/" <3>
-  operators.operatorframework.io.bundle.package.v1: "test-operator" <4>
-  operators.operatorframework.io.bundle.channels.v1: "beta,stable" <5>
-  operators.operatorframework.io.bundle.channel.default.v1: "stable" <6>
-----
-<1> The media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
-<2> The path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
-<3> The path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
-<4> The package name of the bundle.
-<5> The list of channels the bundle is subscribing to when added into an Operator Registry.
-<6> The default channel an Operator should be subscribed to when installed from a registry.
-
-[NOTE]
-====
-In case of a mismatch, the `annotations.yaml` file is authoritative because the on-cluster Operator Registry that relies on these annotations only has access to this file.
-====

--- a/modules/olm-fb-catalogs-cli.adoc
+++ b/modules/olm-fb-catalogs-cli.adoc
@@ -6,6 +6,11 @@
 [id="olm-fb-catalogs-cli_{context}"]
 = CLI usage
 
-For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
+[role="_abstract"]
+You can create and manage file-based Operator catalogs in {product-title} by using the `opm` CLI. Refer to the managing custom catalogs and CLI reference documentation for procedures and command details.
 
-For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs]
+* xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools]

--- a/modules/olm-fb-catalogs-cli.adoc
+++ b/modules/olm-fb-catalogs-cli.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-fb-catalogs-cli_{context}"]
+= CLI usage
+
+For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
+
+For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -10,6 +10,12 @@ This guide outlines the packaging format for Operators supported by Operator Lif
 
 include::modules/olm-bundle-format.adoc[leveloffset=+1]
 
+include::modules/olm-bundle-format-manifests.adoc[leveloffset=+2]
+
+include::modules/olm-bundle-format-manifests-optional.adoc[leveloffset=+2]
+
+include::modules/olm-bundle-format-annotations.adoc[leveloffset=+2]
+
 include::modules/olm-dependencies.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -73,11 +79,6 @@ include::modules/olm-fb-catalogs-example.adoc[leveloffset=+2]
 
 include::modules/olm-fb-catalogs-guidelines.adoc[leveloffset=+2]
 
-[id="olm-fb-catalogs-cli"]
-=== CLI usage
-
-For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
-
-For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].
+include::modules/olm-fb-catalogs-cli.adoc[leveloffset=+2]
 
 include::modules/olm-fb-catalogs-automation.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
Split nested sections for DITA migration on the olm-packaging-format attachment:
- Split `olm-bundle-format` into parent plus child modules (manifests, optional objects, annotations)
- Extract assembly `=== CLI usage` into `olm-fb-catalogs-cli` module
- Update assembly includes
- Apply abstracts, callout rewrites, and remaining AsciiDocDITA fixes **only on newly created modules** (they do not exist on `main` yet)

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16939

## Versions
4.20+

## Merge order
Independent branch from `main` (split-modules series). Preferred first among the [OSDOCS-16939](https://redhat.atlassian.net/browse/OSDOCS-16939) DITA set when reviewing packaging modules.

## Files changed
- `modules/olm-bundle-format.adoc`
- `modules/olm-bundle-format-manifests.adoc` (new)
- `modules/olm-bundle-format-manifests-optional.adoc` (new)
- `modules/olm-bundle-format-annotations.adoc` (new)
- `modules/olm-fb-catalogs-cli.adoc` (new)
- `operators/understanding/olm-packaging-format.adoc`

## Vale rules addressed
- AsciiDocDITA.NestedSection
- AsciiDocDITA.ShortDescription / CalloutList / related (new modules only)

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Independent series PR — does not include abstracts/callouts/other fixes for files already on `main`

Made with [Cursor](https://cursor.com)