### PR TITLE
OCPBUGS-98621: Add without-external-DNS command variant for Azure HCP

### DIFF
--- a/modules/hcp-azure-hosted.adoc
+++ b/modules/hcp-azure-hosted.adoc
@@ -53,6 +53,11 @@ $ hcp create cluster azure \
   --diagnostics-storage-account-type Managed \
   --external-dns-domain "${DNS_ZONE_NAME}"
 ----
++
+[NOTE]
+====
+For non-production environments, you can create a hosted cluster without external DNS by omitting the `--external-dns-domain` and `--assign-service-principal-roles` flags. In that case, the API server is accessible through an {azure-short} load balancer hostname instead of a custom DNS name.
+====
 
 .Verification
 


### PR DESCRIPTION
## Summary

- Add a second `hcp create cluster azure` command variant for creating a hosted cluster without external DNS
- Update the prerequisite from requiring external DNS to making it conditional
- Add a NOTE explaining that without external DNS, the API server uses an Azure load balancer hostname

## Why this change

The prerequisites doc (hcp-azure-infra-creds.adoc) documents "Without external DNS" as a valid approach for development and testing. However, the actual cluster creation procedure only shows the command with `--external-dns-domain`. A user choosing the documented "without external DNS" path has no guidance on which flags to omit.

This follows the pattern used in the AWS HCP docs, where separate procedures exist for with and without external DNS (hcp-aws-hc-ext-dns.adoc vs hcp-aws-deploy-hc.adoc). For Azure, both variants are included in the same module to keep the change minimal.

## Verified

Deployed an Azure HCP cluster without external DNS on OCP 4.22.4 management cluster (MCE 2.17.0, eastus2 region). The hosted cluster was created successfully using the command without `--external-dns-domain` and `--assign-service-principal-roles`.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-98621