### PR TITLE
OSDOCS-17172-olm-certs CQA

### DIFF
--- a/security/certificate_types_descriptions/olm-certificates.adoc
+++ b/security/certificate_types_descriptions/olm-certificates.adoc
@@ -6,25 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Understand how Operator Lifecycle Manager (OLM) manages certificates for OLM components and creates and rotates certificates when installing Operators that include webhooks or API services. In proxy environments, you must manage Operator certificates yourself because OLM does not update them.
+
 == Management
 
-All certificates for Operator Lifecycle Manager (OLM) components (`olm-operator`, `catalog-operator`, `packageserver`, and `marketplace-operator`) are managed by the system.
+All certificates for Operator Lifecycle Manager (OLM) components, such as `olm-operator`, `catalog-operator`, `packageserver`, and `marketplace-operator`, are managed by the system.
 
 When installing Operators that include webhooks or API services in their `ClusterServiceVersion` (CSV) object, OLM creates and rotates the certificates for these resources. Certificates for resources in the `openshift-operator-lifecycle-manager` namespace are managed by OLM.
 
 OLM does not update the certificates of Operators that it manages in proxy environments. These certificates must be managed by the user using the subscription config.
 
 [role="_additional-resources"]
-.Next steps
-
-* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]
-
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-[role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]
 * xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-certificates[Proxy certificates]
 * xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Replacing the default ingress certificate]
 * xref:../../security/certificates/updating-ca-bundle.adoc#updating-ca-bundle[Updating the CA bundle]
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://115238--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/olm-certificates.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
