### PR TITLE
OSDOCS-16939: DITA split-modules — olm packaging format

### DIFF
--- a/modules/olm-bundle-format-annotations.adoc
+++ b/modules/olm-bundle-format-annotations.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-bundle-format-annotations_{context}"]
+= Annotations
+
+[role="_abstract"]
+Operator bundle annotations in `annotations.yaml` define aggregate metadata that describes how a bundle is indexed in {product-title}. These annotations specify media type, manifest paths, package name, channels, and the default channel for catalog registration.
+
+A bundle includes an `annotations.yaml` file in its `/metadata` directory:
+
+.Example `annotations.yaml`
+[source,yaml]
+----
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "test-operator"
+  operators.operatorframework.io.bundle.channels.v1: "beta,stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"
+----
++
+where:
+
+`annotations.operators.operatorframework.io.bundle.mediatype.v1`:: Specifies the media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
+`annotations.operators.operatorframework.io.bundle.manifests.v1`:: Specifies the path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
+`annotations.operators.operatorframework.io.bundle.metadata.v1`:: Specifies the path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
+`annotations.operators.operatorframework.io.bundle.package.v1`:: Specifies the package name of the bundle.
+`annotations.operators.operatorframework.io.bundle.channels.v1`:: Specifies the list of channels the bundle is subscribing to when added into an Operator Registry.
+`annotations.operators.operatorframework.io.bundle.channel.default.v1`:: Specifies the default channel an Operator should be subscribed to when installed from a registry.
+
+[NOTE]
+====
+In case of a mismatch, the `annotations.yaml` file is authoritative because the on-cluster Operator Registry that relies on these annotations only has access to this file.
+====

--- a/modules/olm-bundle-format-manifests-optional.adoc
+++ b/modules/olm-bundle-format-manifests-optional.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="olm-bundle-format-manifests-optional_{context}"]
+= Additionally supported objects
+
+[role="_abstract"]
+Operator bundles can optionally include additional Kubernetes object types in the `/manifests` directory for deployment with a cluster service version (CSV) in {product-title}. When included, Operator Lifecycle Manager (OLM) creates and manages the lifecycle of these objects alongside the CSV.
+
+The following optional object types are supported:
+
+[.small]
+* `ClusterRole`
+* `ClusterRoleBinding`
+* `ConfigMap`
+* `ConsoleCLIDownload`
+* `ConsoleLink`
+* `ConsoleQuickStart`
+* `ConsoleYamlSample`
+* `PodDisruptionBudget`
+* `PriorityClass`
+* `PrometheusRule`
+* `Role`
+* `RoleBinding`
+* `Secret`
+* `Service`
+* `ServiceAccount`
+* `ServiceMonitor`
+* `VerticalPodAutoscaler`
+
+OLM manages the lifecycle of these optional objects as follows:
+
+* When the CSV is deleted, OLM deletes the optional object.
+* When the CSV is upgraded:
+** If the name of the optional object is the same, OLM updates it in place.
+** If the name of the optional object has changed between versions, OLM deletes and recreates it.

--- a/modules/olm-bundle-format-manifests.adoc
+++ b/modules/olm-bundle-format-manifests.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-bundle-format-manifests_{context}"]
+= Manifests
+
+[role="_abstract"]
+Bundle manifests are Kubernetes objects in an Operator bundle that define the deployment and RBAC model for an Operator in {product-title}. A bundle includes one CSV and typically the CRDs for APIs owned by that CSV in its `/manifests` directory.
+
+.Example bundle format layout
+[source,terminal]
+----
+etcd
+├── manifests
+│   ├── etcdcluster.crd.yaml
+│   └── etcdoperator.clusterserviceversion.yaml
+│   └── secret.yaml
+│   └── configmap.yaml
+└── metadata
+    └── annotations.yaml
+    └── dependencies.yaml
+----

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -2,12 +2,14 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-bundle-format_{context}"]
 = Bundle format
 
-The _bundle format_ for Operators is a packaging format introduced by the Operator Framework. To improve scalability and to better enable upstream users hosting their own catalogs, the bundle format specification simplifies the distribution of Operator metadata.
+[role="_abstract"]
+The bundle format is an Operator Framework packaging format that simplifies distributing Operator metadata for catalogs in {product-title}. An Operator bundle is a single Operator version shipped as a non-runnable container image that stores Kubernetes manifests and metadata.
 
-An Operator bundle represents a single version of an Operator. On-disk _bundle manifests_ are containerized and shipped as a _bundle image_, which is a non-runnable container image that stores the Kubernetes manifests and Operator metadata. Storage and distribution of the bundle image is then managed using existing container tools like `podman` and `docker` and container registries such as Quay.
+Storage and distribution of the bundle image is managed using existing container tools like `podman` and `docker` and container registries such as Quay.
 
 Operator metadata can include:
 
@@ -21,86 +23,3 @@ When loading manifests into the Operator Registry database, the following requir
 * The bundle must have at least one channel defined in the annotations.
 * Every bundle has exactly one cluster service version (CSV).
 * If a CSV owns a custom resource definition (CRD), that CRD must exist in the bundle.
-
-[id="olm-bundle-format-manifests_{context}"]
-== Manifests
-
-Bundle manifests refer to a set of Kubernetes manifests that define the deployment and RBAC model of the Operator.
-
-A bundle includes one CSV per directory and typically the CRDs that define the owned APIs of the CSV in its `/manifests` directory.
-
-.Example bundle format layout
-[source,terminal]
-----
-etcd
-├── manifests
-│   ├── etcdcluster.crd.yaml
-│   └── etcdoperator.clusterserviceversion.yaml
-│   └── secret.yaml
-│   └── configmap.yaml
-└── metadata
-    └── annotations.yaml
-    └── dependencies.yaml
-----
-
-
-[id="olm-bundle-format-manifests-optional_{context}"]
-=== Additionally supported objects
-
-The following object types can also be optionally included in the `/manifests` directory of a bundle:
-
-.Supported optional object types
-[.small]
-* `ClusterRole`
-* `ClusterRoleBinding`
-* `ConfigMap`
-* `ConsoleCLIDownload`
-* `ConsoleLink`
-* `ConsoleQuickStart`
-* `ConsoleYamlSample`
-* `PodDisruptionBudget`
-* `PriorityClass`
-* `PrometheusRule`
-* `Role`
-* `RoleBinding`
-* `Secret`
-* `Service`
-* `ServiceAccount`
-* `ServiceMonitor`
-* `VerticalPodAutoscaler`
-
-When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
-
-.Lifecycle for optional objects
-* When the CSV is deleted, OLM deletes the optional object.
-* When the CSV is upgraded:
-** If the name of the optional object is the same, OLM updates it in place.
-** If the name of the optional object has changed between versions, OLM deletes and recreates it.
-
-[id="olm-bundle-format-annotations_{context}"]
-== Annotations
-
-A bundle also includes an `annotations.yaml` file in its `/metadata` directory. This file defines higher level aggregate data that helps describe the format and package information about how the bundle should be added into an index of bundles:
-
-.Example `annotations.yaml`
-[source,yaml]
-----
-annotations:
-  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1" <1>
-  operators.operatorframework.io.bundle.manifests.v1: "manifests/" <2>
-  operators.operatorframework.io.bundle.metadata.v1: "metadata/" <3>
-  operators.operatorframework.io.bundle.package.v1: "test-operator" <4>
-  operators.operatorframework.io.bundle.channels.v1: "beta,stable" <5>
-  operators.operatorframework.io.bundle.channel.default.v1: "stable" <6>
-----
-<1> The media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
-<2> The path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
-<3> The path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
-<4> The package name of the bundle.
-<5> The list of channels the bundle is subscribing to when added into an Operator Registry.
-<6> The default channel an Operator should be subscribed to when installed from a registry.
-
-[NOTE]
-====
-In case of a mismatch, the `annotations.yaml` file is authoritative because the on-cluster Operator Registry that relies on these annotations only has access to this file.
-====

--- a/modules/olm-fb-catalogs-cli.adoc
+++ b/modules/olm-fb-catalogs-cli.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olm-fb-catalogs-cli_{context}"]
+= CLI usage
+
+[role="_abstract"]
+You can create and manage file-based Operator catalogs in {product-title} by using the `opm` CLI.
+

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -10,6 +10,12 @@ This guide outlines the packaging format for Operators supported by Operator Lif
 
 include::modules/olm-bundle-format.adoc[leveloffset=+1]
 
+include::modules/olm-bundle-format-manifests.adoc[leveloffset=+2]
+
+include::modules/olm-bundle-format-manifests-optional.adoc[leveloffset=+3]
+
+include::modules/olm-bundle-format-annotations.adoc[leveloffset=+2]
+
 include::modules/olm-dependencies.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -73,11 +79,12 @@ include::modules/olm-fb-catalogs-example.adoc[leveloffset=+2]
 
 include::modules/olm-fb-catalogs-guidelines.adoc[leveloffset=+2]
 
-[id="olm-fb-catalogs-cli"]
-=== CLI usage
+include::modules/olm-fb-catalogs-cli.adoc[leveloffset=+2]
 
-For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
+[role="_additional-resources"]
+.Additional resources
 
-For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs]
+* xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools]
 
 include::modules/olm-fb-catalogs-automation.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
Splits NestedSection content for Operator Framework packaging format into child modules with preserved `leveloffset` nesting (`===` sections use parent+2). Applies abstracts, callout rewrite, BlockTitle lead-ins on new topics. Moves `xref:` from `olm-fb-catalogs-cli` module to assembly `.Additional resources` under that include.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16939

## Versions
4.20+

## Merge order
First PR for NestedSection; targets openshift:main. Preferred merge before abstracts/callouts/other-vale PRs that touch overlapping assemblies.

## Files changed
- `modules/olm-bundle-format.adoc`
- `modules/olm-bundle-format-manifests.adoc`
- `modules/olm-bundle-format-manifests-optional.adoc` (`leveloffset=+3`)
- `modules/olm-bundle-format-annotations.adoc`
- `modules/olm-fb-catalogs-cli.adoc`
- `operators/understanding/olm-packaging-format.adoc`

## Vale rules addressed
- AsciiDocDITA.NestedSection
- AsciiDocDITA.ContentType
- AsciiDocDITA.ShortDescription (new modules)
- AsciiDocDITA.CalloutList (annotations)
- AsciiDocDITA.BlockTitle
- AsciiDocDITA.ConceptLink (xrefs in assembly only)

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)

Made with [Cursor](https://cursor.com)