### PR TITLE
OSDOCS-16940: DITA abstracts — OLM admin/user topics

### DIFF
--- a/modules/olm-changing-update-channel.adoc
+++ b/modules/olm-changing-update-channel.adoc
@@ -6,7 +6,8 @@
 [id="olm-changing-update-channel_{context}"]
 = Changing the update channel for an Operator
 
-You can change the update channel for an Operator by using the {product-title} web console.
+[role="_abstract"]
+To move an installed Operator to a newer update channel, you can change the channel in the {product-title} web console. Selecting a new channel determines which Operator versions your subscription tracks and receives.
 
 [TIP]
 ====

--- a/modules/olm-creating-etcd-cluster-from-operator.adoc
+++ b/modules/olm-creating-etcd-cluster-from-operator.adoc
@@ -2,7 +2,8 @@
 [id="olm-creating-etcd-cluster-from-operator_{context}"]
 = Creating an etcd cluster using an Operator
 
-This procedure walks through creating a new etcd cluster using the etcd Operator, managed by Operator Lifecycle Manager (OLM).
+[role="_abstract"]
+To deploy an etcd cluster from an installed Operator in {product-title}, you can use the etcd Operator in the web console. Operator Lifecycle Manager (OLM) manages the Operator while you create and configure etcd cluster resources.
 
 .Prerequisites
 

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -7,7 +7,8 @@
 [id="olm-deleting-operator-from-a-cluster-using-cli_{context}"]
 = Deleting Operators from a cluster using the CLI
 
-Cluster administrators can delete installed Operators from a selected namespace by using the CLI.
+[role="_abstract"]
+To remove an installed Operator from a {product-title} namespace, you can delete its subscription and cluster service version (CSV) by using the CLI. You must remove the Operator completely before you reinstall it.
 
 .Prerequisites
 

--- a/modules/olm-installing-from-software-catalog-using-cli.adoc
+++ b/modules/olm-installing-from-software-catalog-using-cli.adoc
@@ -16,7 +16,8 @@ endif::[]
 [id="olm-installing-operator-from-software-catalog-using-cli_{context}"]
 = Installing from the software catalog by using the CLI
 
-Instead of using the {product-title} web console, you can install an Operator from the software catalog by using the CLI. Use the `oc` command to create or update a `Subscription` object.
+[role="_abstract"]
+To install an Operator from the software catalog without the web console, you can create or update a `Subscription` object by using the `oc` command in {product-title}.
 
 For `SingleNamespace` install mode, you must also ensure an appropriate Operator group exists in the related namespace. An Operator group, defined by an `OperatorGroup` object, selects target namespaces in which to generate required RBAC access for all Operators in the same namespace as the Operator group.
 

--- a/modules/olm-installing-from-software-catalog-using-web-console.adoc
+++ b/modules/olm-installing-from-software-catalog-using-web-console.adoc
@@ -33,7 +33,8 @@ endif::[]
 [id="olm-installing-from-software-catalog-using-web-console_{context}"]
 = Installing from the software catalog by using the web console
 
-You can install and subscribe to an Operator from software catalog by using the {product-title} web console.
+[role="_abstract"]
+To install and subscribe to an Operator from the software catalog in {product-title}, you can use the web console. The console guides you through selecting an install mode, namespace, and approval strategy.
 
 .Prerequisites
 

--- a/modules/olm-installing-global-namespaces.adoc
+++ b/modules/olm-installing-global-namespaces.adoc
@@ -6,15 +6,10 @@
 [id="olm-installing-global-namespaces_{context}"]
 = Installing global Operators in custom namespaces
 
-When installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace. This can cause issues related to shared install plans and update policies between all Operators in the namespace. For more details on these limitations, see "Multitenancy and Operator colocation".
+[role="_abstract"]
+To avoid installing global Operators in the default `openshift-operators` namespace, you can create a custom global namespace in {product-title} and install Operators there instead.
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As a cluster administrator,
-endif::[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As an administrator with the `dedicated-admin` role,
-endif::[]
-you can bypass this default behavior manually by creating a custom global namespace and using that namespace to install your individual or scoped set of Operators and their dependencies.
+When installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace. This can cause issues related to shared install plans and update policies between all Operators in the namespace. For more details on these limitations, see "Multitenancy and Operator colocation".
 
 .Prerequisites
 

--- a/modules/olm-installing-operators-from-software-catalog.adoc
+++ b/modules/olm-installing-operators-from-software-catalog.adoc
@@ -16,7 +16,8 @@ endif::[]
 [id="olm-installing-operators-from-software-catalog_{context}"]
 = About Operator installation from the software catalog
 
-The software catalog is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
+[role="_abstract"]
+The software catalog in {product-title} is the interface for discovering Operators that Operator Lifecycle Manager (OLM) installs and manages on your cluster. You can choose installation settings such as install mode, namespace, and approval strategy during subscription.
 
 ifndef::olm-user,openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator, you can install an Operator from the software catalog by using the {product-title}

--- a/modules/olm-overriding-operatorconditions.adoc
+++ b/modules/olm-overriding-operatorconditions.adoc
@@ -6,20 +6,8 @@
 [id="olm-supported-operatorconditions_{context}"]
 = Overriding Operator conditions
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As a cluster administrator,
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As an administrator with the `dedicated-admin` role,
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Spec.Conditions` array, allowing
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-cluster administrators
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-`dedicated-admin` administrators
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
+[role="_abstract"]
+To bypass a supported Operator condition that an Operator reports incorrectly, you can add an override to the `OperatorCondition` object in {product-title}. Overrides in `Spec.Overrides` take precedence over conditions in `Spec.Conditions`.
 
 [NOTE]
 ====

--- a/modules/olm-pod-placement.adoc
+++ b/modules/olm-pod-placement.adoc
@@ -6,7 +6,8 @@
 [id="olm-pod-placement_{context}"]
 = Pod placement of Operator workloads
 
-By default, Operator Lifecycle Manager (OLM) places pods on arbitrary worker nodes when installing an Operator or deploying Operand workloads. As an administrator, you can use projects with a combination of node selectors, taints, and tolerations to control the placement of Operators and Operands to specific nodes.
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) places Operator and Operand pods on arbitrary worker nodes by default in {product-title}. You can steer pod placement to specific nodes by using projects with node selectors, taints, and tolerations.
 
 Controlling pod placement of Operator and Operand workloads has the following prerequisites:
 

--- a/modules/olm-preparing-multitenant-operators.adoc
+++ b/modules/olm-preparing-multitenant-operators.adoc
@@ -6,13 +6,8 @@
 [id="olm-preparing-operators-multitenant_{context}"]
 = Preparing for multiple instances of an Operator for multitenant clusters
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As a cluster administrator,
-endif::[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As an administrator with the `dedicated-admin` role,
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-you can add multiple instances of an Operator for use in multitenant clusters. This is an alternative solution to either using the standard *All namespaces* install mode, which can be considered to violate the principle of least privilege, or the *Multinamespace* mode, which is not widely adopted. For more information, see "Operators in multitenant clusters".
+[role="_abstract"]
+To provide separate Operator instances for each tenant in a multitenant {product-title} cluster, you can install multiple instances of the same Operator in dedicated namespaces. This approach limits privileges compared with the *All namespaces* install mode.
 
 In the following procedure, the _tenant_ is a user or group of users that share common access and privileges for a set of deployed workloads. The _tenant Operator_ is the instance of an Operator that is intended for use by only that tenant.
 

--- a/modules/olm-preparing-upgrade.adoc
+++ b/modules/olm-preparing-upgrade.adoc
@@ -6,7 +6,8 @@
 [id="olm-preparing-upgrade_{context}"]
 = Preparing for an Operator update
 
-The subscription of an installed Operator specifies an update channel that tracks and receives updates for the Operator. You can change the update channel to start tracking and receiving updates from a newer channel.
+[role="_abstract"]
+An installed Operator subscription in {product-title} tracks updates through an update channel that you can change to receive newer versions. Update channel names typically follow the Operator's release stream or update frequency.
 
 The names of update channels in a subscription can differ between Operators, but the naming scheme typically follows a common convention within a given Operator. For example, channel names might follow a minor release update stream for the application provided by the Operator (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
 

--- a/modules/olm-updating-use-operatorconditions.adoc
+++ b/modules/olm-updating-use-operatorconditions.adoc
@@ -6,7 +6,8 @@
 [id="olm-updating-use-operatorconditions_{context}"]
 = Updating your Operator to use Operator conditions
 
-Operator Lifecycle Manager (OLM) automatically creates an `OperatorCondition` resource for each `ClusterServiceVersion` resource that it reconciles. All service accounts in the CSV are granted the RBAC to interact with the `OperatorCondition` owned by the Operator.
+[role="_abstract"]
+Operator authors can update an Operator in {product-title} to report its status through Operator conditions that Operator Lifecycle Manager (OLM) reconciles. OLM creates an `OperatorCondition` resource for each `ClusterServiceVersion` and grants RBAC for condition management.
 
 An Operator author can develop their Operator to use the `operator-lib` library such that, after the Operator has been deployed by OLM, it can set its own conditions. For more resources about setting Operator conditions as an Operator author, see the link:https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-generating-csvs.html#osdk-operatorconditions_osdk-generating-csvs[Enabling Operator conditions] page.
 

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -9,13 +9,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Using Operator Lifecycle Manager (OLM),
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-cluster administrators can install OLM-based Operators to an {product-title} cluster.
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-administrators with the `dedicated-admin` role can install OLM-based Operators to a {product-title} cluster.
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+[role="_abstract"]
+You can install OLM-based Operators on your {product-title} cluster by using Operator Lifecycle Manager (OLM). This assembly covers software catalog installation, multitenant setup, custom global namespaces, and pod placement.
 
 [NOTE]
 ====

--- a/operators/admin/olm-deleting-operators-from-cluster.adoc
+++ b/operators/admin/olm-deleting-operators-from-cluster.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following describes how to delete, or uninstall, Operators that were previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
+[role="_abstract"]
+You can delete Operators that were previously installed with Operator Lifecycle Manager (OLM) on your {product-title} cluster. Use the web console or CLI to remove subscriptions and cluster service versions.
 
 [IMPORTANT]
 ====

--- a/operators/admin/olm-managing-operatorconditions.adoc
+++ b/operators/admin/olm-managing-operatorconditions.adoc
@@ -6,12 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As a cluster administrator, you can manage Operator conditions by using Operator Lifecycle Manager (OLM).
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-As an administrator with the `dedicated-admin` role, you can manage Operator conditions by using Operator Lifecycle Manager (OLM).
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+[role="_abstract"]
+You can manage Operator conditions in {product-title} by using Operator Lifecycle Manager (OLM). This assembly covers overriding reported conditions and updating Operators to use condition reporting.
 
 include::modules/olm-overriding-operatorconditions.adoc[leveloffset=+1]
 

--- a/operators/admin/olm-status.adoc
+++ b/operators/admin/olm-status.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Understanding the state of the system in Operator Lifecycle Manager (OLM) is important for making decisions about and debugging problems with installed Operators. OLM provides insight into subscriptions and related catalog sources regarding their state and actions performed. This helps users better understand the healthiness of their Operators.
+[role="_abstract"]
+You can view the status of installed Operators in {product-title} through Operator Lifecycle Manager (OLM). OLM reports subscription and catalog source conditions to help you assess Operator health.
 
 include::modules/olm-status-conditions.adoc[leveloffset=+1]
 

--- a/operators/admin/olm-troubleshooting-operator-issues.adoc
+++ b/operators/admin/olm-troubleshooting-operator-issues.adoc
@@ -8,7 +8,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-If you experience Operator issues, verify Operator subscription status. Check Operator pod health across the cluster and gather Operator logs for diagnosis.
+[role="_abstract"]
+You can troubleshoot Operator issues in {product-title} by checking subscription status, Operator pod health, and Operator logs. These diagnostics help you identify and resolve problems with Operators installed by Operator Lifecycle Manager (OLM).
 
 // Operator subscription condition types
 include::modules/olm-status-conditions.adoc[leveloffset=+1]

--- a/operators/admin/olm-upgrading-operators.adoc
+++ b/operators/admin/olm-upgrading-operators.adoc
@@ -6,14 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-a cluster administrator,
-endif::[]
-ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-an administrator with the `dedicated-admin` role,
-endif::[]
-you can update Operators that have been previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
+[role="_abstract"]
+You can update Operators previously installed with Operator Lifecycle Manager (OLM) on your {product-title} cluster. This assembly covers preparing for updates, changing update channels, and approving pending upgrades.
 
 [NOTE]
 ====

--- a/operators/user/olm-creating-apps-from-installed-operators.adoc
+++ b/operators/user/olm-creating-apps-from-installed-operators.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide walks developers through an example of creating applications from an installed Operator using the {product-title} web console.
+[role="_abstract"]
+You can create applications from installed Operators in {product-title} by using the web console. The included example deploys an etcd cluster from the etcd Operator.
 
 include::modules/olm-creating-etcd-cluster-from-operator.adoc[leveloffset=+1]

--- a/operators/user/olm-installing-operators-in-namespace.adoc
+++ b/operators/user/olm-installing-operators-in-namespace.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-If a cluster administrator has delegated Operator installation permissions to your account, you can install and subscribe an Operator to your namespace in a self-service manner.
+[role="_abstract"]
+You can install and subscribe to Operators in your namespace on {product-title} when a cluster administrator has delegated installation permissions. This self-service workflow uses the software catalog in the web console or CLI.
 
 [id="olm-installing-operators-in-namespace-prereqs"]
 == Prerequisites


### PR DESCRIPTION
## Summary
Adds rewritten DITA short descriptions (`[role="_abstract"]`) to 20 OLM admin and user assembly/module topics for [OSDOCS-16940](https://redhat.atlassian.net/browse/OSDOCS-16940). Duplicative intro paragraphs were removed where the new abstract covers the same intent.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16940

## Versions
4.20+

## Merge order
Independent branch from main (abstracts only). No dependency on other [OSDOCS-16940](https://redhat.atlassian.net/browse/OSDOCS-16940) series PRs.

## Files changed
- `modules/olm-changing-update-channel.adoc`
- `modules/olm-creating-etcd-cluster-from-operator.adoc`
- `modules/olm-deleting-operators-from-a-cluster-using-cli.adoc`
- `modules/olm-installing-from-software-catalog-using-cli.adoc`
- `modules/olm-installing-from-software-catalog-using-web-console.adoc`
- `modules/olm-installing-global-namespaces.adoc`
- `modules/olm-installing-operators-from-software-catalog.adoc`
- `modules/olm-overriding-operatorconditions.adoc`
- `modules/olm-pod-placement.adoc`
- `modules/olm-preparing-multitenant-operators.adoc`
- `modules/olm-preparing-upgrade.adoc`
- `modules/olm-updating-use-operatorconditions.adoc`
- `operators/admin/olm-adding-operators-to-cluster.adoc`
- `operators/admin/olm-deleting-operators-from-cluster.adoc`
- `operators/admin/olm-managing-operatorconditions.adoc`
- `operators/admin/olm-status.adoc`
- `operators/admin/olm-troubleshooting-operator-issues.adoc`
- `operators/admin/olm-upgrading-operators.adoc`
- `operators/user/olm-creating-apps-from-installed-operators.adoc`
- `operators/user/olm-installing-operators-in-namespace.adoc`

## Vale rules addressed
- AsciiDocDITA.ShortDescription

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted
- 20 files changed, 109 lines (43 insertions, 66 deletions)

Made with [Cursor](https://cursor.com)