### PR TITLE
OCPBUGS-98622: Add azure and openstack to HCP CLI supported platforms list

### DIFF
--- a/modules/hcp-cli-console.adoc
+++ b/modules/hcp-cli-console.adoc
@@ -53,4 +53,4 @@ If you download the CLI on a Mac computer, you might see a warning about the `hc
 $ hcp create cluster <platform> --help
 ----
 +
-You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.
+You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `agent`, `aws`, and `kubevirt`. The `azure` and `openstack` platforms are also available as Technology Preview features.

--- a/modules/hcp-cli-gateway.adoc
+++ b/modules/hcp-cli-gateway.adoc
@@ -51,4 +51,4 @@ If you download the CLI on a Mac computer, you might see a warning about the `hc
 $ hcp create cluster <platform> --help
 ----
 +
-You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.
+You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `agent`, `aws`, and `kubevirt`. The `azure` and `openstack` platforms are also available as Technology Preview features.

--- a/modules/hcp-cli-terminal.adoc
+++ b/modules/hcp-cli-terminal.adoc
@@ -65,4 +65,4 @@ If you download the CLI on a Mac computer, you might see a warning about the `hc
 $ hcp create cluster <platform> --help
 ----
 +
-You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.
+You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `agent`, `aws`, and `kubevirt`. The `azure` and `openstack` platforms are also available as Technology Preview features.


### PR DESCRIPTION
## Summary

- Add `azure` and `openstack` to the supported platforms list in all three HCP CLI installation modules (terminal, console, gateway)
- Alphabetize the list for consistency

## Why this change

The verification step in the HCP CLI installation docs says "The supported platforms are `aws`, `agent`, and `kubevirt`." This only lists GA platforms. The `azure` and `openstack` platforms are available as Technology Preview and have full documentation (hcp-deploy-azure.adoc, hcp-deploy-openstack.adoc), but are missing from this list.

Confirmed by running `hcp create cluster --help` on an OCP 4.22.4 cluster with MCE 2.17.0, which shows both `azure` and `openstack` as available commands.

The same text appears in three modules (hcp-cli-terminal.adoc, hcp-cli-console.adoc, hcp-cli-gateway.adoc), all updated.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-98622