### PR TITLE
[TELCODOCS-2917]: Release note for dual time receiver port HA on WPC E810

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -430,6 +430,15 @@ PTP T-GM on GNR-D is available as a Technology Preview feature.
 +
 For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_configuring-ptp[Telecom Grandmaster clocks on Intel Granite Rapids-D hardware].
 
+// TELCODOCS-2917
+High availability for PTP boundary clocks with dual time receiver ports on Intel E810 hardware::
++
+You can configure dual time receiver (TR) ports on a single Intel Westport Channel E810-XXVDA4T network interface card (NIC) for Precision Time Protocol (PTP) Telecom Boundary Clock (T-BC) high availability. This configuration uses the Alternate Best Master Clock Algorithm (A-BMCA) to support automatic switchover between the upstream paths if the active port goes down or its quality degrades. As a result, downstream devices maintain continuous time synchronization without manual intervention during upstream path failures.
++
+The `PtpConfig` custom resource (CR) uses a two-profile architecture with a time receiver profile and a time transmitter profile on separate PTP domains. Both TR ports share the same Physical Hardware Clock (PHC), so failover relies on A-BMCA reselection rather than switching between separate clock servos.
++
+For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-dual-port-bc_configuring-ptp[Configuring PTP boundary clock high availability with dual time receiver ports].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[TELCODOCS-2917](https://redhat.atlassian.net/browse/TELCODOCS-2917): Release note for dual time receiver port HA on WPC E810

Version(s): 5.0

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2917

Link to docs preview: https://115354--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:
RN-only PR accompanying the docs PR #115293. Adds a release note entry under the Networking section for the dual time receiver port high availability feature on Intel Westport Channel E810-XXVDA4T NICs (T-BC).