### PR TITLE
OSDOCS-20665 added 4-21 assemblies and modules to 4-20

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1311,6 +1311,10 @@ Topics:
     File: zero-trust-manager-oidc-federation
   - Name: Configuring Zero Trust Workload Identity Manager SPIRE Federation
     File: zero-trust-manager-spire-federation
+  - Name: Using the SPIFFE Helper container image
+    File: zero-trust-manager-spiffe-helper
+  - Name: Integrating OpenShift Service Mesh with Zero Trust Workload Identity Manager
+    File: zero-trust-manager-mesh-integration
   - Name: Enabling create-only mode for the Zero Trust Workload Identity Manager
     File: zero-trust-manager-reconciliation
   - Name: SPIRE UpstreamAuthority plugins for Zero Trust Workload Identity Manager

--- a/modules/zero-trust-manager-about-spire-integration.adoc
+++ b/modules/zero-trust-manager-about-spire-integration.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-spire-integration_{context}"]
+= SPIRE integration with {SMProductName}
+
+[role="_abstract"]
+{SMProductName} integrates with {zero-trust-full} so Envoy sidecars obtain mTLS certificates from {spiffe-full} instead of Istio's built-in CA, enabling cryptographically verified workload identities.
+
+SPIRE provides cryptographic workload identities based on the {spiffe-full} standard. This integration enables a zero-trust security model where workload identities are cryptographically verified rather than relying on network-based authentication.
+
+[id="multi-mesh-component-overview_{context}"]
+== Component overview
+
+The following table summarizes the main components in a single-cluster SPIFFE and {SMProductName} integration and what each one does.
+
+[cols="2,2",options="header"]
+|===
+| Component
+| Purpose
+
+| *{zero-trust-full}*
+| Manages SPIRE deployment on {product-title}
+
+| *SPIRE Server*
+| Certificate Authority; issues SVIDs
+
+| *SPIRE Agent*
+| Runs on each node; provides SDS API to workloads
+
+| *SPIFFE CSI Driver*
+| Mounts SPIRE socket into pods
+
+| *ClusterSPIFFEID*
+| Registers which pods get which identities
+
+| *{SMProductName} Operator*
+| Manages Istio deployment
+
+| *Istiod*
+| Istio control plane
+
+| *Envoy Sidecar*
+| Proxy in each pod; uses SPIRE for certificates
+|===

--- a/modules/zero-trust-manager-deploy-istio.adoc
+++ b/modules/zero-trust-manager-deploy-istio.adoc
@@ -1,0 +1,240 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-istio_{context}"]
+= Deploying {SMProductName} for SPIRE integration
+
+[role="_abstract"]
+Deploy {SMProductName} by creating the `IstioCNI` and `Istio` CRs with SPIRE integration settings so Envoy sidecars obtain SPIRE-issued certificates for workload mTLS after the SPIRE stack is running.
+
+.Prerequisites
+
+* You have installed {zero-trust-full}.
+* The {oc-first} is configured with access to the cluster.
+* You have permissions to create namespaces and custom resources in the `istio-cni` and `istio-system` namespaces.
+* You have permissions to read secrets in the `zero-trust-workload-identity-manager` namespace.
+
+.Procedure
+
+. Set the Istio environment variables by running the following commands:
++
+[source,terminal]
+----
+$ export ZTWIM_NS=zero-trust-workload-identity-manager
+$ export TRUST_DOMAIN=ocp.one
+$ export JWT_ISSUER="https://oidc-discovery.$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})"
+$ export OSSM_NS=istio-system
+$ export OSSM_CNI=istio-cni
+$ export VERIFY_NS=verify-ossm-ztwim
+$ export EXTRA_ROOT_CA="$(oc get secret oidc-serving-cert \
+                         -n ${ZTWIM_NS} -o json | \
+                         jq -r '.data."tls.crt"' | \
+                         base64 -d | \
+                         sed 's/^/        /')"
+----
+
+. Create the `IstioCNI` CR to deploy Istio CNI by running the following commands:
++
+[source,terminal]
+----
+$ oc new-project "${OSSM_CNI}" 2>/dev/null || oc project "${OSSM_CNI}"
+----
++
+[source,yaml]
+----
+$ oc apply -f - <<EOF
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: <version>
+  namespace: ${OSSM_CNI}
+EOF
+----
++ 
+where:
+
+`spec.version`:: Replace `<version>` with the Istio version supported by your {SMProductName} Operator. You can find supported versions by running `oc get IstioCNI -o jsonpath='{.items[*].spec.version}'` after the Operator is installed.
+
+. Wait for Istio CNI to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get daemonset/istio-cni-node -n "${OSSM_CNI}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ kubectl rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
+----
++
+The `until` loop waits for the {SMProductName} Operator to create the `istio-cni-node` DaemonSet. The `oc rollout status` command waits for the DaemonSet pods to become ready.
+
+. Install the Istio CR with SPIRE integration by running the following commands:
++
+[source,terminal]
+----
+$ oc new-project "${OSSM_NS}" 2>/dev/null
+----
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  updateStrategy:
+    type: InPlace
+  values:
+    pilot:
+      jwksResolverExtraRootCA: |
+${EXTRA_ROOT_CA}
+      env:
+        PILOT_JWT_ENABLE_REMOTE_JWKS: "true"
+    meshConfig:
+      trustDomain: $TRUST_DOMAIN
+      defaultConfig:
+        proxyMetadata:
+          WORKLOAD_IDENTITY_SOCKET_FILE: "spire-agent.sock"
+    sidecarInjectorWebhook:
+      templates:
+        spire: |
+          spec:
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+        spireGateway: |
+          spec:
+            containers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+EOF
+----
+
+. Wait for all of the resources to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get deployment istiod -n "${OSSM_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ oc wait --for=condition=Available deployment/istiod -n "${OSSM_NS}" --timeout=300s
+----
+
+.Verification
+
+. Verify that Istio is integrated with SPIRE:
+
+.. Create a test workload with the `spire` injection template by running the following commands:
++
+[source,terminal]
+----
+$ oc new-project "${VERIFY_NS}" 2>/dev/null
+----
+
+.. Enable the sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace "${VERIFY_NS}" istio-injection=enabled
+----
+
+.. Create the `httpbin` workload:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: ${VERIFY_NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: "sidecar,spire"
+        spiffe.io/audience: "test-audience"
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      containers:
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 8080
+EOF
+----
+
+.. Wait for all of the resources to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get deployment httpbin -n "${VERIFY_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ oc wait --for=condition=Available deployment/httpbin -n "${VERIFY_NS}" --timeout=300s
+----
+
+.. Verify the SPIRE workload identity by running the following command:
++
+[source,terminal]
+----
+$ HTTPBIN_POD=$(oc get pod -l app=httpbin -n "${VERIFY_NS}" -o jsonpath="{.items[0].metadata.name}")
+
+$ istioctl proxy-config secret "$HTTPBIN_POD" \
+  -n "${VERIFY_NS}" -o json \
+  | jq -r '.dynamicActiveSecrets[0].secret.tlsCertificate.certificateChain.inlineBytes' \
+  | base64 --decode > chain.pem
+
+openssl x509 -in chain.pem -text | grep SPIRE
+----
++
+.Example output
+[source,terminal]
+----
+ Issuer: C=US, O=RH, CN=<APP_DOMAIN>/serialNumber=...
+        Subject: C=US, O=SPIRE
+----
++
+If you see `SPIRE` in both `Issuer` and `Subject`, the integration is working. Envoy is getting its certificates from SPIRE, not from Istio's built-in CA.
+
+.. Remove the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete namespace "${VERIFY_NS}"
+----

--- a/modules/zero-trust-manager-deploy-spiffe-helper.adoc
+++ b/modules/zero-trust-manager-deploy-spiffe-helper.adoc
@@ -1,0 +1,479 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-spiffe-helper_{context}"]
+= Deploying PostgreSQL with SPIFFE Helper
+
+[role="_abstract"]
+Deploy a PostgreSQL server and client that use SPIFFE Helper to fetch X.509 {svid-full} from the SPIFFE Workload API and write them to disk for mutual Transport Layer Security (mTLS).
+
+The manifests in this procedure use the {zero-trust-full} SPIFFE Helper image.
+
+When certificates renew, the server must reload PostgreSQL TLS configuration. Containers in the same pod use separate process namespaces, so the SPIFFE Helper sidecar cannot signal the PostgreSQL container directly. Instead, SPIFFE Helper uses the *managed-child* pattern. This pattern in daemon mode it runs `cmd` (`/usr/bin/psql`) with `cmd_args` to execute `SELECT pg_reload_conf();` as a child process inside the helper container whenever X.509 material is updated.
+
+The stock SPIFFE Helper image does not include the `psql` client required for that reload command. Build a custom image that extends the {zero-trust-full} image and adds the PostgreSQL client package.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {zero-trust-full}.
+* The `ZeroTrustWorkloadIdentityManager` custom resource reports `Ready`.
+
+.Procedure
+
+. Create a `Containerfile` with the following contents:
++
+[source,dockerfile]
+----
+FROM registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+
+USER 0
+
+RUN dnf install -y postgresql && \
+    dnf clean all
+
+USER 65534
+----
++
+Replace `<version>` with the tag that matches your {zero-trust-full} installation.
+
+. Build and push a custom SPIFFE Helper image for the PostgreSQL server by running the following command.
++
+[source,terminal]
+----
+$ podman build -f Containerfile \
+  -t <registry>/spiffe-helper-postgresql:latest .
+----
++
+[source,terminal]
+----
+$ podman push <registry>/spiffe-helper-postgresql:latest
+----
++
+Replace `<registry>` with your container registry.
+
+. Create the PostgreSQL server resources by using the following example:
++
+[source,yaml]
+----
+$ oc apply -f - << 'EOF'
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: postgresql-spiffe
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: postgresql-spiffe
+  namespace: postgresql-spiffe
+---
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: postgresql-spiffe
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  dnsNameTemplates:
+    - postgresql-spiffe.postgresql-spiffe.svc
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: postgresql-spiffe
+  podSelector:
+    matchLabels:
+      app: postgresql-spiffe
+  spiffeIDTemplate: 'spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}'
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: postgres-config
+  namespace: postgresql-spiffe
+data:
+  pg_hba.conf: |
+    # TYPE      DATABASE        USER            ADDRESS                 METHOD
+    local       all             all                                     trust
+    host        postgres        postgres        127.0.0.1/32            trust
+    hostnossl   postgres        postgres        127.0.0.1/32            trust
+    hostnossl   all             all             0.0.0.0/0               reject
+    hostssl     all             all             0.0.0.0/0               cert
+  postgresql.conf: |
+    listen_addresses '*'
+    ssl = on
+    ssl_cert_file = '/opt/postgresql-certs/svid.pem'
+    ssl_key_file = '/opt/postgresql-certs/svid.key'
+    ssl_ca_file = '/opt/postgresql-certs/svid_bundle.pem'
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: postgresql-init-db
+  namespace: postgresql-spiffe
+data:
+  initdb.sh: |
+    # Copy configuration files
+    cp /opt/pg_hba/pg_hba.conf /var/lib/pgsql/data/userdata
+    # Create postgresql resources
+    psql -U postgres <<!!EOF
+        CREATE DATABASE $SPIFFE_DATABASE;
+        CREATE USER $SPIFFE_USER WITH encrypted password '$SPIFFE_PASSWORD';
+        GRANT ALL privileges ON database $SPIFFE_DATABASE TO $SPIFFE_USER;
+        \c $SPIFFE_DATABASE;
+        CREATE TABLE test_table (
+          id bigserial primary key,
+          name VARCHAR(255) NOT NULL,
+          text VARCHAR(255) NOT NULL
+        );
+        GRANT ALL privileges ON table test_table TO $SPIFFE_USER;
+        GRANT ALL privileges ON sequence test_table_id_seq TO $SPIFFE_USER;
+    !!EOF
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: spiffe-helper
+  namespace: postgresql-spiffe
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = "/usr/bin/psql"
+    cmd_args = "-U postgres -h 127.0.0.1 -c \"SELECT pg_reload_conf();\""
+    cert_dir = "/opt/postgresql-certs"
+    renew_signal = ""
+    svid_file_name = "svid.pem"
+    svid_key_file_name = "svid.key"
+    svid_bundle_file_name = "svid_bundle.pem"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: postgresql-spiffe
+  namespace: postgresql-spiffe
+spec:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP
+  selector:
+    app: postgresql-spiffe
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: postgresql-spiffe
+  namespace: postgresql-spiffe
+  labels:
+    app: postgresql-spiffe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql-spiffe
+  template:
+    metadata:
+      labels:
+        app: postgresql-spiffe
+    spec:
+      serviceAccountName: postgresql-spiffe
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: spiffe-helper-init
+          image: <registry>/spiffe-helper-postgresql:latest
+          args:
+            - '-config'
+            - /etc/spiffe-helper/helper.conf
+            - '-daemon-mode=false'
+          volumeMounts:
+            - name: spiffe-workload-api
+              readOnly: true
+              mountPath: /spiffe-workload-api
+            - name: postgresql-certs
+              mountPath: /opt/postgresql-certs
+            - name: spiffe-helper
+              mountPath: /etc/spiffe-helper
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: postgresql-spiffe
+          image: registry.redhat.io/rhel9/postgresql-16:latest
+          env:
+            - name: POSTGRESQL_USER
+              value: user
+            - name: POSTGRESQL_PASSWORD
+              value: wearenotusingthissoIdontworryaboutit
+            - name: SPIFFE_USER
+              value: postgresql_spiffe
+            - name: SPIFFE_PASSWORD
+              value: somealsonotusedpassword
+            - name: SPIFFE_DATABASE
+              value: testdb
+            - name: POSTGRESQL_DATABASE
+              value: sampledb
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgresql-certs
+              mountPath: /opt/postgresql-certs
+            - name: pg-hba
+              mountPath: /opt/pg_hba
+            - name: postgresql-init-db
+              mountPath: /opt/app-root/src/postgresql-init
+            - name: postgres-config
+              mountPath: /opt/app-root/src/postgresql-cfg
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+        - name: spiffe-helper
+          image: <registry>/spiffe-helper-postgresql:latest
+          args:
+            - '-config'
+            - /etc/spiffe-helper/helper.conf
+          volumeMounts:
+            - name: spiffe-workload-api
+              readOnly: true
+              mountPath: /spiffe-workload-api
+            - name: postgresql-certs
+              mountPath: /opt/postgresql-certs
+            - name: spiffe-helper
+              mountPath: /etc/spiffe-helper
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: postgresql-certs
+          emptyDir:
+            medium: Memory
+        - name: spiffe-helper
+          configMap:
+            name: spiffe-helper
+        - name: postgresql-init-db
+          configMap:
+            name: postgresql-init-db
+        - name: pg-hba
+          configMap:
+            name: postgres-config
+            items:
+              - key: pg_hba.conf
+                path: pg_hba.conf
+        - name: postgres-config
+          configMap:
+            name: postgres-config
+            items:
+              - key: postgresql.conf
+                path: postgresql.conf
+EOF
+----
++
+Replace both `<registry>` occurrences in the deployment with your container registry.
+
+. Confirm that the SPIFFE Helper configuration matches the PostgreSQL TLS settings by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap spiffe-helper -n postgresql-spiffe \
+  -o jsonpath='{.data.helper\.conf}{"\n"}'
+----
++
+The `cert_dir` and `svid_*` file names must match the `ssl_*_file` paths in `postgresql.conf`. The server `helper.conf` must include settings similar to the following example:
++
+[source,terminal]
+----
+agent_address = "/spiffe-workload-api/spire-agent.sock"
+cmd = "/usr/bin/psql"
+cmd_args = "-U postgres -h 127.0.0.1 -c \"SELECT pg_reload_conf();\""
+cert_dir = "/opt/postgresql-certs"
+renew_signal = ""
+svid_file_name = "svid.pem"
+svid_key_file_name = "svid.key"
+svid_bundle_file_name = "svid_bundle.pem"
+----
+
+. Create the PostgreSQL client by using the following example. The client uses the stock SPIFFE Helper image from the {zero-trust-full}. Only the server deployment requires the custom image with the `psql` client.
++
+[source,yaml]
+----
+$ oc apply -f - << 'EOF'
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: postgresql-spiffe-client
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: postgresql-spiffe-client
+  namespace: postgresql-spiffe-client
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: spiffe-helper
+  namespace: postgresql-spiffe-client
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = ""
+    cmd_args = ""
+    cert_dir = "/opt/postgresql-certs"
+    renew_signal = ""
+    svid_file_name = "svid.pem"
+    svid_key_file_name = "svid.key"
+    svid_bundle_file_name = "svid_bundle.pem"
+---
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: postgresql-spiffe-client
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  dnsNameTemplates:
+    - postgresql-spiffe
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: postgresql-spiffe-client
+  podSelector:
+    matchLabels:
+      app: postgresql-spiffe-client
+  spiffeIDTemplate: 'spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}'
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: postgresql-spiffe-client
+  namespace: postgresql-spiffe-client
+  labels:
+    app: postgresql-spiffe-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql-spiffe-client
+  template:
+    metadata:
+      labels:
+        app: postgresql-spiffe-client
+    spec:
+      serviceAccountName: postgresql-spiffe-client
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgresql-spiffe-client
+          image: registry.redhat.io/rhel9/postgresql-16:latest
+          command:
+            - /bin/bash
+            - '-c'
+            - sleep infinity
+          volumeMounts:
+            - name: postgresql-certs
+              mountPath: /opt/postgresql-certs
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+        - name: spiffe-helper
+          image: registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:
+          args:
+            - '-config'
+            - /etc/spiffe-helper/helper.conf
+          volumeMounts:
+            - name: spiffe-workload-api
+              readOnly: true
+              mountPath: /spiffe-workload-api
+            - name: postgresql-certs
+              mountPath: /opt/postgresql-certs
+            - name: spiffe-helper
+              mountPath: /etc/spiffe-helper
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: postgresql-certs
+          emptyDir:
+            medium: Memory
+        - name: spiffe-helper
+          configMap:
+            name: spiffe-helper
+EOF
+----
++
+Replace `<version>` with the tag that matches your {zero-trust-full} installation.
+
+. Confirm that pods are running in both namespaces by running the following commands:
++
+[source,terminal]
+----
+$ oc get pods -n postgresql-spiffe
+----
++
+[source,terminal]
+----
+$ oc get pods -n postgresql-spiffe-client
+----
+
+.Verification
+
+. Inspect the server certificate by running the following command:
++
+[source,terminal]
+----
+$ oc rsh -n postgresql-spiffe -c postgresql-spiffe \
+  deployment/postgresql-spiffe \
+  cat /opt/postgresql-certs/svid.pem | openssl x509 -noout -text
+----
++
+The server certificate should include the service hostname `postgresql-spiffe.postgresql-spiffe.svc`.
+
+. Inspect the client certificate by running the following command:
++
+[source,terminal]
+----
+$ oc rsh -n postgresql-spiffe-client -c postgresql-spiffe-client \
+  deployment/postgresql-spiffe-client \
+  cat /opt/postgresql-certs/svid.pem | openssl x509 -noout -text
+----
++
+The certificate common name (CN) field should be `postgresql_spiffe`.
+
+. Connect to PostgreSQL from the client pod by running the following commands:
++
+[source,terminal]
+----
+$ oc rsh -n postgresql-spiffe-client -c postgresql-spiffe-client \
+  deployment/postgresql-spiffe-client
+----
++
+[source,terminal]
+----
+$ psql "host=postgresql-spiffe.postgresql-spiffe.svc port=5432 \
+  user=postgresql_spiffe dbname=testdb sslmode=verify-full \
+  sslcert=/opt/postgresql-certs/svid.pem \
+  sslkey=/opt/postgresql-certs/svid.key \
+  sslrootcert=/opt/postgresql-certs/svid_bundle.pem"
+----
++
+If the deployment succeeded, `psql` connects to the database.

--- a/modules/zero-trust-manager-deploy-spire.adoc
+++ b/modules/zero-trust-manager-deploy-spire.adoc
@@ -1,0 +1,324 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-spire_{context}"]
+= Deploying SPIRE operands for {SMProductName} integration
+
+[role="_abstract"]
+Deploy SPIRE operands by creating the `ZeroTrustWorkloadIdentityManager` custom resource (CR) and related SPIRE operand CRs together. A running SPIRE deployment is required before you configure {SMProductName} to use SPIRE-issued certificates for workload mTLS.
+
+.Prerequisites
+
+* You have installed {zero-trust-full}.
+* The {oc-first} is configured with access to the cluster.
+* You have permissions to create custom resources in the `zero-trust-workload-identity-manager` namespace.
+
+.Procedure
+
+. Set the environment variables by running the following commands:
++
+[source,terminal]
+----
+$ export TRUST_DOMAIN=ocp.one
+$ export ZTWIM_NS=zero-trust-workload-identity-manager
+$ export JWT_ISSUER="https://oidc-discovery.$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})"
+----
+
+. Deploy all SPIRE operand CRs, including the `ZeroTrustWorkloadIdentityManager` CR:
+
+.. Create the `ZeroTrustWorkloadIdentityManager` CR:
++
+[source,yaml]
+----
+$ oc apply -f - <<EOF
+apiVersion: operator.openshift.io/v1alpha1
+kind: ZeroTrustWorkloadIdentityManager
+metadata:
+ name: cluster
+ labels:
+   app.kubernetes.io/name: zero-trust-workload-identity-manager
+   app.kubernetes.io/managed-by: zero-trust-workload-identity-manager
+spec:
+  trustDomain: ${TRUST_DOMAIN}
+  clusterName: ""
+  bundleConfigMap: "spire-bundle"
+EOF
+----
+
+.. Create the `SpireServer` CR:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireServer
+metadata:
+ name: cluster
+spec:
+  logLevel: "info"
+  logFormat: "text"
+  jwtIssuer: $JWT_ISSUER
+  caValidity: "24h"
+  defaultX509Validity: "1h"
+  defaultJWTValidity: "5m"
+  caKeytype: “rsa-2048”
+  jwtKeyType: "rsa-2048"
+  keyManager: “”
+  caSubject:
+    country: "US"
+    organization: "RH"
+    commonName: "SPIRE Server CA"
+  persistence:
+    size: "5Gi"
+    accessMode: "ReadWriteOnce"
+  datastore:
+    databaseType: "sqlite3"
+    connectionString: "/run/spire/data/datastore.sqlite3"
+    tlsSecretName: ""
+    maxOpenConns: 100
+    maxIdleConns: 10
+    connMaxLifetime: 0
+    disableMigration: "false"
+EOF
+----
+
+.. Wait for the SPIRE Server to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get statefulset/spire-server -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ kubectl rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
+----
+
+.. Create the `SpireAgent` CR:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireAgent
+metadata:
+  name: cluster
+spec:
+  socketPath: "/run/spire/agent-sockets"
+  logLevel: "info"
+  logFormat: "text"
+  nodeAttestor:
+    k8sPSATEnabled: "true"
+  workloadAttestors:
+    k8sEnabled: "true"
+    workloadAttestorsVerification:
+      type: "auto"
+      hostCertBasePath: "/etc/kubernetes"
+      hostCertFileName: "kubelet-ca.crt"
+    disableContainerSelectors: "false"
+    useNewContainerLocator: "true"
+EOF
+----
+
+.. Wait for the SPIRE Agent to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get daemonset/spire-agent -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ kubectl rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
+----
+
+.. Deploy the `SpiffeCSIDriver` CR:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpiffeCSIDriver
+metadata:
+  name: cluster
+spec:
+  agentSocketPath: '/run/spire/agent-sockets'
+  pluginName: "csi.spiffe.io"
+EOF
+----
+
+.. Wait for the SPIFFE CSI Driver to become ready by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ kubectl rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
+----
+
+.. Deploy the `SpireOIDCDiscoveryProvider` CR:
++
+[source,terminal]
+----
+$ export OIDC_DISCOVERY_CONFIG_MAP=spire-spiffe-oidc-discovery-provider
+----
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireOIDCDiscoveryProvider
+metadata:
+  name: cluster
+spec:
+  logLevel: "info"
+  logFormat: "text"
+  csiDriverName: "csi.spiffe.io"
+  jwtIssuer: $JWT_ISSUER
+  replicaCount: 1
+  managedRoute: "true"
+EOF
+----
+
+.. Wait for the OIDC Discovery Provider to be created by running the following commands:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get deployment spire-spiffe-oidc-discovery-provider -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ oc wait --for=condition=Available deployment/spire-spiffe-oidc-discovery-provider -n "${ZTWIM_NS}" --timeout=300s
+----
+
+.Verification
+
+. Verify that {zero-trust-full} is installed:
+
+.. Deploy the client workload and try to fetch a workload SVID:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ztwim-client
+  namespace: default
+  labels:
+    app: ztwim-client
+spec:
+  selector:
+    matchLabels:
+      app: ztwim-client
+  template:
+    metadata:
+      labels:
+        app: ztwim-client
+    spec:
+      containers:
+        - name: client
+          image: ghcr.io/spiffe/spire-agent:1.5.1
+          command: ["/opt/spire/bin/spire-agent"]
+          args: [ "api", "watch",  "-socketPath", "/run/spire/sockets/spire-agent.sock" ]
+          volumeMounts:
+            - mountPath: /run/spire/sockets
+              name: spiffe-workload-api
+              readOnly: true
+      volumes:
+      - name: spiffe-workload-api
+        csi:
+          driver: csi.spiffe.io
+          readOnly: true
+EOF
+----
+
+.. Wait for the client deployment to become ready by running the following command:
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ until oc get deployment ztwim-client -n default &> /dev/null; do sleep 3; done
+----
++
+[source,terminal]
+----
+$ oc wait --for=condition=Available deployment/ztwim-client -n default --timeout=300s
+----
++
+[source,terminal]
+----
+$ sleep 5
+----
+
+. Verify that the x509 SVID is available by running the following command:
++
+[source,terminal]
+----
+$ oc exec -it \
+  "$(oc get \
+      pods -o=jsonpath='{.items[0].metadata.name}' \
+      -l app=ztwim-client \
+      -n default \
+   )" -n default -- \
+  /opt/spire/bin/spire-agent \
+    api fetch -socketPath /run/spire/sockets/spire-agent.sock
+----
++
+The expected output is an SVID like the following example:
++
+[source,text]
+----
+Received 1 svid after 29.636075ms
+
+SPIFFE ID:		spiffe://ocp.one/ns/default/sa/default
+SVID Valid After:	 2025-10-21 14:04:03 +0000 UTC
+SVID Valid Until:	 2025-10-21 15:04:13 +0000 UTC
+CA #1 Valid After:	2025-10-21 07:38:03 +0000 UTC
+CA #1 Valid Until:	2025-10-22 07:38:13 +0000 UTC
+----
+
+. Verify that the JSON Web Token (JWT) SVID is available by running the following command:
++
+[source,terminal]
+----
+$ oc exec -it \
+  "$(oc get \
+      pods -o=jsonpath='{.items[0].metadata.name}' \
+      -l app=ztwim-client \
+      -n default \
+   )" -n default -- \
+  /opt/spire/bin/spire-agent \
+    api fetch jwt -audience=sample-aud -socketPath /run/spire/sockets/spire-agent.sock
+----
++
+The expected output is a JWT SVID like the following example:
++
+[source,text]
+----
+token(spiffe://ocp.one/ns/default/sa/default):
+	eyJhbGciOiJSUzI1NiIsImtpZCI6Ij....IsIm
+bundle(spiffe://ocp.one):
+	{
+    "keys": [
+        {
+            "kty": "RSA",
+            "kid": "6k9PfhrAdfajT6jvLvR6bdomFvQxMeGf",
+            "n": "wEYTV0ri4OOcdgEVgzN0...KhUEGf0NKxnuaeGQ",
+            "e": "AQAB"
+        }
+    ]
+}
+----
+
+. Remove the client workload by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment ztwim-client -n default
+----

--- a/modules/zero-trust-manager-manually-delete-scc.adoc
+++ b/modules/zero-trust-manager-manually-delete-scc.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-manually-delete-scc_{context}"]
+= Manually delete the custom security context constraints
+
+[role="_abstract"]
+You can delete the `spire-spiffe-csi-driver` custom SCC when the SPIFFE CSI driver is ready and its pods are using the `privileged` security context constraint (SCC). 
+
+.Prerequisites
+
+* You have upgraded {zero-trust-full} to 1.1.0 from the **OperatorHub** catalog.
+
+.Procedure
+
+. Confirm the SPIFFE CSI driver is ready by running the following command:
++
+[source,terminal]
+----
+$ oc get spiffecsidriver cluster -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
+----
++
+The expected output includes `DaemonSetAvailable=True` and `Ready=True`.
+
+. Confirm that the CSI `DaemonSet` is available by running the following command:
++
+[source,terminal]
+----
+$ oc get ds spire-spiffe-csi-driver -n zero-trust-workload-identity-manager
+----
+
+. Confirm the CSI pods are running and are using the `privileged` SCC by running the following commands:
++
+[source,terminal]
+----
+$ oc get pods -n zero-trust-workload-identity-manager -l app.kubernetes.io/name=spiffe-csi-driver
+----
++
+[source,terminal]
+----
+$ oc get pod -n zero-trust-workload-identity-manager -l app.kubernetes.io/name=spiffe-csi-driver \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.openshift\.io/scc}{"\n"}{end}'
+----
++
+Every pod should show `privileged`.
+
+. After all checks have passed, delete the legacy custom SCC by running the following commands:
++
+[source,terminal]
+----
+$ oc get scc spire-spiffe-csi-driver
+----
++
+[source,terminal]
+----
+$ oc delete scc spire-spiffe-csi-driver
+----
++
+If the SCC is already absent, no action is needed.

--- a/modules/zero-trust-manager-mesh-architecture.adoc
+++ b/modules/zero-trust-manager-mesh-architecture.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-mesh-architecture_{context}"]
+= SPIRE integration architecture components
+
+[role="_abstract"]
+Learn about the key components in the SPIRE integration architecture and how they work together to enable zero-trust workload identity and automated certificate management for secure mTLS connections in {SMProductName}.
+
+{zero-trust-full}:: Manages the SPIRE deployment lifecycle on {product-title}, including custom resources for SPIRE Server, SPIRE Agent, and related components.
+
+SPIRE Server:: Acts as the certificate authority that issues SPIFFE Verifiable Identity Documents (SVIDs) to authenticated workloads.
+
+SPIRE Agent:: Runs as a DaemonSet on each cluster node, providing the Envoy Secret Discovery Service (SDS) API to workloads on that node.
+
+SPIFFE CSI Driver:: Mounts the SPIRE Agent UNIX domain socket into pods, enabling secure communication between Envoy sidecars and the SPIRE Agent.
+
+{SMProductName}:: Manages the Istio deployment through the `servicemeshoperator3` Operator.
+
+Istiod:: The Istio control plane that configures Envoy proxies but delegates certificate issuance to SPIRE.
+
+Envoy sidecar:: The proxy injected into each workload pod that uses SPIRE-issued certificates for mTLS connections.

--- a/modules/zero-trust-manager-release-notes-1-1-0.adoc
+++ b/modules/zero-trust-manager-release-notes-1-1-0.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-1-1-0_{context}"]
+= {zero-trust-full} 1.1.0
+
+Issued: 30 Jun 2026
+
+[role="_abstract"]
+This release adds integration and operational capabilities for workloads that use external certificate authorities, service mesh deployments, or file-based Transport Layer Security (TLS) credentials. The release includes a supported SPIFFE Helper container image, SPIRE UpstreamAuthority plugins for cert-manager and HashiCorp Vault, and {SMProductName} integration with SPIRE for single-cluster and federated multi-cluster mutual Transport Layer Security (mTLS).
+
+The following advisories are available for {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2026:28869[RHBA-2026:28869]
+* https://access.redhat.com/errata/RHBA-2026:28784[RHBA-2026:28784]
+* https://access.redhat.com/errata/RHBA-2026:28399[RHBA-2026:28399]
+* https://access.redhat.com/errata/RHBA-2026:28392[RHBA-2026:28392]
+* https://access.redhat.com/errata/RHBA-2026:28391[RHBA-2026:28391]
+* https://access.redhat.com/errata/RHBA-2026:28260[RHBA-2026:28260]
+* https://access.redhat.com/errata/RHBA-2026:28200[RHBA-2026:28200]
+* https://access.redhat.com/errata/RHBA-2026:28140[RHBA-2026:28140]
+
+{zero-trust-full} supports the following components and versions:
+
+[cols="1,1",options="header"]
+|===
+| Component
+| Version
+
+| {zero-trust-full}
+| 1.1.0
+
+| SPIRE Server
+| 1.14.7
+
+| SPIRE Agent
+| 1.14.7
+
+| SPIRE Controller Manager
+| 0.6.4
+
+| SPIRE OIDC Discovery Provider
+| 1.14.7
+
+| SPIFFE CSI Driver
+| 0.2.8
+|===
+
+[id="zero-trust-manager-1-1-0-features-enhancements_{context}"]
+== New features and enhancements
+
+Supported SPIFFE Helper container image::
+
+{zero-trust-full} now provides a supported SPIFFE Helper container image for workloads that cannot use the SPIFFE Workload API directly but can read Transport Layer Security (TLS) credentials from a shared volume. The image is based on upstream SPIFFE Helper. The configuration file format, command-line flags, and Workload API behavior remain compatible.
+
+SPIRE UpstreamAuthority plugins for external certificate authorities::
+
+{zero-trust-full} now supports SPIRE Server UpstreamAuthority plugins that obtain intermediate signing certificates from external certificate management systems while preserving {spiffe-full} identity standards.
+
+* Supported plugins:
+
+** cert-manager UpstreamAuthority plugin: integrates SPIRE Server with {cert-manager-operator}.
+** Vault UpstreamAuthority plugin: integrates SPIRE Server with the HashiCorp Vault Public Key Infrastructure (PKI) secrets engine.
+
+cert-manager UpstreamAuthority plugin::
+
+The cert-manager UpstreamAuthority plugin connects SPIRE Server to {cert-manager-operator} for automated intermediate certificate provisioning. SPIRE Server creates a `CertificateRequest` custom resource, then the configured `Issuer` or `ClusterIssuer` signs the request, and then the SPIRE Server uses the signed intermediate certificate to issue workload identities.
+
+Vault UpstreamAuthority plugin::
+
+The Vault UpstreamAuthority plugin connects SPIRE Server to the HashiCorp Vault PKI secrets engine for automated intermediate certificate authority (CA) certificate signing. Use this plugin when PKI is centralized in Vault and SPIRE must obtain intermediate signing certificates through Vault policies and authentication.
+
+Single-cluster Service Mesh integration with SPIRE::
+
+{zero-trust-full} now supports single-cluster integration with {SMProductName}. SPIRE replaces Istio's built-in certificate authority (CA) with SPIFFE-compliant identities and short-lived certificates that rotate automatically for workload mutual Transport Layer Security (mTLS).
+
+Multi-cluster Service Mesh integration with SPIRE federation::
+
+{zero-trust-full} now supports multi-cluster integration with {SMProductName} through SPIRE federation, enabling cross-cluster mutual Transport Layer Security (mTLS) authentication and zero trust workload identity across separate {product-title} clusters.
+
+* Cross-cluster trust requires federation at two layers:
+
+** SPIRE federation: SPIRE Servers exchange trust bundles through the `https_spiffe` profile.
+** Istio federation: Istio discovers remote endpoints through remote secrets and routes traffic through East-West Gateways.
+
+[id="zero-trust-manager-1-1-0-deprecated-features_{context}"]
+== Deprecated features
+
+Custom SCC `spire-spiffe-csi-driver`::
+
+Starting in {zero-trust-full} 1.1.0, the SPIFFE CSI Driver no longer uses the custom `SecurityContextConstraints` (SCC) `spire-spiffe-csi-driver`.
++
+{zero-trust-full} now grants the CSI `ServiceAccount` access to the platform `privileged` SCC through a `RoleBinding` namespace.
++
+{zero-trust-full} uses only the existing OpenShift `privileged` SCC. {zero-trust-full} does not create, modify, update, or delete the `privileged` SCC.
+
+Action required after upgrade::
+
+{zero-trust-full} does not remove the legacy custom SCC `spire-spiffe-csi-driver`. After you upgrade {zero-trust-full} to 1.1.0 from the **OpenShift OperatorHub** catalog, remove it manually once CSI is healthy on the platform SCC.
++
+For more information, see xref:../../security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc#zero-trust-manager-manually-delete-scc_zero-trust-manager-configuration[Manually delete the custom security context constraints].
+
+[id="zero-trust-manager-1-1-0-bug-fixes_{context}"]
+== Fixed issues
+
+Managed route TLS secrets no longer require manual RBAC configuration::
++
+* Before this update, when you configured a managed route with an `externalSecretRef` TLS certificate on the `SpireOIDCDiscoveryProvider` or `SpireServer` custom resource (CR), {zero-trust-full} did not create the `RoleBinding` that grants the OpenShift Ingress router service account permission to read the referenced Secret. As a consequence, route reconciliation failed with a `ManagedRouteUpdateFailed` condition, and you had to manually create `secret-reader`, `Role`, and `RoleBinding` CRs. With this release, {zero-trust-full} automatically reconciles the required `Role` and `RoleBinding` CRs so that the router service account can access the Secrets referenced by the `externalSecretRef` TLS certificate. Managed routes that use externally provided TLS certificates now reconcile without additional manual RBAC steps.
++
+(link:https://issues.redhat.com/browse/SPIRE-164[SPIRE-164])
+
+Pre-existing operand resources are no longer overwritten at installation::
++
+* Before this update, when you installed {zero-trust-full} on a cluster that already contained Kubernetes resources with the same names as operand objects, {zero-trust-full} reconciled and overwrote those resources during the initial installation without reporting a conflict. As a consequence, manually created or third-party resources could be modified unexpectedly before you had a chance to resolve naming collisions. With this release, {zero-trust-full} checks the `app.kubernetes.io/managed-by` label before updating any existing resource during installation. If a matching resource is not managed by {zero-trust-full}, {zero-trust-full} sets a `ResourceConflict` status condition and stops reconciliation instead of overwriting the resource.
++
+(link:https://issues.redhat.com/browse/SPIRE-340[SPIRE-340])
+
+Unmanaged cluster resources are protected during reconciliation::
++
+* Before this update, after {zero-trust-full} was already running, operand controllers could still update Kubernetes resources with matching names even when those resources were not owned by {zero-trust-full}. This could occur when a name collision appeared later or when the `app.kubernetes.io/managed-by: zero-trust-workload-identity-manager` label was removed from a resource that {zero-trust-full} had previously managed. With this release, each operand controller verifies the `managed-by` label on every reconcile cycle before applying updates. When the label is absent, {zero-trust-full} sets a `ResourceConflict` status condition on the custom resource and skips the update to the conflicting object. Operand updates proceed only for resources that {zero-trust-full} currently manages.
++
+(link:https://issues.redhat.com/browse/SPIRE-344[SPIRE-344])
+
+Duplicate health check port names resolved in SPIRE Server StatefulSet::
++
+* Before this update, the `spire-server` and `spire-controller-manager` containers in the SPIRE Server `StatefulSet` field both declared a port named `healthz` on different container ports. Kubernetes treated this as a duplicate port name within the pod, issued a warning, and the services or probes that selected the ports by name could target the wrong container. With this release, {zero-trust-full} assigns unique port names, such as `server-healthz` and `ctrlmgr-healthz`, and updates the liveness and readiness probes to reference those names. Health checks and monitoring configurations now resolve to the intended container.
++
+(link:https://issues.redhat.com/browse/SPIRE-353[SPIRE-353])
+
+Create-only mode disabled status now updates on the main custom resource::
++
+* Before this update, after you disabled create-only mode by setting `CREATE_ONLY_MODE` to `false` in the Operator subscription, the `CreateOnlyMode` condition on the main `ZeroTrustWorkloadIdentityManager` CR could remain `True` with the reason `CreateOnlyModeEnabled`. Because {zero-trust-full} set that condition from operand status instead of from the `CREATE_ONLY_MODE` environment variable in the subscription, the main CR status did not reflect that create-only mode was disabled even though the operand reconciliation had resumed. With this release, {zero-trust-full} sets the `CreateOnlyMode` condition on the main CR directly from the `CREATE_ONLY_MODE` environment variable and updates it to `False` with reason `CreateOnlyModeDisabled` when create-only mode is turned off.
++
+(link:https://issues.redhat.com/browse/SPIRE-365[SPIRE-365])
+
+
+Create-only mode status updates reconcile reliably::
++
+* Before this update, {zero-trust-full} controllers wrote the custom resource (CR) status twice during each reconciliation cycle. The CR status was written at the start through the `SetInitialReconciliationStatus` cycle and again at the end through the status manager. Because the informer cache could return a stale `ResourceVersion` after the first write, the deferred status update was rejected with `HTTP 409 Conflict`. Status conditions, including `CreateOnlyMode`, could fail to transition to the expected state even after you changed configuration in the Operator subscription. With this release, controllers apply the status in a single update at the end of reconciliation, and status update retry logic now complies with the `RetryOnConflict` contract. CR status updates, including create-only mode transitions, are now completed.
++
+(link:https://issues.redhat.com/browse/SPIRE-506[SPIRE-506])

--- a/modules/zero-trust-manager-spiffe-helper-about.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-spiffe-helper-about_{context}"]
+= SPIFFE Helper container image
+
+[role="_abstract"]
+Use SPIFFE Helper with the {zero-trust-full} when your application cannot call the workload API directly but can read TLS certificates from a shared volume.
+
+SPIFFE Helper is a utility that connects to the SPIFFE Workload API, fetches identity credentials, writes them to files on disk, and optionally notifies a workload when X.509 material is renewed.
+
+The {zero-trust-full} provides a supported SPIFFE Helper container image based on the upstream SPIFFE Helper. The configuration file format, command-line flags, and workload API behavior are compatible with upstream.
+
+SPIFFE Helper performs the following tasks:
+
+. Connects to the SPIFFE Workload API, usually through the {spire-full} Agent socket exposed by the SPIFFE CSI driver.
+. Fetches X.509 {svid-full}s, JSON Web Token (JWT) SVIDs, and JWT bundles from {spire-full}.
+. Writes credentials to files under a configured directory such as `cert_dir`.
+. Optionally notifies a workload when X.509 authentication credentials are renewed in daemon mode.

--- a/modules/zero-trust-manager-spiffe-helper-architecture.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-architecture.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-spiffe-helper-architecture_{context}"]
+= SPIFFE Helper architecture
+
+[role="_abstract"]
+The SPIFFE Helper working pattern demonstrates how to apply the same certificate and identity flow to your own workloads.
+
+The SPIFFE Helper architecture deploys PostgreSQL with mTLS across two namespaces, with SPIFFE Helper provisioning and renewing certificates, `ClusterSPIFFEID` defining identities, and the SPIFFE CSI driver connecting to the SPIFFE Workload API. Understanding this pattern helps you apply the same certificate and identity flow to your own workloads.
+
+
+* *`postgresql-spiffe`* -- PostgreSQL server. SPIFFE Helper runs as an init container (non-daemon mode) to write initial certificates to a shared volume, then as a sidecar (daemon mode) to renew them. PostgreSQL reads TLS files from that volume and `pg_hba.conf` requires certificate authentication for remote connections.
+* *`postgresql-spiffe-client`* -- Client pod with the stock SPIFFE Helper sidecar. The client uses SPIFFE-issued certificates from the same shared volume pattern when connecting with `psql`.
+
+Each namespace defines a `ClusterSPIFFEID` so {spire-full} issues X.509 {svid-full}s with the correct DNS names: the server identity includes `postgresql-spiffe.postgresql-spiffe.svc`; the client identity includes `postgresql_spiffe`, which must match the PostgreSQL user created during database initialization.
+
+SPIFFE Helper connects to the SPIFFE Workload API through the SPIFFE CSI driver, which mounts the agent socket at `/spiffe-workload-api/spire-agent.sock`.

--- a/modules/zero-trust-manager-spiffe-helper-credential-types.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-credential-types.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-spiffe-helper-credential-types_{context}"]
+= SPIFFE Helper credential types
+
+[role="_abstract"]
+SPIFFE Helper supports X.509 {svid-full}, JSON Web Token (JWT) bundle, and JWT SVID outputs configured in the SPIFFE Helper configuration file and written under `cert_dir` for workloads that cannot use the workload API directly.
+
+At least one complete set must be specified:
+
+* *X.509 SVID* -- Requires `svid_file_name`, `svid_key_file_name`, and `svid_bundle_file_name`. SPIFFE Helper writes Privacy-Enhanced Mail (PEM) certificate, PEM private key, and PEM trust bundle files under `cert_dir`.
+
+* *JWT bundle* -- Requires `jwt_bundle_file_name`. SPIFFE Helper writes a JSON bundle file.
+
+* *JWT SVIDs* -- Requires one or more `jwt_svids` blocks with `jwt_audience`, `jwt_svid_file_name`, and related settings. SPIFFE Helper writes base64-encoded token files.
+
+The `cert_dir` directory must exist before SPIFFE Helper starts.
+
+The following `helper.conf` excerpt configures X.509 SVID output for a PostgreSQL server:
+
+[source,terminal]
+----
+agent_address = "/spiffe-workload-api/spire-agent.sock"
+cert_dir = "/opt/postgresql-certs"
+svid_file_name = "svid.pem"
+svid_key_file_name = "svid.key"
+svid_bundle_file_name = "svid_bundle.pem"
+----
+
+The following `helper.conf` excerpt configures JWT SVID output:
+
+[source,terminal]
+----
+agent_address = "/spiffe-workload-api/spire-agent.sock"
+cert_dir = "/opt/jwt-certs"
+jwt_svids = [{
+  jwt_audience = "your-audience"
+  jwt_svid_file_name = "jwt_svid.token"
+}]
+----
+
+For JWT bundle output, set `jwt_bundle_file_name` instead of the X.509 or JWT SVID file names.

--- a/modules/zero-trust-manager-spiffe-helper-modes.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-modes.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-spiffe-helper-modes_{context}"]
+= SPIFFE Helper modes
+
+[role="_abstract"]
+SPIFFE Helper fetches credentials from the SPIFFE Workload API and writes them to disk for workloads that cannot call the API directly. On {product-title}, a pod typically uses non-daemon mode in an init container for initial certificates and daemon mode in a sidecar to rotate them before expiring.
+
+SPIFFE Helper runs in one of two modes:
+
+* *Non-daemon mode* (`-daemon-mode=false` or `daemon_mode = false`): Fetches credentials once, writes files, and exits. Use this mode in an init container to bootstrap TLS before the main application starts. In this mode, `cmd` and `renew_signal` are ignored.
+
+* *Daemon mode* (default): Stays running until the pod is terminated or an unrecoverable error occurs. Watches the Workload API and renews credentials before they expire. Supports `cmd`, `pid_file_name`, `renew_signal`, and optional HTTP health checks. SPIFFE Helper does not background itself like a traditional Unix daemon.
+
+On {product-title}, a typical pod uses both modes:
+
+* An init container runs SPIFFE Helper in non-daemon mode to populate a shared `emptyDir` volume with initial TLS material.
+
+* A sidecar container runs SPIFFE Helper in daemon mode to rotate certificates before they expire.
+
+* The main application container mounts the shared certificate directory and uses the files for TLS.
+
+The SPIFFE workload API is exposed through the SPIFFE container storage interface (CSI), which mounts the Workload API socket into the pod at a path such as `/spiffe-workload-api/spire-agent.sock`.
+
+The following deployment excerpt shows the init container and sidecar pattern on {product-title}:
+
+[source,yaml]
+----
+initContainers:
+- name: spiffe-helper-init
+  image: registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+  args:
+  - '-config'
+  - /etc/spiffe-helper/helper.conf
+  - '-daemon-mode=false'
+  volumeMounts:
+  - name: spiffe-workload-api
+    readOnly: true
+    mountPath: /spiffe-workload-api
+  - name: postgresql-certs
+    mountPath: /opt/postgresql-certs
+  - name: spiffe-helper
+    mountPath: /etc/spiffe-helper
+containers:
+- name: spiffe-helper
+  image: registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+  args:
+  - '-config'
+  - /etc/spiffe-helper/helper.conf
+  volumeMounts:
+  - name: spiffe-workload-api
+    readOnly: true
+    mountPath: /spiffe-workload-api
+  - name: postgresql-certs
+    mountPath: /opt/postgresql-certs
+  - name: spiffe-helper
+    mountPath: /etc/spiffe-helper
+volumes:
+- name: spiffe-workload-api
+  csi:
+    driver: csi.spiffe.io
+    readOnly: true
+- name: postgresql-certs
+  emptyDir:
+    medium: Memory
+- name: spiffe-helper
+  configMap:
+    name: spiffe-helper
+----
+
+Replace `<version>` with the tag that matches your {zero-trust-full} installation.

--- a/modules/zero-trust-manager-spiffe-helper-reference.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-reference.adoc
@@ -1,0 +1,210 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-spiffe-helper-reference_{context}"]
+= SPIFFE Helper image reference
+
+[role="_abstract"]
+Reference information for the SPIFFE Helper container image included with the {zero-trust-full}, including image location, command-line flags, configuration options, and volume requirements.
+
+[id="zero-trust-manager-spiffe-helper-image-location_{context}"]
+== Image location
+
+The {zero-trust-full} provides a SPIFFE Helper image at the following location:
+
+[source,text]
+----
+registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+----
+
+Replace `<version>` with the tag that matches your {zero-trust-full} installation. Some workloads require additional tools in the helper image.
+
+[id="zero-trust-manager-spiffe-helper-cli-flags_{context}"]
+== Command-line flags
+
+[cols="1,2", options="header"]
+|===
+|Flag |Description
+
+|`-config <path>`
+|Path to the SPIFFE Helper configuration file. Required.
+
+|`-daemon-mode <boolean>`
+|Controls operating mode. `true` (default) runs continuously and renews credentials. `false` fetches once and exits.
+
+|`-version`
+|Prints version information and exits.
+|===
+
+.Examples of command-line flags
+[source,terminal]
+----
+$ spiffe-helper -config /etc/spiffe-helper/helper.conf
+$ spiffe-helper -config /etc/spiffe-helper/helper.conf -daemon-mode=false
+----
+
+[id="zero-trust-manager-spiffe-helper-config-file-options_{context}"]
+== Configuration file options
+
+SPIFFE Helper reads a configuration file. The following table describes the most common options for X.509 workloads on {product-title}.
+
+[cols="1,2", options="header"]
+|===
+|Option |Description
+
+|`agent_address`
+|Path to the {spire-full} Agent Workload API socket. On Linux, SPIFFE Helper connects with `unix://<path>`. With the SPIFFE CSI driver, use `/spiffe-workload-api/spire-agent.sock`. You can also set the `SPIFFE_ENDPOINT_SOCKET` environment variable.
+
+|`cert_dir`
+|Directory where SPIFFE Helper writes credential files. The directory must exist before SPIFFE Helper starts.
+
+|`daemon_mode`
+|When `true` (default), runs continuously. When `false`, fetches once and exits. Can also be controlled with the `-daemon-mode` flag.
+
+|`svid_file_name`, `svid_key_file_name`, `svid_bundle_file_name`
+|File names for the X.509 SVID certificate, private key, and trust bundle. All three are required to enable X.509 output.
+
+|`jwt_bundle_file_name`
+|File name for a JWT bundle JSON file.
+
+|`jwt_svids`
+|Block defining JWT SVID audiences and output file names.
+
+|`cmd`
+|Executable path for the managed-child pattern. On the first successful X.509 write, SPIFFE Helper starts this process. Ignored in non-daemon mode.
+
+|`cmd_args`
+|Space-separated arguments for `cmd`. Use quoted strings for arguments that contain spaces. Not parsed by a shell unless you start a shell explicitly, for example `/bin/sh -c "..."`.
+
+|`pid_file_name`
+|Path to a file containing one integer PID for the external-process pattern. Requires `renew_signal`. Invalid in non-daemon mode.
+
+|`renew_signal`
+|POSIX signal name sent on renewal, for example `SIGUSR1` or `SIGHUP`. Required when `pid_file_name` is set. Optional with `cmd`; when empty and `cmd` is set, later renewals do not signal the child.
+
+|`health_checks`
+|Optional HTTP liveness and readiness endpoints. Available in daemon mode only.
+|===
+
+[id="zero-trust-manager-spiffe-helper-vol-mount-reqs_{context}"]
+== Volume and mount requirements
+
+When deploying SPIFFE Helper on {product-title}, mount the following resources:
+
+[cols="1,2,1", options="header"]
+|===
+|Volume |Mount path |Access
+
+|SPIFFE Workload API (CSI)
+|`/spiffe-workload-api` (or path matching `agent_address`)
+|Read-only
+
+|SPIFFE Helper configuration (`ConfigMap`)
+|Path passed to `-config`, for example `/etc/spiffe-helper/helper.conf`
+|Read-only
+
+|Certificate directory (`emptyDir` or persistent volume)
+|Path matching `cert_dir`, for example `/opt/postgresql-certs` or `/certs`
+|Read/write for the helper; read-only for the application container when possible
+|===
+
+.CSI volume example
+[source,yaml]
+----
+apiVersion: apps/v1
+metadata:
+  name: postgresql-spiffe-client
+  namespace: postgresql-spiffe-client
+  labels:
+    app: postgresql-spiffe-client
+# ...
+volumes:
+- name: spiffe-workload-api
+  csi:
+    driver: csi.spiffe.io
+    readOnly: true
+----
+
+.Init and sidecar container example
+[source,yaml]
+----
+apiVersion: apps/v1
+metadata:
+  name: postgresql-spiffe
+  namespace: postgresql-spiffe
+  labels:
+    app: postgresql-spiffe
+# ...
+initContainers:
+- name: spiffe-helper-init
+  image: registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+  args:
+  - '-config'
+  - /etc/spiffe-helper/helper.conf
+  - '-daemon-mode=false'
+  volumeMounts:
+  - name: spiffe-workload-api
+    readOnly: true
+    mountPath: /spiffe-workload-api
+  - name: postgresql-certs
+    mountPath: /opt/postgresql-certs
+  - name: spiffe-helper
+    mountPath: /etc/spiffe-helper
+containers:
+- name: spiffe-helper
+  image: registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>
+  args:
+  - '-config'
+  - /etc/spiffe-helper/helper.conf
+  volumeMounts:
+  - name: spiffe-workload-api
+    readOnly: true
+    mountPath: /spiffe-workload-api
+  - name: postgresql-certs
+    mountPath: /opt/postgresql-certs
+  - name: spiffe-helper
+    mountPath: /etc/spiffe-helper
+----
+
+.SPIFFE Helper configuration example
+[source,text]
+----
+agent_address = "/spiffe-workload-api/spire-agent.sock"
+cert_dir = "/opt/postgresql-certs"
+svid_file_name = "svid.pem"
+svid_key_file_name = "svid.key"
+svid_bundle_file_name = "svid_bundle.pem"
+cmd = "/usr/bin/psql"
+cmd_args = "-U postgres -h 127.0.0.1 -c \"SELECT pg_reload_conf();\""
+renew_signal = ""
+----
+
+Replace `<version>` with the tag that matches your {zero-trust-full} installation.
+
+[id="zero-trust-manager-spiffe-helper-quick-reference_{context}"]
+== Quick reference
+
+[cols="1,2", options="header"]
+|===
+|Question |Answer
+
+|What happens if both `cmd` and `pid_file_name` are set?
+|SPIFFE Helper writes files, then runs managed-child logic, then PID-file logic. There is no priority between them.
+
+|Is `renew_signal` required for `pid_file_name`?
+|Yes. Validation fails if `pid_file_name` is set without `renew_signal`.
+
+|Does SPIFFE Helper watch files for the application?
+|No. The application watches disk, polls, reads at connection time, or handles signals.
+
+|What happens in non-daemon mode?
+|SPIFFE Helper fetches once, writes files, and exits. No watching, `cmd`, or signals.
+
+|What triggers workload notification?
+|Only X.509 updates in daemon mode. JWT-only refreshes write files only.
+
+|Can SPIFFE Helper signal another container in the same pod?
+|Not by default. Containers use separate process namespaces unless `shareProcessNamespace: true` is set.
+|===

--- a/modules/zero-trust-manager-spiffe-helper-troubleshooting.adoc
+++ b/modules/zero-trust-manager-spiffe-helper-troubleshooting.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-spiffe-helper-troubleshooting_{context}"]
+= Troubleshooting SPIFFE Helper deployments
+
+[role="_abstract"]
+Resolve common issues when deploying the SPIFFE Helper image with {zero-trust-full}, and use the diagnostic `oc` commands to verify readiness, sidecars, and on-disk SVID certificates.
+
+[id="zero-trust-manager-spiffe-helper-common-issues_{context}"]
+== Common issues
+
+Certificate output directory is empty::
+SPIFFE Helper cannot reach the Workload API, cannot write to `cert_dir`, or the workload is not registered with {spire-full}. Confirm the `ZeroTrustWorkloadIdentityManager` custom resource reports `Ready`, the CSI volume is mounted at the path in `agent_address`, and a matching `ClusterSPIFFEID` exists for the pod namespace and labels. Verify `cert_dir` exists before SPIFFE Helper starts; an `emptyDir` volume satisfies this requirement.
+
+Init container exits but TLS files are missing::
+The init container must run with `-daemon-mode=false`. Check init container logs. If SPIFFE Helper reports configuration warnings about ignored `cmd` or `renew_signal`, that is expected in non-daemon mode. Ensure the certificate volume is shared with the main application container.
+
+Sidecar runs but certificates are not renewed::
+Confirm the sidecar container does not set `-daemon-mode=false`. Check sidecar logs for Workload API or write errors. If writes fail, SPIFFE Helper logs the error and does not run `cmd` or PID-file notification logic.
+
+Application does not pick up renewed certificates::
+SPIFFE Helper overwrites files in `cert_dir`; it does not notify your application unless you configure `cmd`, `pid_file_name`, or the application watches or polls the directory. For sidecar deployments with empty `cmd`, the application must reload TLS from disk. For PostgreSQL, configure the managed-child pattern with `psql` and `pg_reload_conf()` in the server sidecar.
+
+`cmd` or `renew_signal` appears to have no effect::
+In non-daemon mode, SPIFFE Helper ignores `cmd` and `renew_signal`. In daemon mode, `cmd` and PID-file logic run only after a successful X.509 write. JWT bundle or JWT SVID updates do not trigger them. If `renew_signal` is empty while `cmd` is set, the child starts on first write but later renewals send no signal.
+
+Cannot signal the application container from the helper sidecar::
+Containers in the same pod use separate process namespaces by default. `pid_file_name` and `cmd` cannot signal another container unless you set `shareProcessNamespace: true` or run the reload command as a child of SPIFFE Helper. The PostgreSQL example uses `cmd` to run `psql` locally instead of signaling the database container.
+
+Configuration validation fails for `pid_file_name`::
+`renew_signal` is required when `pid_file_name` is set. `pid_file_name` is not valid in non-daemon mode.
+
+Workload API socket is not accessible::
+Verify the CSI volume is mounted and the socket path matches `agent_address`, typically `/spiffe-workload-api/spire-agent.sock`. Confirm the {zero-trust-full} operands are running and the pod service account matches the `ClusterSPIFFEID` selectors.
+
+Permission denied when reading certificate files::
+Check file ownership and permissions on the shared volume. Consider setting `fsGroup` in the pod `securityContext` so the application container can read files written by SPIFFE Helper. Mount the certificate directory read-only in the application container when possible.
+
+Image pull errors for the SPIFFE Helper image::
+Confirm your cluster can pull `registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:<version>`. If you use a custom image, verify the registry credentials and image reference in the deployment manifest.
+
+PostgreSQL mTLS connection fails after deployment::
+Confirm SPIFFE Helper wrote files to `/opt/postgresql-certs`, the client certificate CN matches the PostgreSQL user, and `pg_hba.conf` requires certificate authentication. Compare server and client SVIDs with `openssl x509 -noout -text`.
+
+[id="zero-trust-manager-spiffe-helper-diagnostic-commands_{context}"]
+Use the following `oc` commands when investigating SPIFFE Helper deployments and workloads such as PostgreSQL.
+
+[id="zero-trust-manager-spiffe-helper-verify-readiness_{context}"]
+== Verify {zero-trust-full} readiness
+
+[source,terminal]
+----
+$ oc get ZeroTrustWorkloadIdentityManager cluster \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+----
+
+[source,terminal]
+----
+$ oc get clusterspiffeid
+----
+
+[id="zero-trust-manager-spiffe-helper-inspect-pods_{context}"]
+== Inspect SPIFFE Helper pods
+
+[source,terminal]
+----
+$ oc get pods -n postgresql-spiffe
+----
+
+[source,terminal]
+----
+$ oc get pods -n postgresql-spiffe-client
+----
+
+[id="zero-trust-manager-spiffe-helper-review-logs_{context}"]
+== Review SPIFFE Helper logs
+
+[source,terminal]
+----
+$ oc logs -n postgresql-spiffe deployment/postgresql-spiffe -c spiffe-helper-init
+----
+
+[source,terminal]
+----
+$ oc logs -n postgresql-spiffe deployment/postgresql-spiffe -c spiffe-helper
+----
+
+[source,terminal]
+----
+$ oc logs -n postgresql-spiffe-client deployment/postgresql-spiffe-client -c spiffe-helper
+----
+
+[id="zero-trust-manager-spiffe-helper-verify-svid-certificates_{context}"]
+== Verify on-disk SVID certificates
+
+[source,terminal]
+----
+$ oc rsh -n postgresql-spiffe deployment/postgresql-spiffe -c postgresql-spiffe \
+  -- ls -la /opt/postgresql-certs
+----
+
+[source,terminal]
+----
+$ oc rsh -n postgresql-spiffe deployment/postgresql-spiffe -c postgresql-spiffe -- \
+  cat /opt/postgresql-certs/svid.pem | openssl x509 -noout -dates -subject
+----

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -38,8 +38,10 @@ include::modules/zero-trust-manager-spiffe-csidriver-config.adoc[leveloffset=+1]
 // Deploying and configuring OIDC Discovery Provider
 include::modules/zero-trust-manager-oidc-config.adoc[leveloffset=+1]
 
-
 // Deploying and configuring OIDC Discovery Provider
 include::modules/zero-trust-manager-verify-operands.adoc[leveloffset=+1]
+
+// Deploying and configuring OIDC Discovery Provider
+include::modules/zero-trust-manager-manually-delete-scc.adoc[leveloffset=+1]
 
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-mesh-integration_{context}"]
+= Integrating Red Hat OpenShift Service Mesh with Zero Trust Workload Identity Manager in a single-cluster
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-mesh-integration
+
+toc::[]
+
+[role="_abstract"]
+Deploy and configure {spire-full} as the certificate authority (CA) for {SMProductName} workloads, replacing the Istio built-in CA with SPIFFE-compliant identities and automatically rotated short-lived certificates.
+
+// About SPIRE and Service Mesh integration
+include::modules/zero-trust-manager-about-spire-integration.adoc[leveloffset=+1]
+
+// About service mesh architecture
+include::modules/zero-trust-manager-mesh-architecture.adoc[leveloffset=+1]
+
+// Deploy service mesh and spire
+include::modules/zero-trust-manager-deploy-spire.adoc[leveloffset=+1]
+
+// Deploy istio
+include::modules/zero-trust-manager-deploy-istio.adoc[leveloffset=+1]
+
+[id="additional-resources-service-mesh-zero-trust_{context}"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.3/html-single/about/index[About OpenShift Service Mesh]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.3/html-single/installing/index#ossm-supported-platforms-configurations[Installing OpenShift Service Mesh]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
@@ -11,6 +11,9 @@ The {zero-trust-full} leverages Secure Production Identity Framework for Everyon
 
 These release notes track the development of {zero-trust-full}.
 
+// RNs 1.1.0
+include::modules/zero-trust-manager-release-notes-1-1-0.adoc[leveloffset=+1]
+
 // RNs 1.0.1
 include::modules/zero-trust-manager-release-notes-1-0-1.adoc[leveloffset=+1]
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-spiffe-helper"]
+= Using the SPIFFE Helper container image
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-spiffe-helper
+
+toc::[]
+
+[role="_abstract"]
+SPIFFE Helper writes Transport Layer Security (TLS) certificates to disk for applications that cannot use the SPIFFE Workload API. Use it to eliminate manual certificate management and reduce the risk of expired certificates.
+
+// about spiffe helper
+include::modules/zero-trust-manager-spiffe-helper-about.adoc[leveloffset=+1]
+
+// spiffe helper modes
+include::modules/zero-trust-manager-spiffe-helper-modes.adoc[leveloffset=+1]
+
+// spiffe helper credential types
+include::modules/zero-trust-manager-spiffe-helper-credential-types.adoc[leveloffset=+1]
+
+// deploy spiffe helper
+include::modules/zero-trust-manager-deploy-spiffe-helper.adoc[leveloffset=+1]
+
+// spiffe helper reference
+include::modules/zero-trust-manager-spiffe-helper-reference.adoc[leveloffset=+1]
+
+// troubleshooting spiffe helper
+include::modules/zero-trust-manager-spiffe-helper-troubleshooting.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20665

Link to docs preview:
https://115289--ocpdocs-pr.netlify.app/
https://115289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.html
https://115289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration.html
https://115289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.html
https://115289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.html

QE review:
- [x] QE has approved this change.


Additional information:
Merge review: These files are just a copy and paste from the 4.21 documents that have already been approved by QE and have been merged reviewed. Just should be a small review.

The files that were added are based on the following PRs that were already QE/merge reviewed

https://github.com/openshift/openshift-docs/pull/112997
https://github.com/openshift/openshift-docs/pull/109990
https://github.com/openshift/openshift-docs/pull/110184

