### PR TITLE
OSDOCS CQA AUTH-4 Service Accounts and Cloud Credential Operator IV

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -6,89 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Cloud Credential Operator (CCO) manages cloud provider credentials as  custom resource definitions (CRDs). The CCO syncs on `CredentialsRequest` custom resources (CRs) to allow {product-title} components to request cloud provider credentials with the specific permissions that are required for the cluster to run.
+[role="_abstract"]
+To allow {product-title} components to request cloud provider credentials with the specific permissions that are required for the cluster to run, you can use the Cloud Credential Operator (CCO) to manage cloud provider credentials as custom resource definitions (CRDs). 
 
-By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in several different modes. If no mode is specified, or the `credentialsMode` parameter is set to an empty string (`""`), the CCO operates in its default mode.
+You can configure the Cloud Credential Operator (CCO) to operate in several different modes. These options provide transparency and flexibility in how the CCO uses cloud credentials.
 
-[id="about-cloud-credential-operator-modes_{context}"]
-== Modes
+include::modules/cco-mode-about.adoc[leveloffset=+1]
 
-By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in _mint_, _passthrough_, or _manual_ mode. These options provide transparency and flexibility in how the CCO uses cloud credentials to process `CredentialsRequest` CRs in the cluster, and allow the CCO to be configured to suit the security requirements of your organization. Not all CCO modes are supported for all cloud providers.
-
-* **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#cco-mode-mint[Mint]**: In mint mode, the CCO uses the provided admin-level cloud credential to create new credentials for components in the cluster with only the specific permissions that are required.
-
-* **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#cco-mode-passthrough[Passthrough]**: In passthrough mode, the CCO passes the provided cloud credential to the components that request cloud credentials.
-
-* **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual mode with long-term credentials for components]**: In manual mode, you can manage long-term cloud credentials instead of the CCO.
-
-* **xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components]**: For some providers, you can use the CCO utility (`ccoctl`) during installation to implement short-term credentials for individual components. These credentials are created and managed outside the {product-title} cluster.
-
-.CCO mode support matrix
-[cols="<.^2,^.^1,^.^1,^.^1,^.^1"]
-|====
-|Cloud provider |Mint |Passthrough |Manual with long-term credentials |Manual with short-term credentials
-
-|Amazon Web Services (AWS)
-|X
-|X
-|X
-|X
-
-|Global Microsoft Azure
-|
-|X
-|X
-|X
-
-|Microsoft Azure Stack Hub
-|
-|
-|X
-|
-
-|{gcp-first}
-|X
-|X
-|X
-|X
-
-|{ibm-cloud-name}
-|
-|
-|X ^[1]^
-|
-
-|Nutanix
-|
-|
-|X ^[1]^
-|
-
-|{rh-openstack-first}
-|
-|X
-|
-|
-
-|VMware vSphere
-|
-|X
-|
-|
-
-|====
-[.small]
---
-1. This platform uses the `ccoctl` utility during installation to configure long-term credentials.
---
-
-[id="cco-determine-mode_{context}"]
-== Determining the Cloud Credential Operator mode
-
-For platforms that support using the CCO in multiple modes, you can determine what mode the CCO is configured to use by using the web console or the CLI.
-
-.Determining the CCO configuration
-image::334_OpenShift_cluster_updating_and_CCO_workflows_0923_4.11_A_AliCloud_patch.png[Decision tree showing how to determine the configured CCO credentials mode for your cluster.]
+include::modules/cco-determine-mode.adoc[leveloffset=+1]
 
 //Determining the Cloud Credential Operator mode by using the web console
 include::modules/cco-determine-mode-gui.adoc[leveloffset=+2]
@@ -96,20 +21,14 @@ include::modules/cco-determine-mode-gui.adoc[leveloffset=+2]
 //Determining the Cloud Credential Operator mode by using the CLI
 include::modules/cco-determine-mode-cli.adoc[leveloffset=+2]
 
-[id="about-cloud-credential-operator-default_{context}"]
-== Default behavior
-For platforms on which multiple modes are supported (AWS, Azure, and {gcp-short}), when the CCO operates in its default mode, it checks the provided credentials dynamically to determine for which mode they are sufficient to process `CredentialsRequest` CRs.
-
-By default, the CCO determines whether the credentials are sufficient for mint mode, which is the preferred mode of operation, and uses those credentials to create appropriate credentials for components in the cluster. If the credentials are not sufficient for mint mode, it determines whether they are sufficient for passthrough mode. If the credentials are not sufficient for passthrough mode, the CCO cannot adequately process `CredentialsRequest` CRs.
-
-If the provided credentials are determined to be insufficient during installation, the installation fails. For AWS, the installation program fails early in the process and indicates which required permissions are missing. Other providers might not provide specific information about the cause of the error until errors are encountered.
-
-If the credentials are changed after a successful installation and the CCO determines that the new credentials are insufficient, the CCO puts conditions on any new `CredentialsRequest` CRs to indicate that it cannot process them because of the insufficient credentials.
-
-To resolve insufficient credentials issues, provide a credential with sufficient permissions. If an error occurred during installation, try installing again. For issues with new `CredentialsRequest` CRs, wait for the CCO to try to process the CR again. As an alternative, you can configure your cluster to use a different CCO mode that is supported for your cloud provider.
+include::modules/cco-about-default-behaviors.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_about-cloud-credential-operator_{context}"]
 == Additional resources
 
 * xref:../../operators/operator-reference.adoc#cloud-credential-operator_operator-reference[Cluster Operators reference page for the Cloud Credential Operator]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#cco-mode-mint[About the Cloud Credential Operator in mint mode]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#cco-mode-passthrough[About the Cloud Credential Operator in passthrough mode]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[About the Cloud Credential Operator in manual mode with long-term credentials for components]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[About the Cloud Credential Operator in manual mode with short-term credentials for components]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
@@ -6,82 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Passthrough mode is supported for Amazon Web Services (AWS), Microsoft Azure, {gcp-first}, {rh-openstack-first}, and VMware vSphere.
+[role="_abstract"]
+To allow the Cloud Credential Operator (CCO) to pass cloud credentials to the components that request them, you can configure the Cloud Credential Operator (CCO) to operate in passthrough mode.
 
-In passthrough mode, the Cloud Credential Operator (CCO) passes the provided cloud credential to the components that request cloud credentials. The credential must have permissions to perform the installation and complete the operations that are required by components in the cluster, but does not need to be able to create new credentials. The CCO does not attempt to create additional limited-scoped credentials in passthrough mode.
+The credential must have permissions to perform the installation and complete the operations that are required by components in the cluster, but does not need to be able to create new credentials. The CCO does not attempt to create additional limited-scoped credentials in passthrough mode.
+
+Passthrough mode is supported for {aws-first}, {azure-first}, {gcp-first}, {rh-openstack-first}, and {vmw-first}.
 
 [NOTE]
 ====
-xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual mode] is the only supported CCO configuration for Microsoft Azure Stack Hub.
+Manual mode is the only supported CCO configuration for Microsoft Azure Stack Hub.
 ====
 
-[id="passthrough-mode-permissions"]
-== Passthrough mode permissions requirements
-When using the CCO in passthrough mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials the CCO passes to a component that creates a `CredentialsRequest` CR are not sufficient, that component will report an error when it tries to call an API that it does not have permissions for.
-
-[id="passthrough-mode-permissions-aws"]
-=== Amazon Web Services (AWS) permissions
-The credential you provide for passthrough mode in AWS must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
-
-To locate the `CredentialsRequest` CRs that are required, see xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials for AWS].
-
-[id="passthrough-mode-permissions-azure"]
-=== Microsoft Azure permissions
-The credential you provide for passthrough mode in Azure must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
-
-To locate the `CredentialsRequest` CRs that are required, see xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#manually-create-iam_installing-azure-customizations[Manually creating long-term credentials for Azure].
-
-[id="passthrough-mode-permissions-gcp"]
-=== {gcp-first} permissions
-The credential you provide for passthrough mode in {gcp-short} must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
-
-To locate the `CredentialsRequest` CRs that are required, see xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}].
-
-[id="passthrough-mode-permissions-rhosp"]
-=== {rh-openstack-first} permissions
-To install an {product-title} cluster on {rh-openstack}, the CCO requires a credential with the permissions of a `member` user role.
-
-[id="passthrough-mode-permissions-vsware"]
-=== VMware vSphere permissions
-To install an {product-title} cluster on VMware vSphere, the CCO requires a credential with the following vSphere privileges:
-
-.Required vSphere privileges
-[cols="1,2"]
-|====
-|Category |Privileges
-
-|Datastore
-|_Allocate space_
-
-|Folder
-|_Create folder_, _Delete folder_
-
-|vSphere Tagging
-|All privileges
-
-|Network
-|_Assign network_
-
-|Resource
-|_Assign virtual machine to resource pool_
-
-|Profile-driven storage
-|All privileges
-
-|vApp
-|All privileges
-
-|Virtual machine
-|All privileges
-
-|====
+//Passthrough mode permissions requirements
+include::modules/cco-passthrough-mode-permissions.adoc[leveloffset=+1]
 
 //Admin credentials root secret format
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
-
-[id="passthrough-mode-maintenance"]
-== Passthrough mode credential maintenance
-If `CredentialsRequest` CRs change over time as the cluster is upgraded, you must manually update the passthrough mode credential to meet the requirements. To avoid credentials issues during an upgrade, check the `CredentialsRequest` CRs in the release image for the new version of {product-title} before upgrading. To locate the `CredentialsRequest` CRs that are required for your cloud provider, see _Manually creating long-term credentials_ for xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[AWS], xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#manually-create-iam_installing-azure-customizations[Azure], or xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[{gcp-short}].
 
 //Rotating cloud provider credentials manually
 include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
@@ -90,15 +31,11 @@ include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc[vSphere CSI Driver Operator]
 
-[id="passthrough-mode-reduce-permissions"]
-== Reducing permissions after installation
-When using passthrough mode, each component has the same permissions used by all other components. If you do not reduce the permissions after installing, all components have the broad permissions that are required to run the installer.
-
-After installation, you can reduce the permissions on your credential to only those that are required to run the cluster, as defined by the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are using.
-
-To locate the `CredentialsRequest` CRs that are required for AWS, Azure, or {gcp-short} and learn how to change the permissions the CCO uses, see _Manually creating long-term credentials_ for xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[AWS], xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#manually-create-iam_installing-azure-customizations[Azure], or xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[{gcp-short}].
+//Reducing permissions after installation
+include::modules/cco-passthrough-mode-permissions-reduce.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials for AWS]

--- a/authentication/understanding-and-creating-service-accounts.adoc
+++ b/authentication/understanding-and-creating-service-accounts.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To control API access without sharing regular user credentials, you can use service accounts.
+
 include::modules/service-accounts-overview.adoc[leveloffset=+1]
 
 include::modules/service-account-auto-secret-removed.adoc[leveloffset=+2]

--- a/modules/cco-about-default-behaviors.adoc
+++ b/modules/cco-about-default-behaviors.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="cco-about-default-behaviors_{context}"]
+= About the Cloud Credential Operator default behavior
+
+[role="_abstract"]
+To better manage cloud credentials, you should familiarize yourself with the default behaviors of the Cloud Credential Operator.
+
+For platforms on which multiple modes are supported (AWS, Azure, and {gcp-short}), when the CCO operates in its default mode, it checks the provided credentials dynamically to determine for which mode they are sufficient to process `CredentialsRequest` CRs.
+
+By default, the CCO determines whether the credentials are sufficient for mint mode, which is the preferred mode of operation, and uses those credentials to create appropriate credentials for components in the cluster. If the credentials are not sufficient for mint mode, it determines whether they are sufficient for passthrough mode. If the credentials are not sufficient for passthrough mode, the CCO cannot adequately process `CredentialsRequest` CRs.
+
+If the provided credentials are determined to be insufficient during installation, the installation fails. For AWS, the installation program fails early in the process and indicates which required permissions are missing. Other providers might not provide specific information about the cause of the error until errors are encountered.
+
+If the credentials are changed after a successful installation and the CCO determines that the new credentials are insufficient, the CCO puts conditions on any new `CredentialsRequest` CRs to indicate that it cannot process them because of the insufficient credentials.
+
+To resolve insufficient credentials issues, provide a credential with sufficient permissions. If an error occurred during installation, try installing again. For issues with new `CredentialsRequest` CRs, wait for the CCO to try to process the CR again. As an alternative, you can configure your cluster to use a different CCO mode that is supported for your cloud provider.
+

--- a/modules/cco-determine-mode-cli.adoc
+++ b/modules/cco-determine-mode-cli.adoc
@@ -16,7 +16,9 @@ endif::[]
 = Determining the Cloud Credential Operator mode by using the CLI
 
 [role="_abstract"]
-Determine the Cloud Credential Operator (CCO) mode by querying the cluster with the CLI. Before you perform upgrades or troubleshoot, ensure you understand your cluster's credential management configuration.
+You can determine what mode the Cloud Credential Operator (CCO) is configured to use by using the CLI.
+
+Before you perform upgrades or troubleshoot, ensure you understand your cluster's credential management configuration.
 
 [NOTE]
 ====
@@ -112,30 +114,6 @@ This command displays the value of the `.spec.serviceAccountIssuer` parameter in
 
 * An empty output indicates that the cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility.
 --
-
-ifdef::update[]
-.Next steps
-
-* If you are updating a cluster that has the CCO operating in mint or passthrough mode and the root secret is present, you do not need to update any cloud provider resources and can continue to the next part of the update process.
-
-* If your cluster is using the CCO in mint mode with the root secret removed, you must reinstate the credential secret with the administrator-level credential before continuing to the next part of the update process.
-
-* If your cluster was configured using the CCO utility (`ccoctl`), you must take the following actions:
-
-.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
-
-.. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
-
-.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
-
-* If your cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility, you must take the following actions:
-
-.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
-
-.. Manually update the cloud provider resources for the new release.
-
-.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
-endif::update[]
 
 ifeval::["{context}" == "preparing-manual-creds-update"]
 :!update:

--- a/modules/cco-determine-mode-gui.adoc
+++ b/modules/cco-determine-mode-gui.adoc
@@ -16,7 +16,9 @@ endif::[]
 = Determining the Cloud Credential Operator mode by using the web console
 
 [role="_abstract"]
-Determine the Cloud Credential Operator (CCO) mode by using the web console. Before you perform upgrades or troubleshoot, ensure you understand your cluster's credential management configuration.
+You can determine what mode the Cloud Credential Operator (CCO) is configured to use by using the web console.
+
+Before you perform upgrades or troubleshoot, ensure you understand your cluster's credential management configuration.
 
 [NOTE]
 ====
@@ -135,30 +137,6 @@ Ensure that the *Project* dropdown is set to *All Projects*.
 
 * An empty value (`''`) indicates that the cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility.
 --
-
-ifdef::update[]
-.Next steps
-
-* If you are updating a cluster that has the CCO operating in mint or passthrough mode and the root secret is present, you do not need to update any cloud provider resources and can continue to the next part of the update process.
-
-* If your cluster is using the CCO in mint mode with the root secret removed, you must reinstate the credential secret with the administrator-level credential before continuing to the next part of the update process.
-
-* If your cluster was configured using the CCO utility (`ccoctl`), you must take the following actions:
-
-.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
-
-.. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
-
-.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
-
-* If your cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility, you must take the following actions:
-
-.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
-
-.. Manually update the cloud provider resources for the new release.
-
-.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
-endif::update[]
 
 ifeval::["{context}" == "preparing-manual-creds-update"]
 :!update:

--- a/modules/cco-determine-mode-next.adoc
+++ b/modules/cco-determine-mode-next.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="cco-determine-mode-next_{context}"]
+= Determining the next steps in the update
+
+[role="_abstract"]
+After you determine the Cloud Credential Operator mode, it is important to understand how to proceed with the update. 
+
+.Procedure
+
+* If you are updating a cluster that has the CCO operating in mint or passthrough mode and the root secret is present, you do not need to update any cloud provider resources and can continue to the next part of the update process.
+
+* If your cluster is using the CCO in mint mode with the root secret removed, you must reinstate the credential secret with the administrator-level credential before continuing to the next part of the update process.
+
+* If your cluster was configured using the CCO utility (`ccoctl`), you must take the following actions:
+
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+
+.. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
+
+.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
+
+* If your cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility, you must take the following actions:
+
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+
+.. Manually update the cloud provider resources for the new release.
+
+.. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.

--- a/modules/cco-determine-mode.adoc
+++ b/modules/cco-determine-mode.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cco-determine-mode_{context}"]
+= Determining the Cloud Credential Operator mode
+
+[role="_abstract"]
+For platforms that support using the CCO in multiple modes, you can determine what mode the CCO is configured to use by using the web console or the CLI.
+
+.Determining the CCO configuration
+image::334_OpenShift_cluster_updating_and_CCO_workflows_0923_4.11_A_AliCloud_patch.png[Decision tree showing how to determine the configured CCO credentials mode for your cluster.]

--- a/modules/cco-mode-about.adoc
+++ b/modules/cco-mode-about.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cco-mode-about_{context}"]
+= About Cloud Credential Operator modes
+
+[role="_abstract"]
+You can configure the Cloud Credential Operator (CCO) to operate in several different modes. These options provide transparency and flexibility in how the CCO uses cloud credentials to process `CredentialsRequest` CRs in the cluster to suit the security requirements of your organization.
+
+By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, you can configure the CCO to operate in _mint_, _passthrough_, or _manual_ mode.
+
+* **Mint**: In mint mode, the CCO uses the provided admin-level cloud credential to create new credentials for components in the cluster with only the specific permissions that are required.
+
+* **Passthrough**: In passthrough mode, the CCO passes the provided cloud credential to the components that request cloud credentials.
+
+* **Manual mode with long-term credentials for components**: In manual mode, you can manage long-term cloud credentials instead of the CCO.
+
+* **Manual mode with short-term credentials for components**: For some providers, you can use the CCO utility (`ccoctl`) during installation to implement short-term credentials for individual components. These credentials are created and managed outside the {product-title} cluster.
+
+If no mode is specified, or the `credentialsMode` parameter is set to an empty string (""), the CCO operates in its default mode.
+
+Not all CCO modes are supported for all cloud providers, as described in the following table: 
+
+.CCO mode support matrix
+[cols="<.^2,^.^1,^.^1,^.^1,^.^1"]
+|====
+|Cloud provider |Mint |Passthrough |Manual with long-term credentials |Manual with short-term credentials
+
+|Amazon Web Services (AWS)
+|X
+|X
+|X
+|X
+
+|Global Microsoft Azure
+|
+|X
+|X
+|X
+
+|Microsoft Azure Stack Hub
+|
+|
+|X
+|
+
+|{gcp-first}
+|X
+|X
+|X
+|X
+
+|{ibm-cloud-name}
+|
+|
+|X ^[1]^
+|
+
+|Nutanix
+|
+|
+|X ^[1]^
+|
+
+|{rh-openstack-first}
+|
+|X
+|
+|
+
+|VMware vSphere
+|
+|X
+|
+|
+
+|====
+[.small]
+--
+1. This platform uses the `ccoctl` utility during installation to configure long-term credentials.
+--
+

--- a/modules/cco-passthrough-mode-permissions-reduce.adoc
+++ b/modules/cco-passthrough-mode-permissions-reduce.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cco-passthrough-mode-permissions-reduce_{context}"]
+= Reducing permissions after installation
+
+[role="_abstract"]
+When using passthrough mode, after installing you can reduce the installed permissions to only those permissions required to run the cluster. 
+
+In passthrough mode, each component has the same permissions used by all other components. If you do not reduce the permissions after installing, all components have the broad permissions that are required to run the installation program.
+
+After installation, reduce the permissions on your credential to only those defined by the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are using.
+
+To locate the `CredentialsRequest` CRs that are required for {aws-short}, {azure-short}, or {gcp-short} and learn how to change the permissions the CCO uses, see the _Manually creating long-term credentials_ topic for your platform.

--- a/modules/cco-passthrough-mode-permissions.adoc
+++ b/modules/cco-passthrough-mode-permissions.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-passthrough
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cco-passthrough-mode-permissions_{context}"]
+= Passthrough mode permissions requirements
+
+[role="_abstract"]
+When using the CCO in passthrough mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials the CCO passes to a component that creates a `CredentialsRequest` CR are not sufficient, that component will report an error when it tries to call an API that it does not have permissions for.
+
+Amazon Web Services (AWS) permissions::
+The credential you provide for passthrough mode in AWS must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
++
+To locate the `CredentialsRequest` CRs that are required, see "Manually creating long-term credentials for AWS.
+
+Microsoft Azure permissions::
+The credential you provide for passthrough mode in Azure must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
++
+To locate the `CredentialsRequest` CRs that are required, see "Manually creating long-term credentials for Azure".
+
+{gcp-first} permissions::
+The credential you provide for passthrough mode in {gcp-short} must have all the requested permissions for all `CredentialsRequest` CRs that are required by the version of {product-title} you are running or installing.
++
+To locate the `CredentialsRequest` CRs that are required, see "Manually creating long-term credentials for {gcp-short}".
+
+{rh-openstack-first} permissions::
+To install an {product-title} cluster on {rh-openstack}, the CCO requires a credential with the permissions of a `member` user role.
+
+VMware vSphere permissions::
+To install an {product-title} cluster on VMware vSphere, the CCO requires a credential with the following vSphere privileges:
+
+.Required vSphere privileges
+[cols="1,2"]
+|====
+|Category |Privileges
+
+|Datastore
+|_Allocate space_
+
+|Folder
+|_Create folder_, _Delete folder_
+
+|vSphere Tagging
+|All privileges
+
+|Network
+|_Assign network_
+
+|Resource
+|_Assign virtual machine to resource pool_
+
+|Profile-driven storage
+|All privileges
+
+|vApp
+|All privileges
+
+|Virtual machine
+|All privileges
+
+|====
+
+If `CredentialsRequest` CRs change over time as the cluster is upgraded, you must manually update the passthrough mode credential to meet the requirements. To avoid credentials issues during an upgrade, check the `CredentialsRequest` CRs in the release image for the new version of {product-title} before upgrading.
+
+To locate the `CredentialsRequest` CRs that are required for {aws-short}, {azure-short}, or {gcp-short}, see the _Manually creating long-term credentials_ topic for your platform.

--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="service-accounts-as-oauth-clients_{context}"]
-= Service accounts as OAuth clients
+= About service accounts as OAuth clients
 
 [role="_abstract"]
-To authenticate users when restricting access to a specific namespace, you can use a service account as a constrained form of OAuth client.
+You can configure a service account to function as a constrained OAuth client that can request a limited subset of scopes.
 
 Service accounts can request only a subset of scopes that
 allow access to the following basic user information

--- a/modules/service-accounts-creating.adoc
+++ b/modules/service-accounts-creating.adoc
@@ -6,6 +6,7 @@
 [id="service-accounts-managing_{context}"]
 = Creating service accounts
 
+[role="_abstract"]
 You can create a service account in a project and grant it permissions by
 binding it to a role.
 
@@ -31,9 +32,10 @@ deployer   1         2d
 +
 [source,terminal]
 ----
-$ oc create sa <service_account_name> <1>
+$ oc create sa <service_account_name>
 ----
-<1> To create a service account in a different project, specify `-n <project_name>`.
++
+To create a service account in a different project, specify `-n <project_name>`.
 +
 .Example output
 [source,terminal]

--- a/modules/service-accounts-granting-roles.adoc
+++ b/modules/service-accounts-granting-roles.adoc
@@ -6,6 +6,7 @@
 [id="service-accounts-granting-roles_{context}"]
 = Granting roles to service accounts
 
+[role="_abstract"]
 You can grant roles to service accounts in the same way that you grant roles
 to a regular user account.
 

--- a/modules/service-accounts-overview.adoc
+++ b/modules/service-accounts-overview.adoc
@@ -6,9 +6,11 @@
 [id="service-accounts-overview_{context}"]
 = Service accounts overview
 
-A service account is an {product-title} account that allows a component to
-directly access the API. Service accounts are API objects that exist within each project.
-Service accounts provide a flexible way to control API
+[role="_abstract"]
+You can use {product-title} service accounts to allow a {product-title} component to
+directly access the API. 
+
+Service accounts are API objects that exist within each project that provide a flexible way to control API
 access without sharing a regular user's credentials.
 
 When you use the {product-title} CLI or web console, your API token

--- a/updating/preparing_for_updates/preparing-manual-creds-update.adoc
+++ b/updating/preparing_for_updates/preparing-manual-creds-update.adoc
@@ -40,6 +40,8 @@ include::modules/cco-determine-mode-gui.adoc[leveloffset=+2]
 //Determining the Cloud Credential Operator mode by using the CLI
 include::modules/cco-determine-mode-cli.adoc[leveloffset=+2]
 
+include::modules/cco-determine-mode-next.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update[Extracting and preparing credentials request resources]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16962

Previews
[Using a service account as an OAuth client](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/using-service-accounts-as-oauth-client)
[About the Cloud Credential Operator](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator)
[About the Cloud Credential Operator in passthrough mode](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough)
[Understanding and creating service accounts](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/understanding-and-creating-service-accounts)

 Updating clusters Preparing to update a cluster  Preparing to update a cluster with manually maintained credentials:
[Determining the Cloud Credential Operator mode by using the web console](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-determine-mode-gui_preparing-manual-creds-update) -- Moved next steps to new module.
[Determining the Cloud Credential Operator mode by using the CLI](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-determine-mode-cli_preparing-manual-creds-update) -- Moved next steps to new module.
[Determining the next steps in the update](https://115292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-determine-mode-next_preparing-manual-creds-update) -- New module for the next steps.

assemblies
using-service-accounts-as-oauth-client.adoc
about-cloud-credential-operator.adoc
cco-mode-passthrough.adoc
understanding-and-creating-service-accounts.adoc