### PR TITLE
OSDOCS-16939: DITA callouts — OLM catalogsource and deprecations

### DIFF
--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -29,59 +29,62 @@ The `spec` of a `CatalogSource` object indicates how to construct a pod or how t
 kind: CatalogSource
 metadata:
   generation: 1
-  name: example-catalog <1>
-  namespace: {global_ns} <2>
+  name: example-catalog
+  namespace: {global_ns}
   annotations:
-    olm.catalogImageTemplate: <3>
+    olm.catalogImageTemplate:
       "quay.io/example-org/example-catalog:v{kube_major_version}.{kube_minor_version}.{kube_patch_version}"
 spec:
-  displayName: Example Catalog <4>
-  image: quay.io/example-org/example-catalog:v1 <5>
-  priority: -400 <6>
+  displayName: Example Catalog
+  image: quay.io/example-org/example-catalog:v1
+  priority: -400
   publisher: Example Org
-  sourceType: grpc <7>
+  sourceType: grpc
   grpcPodConfig:
-    securityContextConfig: <security_mode> <8>
-    nodeSelector: <9>
+    securityContextConfig: <security_mode>
+    nodeSelector:
       custom_label: <label>
-    priorityClassName: system-cluster-critical <10>
-    tolerations: <11>
+    priorityClassName: system-cluster-critical
+    tolerations:
       - key: "key1"
         operator: "Equal"
         value: "value1"
         effect: "NoSchedule"
   updateStrategy:
-    registryPoll: <12>
+    registryPoll:
       interval: 30m0s
 status:
   connectionState:
     address: example-catalog.{global_ns}.svc:50051
     lastConnect: 2021-08-26T18:14:31Z
-    lastObservedState: READY <13>
-  latestImageRegistryPoll: 2021-08-26T18:46:25Z <14>
-  registryService: <15>
+    lastObservedState: READY
+  latestImageRegistryPoll: 2021-08-26T18:46:25Z
+  registryService:
     createdAt: 2021-08-26T16:16:37Z
     port: 50051
     protocol: grpc
     serviceName: example-catalog
     serviceNamespace: {global_ns}
 ----
-<1> Name for the `CatalogSource` object. This value is also used as part of the name for the related pod that is created in the requested namespace.
-<2> Namespace to create the catalog in. To make the catalog available cluster-wide in all namespaces, set this value to `{global_ns}`. The default Red Hat-provided catalog sources also use the `{global_ns}` namespace. Otherwise, set the value to a specific namespace to make the Operator only available in that namespace.
-<3> Optional: To avoid cluster upgrades potentially leaving Operator installations in an unsupported state or without a continued update path, you can enable automatically changing your Operator catalog's index image version as part of cluster upgrades.
++
+where:
+
+`metadata.name`:: Specifies the name for the `CatalogSource` object. This value is also used as part of the name for the related pod that is created in the requested namespace.
+`metadata.namespace`:: Specifies the namespace to create the catalog in. To make the catalog available cluster-wide in all namespaces, set this value to `{global_ns}`. The default Red Hat-provided catalog sources also use the `{global_ns}` namespace. Otherwise, set the value to a specific namespace to make the Operator only available in that namespace.
+`metadata.annotations.olm.catalogImageTemplate`:: Specifies that to avoid cluster upgrades potentially leaving Operator installations in an unsupported state or without a continued update path, you can enable automatically changing your Operator catalog's index image version as part of cluster upgrades. This field is optional.
 +
 Set the `olm.catalogImageTemplate` annotation to your index image name and use one or more of the Kubernetes cluster version variables as shown when constructing the template for the image tag. The annotation overwrites the `spec.image` field at run time. See the "Image template for custom catalog sources" section for more details.
-<4> Display name for the catalog in the web console and CLI.
-<5> Index image for the catalog. Optionally, can be omitted when using the `olm.catalogImageTemplate` annotation, which sets the pull spec at run time.
-<6> Weight for the catalog source. OLM uses the weight for prioritization during dependency resolution. A higher weight indicates the catalog is preferred over lower-weighted catalogs.
-<7> Source types include the following:
+`spec.displayName`:: Specifies the display name for the catalog in the web console and CLI.
+`spec.image`:: Specifies the index image for the catalog. Optionally, can be omitted when using the `olm.catalogImageTemplate` annotation, which sets the pull spec at run time.
+`spec.priority`:: Specifies the weight for the catalog source. OLM uses the weight for prioritization during dependency resolution. A higher weight indicates the catalog is preferred over lower-weighted catalogs.
+`spec.sourceType`:: Specifies that source types include the following:
 +
 --
 * `grpc` with an `image` reference: OLM pulls the image and runs the pod, which is expected to serve a compliant API.
 * `grpc` with an `address` field: OLM attempts to contact the gRPC API at the given address. This should not be used in most cases.
 * `configmap`: OLM parses config map data and runs a pod that can serve the gRPC API over it.
 --
-<8> Specify the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`.
+`spec.grpcPodConfig.securityContextConfig`:: Specifies the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`.
 +
 --
 [NOTE]
@@ -89,11 +92,11 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 If your catalog cannot run with `restricted` permissions, it is recommended that you manually set this field to `legacy`.
 ====
 --
-<9> Optional: For `grpc` type catalog sources, overrides the default node selector for the pod serving the content in `spec.image`, if defined.
-<10> Optional: For `grpc` type catalog sources, overrides the default priority class name for the pod serving the content in `spec.image`, if defined. Kubernetes provides `system-cluster-critical` and `system-node-critical` priority classes by default. Setting the field to empty (`""`) assigns the pod the default priority. Other priority classes can be defined manually.
-<11> Optional: For `grpc` type catalog sources, overrides the default tolerations for the pod serving the content in `spec.image`, if defined.
-<12> Automatically check for new versions at a given interval to stay up-to-date.
-<13> Last observed state of the catalog connection. For example:
+`spec.grpcPodConfig.nodeSelector`:: Specifies that for `grpc` type catalog sources, it overrides the default node selector for the pod serving the content in `spec.image`, if defined. This field is optional.
+`spec.grpcPodConfig.priorityClassName`:: Specifies that for `grpc` type catalog sources, it overrides the default priority class name for the pod serving the content in `spec.image`, if defined. Kubernetes provides `system-cluster-critical` and `system-node-critical` priority classes by default. Setting the field to empty (`""`) assigns the pod the default priority. Other priority classes can be defined manually. This field is optional.
+`spec.grpcPodConfig.tolerations`:: Specifies that for `grpc` type catalog sources, it overrides the default tolerations for the pod serving the content in `spec.image`, if defined. This field is optional.
+`spec.updateStrategy.registryPoll`:: Specifies that new versions are automatically checked at a given interval to stay up-to-date.
+`status.connectionState.lastObservedState`:: Specifies the last observed state of the catalog connection. For example:
 +
 --
 * `READY`: A connection is successfully established.
@@ -102,8 +105,8 @@ If your catalog cannot run with `restricted` permissions, it is recommended that
 --
 +
 See link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity] in the gRPC documentation for more details.
-<14> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
-<15> Status information for the catalog's Operator Registry service.
+`status.latestImageRegistryPoll`:: Specifies the latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
+`status.registryService`:: Specifies status information for the catalog's Operator Registry service.
 
 Referencing the `name` of a `CatalogSource` object in a subscription instructs OLM where to search to find a requested Operator:
 

--- a/modules/olm-deprecations-schema.adoc
+++ b/modules/olm-deprecations-schema.adoc
@@ -39,31 +39,34 @@ Each `reference` type has their own requirements, as detailed in the following e
 [source,yaml]
 ----
 schema: olm.deprecations
-package: my-operator <1>
+package: my-operator
 entries:
   - reference:
-      schema: olm.package <2>
-    message: | <3>
+      schema: olm.package
+    message: |
     The 'my-operator' package is end of life. Please use the
     'my-operator-new' package for support.
   - reference:
       schema: olm.channel
-      name: alpha <4>
+      name: alpha
     message: |
     The 'alpha' channel is no longer supported. Please switch to the
     'stable' channel.
   - reference:
       schema: olm.bundle
-      name: my-operator.v1.68.0 <5>
+      name: my-operator.v1.68.0
     message: |
     my-operator.v1.68.0 is deprecated. Uninstall my-operator.v1.68.0 and
     install my-operator.v1.72.0 for support.
 ----
-<1> Each deprecation schema must have a `package` value, and that package reference must be unique across the catalog. There must not be an associated `name` field.
-<2> The `olm.package` schema must not include a `name` field, because it is determined by the `package` field defined earlier in the schema.
-<3> All `message` fields, for any `reference` type, must be a non-zero length and represented as an opaque text blob.
-<4> The `name` field for the `olm.channel` schema is required.
-<5> The `name` field for the `olm.bundle` schema is required.
++
+where:
+
+`package`:: Specifies that each deprecation schema must have a `package` value, and that package reference must be unique across the catalog. There must not be an associated `name` field.
+`entries.reference.schema`:: Specifies that the `olm.package` schema must not include a `name` field, because it is determined by the `package` field defined earlier in the schema.
+`entries.message`:: Specifies that all `message` fields, for any `reference` type, must be a non-zero length and represented as an opaque text blob.
+`entries.reference.name`:: Specifies that the `name` field for the `olm.channel` schema is required.
+`entries.reference.name`:: Specifies that the `name` field for the `olm.bundle` schema is required.
 ====
 
 [NOTE]


### PR DESCRIPTION
## Summary
Replaces AsciiDoc callout lists with DITA-safe `where:` / `Specifies` definition lists in OLM catalog source and deprecations schema modules.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16939

## Versions
4.20+

## Merge order
Independent branch from main (callouts only). Bundle-format callouts handled in split PR #115268.

## Files changed
- `modules/olm-catalogsource.adoc`
- `modules/olm-deprecations-schema.adoc`

## Vale rules addressed
- AsciiDocDITA.CalloutList

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)

Made with [Cursor](https://cursor.com)