### PR TITLE
OSDOCS-16939: DITA abstracts — OLM understanding topics

### DIFF
--- a/modules/olm-about-opm.adoc
+++ b/modules/olm-about-opm.adoc
@@ -7,6 +7,7 @@
 [id="olm-about-opm_{context}"]
 = About the opm CLI
 
-The `opm` CLI tool is provided by the Operator Framework for use with the Operator bundle format. This tool allows you to create and maintain catalogs of Operators from a list of Operator bundles that are similar to software repositories. The result is a container image which can be stored in a container registry and then installed on a cluster.
+[role="_abstract"]
+The `opm` CLI is an Operator Framework tool for creating and maintaining Operator catalogs from bundle images in {product-title}. You can use it to build catalog container images that Operator Lifecycle Manager (OLM) references through catalog sources.
 
 A catalog contains a database of pointers to Operator manifest content that can be queried through an included API that is served when the container image is run. On {product-title}, Operator Lifecycle Manager (OLM) can reference the image in a catalog source, defined by a `CatalogSource` object, which polls the image at regular intervals to enable frequent updates to installed Operators on the cluster.

--- a/modules/olm-arch-catalog-operator.adoc
+++ b/modules/olm-arch-catalog-operator.adoc
@@ -7,7 +7,8 @@
 [id="olm-arch-catalog-operator_{context}"]
 = Catalog Operator
 
-The Catalog Operator is responsible for resolving and installing cluster service versions (CSVs) and the required resources they specify. It is also responsible for watching catalog sources for updates to packages in channels and upgrading them, automatically if desired, to the latest available versions.
+[role="_abstract"]
+The Catalog Operator in {product-title} resolves and installs cluster service versions (CSVs) and their required resources from catalog sources. It watches subscriptions and catalog sources to create install plans and upgrade packages in channels.
 
 To track a package in a channel, you can create a `Subscription` object configuring the desired package, channel, and the `CatalogSource` object you want to use for pulling updates. When updates are found, an appropriate `InstallPlan` object is written into the namespace on behalf of the user.
 

--- a/modules/olm-arch-catalog-registry.adoc
+++ b/modules/olm-arch-catalog-registry.adoc
@@ -7,6 +7,7 @@
 [id="olm-arch-catalog-registry_{context}"]
 = Catalog Registry
 
-The Catalog Registry stores CSVs and CRDs for creation in a cluster and stores metadata about packages and channels.
+[role="_abstract"]
+The Catalog Registry stores CSVs, CRDs, and metadata about packages and channels for Operator installation in {product-title}. Package manifests link package identities to CSVs so the Catalog Operator can step through channel upgrade paths.
 
 A _package manifest_ is an entry in the Catalog Registry that associates a package identity with sets of CSVs. Within a package, channels point to a particular CSV. Because CSVs explicitly reference the CSV that they replace, a package manifest provides the Catalog Operator with all of the information that is required to update a CSV to the latest version in a channel, stepping through each intermediate version.

--- a/modules/olm-arch-olm-operator.adoc
+++ b/modules/olm-arch-olm-operator.adoc
@@ -7,7 +7,8 @@
 [id="olm-arch-olm-operator_{context}"]
 = OLM Operator
 
-The OLM Operator is responsible for deploying applications defined by CSV resources after the required resources specified in the CSV are present in the cluster.
+[role="_abstract"]
+The OLM Operator in {product-title} deploys applications defined by cluster service versions after their required resources are present in the cluster. It watches CSVs in a namespace, verifies requirements, and runs the install strategy when conditions are met.
 
 The OLM Operator is not concerned with the creation of the required resources; you can choose to manually create these resources using the CLI or using the Catalog Operator. This separation of concern allows users incremental buy-in in terms of how much of the OLM framework they choose to leverage for their application.
 

--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -14,10 +14,15 @@ ifeval::["{context}" == "operator-reference"]
 endif::[]
 
 ifeval::["{context}" != "operator-reference"]
-Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM Operator and the Catalog Operator.
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) in {product-title} consists of the OLM Operator and Catalog Operator, which manage the custom resources that drive Operator installation and updates. Each Operator creates Kubernetes resources and manages specific CRDs in the OLM framework.
 endif::[]
 
-The OLM and Catalog Operators are responsible for managing the custom resource definitions (CRDs) that are the basis for the OLM framework:
+ifeval::["{context}" == "operator-reference"]
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) and the Catalog Operator manage the following custom resource definitions (CRDs) in {product-title}. These resources define catalog sources, subscriptions, install plans, and cluster service versions for Operator lifecycle management.
+
+endif::[]
 
 .CRDs managed by OLM and Catalog Operators
 [cols="2a,1a,1a,8a",options="header"]

--- a/modules/olm-bundle-schema.adoc
+++ b/modules/olm-bundle-schema.adoc
@@ -6,6 +6,9 @@
 [id="olm-bundle-schema_{context}"]
 = olm.bundle schema
 
+[role="_abstract"]
+The `olm.bundle` schema defines the structure of bundle entries stored in an Operator catalog index for {product-title}. It specifies required fields such as package name, bundle name, image reference, and optional properties and related images.
+
 .`olm.bundle` schema
 [%collapsible]
 ====

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -12,6 +12,9 @@ endif::[]
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 
+[role="_abstract"]
+The `olm.catalogImageTemplate` annotation on a `CatalogSource` object lets you reference index image tags with Kubernetes version variables in {product-title}. You can use this template so OLM updates custom catalog index images automatically during cluster upgrades.
+
 Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} {product-version}.

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -13,7 +13,8 @@ endif::[]
 [id="olm-catalogsource_{context}"]
 = Catalog source
 
-A _catalog source_ represents a store of metadata, typically by referencing an _index image_ stored in a container registry. Operator Lifecycle Manager (OLM) queries catalog sources to discover and install Operators and their dependencies. The software catalog in the {product-title} web console also displays the Operators provided by catalog sources.
+[role="_abstract"]
+A catalog source is a metadata store, typically an index image in a container registry, that Operator Lifecycle Manager (OLM) queries to discover Operators in {product-title}. The web console OperatorHub also displays Operators from enabled catalog sources on the cluster.
 
 [TIP]
 ====

--- a/modules/olm-channel-schema.adoc
+++ b/modules/olm-channel-schema.adoc
@@ -6,7 +6,8 @@
 [id="olm-channel-schema_{context}"]
 = olm.channel schema
 
-The `olm.channel` schema defines a channel within a package, the bundle entries that are members of the channel, and the upgrade paths for those bundles.
+[role="_abstract"]
+The `olm.channel` schema defines a channel within an Operator package, including bundle entries and upgrade paths for catalog indexes in {product-title}. Each entry names an `olm.bundle`, with optional `replaces`, `skips`, and `skipRange` fields that control upgrade graph behavior.
 
 If a bundle entry represents an edge in multiple `olm.channel` blobs, it can only appear once per channel.
 

--- a/modules/olm-crds.adoc
+++ b/modules/olm-crds.adoc
@@ -6,7 +6,8 @@
 [id="olm-resources_{context}"]
 = OLM resources
 
-The following custom resource definitions (CRDs) are defined and managed by Operator Lifecycle Manager (OLM):
+[role="_abstract"]
+The following custom resource definitions (CRDs) are defined and managed by Operator Lifecycle Manager (OLM) in {product-title}. Use these resources to configure catalog sources, subscriptions, install plans, cluster service versions, and operator groups.
 
 .CRDs managed by OLM and Catalog Operators
 [cols="2a,2a,8a",options="header"]

--- a/modules/olm-cs-health.adoc
+++ b/modules/olm-cs-health.adoc
@@ -6,10 +6,11 @@
 [id="olm-cs-health_{context}"]
 = Catalog health requirements
 
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) on {product-title} requires that all Operator catalogs in a shared global namespace are healthy. When a catalog is unhealthy, Operator installation and update operations in that namespace fail with a `CatalogSourcesUnhealthy` condition.
+
 Operator catalogs on a cluster are interchangeable from the perspective of installation resolution; a `Subscription` object might reference a specific catalog, but dependencies are resolved using all catalogs on the cluster.
 
 For example, if Catalog A is unhealthy, a subscription referencing Catalog A could resolve a dependency in Catalog B, which the cluster administrator might not have been expecting, because B normally had a lower catalog priority than A.
-
-As a result, OLM requires that all catalogs with a given global namespace (for example, the default `openshift-marketplace` namespace or a custom global namespace) are healthy. When a catalog is unhealthy, all Operator installation or update operations within its shared global namespace will fail with a `CatalogSourcesUnhealthy` condition. If these operations were permitted in an unhealthy state, OLM might make resolution and installation decisions that were unexpected to the cluster administrator.
 
 As a cluster administrator, if you observe an unhealthy catalog and want to consider the catalog as invalid and resume Operator installations, see the "Removing custom catalogs" or "Disabling the default software catalog sources" sections for information about removing the unhealthy catalog.

--- a/modules/olm-csv.adoc
+++ b/modules/olm-csv.adoc
@@ -6,9 +6,8 @@
 [id="olm-csv_{context}"]
 = Cluster service version
 
-A _cluster service version_ (CSV) represents a specific version of a running Operator on your {product-title} cluster. It is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in the cluster.
-
-OLM requires this metadata about an Operator to ensure that it can be kept running safely on a cluster, and to provide information about how updates should be applied as new versions of the Operator are published. This is similar to packaging software for a traditional operating system; think of the packaging step for OLM as the stage at which you make your `rpm`, `deb`, or `apk` bundle.
+[role="_abstract"]
+A cluster service version (CSV) is a YAML manifest that represents a specific version of a running Operator on your {product-title} cluster. OLM uses CSV metadata to run Operators safely and determine how to apply upgrades when new versions are published.
 
 A CSV includes the metadata that accompanies an Operator container image, used to populate user interfaces with information such as its name, version, description, labels, repository link, and logo.
 

--- a/modules/olm-default-install-behavior.adoc
+++ b/modules/olm-default-install-behavior.adoc
@@ -6,7 +6,8 @@
 [id="olm-default-install-modes-behavior_{context}"]
 = Default Operator install modes and behavior
 
-When installing Operators with the web console as an administrator, you typically have two choices for the install mode, depending on the Operator's capabilities:
+[role="_abstract"]
+When you install Operators in {product-title} by using the web console as an administrator, you can choose between single namespace and all namespaces install modes. The install mode you choose determines the namespace permissions granted to the Operator and who can access its APIs.
 
 Single namespace:: Installs the Operator in the chosen single namespace, and makes all permissions that the Operator requests available in that namespace.
 

--- a/modules/olm-dependencies.adoc
+++ b/modules/olm-dependencies.adoc
@@ -14,7 +14,8 @@ ifeval::["{context}" != "olm-packaging-format"]
 
 endif::[]
 
-The dependencies of an Operator are listed in a `dependencies.yaml` file in the `metadata/` folder of a bundle. This file is optional and currently only used to specify explicit Operator-version dependencies.
+[role="_abstract"]
+Operator dependencies define relationships between Operators that Operator Lifecycle Manager (OLM) must resolve during installation on {product-title}. You can list these dependencies in the optional `dependencies.yaml` file in a bundle's `metadata/` folder.
 
 The dependency list contains a `type` field for each item to specify what kind of dependency this is. The following types of Operator dependencies are supported:
 

--- a/modules/olm-deprecations-schema.adoc
+++ b/modules/olm-deprecations-schema.adoc
@@ -6,9 +6,8 @@
 [id="olm-deprecations-schema_{context}"]
 = olm.deprecations schema
 
-The optional `olm.deprecations` schema defines deprecation information for packages, bundles, and channels in a catalog. Operator authors can use this schema to provide relevant messages about their Operators, such as support status and recommended upgrade paths, to users running those Operators from a catalog.
-
-When this schema is defined, the {product-title} web console displays warning badges for the affected elements of the Operator, including any custom deprecation messages, on both the pre- and post-installation pages of the software catalog.
+[role="_abstract"]
+The optional `olm.deprecations` schema defines deprecation information for packages, bundles, and channels in an Operator catalog on {product-title}. When you define this schema, the web console displays warning badges and deprecation messages in the software catalog.
 
 An `olm.deprecations` schema entry contains one or more of the following `reference` types, which indicates the deprecation scope. After the Operator is installed, any specified messages can be viewed as status conditions on the related `Subscription` object.
 

--- a/modules/olm-fb-catalogs-automation.adoc
+++ b/modules/olm-fb-catalogs-automation.adoc
@@ -6,7 +6,8 @@
 [id="olm-fb-catalogs-automation_{context}"]
 = Automation
 
-Operator authors and catalog maintainers are encouraged to automate their catalog maintenance with CI/CD workflows. Catalog maintainers can further improve on this by building GitOps automation to accomplish the following tasks:
+[role="_abstract"]
+Operator authors and catalog maintainers can automate file-based catalog maintenance with CI/CD workflows in {product-title}. You can use GitOps automation to validate catalog changes, verify bundle images, and automatically rebuild and republish catalog images.
 
 * Check that pull request (PR) authors are permitted to make the requested changes, for example by updating their package's image reference.
 * Check that the catalog updates pass the `opm validate` command.

--- a/modules/olm-fb-catalogs-example.adoc
+++ b/modules/olm-fb-catalogs-example.adoc
@@ -6,7 +6,10 @@
 [id="olm-fb-catalogs-example_{context}"]
 = Example catalog
 
-With file-based catalogs, catalog maintainers can focus on Operator curation and compatibility. Because Operator authors have already produced Operator-specific catalogs for their Operators, catalog maintainers can build their catalog by rendering each Operator catalog into a subdirectory of the catalog's root directory.
+[role="_abstract"]
+File-based catalog maintainers on {product-title} can build a catalog by rendering each Operator's catalog into a subdirectory of the catalog root directory. A common approach uses a single configuration file with image references and a script to assemble and publish the catalog.
+
+With file-based catalogs, catalog maintainers can focus on Operator curation and compatibility.
 
 There are many possible ways to build a file-based catalog; the following steps outline a simple approach:
 

--- a/modules/olm-fb-catalogs-guidelines.adoc
+++ b/modules/olm-fb-catalogs-guidelines.adoc
@@ -6,7 +6,8 @@
 [id="olm-fb-catalogs-guidelines_{context}"]
 = Guidelines
 
-Consider the following guidelines when maintaining file-based catalogs.
+[role="_abstract"]
+Follow these guidelines when maintaining file-based Operator catalogs on {product-title}. Treat bundle images and metadata as immutable, and store catalog metadata in source control as the source of truth.
 
 [id="olm-fb-catalogs-immutable_{context}"]
 == Immutable bundles

--- a/modules/olm-fb-catalogs-prop.adoc
+++ b/modules/olm-fb-catalogs-prop.adoc
@@ -6,9 +6,10 @@
 [id="olm-fb-catalogs-prop_{context}"]
 = Properties
 
-Properties are arbitrary pieces of metadata that can be attached to file-based catalog schemas. The `type` field is a string that effectively specifies the semantic and syntactic meaning of the `value` field. The value can be any arbitrary JSON or YAML.
+[role="_abstract"]
+Properties are arbitrary metadata attachments to file-based catalog schemas in Operator Lifecycle Manager (OLM) on {product-title}. Use the `olm.package`, `olm.gvk`, and required property types to define package versions and API dependencies for bundles.
 
-OLM defines a handful of property types, again using the reserved `olm.*` prefix.
+The `type` field is a string that effectively specifies the semantic and syntactic meaning of the `value` field. The value can be any arbitrary JSON or YAML. OLM defines a handful of property types, again using the reserved `olm.*` prefix.
 
 [id="olm-fb-catalogs-package-prop_{context}"]
 == olm.package property

--- a/modules/olm-fb-catalogs-schemas.adoc
+++ b/modules/olm-fb-catalogs-schemas.adoc
@@ -6,7 +6,8 @@
 [id="olm-fb-catalogs-schemas_{context}"]
 = Schemas
 
-File-based catalogs use a format, based on the link:https://cuelang.org/docs/references/spec/[CUE language specification], that can be extended with arbitrary schemas. The following  `_Meta` CUE schema defines the format that all file-based catalog blobs must adhere to:
+[role="_abstract"]
+File-based catalogs on {product-title} use a CUE-based format with schemas that define catalog structure for Operator Lifecycle Manager (OLM). Each Operator package requires one `olm.package` blob, at least one `olm.channel` blob, and one or more `olm.bundle` blobs.
 
 .`_Meta` schema
 [source,go]
@@ -35,10 +36,6 @@ _Meta: {
 ====
 No CUE schemas listed in this specification should be considered exhaustive. The `opm validate` command has additional validations that are difficult or impossible to express concisely in CUE.
 ====
-
-An Operator Lifecycle Manager (OLM) catalog currently uses three schemas (`olm.package`, `olm.channel`, and `olm.bundle`), which correspond to OLM's existing package and bundle concepts.
-
-Each Operator package in a catalog requires exactly one `olm.package` blob, at least one `olm.channel` blob, and one or more `olm.bundle` blobs.
 
 [NOTE]
 ====

--- a/modules/olm-fb-catalogs-structure.adoc
+++ b/modules/olm-fb-catalogs-structure.adoc
@@ -6,7 +6,8 @@
 [id="olm-fb-catalogs-structure_{context}"]
 = Directory structure
 
-File-based catalogs can be stored and loaded from directory-based file systems. The `opm` CLI loads the catalog by walking the root directory and recursing into subdirectories. The CLI attempts to load every file it finds and fails if any errors occur.
+[role="_abstract"]
+You can store file-based Operator catalogs in directory-based file systems on {product-title} that the `opm` CLI loads by walking the root directory. Catalog maintainers can choose their layout, but OLM recommends storing each package's catalog blobs in separate subdirectories.
 
 Non-catalog files can be ignored using `.indexignore` files, which have the same rules for patterns and precedence as `.gitignore` files.
 

--- a/modules/olm-fb-catalogs.adoc
+++ b/modules/olm-fb-catalogs.adoc
@@ -6,7 +6,8 @@
 [id="olm-file-based-catalogs_{context}"]
 = Highlights
 
-_File-based catalogs_ are the latest iteration of the catalog format in Operator Lifecycle Manager (OLM). It is a plain text-based (JSON or YAML) and declarative config evolution of the earlier SQLite database format, and it is fully backwards compatible. The goal of this format is to enable Operator catalog editing, composability, and extensibility.
+[role="_abstract"]
+File-based catalogs are the latest plain text (JSON or YAML) catalog format for Operator Lifecycle Manager (OLM) on {product-title}. This format enables catalog editing, composability, and extensibility while remaining backwards compatible with earlier SQLite-based catalogs.
 
 Editing::
 With file-based catalogs, users interacting with the contents of a catalog are able to make direct changes to the format and verify that their changes are valid. Because this format is plain text JSON or YAML, catalog maintainers can easily manipulate catalog metadata by hand or with widely known and supported JSON or YAML tooling, such as the `jq` CLI.

--- a/modules/olm-installplan.adoc
+++ b/modules/olm-installplan.adoc
@@ -6,7 +6,8 @@
 [id="olm-installplan_{context}"]
 = Install plan
 
-An _install plan_, defined by an `InstallPlan` object, describes a set of resources that Operator Lifecycle Manager (OLM) creates to install or upgrade to a specific version of an Operator. The version is defined by a cluster service version (CSV).
+[role="_abstract"]
+An install plan, defined by an `InstallPlan` object, describes the set of resources that Operator Lifecycle Manager (OLM) creates to install or upgrade to a specific Operator version on {product-title}. A subscription creates an install plan that you can approve automatically or manually before OLM installs the Operator.
 
 To install an Operator, a cluster administrator, or a user who has been granted Operator installation permissions, must first create a `Subscription` object. A subscription represents the intent to subscribe to a stream of available versions of an Operator from a catalog source. The subscription then creates an `InstallPlan` object to facilitate the installation of the resources for the Operator.
 

--- a/modules/olm-multitenancy-solution.adoc
+++ b/modules/olm-multitenancy-solution.adoc
@@ -6,6 +6,9 @@
 [id="olm-multitenancy-solution_{context}"]
 = Recommended solution for multitenant clusters
 
+[role="_abstract"]
+You can install one instance of the same Operator per tenant in {product-title} when you use a dedicated Operator namespace and an Operator group scoped to the tenant namespace. This approach improves separation and least privilege compared with cluster-wide or single-namespace install modes.
+
 While a *Multinamespace* install mode does exist, it is supported by very few Operators. As a middle ground solution between the standard *All namespaces* and *Single namespace* install modes, you can install multiple instances of the same Operator, one for each tenant, by using the following workflow:
 
 // In OSD/ROSA, dedicated-admins can create projects, but not namespaces.

--- a/modules/olm-operator-framework.adoc
+++ b/modules/olm-operator-framework.adoc
@@ -6,7 +6,8 @@
 [id="olm-operator-framework_{context}"]
 = Operator Framework
 
-The Operator Framework is a family of tools and capabilities to deliver on the customer experience described above. It is not just about writing code; testing, delivering, and updating Operators is just as important. The Operator Framework components consist of open source tools to tackle these problems:
+[role="_abstract"]
+The Operator Framework is a set of open source tools for building, testing, delivering, and updating Operators in {product-title}. It includes Operator Lifecycle Manager, the Operator Registry, and the Software Catalog.
 
 Operator Lifecycle Manager::
 Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. It is deployed by default in 

--- a/modules/olm-operator-maturity-model.adoc
+++ b/modules/olm-operator-maturity-model.adoc
@@ -6,6 +6,9 @@
 [id="olm-maturity-model_{context}"]
 = Operator maturity model
 
+[role="_abstract"]
+The Operator maturity model describes five phases of generic Day 2 operations that an Operator can support. Use it to understand how much management logic an Operator encapsulates for its service type.
+
 The level of sophistication of the management logic encapsulated within an Operator can vary. This logic is also in general highly dependent on the type of the service represented by the Operator.
 
 One can however generalize the scale of the maturity of the encapsulated operations of an Operator for certain set of capabilities that most Operators can include. To this end, the following Operator maturity model defines five phases of maturity for generic Day 2 operations of an Operator:

--- a/modules/olm-operatorconditions-about.adoc
+++ b/modules/olm-operatorconditions-about.adoc
@@ -14,9 +14,8 @@ ifeval::["{context}" != "olm-understanding-olm"]
 
 endif::[]
 
-As part of its role in managing the lifecycle of an Operator, Operator Lifecycle Manager (OLM) infers the state of an Operator from the state of Kubernetes resources that define the Operator. While this approach provides some level of assurance that an Operator is in a given state, there are many instances where an Operator might need to communicate information to OLM that could not be inferred otherwise. This information can then be used by OLM to better manage the lifecycle of the Operator.
-
-OLM provides a custom resource definition (CRD) called `OperatorCondition` that allows Operators to communicate conditions to OLM. There are a set of supported conditions that influence management of the Operator by OLM when present in the `Spec.Conditions` array of an `OperatorCondition` resource.
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) infers Operator state from Kubernetes resources, but some conditions require explicit communication. You can use the `OperatorCondition` custom resource definition (CRD) to tell OLM about supported conditions that affect lifecycle management.
 
 [NOTE]
 ====

--- a/modules/olm-operatorgroups-about.adoc
+++ b/modules/olm-operatorgroups-about.adoc
@@ -14,6 +14,7 @@ ifeval::["{context}" != "olm-understanding-olm"]
 
 endif::[]
 
-An _Operator group_, defined by the `OperatorGroup` resource, provides multitenant configuration to OLM-installed Operators. An Operator group selects target namespaces in which to generate required RBAC access for its member Operators.
+[role="_abstract"]
+An Operator group defines multitenant configuration for OLM-installed Operators through an `OperatorGroup` resource. It selects target namespaces and generates the required RBAC access for member Operators in {product-title}.
 
 The set of target namespaces is provided by a comma-delimited string stored in the `olm.targetNamespaces` annotation of a cluster service version (CSV). This annotation is applied to the CSV instances of member Operators and is projected into their deployments.

--- a/modules/olm-operatorgroups-copied-csvs.adoc
+++ b/modules/olm-operatorgroups-copied-csvs.adoc
@@ -6,7 +6,8 @@
 [id="olm-operatorgroups-copied-csvs_{context}"]
 = Copied CSVs
 
-OLM creates copies of all active member CSVs of an Operator group in each of the target namespaces of that Operator group. The purpose of a copied CSV is to tell users of a target namespace that a specific Operator is configured to watch resources created there.
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) creates copied cluster service versions (CSVs) in each target namespace of an Operator group to show which Operators watch resources there. Copied CSVs mirror the source CSV status and are removed when the source or target relationship ends.
 
 Copied CSVs have a status reason `Copied` and are updated to match the status of their source CSV. The `olm.targetNamespaces` annotation is stripped from copied CSVs before they are created on the cluster. Omitting the target namespace selection avoids the duplication of target namespaces between tenants.
 

--- a/modules/olm-operatorgroups-csv-annotations.adoc
+++ b/modules/olm-operatorgroups-csv-annotations.adoc
@@ -6,6 +6,9 @@
 [id="olm-operatorgroups-csv-annotations_{context}"]
 = Operator group CSV annotations
 
+[role="_abstract"]
+Member CSVs of an Operator group carry annotations that identify the group name, namespace, and target namespace selection. OLM applies these annotations to member CSVs and omits the target namespace annotation on copied CSVs to prevent duplication across tenants.
+
 Member CSVs of an Operator group have the following annotations:
 
 [cols="1,1",options="header"]

--- a/modules/olm-operatorgroups-intersections.adoc
+++ b/modules/olm-operatorgroups-intersections.adoc
@@ -6,6 +6,9 @@
 [id="olm-operatorgroups-intersection_{context}"]
 = Operator group intersection
 
+[role="_abstract"]
+Two Operator groups have intersecting provided APIs when they share target namespaces and provide overlapping Kubernetes APIs. OLM checks these intersections during CSV synchronization and can fail or transition Operators when conflicts occur.
+
 Two Operator groups are said to have _intersecting provided APIs_ if the intersection of their target namespace sets is not an empty set and the intersection of their provided API sets, defined by `olm.providedAPIs` annotations, is not an empty set.
 
 A potential issue is that Operator groups with intersecting provided APIs can compete for the same resources in the set of intersecting namespaces.

--- a/modules/olm-operatorgroups-limitations.adoc
+++ b/modules/olm-operatorgroups-limitations.adoc
@@ -6,7 +6,8 @@
 [id="olm-operatorgroups-limitations"]
 = Limitations for multitenant Operator management
 
-{product-title} provides limited support for simultaneously installing different versions of an Operator on the same cluster. Operator Lifecycle Manager (OLM) installs Operators multiple times in different namespaces. One constraint of this is that the Operator's API versions must be the same.
+[role="_abstract"]
+{product-title} supports only limited scenarios for running different versions of the same Operator simultaneously on one cluster, even when Operator Lifecycle Manager (OLM) installs them in different namespaces. Because CRDs are cluster-scoped, competing or incompatible CRD definitions from different Operator versions are not supported in multitenant clusters.
 
 Operators are control plane extensions due to their usage of `CustomResourceDefinition` objects (CRDs), which are global resources in Kubernetes. Different major versions of an Operator often have incompatible CRDs. This makes them incompatible to install simultaneously in different namespaces on a cluster.
 

--- a/modules/olm-operatorgroups-membership.adoc
+++ b/modules/olm-operatorgroups-membership.adoc
@@ -6,10 +6,8 @@
 [id="olm-operatorgroups-membership_{context}"]
 = Operator group membership
 
-An Operator is considered a _member_ of an Operator group if the following conditions are true:
-
-* The CSV of the Operator exists in the same namespace as the Operator group.
-* The install modes in the CSV of the Operator support the set of namespaces targeted by the Operator group.
+[role="_abstract"]
+An Operator becomes a member of an Operator group when its CSV is in the same namespace and its install modes support the group's target namespaces. CSV install mode types define whether an Operator can watch its own namespace, one namespace, multiple namespaces, or all namespaces.
 
 An install mode in a CSV consists of an `InstallModeType` field and a boolean `Supported` field. The spec of a CSV can contain a set of install modes of four distinct `InstallModeTypes`:
 

--- a/modules/olm-operatorgroups-provided-apis-annotations.adoc
+++ b/modules/olm-operatorgroups-provided-apis-annotations.adoc
@@ -6,7 +6,8 @@
 [id="olm-operatorgroups-provided-apis-annotation_{context}"]
 = Provided APIs annotation
 
-A _group/version/kind (GVK)_ is a unique identifier for a Kubernetes API. Information about what GVKs are provided by an Operator group are shown in an `olm.providedAPIs` annotation. The value of the annotation is a string consisting of `<kind>.<version>.<group>` delimited with commas. The GVKs of CRDs and API services provided by all active member CSVs of an Operator group are included.
+[role="_abstract"]
+The `olm.providedAPIs` annotation on an Operator group lists the group/version/kind (GVK) identifiers for APIs that member Operators provide. OLM derives this annotation from the CRDs and API services in all active member CSVs. The value is a comma-delimited string of `<kind>.<version>.<group>` entries.
 
 Review the following example of an `OperatorGroup` object with a single active member CSV that provides the `PackageManifest` resource:
 

--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -6,6 +6,9 @@
 [id="olm-operatorgroups-rbac_{context}"]
 = Role-based access control
 
+[role="_abstract"]
+When you create an Operator group, OLM generates cluster roles and additional RBAC resources for member Operators. Use these roles to grant access to API resources from CRDs and API services in target namespaces.
+
 When an Operator group is created, three cluster roles are generated. When the cluster roles are generated, they are automatically suffixed with a hash value to ensure that each cluster role is unique. Each Operator group contains a single aggregation rule with a cluster role selector set to match a label, as shown in the following table:
 
 [cols="1,1",options="header"]

--- a/modules/olm-operatorgroups-static.adoc
+++ b/modules/olm-operatorgroups-static.adoc
@@ -6,7 +6,8 @@
 [id="olm-operatorgroups-static_{context}"]
 = Static Operator groups
 
-An Operator group is _static_ if its `spec.staticProvidedAPIs` field is set to `true`. As a result, OLM does not modify the `olm.providedAPIs` annotation of an Operator group, which means that it can be set in advance. This is useful when a user wants to use an Operator group to prevent resource contention in a set of namespaces but does not have active member CSVs that provide the APIs for those resources.
+[role="_abstract"]
+A static Operator group has `spec.staticProvidedAPIs` set to `true`, so OLM does not modify the `olm.providedAPIs` annotation. You can set this annotation in advance to reserve API ownership and prevent resource contention without active member CSVs.
 
 Below is an example of an Operator group that protects `Prometheus` resources in all namespaces with the `something.cool.io/cluster-monitoring: "true"` annotation:
 

--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -6,6 +6,9 @@
 [id="olm-operatorgroups-target-namespace_{context}"]
 = Target namespace selection
 
+[role="_abstract"]
+You can define target namespaces for an Operator group with `spec.targetNamespaces`, a label selector in `spec.selector`, or by omitting both to select all namespaces. OLM shows the resolved namespace set in the Operator group `status.namespaces` field.
+
 You can explicitly name the target namespace for an Operator group using the `spec.targetNamespaces` parameter:
 
 [source,yaml]

--- a/modules/olm-package-schema.adoc
+++ b/modules/olm-package-schema.adoc
@@ -6,7 +6,8 @@
 [id="olm-package-schema_{context}"]
 = olm.package schema
 
-The `olm.package` schema defines package-level metadata for an Operator. This includes its name, description, default channel, and icon.
+[role="_abstract"]
+The `olm.package` schema specifies package-level metadata for Operators in file-based catalogs, including name, default channel, and icon. Use this schema reference when you build or validate Operator package definitions for Operator Lifecycle Manager (OLM).
 
 .`olm.package` schema
 [%collapsible]

--- a/modules/olm-subscription.adoc
+++ b/modules/olm-subscription.adoc
@@ -13,9 +13,8 @@ endif::[]
 [id="olm-subscription_{context}"]
 = Subscription
 
-A _subscription_, defined by a `Subscription` object, represents an intention to install an Operator. It is the custom resource that relates an Operator to a catalog source.
-
-Subscriptions describe which channel of an Operator package to subscribe to, and whether to perform updates automatically or manually. If set to automatic, the subscription ensures Operator Lifecycle Manager (OLM) manages and upgrades the Operator to ensure that the latest version is always running in the cluster.
+[role="_abstract"]
+A Subscription custom resource expresses your intent to install an Operator from a catalog source in {product-title}. It defines the Operator package, channel, and whether Operator Lifecycle Manager (OLM) applies updates automatically or manually.
 
 .Example `Subscription` object
 [source,yaml,subs="attributes+"]

--- a/modules/olm-why-use-operators.adoc
+++ b/modules/olm-why-use-operators.adoc
@@ -6,14 +6,8 @@
 [id="olm-why-use-operators_{context}"]
 = Why use Operators?
 
-Operators provide:
-
---
-- Repeatability of installation and upgrade.
-- Constant health checks of every system component.
-- Over-the-air (OTA) updates for OpenShift components and ISV content.
-- A place to encapsulate knowledge from field engineers and spread it to all users, not just one or two.
---
+[role="_abstract"]
+Operators package operational knowledge to automate application lifecycle tasks on Kubernetes. Using Operators in {product-title}, you gain repeatable installs, health checks, over-the-air updates, and shared expertise encoded in software.
 
 Why deploy on Kubernetes?::
 Kubernetes (and by extension, {product-title}) contains all of the primitives needed to build complex distributed systems – secret handling, load balancing, service discovery, autoscaling – that work across on-premise and cloud providers.

--- a/operators/understanding/olm-common-terms.adoc
+++ b/operators/understanding/olm-common-terms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This topic provides a glossary of common terms related to the Operator Framework, including Operator Lifecycle Manager (OLM).
+[role="_abstract"]
+You can use this glossary to learn terminology used across the Operator Framework and Operator Lifecycle Manager (OLM) in {product-title}. The terms help you understand concepts for packaging, installing, and managing Operators.
 
 include::snippets/of-terms-snippet.adoc[leveloffset=+0]

--- a/operators/understanding/olm-multitenancy.adoc
+++ b/operators/understanding/olm-multitenancy.adoc
@@ -6,14 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The default behavior for Operator Lifecycle Manager (OLM) aims to provide simplicity during Operator installation. However, this behavior can lack flexibility, especially in multitenant clusters. In order for multiple tenants on 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-an {product-title} 
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-a {product-title} 
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-cluster to use an Operator, the default behavior of OLM requires that administrators install the Operator in *All namespaces* mode, which can be considered to violate the principle of least privilege.
+[role="_abstract"]
+In multitenant {product-title} clusters, default Operator Lifecycle Manager (OLM) installation behavior favors simplicity and often requires installing Operators in *All namespaces* mode with wide privileges. You can choose an Operator installation workflow that limits tenant access while still enabling required Operators.
 
 Consider the following scenarios to determine which Operator installation workflow works best for your environment and requirements.
 

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the packaging format for Operators supported by Operator Lifecycle Manager (OLM) in {product-title}.
+[role="_abstract"]
+You can use the Operator Framework packaging format to bundle and publish Operator metadata for Operator Lifecycle Manager (OLM) in {product-title}. The format covers bundle images, dependencies, and file-based catalog schemas.
 
 include::modules/olm-bundle-format.adoc[leveloffset=+1]
 

--- a/operators/understanding/olm-what-operators-are.adoc
+++ b/operators/understanding/olm-what-operators-are.adoc
@@ -6,11 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Conceptually, _Operators_ take human operational knowledge and encode it into software that is more easily shared with consumers.
+[role="_abstract"]
+Operators encode human operational knowledge into software that manages complex applications on {product-title}. You can use Operators to package, deploy, and manage Kubernetes applications with the same APIs and tooling as native cluster resources.
 
 Operators are pieces of software that ease the operational complexity of running another piece of software. They act like an extension of the software vendor's engineering team, monitoring a Kubernetes environment (such as {product-title}) and using its current state to make decisions in real time. Advanced Operators are designed to handle upgrades seamlessly, react to failures automatically, and not take shortcuts, like skipping a software backup process to save time.
-
-More technically, Operators are a method of packaging, deploying, and managing a Kubernetes application.
 
 A Kubernetes application is an app that is both deployed on Kubernetes and managed using the Kubernetes APIs and `kubectl` or `oc` tooling. To be able to make the most of Kubernetes, you require a set of cohesive APIs to extend in order to service and manage your apps that run on Kubernetes. Think of Operators as the runtime that manages this type of app on Kubernetes.
 

--- a/operators/understanding/olm/olm-arch.adoc
+++ b/operators/understanding/olm/olm-arch.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the component architecture of Operator Lifecycle Manager (OLM) in {product-title}.
+[role="_abstract"]
+You can learn how Operator Lifecycle Manager (OLM) components interact to manage Operators in {product-title}. The architecture includes the OLM Operator, catalog Operator, and catalog registry.
 
 include::modules/olm-architecture.adoc[leveloffset=+1]
 

--- a/operators/understanding/olm/olm-understanding-olm.adoc
+++ b/operators/understanding/olm/olm-understanding-olm.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide provides an overview of the concepts that drive Operator Lifecycle Manager (OLM) in {product-title}.
+[role="_abstract"]
+You can use this overview to understand the custom resources and concepts that drive Operator Lifecycle Manager (OLM) in {product-title}. The resources include cluster service versions, catalog sources, subscriptions, and Operator groups.
 
 include::modules/olm-overview.adoc[leveloffset=+1]
 

--- a/operators/understanding/olm/olm-understanding-operatorgroups.adoc
+++ b/operators/understanding/olm/olm-understanding-operatorgroups.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the use of Operator groups with Operator Lifecycle Manager (OLM) in {product-title}.
+[role="_abstract"]
+Operator groups control which namespaces an Operator watches and how Operator Lifecycle Manager (OLM) manages related Operators in {product-title}. You can use them to configure install modes, target namespaces, and access for OLM-managed Operators.
 
 include::modules/olm-operatorgroups-about.adoc[leveloffset=+1]
 

--- a/operators/understanding/olm/olm-workflow.adoc
+++ b/operators/understanding/olm/olm-workflow.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the workflow of Operator Lifecycle Manager (OLM) in {product-title}.
+[role="_abstract"]
+You can follow the Operator Lifecycle Manager (OLM) workflow to see how catalog sources, subscriptions, and cluster service versions resolve Operator installs and upgrades in {product-title}. The workflow explains channel heads, the CSV update graph, and skipped releases.
 
 // Operator installation and upgrade workflow in OLM
 include::modules/olm-upgrades.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
Rewrites `[role="_abstract"]` short descriptions across 48 OLM understanding assemblies and modules from [OSDOCS-16939](https://redhat.atlassian.net/browse/OSDOCS-16939) attachments. Removes original intro paragraphs that duplicate the new abstracts.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16939

## Versions
4.20+

## Merge order
Independent branch from main (abstracts only). Preferred merge after split PR #115268 if same-file conflicts; rebase if needed. New split child modules include abstracts in #115268.

## Files changed
48 files (OLM understanding assemblies and modules).

## Vale rules addressed
- AsciiDocDITA.ShortDescription

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted

Made with [Cursor](https://cursor.com)