### PR TITLE
OSDOCS-20427-1:Adding info to the z-stream RN for 4.19.36

### DIFF
--- a/modules/zstream-4-19-36.adoc
+++ b/modules/zstream-4-19-36.adoc
@@ -20,6 +20,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.19.36 --pullspecs
 ----
 
+[id="zstream-4-19-36-known-issues_{context}"]
+== Known issues
+
+* Currently, when you apply the `openshift-node-performance` PerformanceProfile with the non-RT kernel, timer migration (`kernel.timer_migration`) is not enabled. As a consequence, kernel timers such as TCP timeout and keep-alive timers can remain stuck on CPUs assigned to latency-sensitive workloads, causing unwanted interruptions to those workloads. As a workaround, enable timer migration by using a TuneD custom resource to set the `kernel.timer_migration=1` `sysctl` parameter. For more information about configuring TuneD, see link:https://access.redhat.com/solutions/5532341[Performance addons Operator advanced configuration]. (link:https://issues.redhat.com/browse/OCPBUGS-88469[OCPBUGS-88469])
+
 [id="zstream-4-19-36-fixed-issues_{context}"]
 == Fixed issues
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20427

Link to docs preview:
https://115362--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-36-known-issues_release-notes

Additional information:
Adding Known Issues information from OCPBUGS-88469 that was inadvertently omitted.