### PR TITLE
OSDOCS-16939: DITA other AsciiDocDITA fixes — OLM content

### DIFF
--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-architecture_{context}"]
 ifeval::["{context}" != "operator-reference"]
 = Component responsibilities

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -100,8 +100,6 @@ If your catalog cannot run with `restricted` permissions, it is recommended that
 * `CONNECTING`: A connection is attempting to establish.
 * `TRANSIENT_FAILURE`: A temporary problem has occurred while attempting to establish a connection, such as a timeout. The state will eventually switch back to `CONNECTING` and try again.
 --
-+
-See link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity] in the gRPC documentation for more details.
 <14> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
 <15> Status information for the catalog's Operator Registry service.
 
@@ -121,6 +119,11 @@ spec:
   source: example-catalog
   sourceNamespace: {global_ns}
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity (gRPC documentation)]
 
 ifdef::openshift-origin[]
 :!global_ns:

--- a/modules/olm-fb-catalogs-prop.adoc
+++ b/modules/olm-fb-catalogs-prop.adoc
@@ -16,8 +16,6 @@ OLM defines a handful of property types, again using the reserved `olm.*` prefix
 The `olm.package` property defines the package name and version. This is a required property on bundles, and there must be exactly one of these properties. The `packageName` field must match the bundle's first-class `package` field, and the `version` field must be a valid semantic version.
 
 .`olm.package` property
-[%collapsible]
-====
 [source,go]
 ----
 #PropertyPackage: {
@@ -28,7 +26,6 @@ The `olm.package` property defines the package name and version. This is a requi
   }
 }
 ----
-====
 
 [id="olm-fb-catalogs-gvk-prop_{context}"]
 == olm.gvk property
@@ -36,8 +33,6 @@ The `olm.package` property defines the package name and version. This is a requi
 The `olm.gvk` property defines the group/version/kind (GVK) of a Kubernetes API that is provided by this bundle. This property is used by OLM to resolve a bundle with this property as a dependency for other bundles that list the same GVK as a required API. The GVK must adhere to Kubernetes GVK validations.
 
 .`olm.gvk` property
-[%collapsible]
-====
 [source,go]
 ----
 #PropertyGVK: {
@@ -49,7 +44,6 @@ The `olm.gvk` property defines the group/version/kind (GVK) of a Kubernetes API 
   }
 }
 ----
-====
 
 [id="olm-fb-catalogs-package-reqd-prop_{context}"]
 == olm.package.required
@@ -57,8 +51,6 @@ The `olm.gvk` property defines the group/version/kind (GVK) of a Kubernetes API 
 The `olm.package.required` property defines the package name and version range of another package that this bundle requires. For every required package property a bundle lists, OLM ensures there is an Operator installed on the cluster for the listed package and in the required version range. The `versionRange` field must be a valid semantic version (semver) range.
 
 .`olm.package.required` property
-[%collapsible]
-====
 [source,go]
 ----
 #PropertyPackageRequired: {
@@ -69,7 +61,6 @@ The `olm.package.required` property defines the package name and version range o
   }
 }
 ----
-====
 
 [id="olm-fb-catalogs-gvk-reqd-prop_{context}"]
 == olm.gvk.required
@@ -77,8 +68,6 @@ The `olm.package.required` property defines the package name and version range o
 The `olm.gvk.required` property defines the group/version/kind (GVK) of a Kubernetes API that this bundle requires. For every required GVK property a bundle lists, OLM ensures there is an Operator installed on the cluster that provides it. The GVK must adhere to Kubernetes GVK validations.
 
 .`olm.gvk.required` property
-[%collapsible]
-====
 [source,terminal]
 ----
 #PropertyGVKRequired: {
@@ -90,4 +79,3 @@ The `olm.gvk.required` property defines the group/version/kind (GVK) of a Kubern
   }
 }
 ----
-====

--- a/modules/olm-fb-catalogs.adoc
+++ b/modules/olm-fb-catalogs.adoc
@@ -37,3 +37,23 @@ The file-based catalog specification is a low-level representation of a catalog.
 For example, a tool could translate a high-level API, such as `(mode=semver)`, down to the low-level, file-based catalog format for upgrade paths. Or a catalog maintainer might need to customize all of the bundle metadata by adding a new property to bundles that meet a certain criteria.
 +
 While this extensibility allows for additional official tooling to be developed on top of the low-level APIs for future {product-title} releases, the major benefit is that catalog maintainers have this capability as well.
+
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs]
+* xref:../disconnected/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-multitenancy-colocation.adoc
+++ b/modules/olm-multitenancy-colocation.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-multitenancy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-colocation_{context}"]
+= Operator colocation and Operator groups
+
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) treats OLM-managed Operators installed in the same namespace as related, even when their subscriptions are colocated without an actual dependency relationship.
+
+Operator Lifecycle Manager (OLM) handles OLM-managed Operators that are installed in the same namespace, meaning their `Subscription` resources are colocated in the same namespace, as related Operators. Even if they are not actually related, OLM considers their states, such as their version and update policy, when any one of them is updated.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation]

--- a/modules/olm-multitenancy-solution.adoc
+++ b/modules/olm-multitenancy-solution.adoc
@@ -23,7 +23,7 @@ As a result, the Operator resides in the tenant Operator namespace and watches t
 
 This solution provides better tenant separation, least privilege principle at the cost of resource usage, and additional orchestration to ensure the constraints are met. For a detailed procedure, see "Preparing for multiple instances of an Operator for multitenant clusters".
 
-.Limitations and considerations
+== Limitations and considerations
 
 This solution only works when the following constraints are met:
 

--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -137,6 +137,7 @@ Aggregation labels:
 |===
 
 [id="olm-resources-additional-roles-rolebindings_{context}"]
-.Additional roles and role bindings
+== Additional roles and role bindings
+
 * If the CSV defines exactly one target namespace that contains `*`, then a cluster role and corresponding cluster role binding are generated for each permission defined in the `permissions` field of the CSV. All resources generated are given the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels.
 * If the CSV does _not_ define exactly one target namespace that contains `*`, then all roles and role bindings in the Operator namespace with the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels are copied into the target namespace.

--- a/operators/understanding/olm-multitenancy.adoc
+++ b/operators/understanding/olm-multitenancy.adoc
@@ -39,9 +39,4 @@ ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub catalog sources]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-[id="olm-colocation_{context}"]
-== Operator colocation and Operator groups
-
-Operator Lifecycle Manager (OLM) handles OLM-managed Operators that are installed in the same namespace, meaning their `Subscription` resources are colocated in the same namespace, as related Operators. Even if they are not actually related, OLM considers their states, such as their version and update policy, when any one of them is updated.
-
-For more information on Operator colocation and using Operator groups effectively, see xref:../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation].
+include::modules/olm-multitenancy-colocation.adoc[leveloffset=+1]

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -19,36 +19,22 @@ include::modules/olm-dependencies.adoc[leveloffset=+2]
 
 include::modules/olm-about-opm.adoc[leveloffset=+2]
 
-* See xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[CLI tools] for steps on installing the `opm` CLI.
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[Installing the opm CLI]
 
 ifdef::openshift-origin[]
 [id="olm-packaging-format-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources
 
-* See the upstream `operator-framework/operator-registry` project repository for more information on the Operator bundle format:
-** link:https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md[Operator Bundle Overview]
-** link:https://github.com/operator-framework/operator-registry/blob/master/README.md[Operator Registry README]
-* See the project *Releases* page for `opm` CLI downloads:
-** link:https://github.com/operator-framework/operator-registry/releases[Releases]
+* link:https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md[Operator Bundle Overview]
+* link:https://github.com/operator-framework/operator-registry/blob/master/README.md[Operator Registry README]
+* link:https://github.com/operator-framework/operator-registry/releases[Releases]
 endif::[]
 
 include::modules/olm-fb-catalogs.adoc[leveloffset=+1]
-
-[IMPORTANT]
-====
-As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
-
-The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
-
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../disconnected/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs].
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-====
 
 include::modules/olm-fb-catalogs-structure.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
Resolve remaining AsciiDocDITA issues (ContentType, BlockTitle, ExampleBlock, ConceptLink, RelatedLinks, AssemblyContents) on files that exist on `main`.

The packaging-format `=== CLI usage` NestedSection / related ConceptLinks are owned by the split-modules PR (extracted to `olm-fb-catalogs-cli`). Fixes for modules created only by that PR stay there.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16939

## Versions
4.20+

## Merge order
Independent branch from `main` (other AsciiDocDITA only). May overlap files with abstracts/callouts/split — rebase if conflicts appear.

## Files changed
- `modules/olm-architecture.adoc`
- `modules/olm-catalogsource-image-template.adoc`
- `modules/olm-catalogsource.adoc`
- `modules/olm-fb-catalogs-prop.adoc`
- `modules/olm-fb-catalogs.adoc`
- `modules/olm-multitenancy-colocation.adoc` (new)
- `modules/olm-multitenancy-solution.adoc`
- `modules/olm-operatorgroups-rbac.adoc`
- `operators/understanding/olm-multitenancy.adoc`
- `operators/understanding/olm-packaging-format.adoc`

## Vale rules addressed
- AsciiDocDITA.ContentType
- AsciiDocDITA.BlockTitle
- AsciiDocDITA.ExampleBlock
- AsciiDocDITA.ConceptLink
- AsciiDocDITA.RelatedLinks
- AsciiDocDITA.AssemblyContents

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes

Made with [Cursor](https://cursor.com)