### PR TITLE
OCPBUGS-98208: Fix Azure HCP management cluster external DNS configuration

### DIFF
--- a/modules/hcp-azure-mgmt-cluster.adoc
+++ b/modules/hcp-azure-mgmt-cluster.adoc
@@ -147,10 +147,11 @@ $ az role assignment create \
   --scope "${DNS_ID}"
 ----
 
-. Create the content for the {azure-short} credentials file as shown in the following example:
+. Save the {azure-short} credentials to a local file by entering the following command:
 +
-[source,json]
+[source,terminal]
 ----
+$ cat > ${SERVICE_PRINCIPAL_FILEPATH} <<EOF
 {
   "tenantId": "$(az account show --query tenantId -o tsv)",
   "subscriptionId": "$(az account show --query id -o tsv)",
@@ -158,20 +159,14 @@ $ az role assignment create \
   "aadClientId": "$EXTERNAL_DNS_SP_APP_ID",
   "aadClientSecret": "$EXTERNAL_DNS_SP_PASSWORD"
 }
-----
-
-. Create the credentials file by entering the following command:
-+
-[source,terminal]
-----
-$ oc apply -f <service_principal_filepath>.json
+EOF
 ----
 
 . If an existing Kubernetes secret for the {azure-short} credentials exists, delete it by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete secret/azure-config-file --namespace "default" || true
+$ oc delete secret/azure-config-file --namespace "hypershift" || true
 ----
 
 . Create the Kubernetes secret for the {azure-short} credentials by entering the following command:
@@ -179,9 +174,11 @@ $ oc delete secret/azure-config-file --namespace "default" || true
 [source,terminal]
 ----
 $ oc create secret generic azure-config-file \
-  --namespace "default" \
-  --from-file ${SERVICE_PRINCIPAL_FILEPATH}
+  --namespace "hypershift" \
+  --from-file=credentials=${SERVICE_PRINCIPAL_FILEPATH}
 ----
++
+The secret must be created in the `hypershift` namespace where the external DNS deployment runs. The `credentials` key name is required because the external DNS pod mounts the secret at `/etc/provider/credentials`.
 
 . Configure the HyperShift Operator to use external DNS by creating the following `ConfigMap` object:
 +
@@ -193,11 +190,11 @@ metadata:
   name: hypershift-operator-install-flags
   namespace: local-cluster
 data:
-  installFlagsToAdd: "--external-dns-provider=azure --external-dns-credentials <secret> --external-dns-domain-filter <dns_zone>"
+  installFlagsToAdd: "--external-dns-provider=azure --external-dns-secret=azure-config-file --external-dns-domain-filter=<dns_zone>"
   installFlagsToRemove: ""
 ----
 +
-The `data.installFlagsToAdd` parameter specifies the flags to pass to the Operator so it detects the DNS.
+The `--external-dns-secret` flag specifies the name of the Kubernetes secret that contains the {azure-short} credentials. The `data.installFlagsToAdd` parameter specifies the flags to pass to the Operator so it detects the DNS.
 
 . Apply the config map by entering the following command:
 +


### PR DESCRIPTION
## Summary

- Replace `oc apply -f` with `cat` heredoc for saving the Azure credentials JSON to a local file (it is not a Kubernetes manifest)
- Change secret namespace from `default` to `hypershift` (where the external-dns deployment runs)
- Add explicit `credentials` key name to `--from-file` (external-dns expects the file at `/etc/provider/credentials`)
- Change `--external-dns-credentials` to `--external-dns-secret` in the ConfigMap install flags (the former is a local file path, not a Kubernetes secret name)

## Why this approach

Verified each fix against the HyperShift operator source code at `cmd/install/install.go`:

- `--external-dns-credentials` is registered as a local file path: `"Credentials to use for managing DNS records using external-dns"`
- `--external-dns-secret` is registered as a Kubernetes secret name: `"Name of an existing secret containing the external-dns credentials."`
- These are mutually exclusive: `"only one of --external-dns-credentials or --external-dns-credentials-secret is supported"`

The namespace fix was verified by checking that the external-dns deployment runs in the `hypershift` namespace, not `default`. A secret in the wrong namespace causes the pod to fail to mount it.

The `credentials` key name fix was verified from the external-dns Azure provider configuration, which reads credentials from `/etc/provider/credentials`. Without the explicit key name, the mounted file uses the local filename as the key, and external-dns fails with: `failed to read Azure config file '/etc/provider/credentials': open /etc/provider/credentials: no such file or directory`

Bug: https://redhat.atlassian.net/browse/OCPBUGS-98208