### PR TITLE
OSDOCS WMCO add SSH/TOFU troubleshooting

### DIFF
--- a/modules/troubleshooting-ssh-connection-keys-tofu.adoc
+++ b/modules/troubleshooting-ssh-connection-keys-tofu.adoc
@@ -3,7 +3,7 @@
 // * support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
 // * windows_containers/windows-containers-troubleshooting.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshooting-ssh-connection-keys-tofu_{context}"]
 = Troubleshooting SSH connection failures
 

--- a/modules/troubleshooting-ssh-connection-keys-tofu.adoc
+++ b/modules/troubleshooting-ssh-connection-keys-tofu.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
+// * windows_containers/windows-containers-troubleshooting.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="troubleshooting-ssh-connection-keys-tofu_{context}"]
+= Troubleshooting SSH connection failures
+
+[role="_abstract"]
+If an SSH connection to one of your node fails with _host key mismatch_ error, you can examine and possibly delete the SSH host keys used by that node.
+
+The Windows Machine Config Opertor (WMCO) uses Trust On First Use (TOFU) pinning to validate SSH host keys and prevent man-in-the-middle attacks. Host keys are automatically managed and stored in the cluster.
+
+The host keys are stored as a `windowsmachineconfig.openshift.io/ssh-host-key` annotation on each node object after the node joins the cluster.
+
+For a Bring-Your-Own-Host (BYOH) instances that does not have nodes installed yet, the host keys are temporarily stored in the `windows-ssh-host-keys` config map by instance address (IP or hostname).
+
+You can view the host key for a specific node by using the following command:
+
+[source,terminal]
+----
+$ oc get node <node-name> -o jsonpath='{.metadata.annotations.windowsmachineconfig\.openshift\.io/ssh-host-key}'
+----
+
+For BYOH instances without nodes, you can view all of the host keys in the `windows-ssh-host-keys` config map by using the following command:
+
+[source,terminal]
+----
+$ oc get configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator -o yaml
+----
+
+.Procedure
+
+. Check if a stale key exists:
+
+** On an existing node, run the following command:
++
+[source,terminal]
+----
+$ oc get node <node-name> -o jsonpath='{.metadata.annotations}'
+----   
+
+** On a BYOH instances without nodes, run the following command:
++
+[source,terminal]
+----
+$ oc get configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator -o yaml
+----
+
+. If you have a stale key and you are certain that the instance has been recreated or the IP reused, you can remove the stale key:
++
+--
+** On an existing node, run the following commands:
++
+[source,terminal]
+----
+$ oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-
+----
++
+[source,terminal]
+----
+$ oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-type-
+----
+
+** On a BYOH instances before node creation, edit the config map:
++
+[source,terminal]
+----
+$ oc edit configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator
+----
+--
++
+The WMCO will re-establish trust on the next connection attempt using TOFU.

--- a/modules/troubleshooting-ssh-connection-keys-tofu.adoc
+++ b/modules/troubleshooting-ssh-connection-keys-tofu.adoc
@@ -8,13 +8,13 @@
 = Troubleshooting SSH connection failures
 
 [role="_abstract"]
-If an SSH connection to one of your node fails with _host key mismatch_ error, you can examine and possibly delete the SSH host keys used by that node.
+If an SSH connection to one of your nodes fails with the _host key mismatch_ error, you can examine and possibly delete the SSH host keys used by that node.
 
 The Windows Machine Config Opertor (WMCO) uses Trust On First Use (TOFU) pinning to validate SSH host keys and prevent man-in-the-middle attacks. Host keys are automatically managed and stored in the cluster.
 
 The host keys are stored as a `windowsmachineconfig.openshift.io/ssh-host-key` annotation on each node object after the node joins the cluster.
 
-For a Bring-Your-Own-Host (BYOH) instances that does not have nodes installed yet, the host keys are temporarily stored in the `windows-ssh-host-keys` config map by instance address (IP or hostname).
+For a Bring-Your-Own-Host (BYOH) instance that does not have any nodes installed yet, the host keys are temporarily stored in the `windows-ssh-host-keys` config map by the IP or hostname address.
 
 You can view the host key for a specific node by using the following command:
 
@@ -63,7 +63,7 @@ $ oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-
 $ oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-type-
 ----
 
-** On a BYOH instances before node creation, edit the config map:
+** On a BYOH instance before node creation, edit the config map to remove the host keys:
 +
 [source,terminal]
 ----

--- a/support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
+++ b/support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
@@ -18,6 +18,8 @@ include::modules/accessing-windows-node.adoc[leveloffset=+1]
 include::modules/accessing-windows-node-using-ssh.adoc[leveloffset=+2]
 include::modules/accessing-windows-node-using-rdp.adoc[leveloffset=+2]
 
+include::modules/troubleshooting-ssh-connection-keys-tofu.adoc[leveloffset=+1]
+
 include::modules/collecting-kube-node-logs-windows.adoc[leveloffset=+1]
 include::modules/collecting-windows-application-event-logs.adoc[leveloffset=+1]
 include::modules/collecting-containerd-logs-windows.adoc[leveloffset=+1]

--- a/windows_containers/windows-containers-troubleshooting.adoc
+++ b/windows_containers/windows-containers-troubleshooting.adoc
@@ -17,6 +17,8 @@ include::modules/accessing-windows-node.adoc[leveloffset=+1]
 include::modules/accessing-windows-node-using-ssh.adoc[leveloffset=+2]
 include::modules/accessing-windows-node-using-rdp.adoc[leveloffset=+2]
 
+include::modules/troubleshooting-ssh-connection-keys-tofu.adoc[leveloffset=+1]
+
 include::modules/collecting-kube-node-logs-windows.adoc[leveloffset=+1]
 include::modules/collecting-windows-application-event-logs.adoc[leveloffset=+1]
 include::modules/collecting-containerd-logs-windows.adoc[leveloffset=+1]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-20723

Adding [SSH host key validation](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/TROUBLESHOOTING.md#ssh-host-key-validation) from the WMCO internal docs.