### PR TITLE
HCCDOC-5255: Insights Operator: Option to Disable Runtime Extractor follow-up

### DIFF
--- a/modules/insights-operator-insights-config.adoc
+++ b/modules/insights-operator-insights-config.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="insights-operator-insights-config_{context}"]
+= Creating the insights-config ConfigMap object
+
+[role="_abstract"]
+You can create the `insights-config` `ConfigMap` object for the {insights-operator} with custom configurations.
+
+[IMPORTANT]
+====
+Red{nbsp}Hat recommends you consult Red{nbsp}Hat Support before making changes to the default {insights-operator} configuration.
+====
+
+.Prerequisites
+
+* Remote health reporting is enabled, which is the default.
+* You are logged in to the {product-title} web console as a user with `cluster-admin` role.
+
+.Procedure
+
+. Go to *Workloads* -> *ConfigMaps* and select *Project: openshift-insights*.
+
+. Click *Create ConfigMap*.
+
+. Select *Configure via: YAML view* and enter your configuration preferences, for example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: insights-config
+  namespace: openshift-insights
+data:
+  config.yaml: |
+    dataReporting:
+      obfuscation:
+        - networking
+        - workload_names
+    sca:
+      disabled: false
+      interval: 2h
+    alerting:
+       disabled: false
+binaryData: {}
+immutable: false
+----
+
+. Optional: Select *Form view* and enter the necessary information that way.
+
+. In the *ConfigMap Name* field, enter *insights-config*.
+
+. In the *Key* field, enter *config.yaml*.
+
+. For the *Value* field, either browse for a file to drag and drop into the field or enter your configuration parameters manually.
+
+. Click *Create*. The `ConfigMap` object and configuration information are displayed.

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -23,6 +23,9 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/insights-operator-configuring.adoc[leveloffset=+1]
 
+include::modules/insights-operator-configuring-configmap.adoc[leveloffset=+2]
+
+include::modules/insights-operator-insights-config.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/understanding-insights-operator-alerts.adoc[leveloffset=+1]


### PR DESCRIPTION
Follow-up changes to https://github.com/openshift/openshift-docs/pull/114887 and https://github.com/openshift/openshift-docs/pull/115111. Pulling in additional file and includes that did not automatically get pulled into the original CP PR. 

Functionality update went back to 4.19 and SME requested the docs updates align. 

Link to docs preview:
https://115350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#insights-operator-configuring-configmap_using-insights-operator
