### PR TITLE
OSDOCS-16940: DITA callouts — OLM topics

### DIFF
--- a/modules/olm-installing-from-software-catalog-using-cli.adoc
+++ b/modules/olm-installing-from-software-catalog-using-cli.adoc
@@ -47,15 +47,12 @@ endif::[]
 
 . View the list of Operators available to the cluster from the software catalog:
 +
-The following is example output:
-+
 [source,terminal]
 ----
 $ oc get packagemanifests -n openshift-marketplace
 ----
 +
-The following is example output:
-+
+.Example output
 [source,terminal]
 ----
 NAME                               CATALOG               AGE
@@ -83,8 +80,6 @@ $ oc describe packagemanifests <operator_name> -n openshift-marketplace
 ----
 +
 .Example output
-[%collapsible]
-====
 [source,terminal]
 ----
 # ...
@@ -119,7 +114,6 @@ Kind:         PackageManifest
 * The `Install Modes` section indicates which install modes are supported.
 * `stable-3.7` and `stable-3.8` are example channel names.
 * The `Default Channel` field is the channel selected by default if one is not specified.
-====
 +
 [TIP]
 ====
@@ -192,8 +186,6 @@ If you want to subscribe to a specific version of an Operator, set the `starting
 ====
 +
 .Example `Subscription` object
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -247,11 +239,8 @@ where:
 `spec.config.tolerations`:: Specifies a list of tolerations for the pod created by OLM.
 `spec.config.resources`:: Specifies resource constraints for all the containers in the pod created by OLM.
 `spec.config.nodeSelector`:: Specifies a `NodeSelector` for the pod created by OLM.
-====
 +
 .Example `Subscription` object with a specific starting Operator version
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -272,15 +261,12 @@ where:
 
 `spec.installPlanApproval`:: Specifies the approval strategy to `Manual` in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
 `spec.startingCSV`:: Specifies a specific version of an Operator CSV.
-====
 +
 .. For clusters on cloud providers with token authentication enabled, such as {aws-first} {sts-first}, {entra-first}, or {gcp-wid-first}, configure your `Subscription` object by following these steps:
 +
 ... Ensure the `Subscription` object is set to manual update approvals:
 +
 .Example `Subscription` object with manual update approvals
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -290,15 +276,12 @@ spec:
 ----
 +
 Subscriptions with automatic approvals for updates are not recommended because there might be permission changes to make before updating. Subscriptions with manual approvals for updates ensure that administrators have the opportunity to verify the permissions of the later version, take any necessary steps, and then update.
-====
 +
 ... Include the relevant cloud provider-specific fields in the `Subscription` object's `config` section:
 +
 If the cluster is in AWS STS mode, include the following fields:
 +
 .Example `Subscription` object with {aws-short} {sts-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -311,13 +294,10 @@ spec:
 ----
 +
 `<role_arn>`:: Specifies the role ARN details.
-====
 +
 If the cluster is in {entra-short} mode, include the following fields:
 +
 .Example `Subscription` object with {entra-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -338,13 +318,10 @@ where:
 `<client_id>`:: Specifies the client ID.
 `<tenant_id>`:: Specifies the tenant ID.
 `<subscription_id>`:: Specifies the subscription ID.
-====
 +
 If the cluster is in {gcp-wid-short} mode, include the following fields:
 +
 .Example `Subscription` object with {gcp-wid-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -357,7 +334,6 @@ spec:
    - name: SERVICE_ACCOUNT_EMAIL
      value: "<service_account_email>"
 ----
-====
 +
 where:
 

--- a/modules/olm-installing-from-software-catalog-using-cli.adoc
+++ b/modules/olm-installing-from-software-catalog-using-cli.adoc
@@ -47,14 +47,15 @@ endif::[]
 
 . View the list of Operators available to the cluster from the software catalog:
 +
+The following is example output:
++
 [source,terminal]
 ----
 $ oc get packagemanifests -n openshift-marketplace
 ----
 +
-.Example output
-[%collapsible]
-====
+The following is example output:
++
 [source,terminal]
 ----
 NAME                               CATALOG               AGE
@@ -71,7 +72,6 @@ jaeger                             Community Operators   91m
 kubefed                            Community Operators   91m
 # ...
 ----
-====
 +
 Note the catalog for your desired Operator.
 
@@ -90,7 +90,7 @@ $ oc describe packagemanifests <operator_name> -n openshift-marketplace
 # ...
 Kind:         PackageManifest
 # ...
-      Install Modes: <1>
+      Install Modes:
         Supported:  true
         Type:       OwnNamespace
         Supported:  true 
@@ -105,19 +105,20 @@ Kind:         PackageManifest
       Version:    3.7.11
       Name:       example-operator.v3.7.10
       Version:    3.7.10
-    Name:         stable-3.7 <2>
+    Name:         stable-3.7
 # ...
    Entries:
       Name:         example-operator.v3.8.5
       Version:      3.8.5
       Name:         example-operator.v3.8.4
       Version:      3.8.4
-    Name:           stable-3.8 <2>
-  Default Channel:  stable-3.8 <3>
+    Name:           stable-3.8
+  Default Channel:  stable-3.8
 ----
-<1> Indicates which install modes are supported.
-<2> Example channel names.
-<3> The channel selected by default if one is not specified.
++
+* The `Install Modes` section indicates which install modes are supported.
+* `stable-3.7` and `stable-3.8` are example channel names.
+* The `Default Channel` field is the channel selected by default if one is not specified.
 ====
 +
 [TIP]
@@ -166,12 +167,13 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: <operatorgroup_name>
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   targetNamespaces:
-  - <namespace> <1>
+  - <namespace>
 ----
-<1> For `SingleNamespace` install mode, use the same `<namespace>` value for both the `metadata.namespace` and `spec.targetNamespaces` fields.
++
+For `SingleNamespace` install mode, use the same `<namespace>` value for both the `metadata.namespace` and `spec.targetNamespaces` fields.
 +
 .. Create the `OperatorGroup` object:
 +
@@ -198,50 +200,53 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: <subscription_name>
-  namespace: <namespace_per_install_mode> <1>
+  namespace: <namespace_per_install_mode>
 spec:
-  channel: <channel_name> <2>
-  name: <operator_name> <3>
-  source: <catalog_name> <4>
-  sourceNamespace: <catalog_source_namespace> <5>
+  channel: <channel_name>
+  name: <operator_name>
+  source: <catalog_name>
+  sourceNamespace: <catalog_source_namespace>
   config:
-    env: <6>
+    env:
     - name: ARGS
       value: "-v=10"
-    envFrom: <7>
+    envFrom:
     - secretRef:
         name: license-secret
-    volumes: <8>
+    volumes:
     - name: <volume_name>
       configMap:
         name: <configmap_name>
-    volumeMounts: <9>
+    volumeMounts:
     - mountPath: <directory_name>
       name: <volume_name>
-    tolerations: <10>
+    tolerations:
     - operator: "Exists"
-    resources: <11>
+    resources:
       requests:
         memory: "64Mi"
         cpu: "250m"
       limits:
         memory: "128Mi"
         cpu: "500m"
-    nodeSelector: <12>
+    nodeSelector:
       foo: bar
 ----
-<1> For default `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Alternatively, you can specify a custom global namespace, if you have created one. For `SingleNamespace` install mode usage, specify the relevant single namespace.
-<2> Name of the channel to subscribe to.
-<3> Name of the Operator to subscribe to.
-<4> Name of the catalog source that provides the Operator.
-<5> Namespace of the catalog source. Use `openshift-marketplace` for the default software catalog sources.
-<6> The `env` parameter defines a list of environment variables that must exist in all containers in the pod created by OLM.
-<7> The `envFrom` parameter defines a list of sources to populate environment variables in the container.
-<8> The `volumes` parameter defines a list of volumes that must exist on the pod created by OLM.
-<9> The `volumeMounts` parameter defines a list of volume mounts that must exist in all containers in the pod created by OLM. If a `volumeMount` references a `volume` that does not exist, OLM fails to deploy the Operator.
-<10> The `tolerations` parameter defines a list of tolerations for the pod created by OLM.
-<11> The `resources` parameter defines resource constraints for all the containers in the pod created by OLM.
-<12> The `nodeSelector` parameter defines a `NodeSelector` for the pod created by OLM.
++
+where:
+
+`metadata.namespace`:: Specifies that for default `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Alternatively, you can specify a custom global namespace, if you have created one. For `SingleNamespace` install mode usage, specify the relevant single namespace.
+`spec.channel`:: Specifies the name of the channel to subscribe to.
+`spec.name`:: Specifies the name of the Operator to subscribe to.
+`spec.source`:: Specifies the name of the catalog source that provides the Operator.
+`spec.sourceNamespace`:: Specifies the namespace of the catalog source. Use `openshift-marketplace` for the default software catalog sources.
+`spec.config.env`:: Specifies a list of environment variables that must exist in all containers in the pod created by OLM.
+`spec.config.envFrom`:: Specifies a list of sources to populate environment variables in the container.
+`spec.config.volumes`:: Specifies a list of volumes that must exist on the pod created by OLM.
+`spec.config.volumeMounts`:: Specifies a list of volume mounts that must exist in all containers in the pod created by OLM. If a `volumeMount` references a `volume` that does not exist, OLM fails to deploy the Operator.
+`spec.config.tolerations`:: Specifies a list of tolerations for the pod created by OLM.
+`spec.config.resources`:: Specifies resource constraints for all the containers in the pod created by OLM.
+`spec.config.nodeSelector`:: Specifies a `NodeSelector` for the pod created by OLM.
 ====
 +
 .Example `Subscription` object with a specific starting Operator version
@@ -256,14 +261,17 @@ metadata:
   namespace: example-operator
 spec:
   channel: stable-3.7
-  installPlanApproval: Manual <1>
+  installPlanApproval: Manual
   name: example-operator
   source: custom-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: example-operator.v3.7.10 <2>
+  startingCSV: example-operator.v3.7.10
 ----
-<1> Set the approval strategy to `Manual` in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
-<2> Set a specific version of an Operator CSV.
++
+where:
+
+`spec.installPlanApproval`:: Specifies the approval strategy to `Manual` in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
+`spec.startingCSV`:: Specifies a specific version of an Operator CSV.
 ====
 +
 .. For clusters on cloud providers with token authentication enabled, such as {aws-first} {sts-first}, {entra-first}, or {gcp-wid-first}, configure your `Subscription` object by following these steps:
@@ -278,9 +286,10 @@ spec:
 kind: Subscription
 # ...
 spec:
-  installPlanApproval: Manual <1>
+  installPlanApproval: Manual
 ----
-<1> Subscriptions with automatic approvals for updates are not recommended because there might be permission changes to make before updating. Subscriptions with manual approvals for updates ensure that administrators have the opportunity to verify the permissions of the later version, take any necessary steps, and then update.
++
+Subscriptions with automatic approvals for updates are not recommended because there might be permission changes to make before updating. Subscriptions with manual approvals for updates ensure that administrators have the opportunity to verify the permissions of the later version, take any necessary steps, and then update.
 ====
 +
 ... Include the relevant cloud provider-specific fields in the `Subscription` object's `config` section:
@@ -298,9 +307,10 @@ spec:
   config:
     env:
     - name: ROLEARN
-      value: "<role_arn>" <1>
+      value: "<role_arn>"
 ----
-<1> Include the role ARN details.
++
+`<role_arn>`:: Specifies the role ARN details.
 ====
 +
 If the cluster is in {entra-short} mode, include the following fields:
@@ -316,15 +326,18 @@ spec:
  config:
    env:
    - name: CLIENTID
-     value: "<client_id>" <1>
+     value: "<client_id>"
    - name: TENANTID
-     value: "<tenant_id>" <2>
+     value: "<tenant_id>"
    - name: SUBSCRIPTIONID
-     value: "<subscription_id>" <3>
+     value: "<subscription_id>"
 ----
-<1> Include the client ID.
-<2> Include the tenant ID.
-<3> Include the subscription ID.
++
+where:
+
+`<client_id>`:: Specifies the client ID.
+`<tenant_id>`:: Specifies the tenant ID.
+`<subscription_id>`:: Specifies the subscription ID.
 ====
 +
 If the cluster is in {gcp-wid-short} mode, include the following fields:
@@ -340,21 +353,21 @@ spec:
  config:
    env:
    - name: AUDIENCE
-     value: "<audience_url>" <1>
+     value: "<audience_url>"
    - name: SERVICE_ACCOUNT_EMAIL
-     value: "<service_account_email>" <2>
+     value: "<service_account_email>"
 ----
 ====
 +
 where:
-+
-`<audience>`:: Created in {gcp-short} by the administrator when they set up {gcp-wid-short}, the `AUDIENCE` value must be a preformatted URL in the following format:
+
+`<audience_url>`:: Specifies one of the following formats for the `AUDIENCE` value created in {gcp-short} by the administrator when they set up {gcp-wid-short}:
 +
 [source,text]
 ----
 //iam.googleapis.com/projects/<project_number>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>
 ----
-`<service_account_email>`:: The `SERVICE_ACCOUNT_EMAIL` value is a {gcp-short} service account email that is impersonated during Operator operation, for example:
+`<service_account_email>`:: Specifies a {gcp-short} service account email that is impersonated during Operator operation, for example:
 +
 [source,text]
 ----

--- a/modules/olm-overriding-operatorconditions.adoc
+++ b/modules/olm-overriding-operatorconditions.adoc
@@ -66,7 +66,7 @@ metadata:
   namespace: operators
 spec:
   overrides:
-  - type: Upgradeable <1>
+  - type: Upgradeable
     status: "True"
     reason: "upgradeIsSafe"
     message: "This is a known issue with the Operator where it always reports that it cannot be upgraded."
@@ -78,8 +78,10 @@ spec:
     lastTransitionTime: "2020-08-24T23:15:55Z"
 ----
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-<1> Allows the cluster administrator to change the upgrade readiness to `True`.
++
+Allows the cluster administrator to change the upgrade readiness to `True`.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-<1> Allows the `dedicated-admin` user to change the upgrade readiness to `True`.
++
+Allows the `dedicated-admin` user to change the upgrade readiness to `True`.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-preparing-multitenant-operators.adoc
+++ b/modules/olm-preparing-multitenant-operators.adoc
@@ -74,9 +74,10 @@ metadata:
   namespace: team1-operator
 spec:
   targetNamespaces:
-  - team1 <1>
+  - team1
 ----
-<1> Define only the tenant's namespace in the `spec.targetNamespaces` list.
++
+Define only the tenant's namespace in the `spec.targetNamespaces` list.
 
 .. Create the Operator group by running the following command:
 +
@@ -84,4 +85,13 @@ spec:
 ----
 $ oc create -f team1-operatorgroup.yaml
 ----
+
+.Next steps
+
+* Install the Operator in the tenant Operator namespace. This task is more easily performed by using the software catalog in the web console instead of the CLI; for a detailed procedure, "Installing from software catalog using the web console".
++
+[NOTE]
+====
+After completing the Operator installation, the Operator resides in the tenant Operator namespace and watches the tenant namespace, but neither the Operator's pod nor its service account are visible or usable by the tenant.
+====
 


### PR DESCRIPTION
## Summary
Replaces AsciiDoc callout markers and numbered callout lists with DITA-safe prose in three OLM modules (Pattern E `where:` lists, Pattern F output bullets, and single-callout explanatory sentences). Addresses AsciiDocDITA.CalloutList for the callouts series of [OSDOCS-16940](https://redhat.atlassian.net/browse/OSDOCS-16940).

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16940

## Versions
4.20+

## Merge order
Independent branch from main (callouts only). Rebase if same-file conflicts with other [OSDOCS-16940](https://redhat.atlassian.net/browse/OSDOCS-16940) series PRs.

## Files changed
- `modules/olm-installing-from-software-catalog-using-cli.adoc`
- `modules/olm-overriding-operatorconditions.adoc`
- `modules/olm-preparing-multitenant-operators.adoc`

## Vale rules addressed
- AsciiDocDITA.CalloutList

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted

Made with [Cursor](https://cursor.com)