### PR TITLE
OSDOCS-20653: enable developer portal in Kuadrant CR

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -24,6 +24,8 @@
 
 :OTELName: Red{nbsp}Hat build of OpenTelemetry
 
+:rhdh: Red Hat Developer Hub
+
 :service-mesh: OpenShift Service Mesh
 :service-mesh-version: 3.2
 

--- a/develop/rhcl-ocp-web-console.adoc
+++ b/develop/rhcl-ocp-web-console.adoc
@@ -12,3 +12,5 @@ You can manage {prodname} resources and develop API products by using the {ocp} 
 include::modules/con-about-using-openshift-web-console.adoc[leveloffset=+1]
 
 include::modules/proc-rhcl-enable-console-plugin.adoc[leveloffset=+1]
+
+include::modules/proc-enable-rhdh-plugin.adoc[leveloffset=+1]

--- a/modules/proc-enable-rhdh-plugin.adoc
+++ b/modules/proc-enable-rhdh-plugin.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * develop/rhcl-api-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-enable-rhdh-plugin_{context}"]
+= Enabling the {prodname} {rhdh} console plugin
+
+[role="_abstract"]
+If you have a subscription to {rhdh}, you can use the web console as your internal developer portal. You must enable the {prodname} {rhdh} plugin in the `Kuadrant` custom resource (CR) you created during installation before you can use {rhdh}.
+
+You can skip this procedure if you enabled the {rhdh} plugin during {prodname} installation.
+
+.Prerequisites
+
+* You installed {prodname}.
+* You have a {rhdh} subscription.
+* You are logged into {ocp} as a cluster administrator.
+* You are using a supported configuration of {ocp} and required components.
+* You installed the {oc-first}.
+
+.Procedure
+
+. If you have a {rhdh} subscription, update your {prodname} CR with the {rhdh} plugin enabled by using the following example:
++
+[source,yaml]
+----
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+#...
+spec:
+  components:
+    developerPortal:
+      enabled: true
+#...
+----
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<kuadrant.yaml>_
+----
++
+Replace `_<kuadrant.yaml>_` with the name of your {prodname} deployment YAML.
+
+.Verification
+
+. Check the status of the {prodname} CR generation by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc wait kuadrant/kuadrant --for="condition=Ready=true" -n _<kuadrant_system>_ --timeout=300s
+----
++
+Replace `_<kuadrant_system>_` with the namespace you used.
++
+.Example output
+[source,text]
+----
+kuadrant.kuadrant.io/kuadrant Ready
+----
+
+. Check that the {rhdh} pod is ready by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc wait pod -n _<kuadrant_system>_ -l app=developer-portal-controller --for=condition=Ready --timeout=120s
+----
++
+Replace `_<kuadrant_system>_` with the namespace you used.
++
+.Example output
+[source,text]
+----
+pod/developer-portal-controller-7f8d69bc7b-x4z2q condition met
+----
++
+The exact random string at the end of the pod name varies based on your deployment replica set.

--- a/modules/proc-install-in-openshift-web-console.adoc
+++ b/modules/proc-install-in-openshift-web-console.adoc
@@ -46,7 +46,7 @@ An `OperatorGroup` custom resource (CR) is created automatically when you use th
 
 . Click the *Kuadrant* tab, and click *Create Kuadrant* to create a Kuadrant custom resource (CR).
 
-. In the *Configure via* field, click *YAML view* to edit the definition, for example, the Kuadrant CR name.
+. In the *Configure via* field, click *YAML view* to edit the definition, for example, the `Kuadrant` CR name.
 
 . Click *Create* and wait for the deployment to be displayed in the list.
 +

--- a/modules/proc-install-on-openshift-cli-cio.adoc
+++ b/modules/proc-install-on-openshift-cli-cio.adoc
@@ -33,7 +33,7 @@ You can replace the default `_<kuadrant_system>_` with the namespace you want to
 
 . Create the `Subscription` custom resource (CR) by using the following example:
 +
-[source,terminal,subs="+quotes"]
+[source,yaml,subs="+quotes"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -69,7 +69,7 @@ $ oc apply -f subscription.yaml
 
 . Create the `OperatorGroup` custom resource (CR) by using the following example:
 +
-[source,terminal,subs="+quotes"]
+[source,yaml,subs="+quotes"]
 ----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -106,7 +106,7 @@ Expect the status of `installplan.operators.coreos.com/install-<suffix>` when {p
 
 . Create your {prodname} custom resource (CR) by using the following example:
 +
-[source,terminal,subs="+quotes"]
+[source,yaml,subs="+quotes"]
 ----
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
@@ -117,6 +117,21 @@ spec: {}
 ----
 +
 Replace `_<kuadrant_system>_` with the namespace you used.
+
+. Optional. If you have a {rhdh} subscription, enable the {rhdh} plugin enabled by using the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+#...
+spec:
+  components:
+    developerPortal:
+      enabled: true
+#...
+----
 
 . Apply the {prodname} CR by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4
rhcl-docs-1.5

Issue:
[OSDOCS-20653](https://redhat.atlassian.net/browse/OSDOCS-20653)

Link to docs preview:
https://115339--ocpdocs-pr.netlify.app/rhcl/latest/develop/rhcl-ocp-web-console.html#proc-rhcl-enable-rhdh-plugin_rhcl-ocp-web-console (added procedure in console assembly)
https://115339--ocpdocs-pr.netlify.app/rhcl/latest/install-rhcl/install-guide.html#proc-install-on-ocp-cmd-cio_installing-rhcl-on-ocp (added step 8)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
