### PR TITLE
[TELCODOCS-2928] Add oc-mirror v2 requirement for disconnected environments

### DIFF
--- a/modules/telco-core-disconnected-environment.adoc
+++ b/modules/telco-core-disconnected-environment.adoc
@@ -10,7 +10,7 @@
 Telco core clusters are expected to be installed in networks without direct access to the internet.
 
 New in this release::
-* There are no reference design updates in this release.
+* Added requirement to use the `oc mirror` plugin v2 for mirroring image signatures in disconnected environments.
 
 Description::
 Telco core clusters are expected to be installed in networks without direct access to the internet.
@@ -27,5 +27,8 @@ Do not reuse the default catalog names.
 
 Engineering considerations::
 
-* A valid time source must be configured as part of cluster installation
+* A valid time source must be configured as part of cluster installation.
+* In {product-title} {product-version} and later, pulling OpenShift images from a disconnected mirror registry requires copying the image signatures into that registry during the mirroring process.
+The `oc adm mirror` command does not mirror signatures and must not be used.
+Instead, use the `oc mirror` plugin v2 to ensure signatures are properly mirrored.
 

--- a/modules/telco-hub-networking.adoc
+++ b/modules/telco-hub-networking.adoc
@@ -46,3 +46,6 @@ For example, the registry must be available in a scenario where a power failure 
 --
 Engineering considerations::
 * When deploying a hub cluster, ensure you define appropriately sized CIDR range definitions.
+* In {product-title} {product-version} and later, pulling OpenShift images from a disconnected mirror registry requires copying the image signatures into that registry during the mirroring process.
+The `oc adm mirror` command does not mirror signatures and must not be used.
+Instead, use the `oc mirror` plugin v2 to ensure signatures are properly mirrored.

--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -164,3 +164,14 @@ The system is engineered to 3 CPUs (3000mc) at steady-state to allow for periodi
 
 |====
 --
+
+Disconnected environment::
++
+--
+RAN DU clusters are typically deployed in disconnected environments without direct access to the internet.
+All container images needed to install, configure, and operate the cluster must be available in a disconnected registry.
+
+In {product-title} {product-version} and later, pulling OpenShift images from a disconnected mirror registry requires copying the image signatures into that registry during the mirroring process.
+The `oc adm mirror` command does not mirror signatures and must not be used.
+Instead, use the `oc mirror` plugin v2 to ensure signatures are properly mirrored.
+--

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -201,6 +201,8 @@ include::modules/telco-core-disconnected-environment.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+
 * xref:../disconnected/updating/index.adoc#about-disconnected-updates[About cluster updates in a disconnected environment]
 
 * xref:../nodes/containers/nodes-containers-sysctls.adoc#nodes-containers-sysctls[Using sysctl in containers]

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -57,6 +57,7 @@ include::modules/telco-hub-networking.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 * xref:../disconnected/installing.adoc#installing-disconnected-environments[Installing a cluster in a disconnected environment]
 * xref:../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
 * xref:../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster[Configuring the hub cluster to use a disconnected mirror registry]

--- a/scalability_and_performance/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco-ran-du-rds.adoc
@@ -22,6 +22,11 @@ include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+1]
 
 include::modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+
 include::modules/telco-ran-du-application-workloads.adoc[leveloffset=+1]
 
 include::modules/telco-ran-du-reference-design-components.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2928
Documents: https://redhat.atlassian.net/browse/CNF-24746

Link to docs preview:
https://115364--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html
https://115364--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html
https://115364--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html

QE review:
N/A - ports upstream RDS content already reviewed and merged (MR !202).

Additional information:
Adds engineering consideration requiring `oc mirror` plugin v2 for image signature mirroring in disconnected registries to Core, Hub, and RAN DU reference design specification modules. The `oc adm mirror` command does not mirror signatures and must not be used in OCP 4.22+.