### PR TITLE
OSDOCS-16941: DITA abstracts — OLM catalog/config topics

### DIFF
--- a/modules/olm-about-catalogs.adoc
+++ b/modules/olm-about-catalogs.adoc
@@ -6,7 +6,8 @@
 [id="olm-about-catalogs_{context}"]
 = About Operator catalogs
 
-An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog.
+[role="_abstract"]
+An Operator catalog stores metadata that Operator Lifecycle Manager (OLM) queries to discover and install Operators and dependencies on {product-title}. You can package catalogs as index images and reference them from catalog sources to control available Operators.
 
 An index image, based on the Operator bundle format, is a containerized snapshot of a catalog. It is an immutable artifact that contains the database of pointers to a set of Operator manifest content. A catalog can reference an index image to source its content for OLM on the cluster.
 

--- a/modules/olm-accessing-images-private-registries.adoc
+++ b/modules/olm-accessing-images-private-registries.adoc
@@ -6,6 +6,9 @@
 [id="olm-accessing-images-private-registries_{context}"]
 = Accessing images for Operators from private registries
 
+[role="_abstract"]
+To enable Operator Lifecycle Manager (OLM) to install Operators whose images are hosted in private registries, you can create pull secrets in {product-title} and reference them from catalog sources.
+
 ifeval::["{context}" == "olm-managing-custom-catalogs"]
 If certain images relevant to Operators managed by Operator Lifecycle Manager (OLM) are hosted in an authenticated container image registry, also known as a private registry, OLM and the software catalog are unable to pull the images by default. To enable access, you can create a pull secret that contains the authentication credentials for the registry. By referencing one or more pull secrets in a catalog source, OLM can handle placing the secrets in the Operator and catalog namespace to allow installation.
 
@@ -21,8 +24,6 @@ Operator and Operand images:: If an Operator installed from a catalog source use
 +
 Instead, the authentication details can be added to the global cluster pull secret in the `openshift-config` namespace, which provides access to all namespaces on the cluster. Alternatively, if providing access to the entire cluster is not permissible, the pull secret can be added to the `default` service accounts of the target tenant namespaces.
 endif::[]
-
-You can access images from Operator from private registries by creating a secret for your registry credentials and adding the secret for use with relevant catalogs.
 
 .Prerequisites
 

--- a/modules/olm-catalog-source-and-psa.adoc
+++ b/modules/olm-catalog-source-and-psa.adoc
@@ -6,7 +6,8 @@
 [id="olm-catalog-sources-and-psa_{context}"]
 = Catalog sources and pod security admission
 
-_Pod security admission_ was introduced in {product-title} 4.11 to ensure pod security standards. Catalog sources built using the SQLite-based catalog format and a version of the `opm` CLI tool released before {product-title} 4.11 cannot run under restricted pod security enforcement.
+[role="_abstract"]
+Pod security admission in {product-title} can prevent SQLite-based catalog sources built with older `opm` releases from running under restricted enforcement. You can migrate to file-based catalogs or update catalog images to meet restricted pod security standards.
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 In {product-title} {product-version}, 

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -25,6 +25,7 @@ endif::[]
 [id="olm-creating-catalog-from-index_{context}"]
 = Adding a catalog source to a cluster
 
+[role="_abstract"]
 Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators

--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -13,7 +13,8 @@ endif::[]
 [id="olm-creating-fb-catalog-image_{context}"]
 = Creating a file-based catalog image
 
-You can use the `opm` CLI to create a catalog image that uses the plain text _file-based catalog_ format (JSON or YAML), which replaces the deprecated SQLite database format.
+[role="_abstract"]
+To build an Operator catalog for {product-title} in the file-based catalog format, you can use the `opm` CLI to initialize a catalog directory and generate a container image.
 
 .Prerequisites
 

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -6,7 +6,8 @@
 [id="olm-creating-index-image_{context}"]
 = Creating a SQLite-based index image
 
-You can create an index image based on the SQLite database format by using the `opm` CLI.
+[role="_abstract"]
+To create a SQLite-based index image for Operator Lifecycle Manager (OLM) in {product-title}, you can use the `opm index add` command to add bundle images and push the result to a registry.
 
 .Prerequisites
 

--- a/modules/olm-disabling-copied-csvs.adoc
+++ b/modules/olm-disabling-copied-csvs.adoc
@@ -6,11 +6,8 @@
 [id="olm-disabling-copied-csvs_{context}"]
 = Disabling copied CSVs
 
-When an Operator is installed by Operator Lifecycle Manager (OLM), a simplified copy of its cluster service version (CSV) is created by default in every namespace that the Operator is configured to watch. These CSVs are known as _copied CSVs_ and communicate to users which controllers are actively reconciling resource events in a given namespace.
-
-When an Operator is configured to use the `AllNamespaces` install mode, versus targeting a single or specified set of namespaces, a copied CSV for the Operator is created in every namespace on the cluster. On especially large clusters, with namespaces and installed Operators potentially in the hundreds or thousands, copied CSVs consume an untenable amount of resources, such as OLM's memory usage, cluster etcd limits, and networking.
-
-To support these larger clusters, cluster administrators can disable copied CSVs for Operators globally installed with the `AllNamespaces` mode.
+[role="_abstract"]
+To reduce memory, etcd, and network usage on large {product-title} clusters, you can disable copied cluster service versions (CSVs) for Operators installed in `AllNamespaces` mode through the cluster `OLMConfig`.
 
 [NOTE]
 ====

--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -13,14 +13,8 @@ endif::[]
 [id="olm-filtering-fbc_{context}"]
 = Updating or filtering a file-based catalog image
 
-You can use the `opm` CLI to update or filter a catalog image that uses the file-based catalog format. By extracting the contents of an existing catalog image, you can modify the catalog as needed, for example:
-
-* Adding packages
-* Removing packages
-* Updating existing package entries
-* Detailing deprecation messages per package, channel, and bundle
-
-You can then rebuild the image as an updated version of the catalog.
+[role="_abstract"]
+To add, remove, or update packages in a file-based Operator catalog for {product-title}, you can extract catalog contents with the `opm` CLI, edit the metadata, and rebuild the catalog image.
 
 // This note points to a topic that's excluded from OSD and ROSA.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -6,6 +6,7 @@
 [id="olm-inject-custom-ca_{context}"]
 = Injecting a custom CA certificate
 
+[role="_abstract"]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 When a cluster administrator
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
+++ b/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
@@ -6,7 +6,8 @@
 [id="olm-migrating-sqlite-catalog-to-fbc_{context}"]
 = Migrating SQLite database catalogs to the file-based catalog format
 
-You can update your deprecated SQLite database format catalogs to the file-based catalog format.
+[role="_abstract"]
+To move from the deprecated SQLite catalog format to file-based catalogs in {product-title}, you can use the `opm migrate` command to convert an existing catalog image.
 
 .Prerequisites
 

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -6,6 +6,7 @@
 [id="olm-overriding-proxy-settings_{context}"]
 = Overriding proxy settings of an Operator
 
+[role="_abstract"]
 If a cluster-wide egress proxy is configured, Operators running with Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy settings on their deployments.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -26,7 +26,8 @@ endif::[]
 [id="olm-pruning-index-image_{context}"]
 = Filtering a SQLite-based index image
 
-An index image, based on the Operator bundle format, is a containerized snapshot of an Operator catalog. You can filter, or _prune_, an index of all but a specified list of packages, which creates a copy of the source index containing only the Operators that you want.
+[role="_abstract"]
+To include only selected Operators in a SQLite-based index image for {product-title}, you can filter, or prune, the catalog with the `opm index prune` command.
 
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
 When configuring Operator Lifecycle Manager (OLM) to use mirrored content on restricted network {product-title} clusters, use this pruning method if you want to only mirror a subset of Operators from the default catalogs.

--- a/modules/olm-removing-catalogs.adoc
+++ b/modules/olm-removing-catalogs.adoc
@@ -8,7 +8,8 @@
 [id="olm-removing-catalogs_{context}"]
 = Removing custom catalogs
 
-As a cluster administrator, you can remove custom Operator catalogs that have been previously added to your cluster by deleting the related catalog source.
+[role="_abstract"]
+To remove a custom Operator catalog from {product-title}, you can delete the related `CatalogSource` object from the web console or CLI as a cluster administrator.
 
 .Prerequisites
 * You have access to the cluster as a user with the `cluster-admin` role.

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -32,6 +32,7 @@ endif::[]
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Disabling the default software catalog sources
 
+[role="_abstract"]
 Operator catalogs that source content provided by Red Hat and community projects are configured for the software catalog by default during an {product-title} installation.
 ifndef::olm-managing-custom-catalogs[]
 In a restricted network environment, you must disable the default catalogs as a cluster administrator.

--- a/modules/olm-rh-catalogs.adoc
+++ b/modules/olm-rh-catalogs.adoc
@@ -14,7 +14,8 @@ endif::[]
 [id="olm-rh-catalogs_{context}"]
 = About Red Hat-provided Operator catalogs
 
-The Red Hat-provided catalog sources are installed by default in the `{global_ns}` namespace, which makes the catalogs available cluster-wide in all namespaces.
+[role="_abstract"]
+Red Hat distributes default Operator catalogs as index images installed in the `{global_ns}` namespace on {product-title} clusters. These catalogs make Red Hat, certified, and community Operators available cluster-wide in the software catalog.
 
 The following Operator catalogs are distributed by Red Hat:
 

--- a/modules/olm-software-catalog-architecture.adoc
+++ b/modules/olm-software-catalog-architecture.adoc
@@ -7,7 +7,8 @@
 [id="olm-software-catalog-arch_{context}"]
 = Software catalog architecture
 
-The software catalog UI component is driven by the Marketplace Operator by default on {product-title} in the `openshift-marketplace` namespace.
+[role="_abstract"]
+The software catalog UI in {product-title} is driven by the Marketplace Operator, which manages default catalog sources through the cluster `OperatorHub` custom resource.
 
 [id="olm-software-catalog-arch-operatorhub-crd_{context}"]
 == OperatorHub custom resource

--- a/modules/olm-software-catalog-overview.adoc
+++ b/modules/olm-software-catalog-overview.adoc
@@ -7,7 +7,8 @@
 [id="olm-software-catalog-overview_{context}"]
 = About the software catalog
 
-The _software catalog_ is the web console interface in {product-title} that cluster administrators use to discover and install Operators. With one click, an Operator can be pulled from its off-cluster source, installed and subscribed on the cluster, and made ready for engineering teams to self-service manage the product across deployment environments using Operator Lifecycle Manager (OLM).
+[role="_abstract"]
+The software catalog is the {product-title} web console interface for discovering and installing Operators through Operator Lifecycle Manager (OLM). You can browse Red Hat, certified, community, and custom catalog categories to install and subscribe to Operators.
 
 ifndef::openshift-origin[]
 Cluster administrators can choose from catalogs grouped into the following categories:

--- a/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
+++ b/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
@@ -6,10 +6,11 @@
 [id="olm-sqlite-catalog-elevated-privileges_{context}"]
 = Configuring catalogs to run with elevated permissions
 
-If you do not want to update your SQLite database catalog image or migrate your catalog to the file-based catalog format, you can perform the following actions to ensure your catalog source runs when the default pod security enforcement changes to restricted:
+[role="_abstract"]
+To keep SQLite-based catalog sources running when {product-title} enforces restricted pod security, you can set legacy security mode on the catalog source or label the namespace for elevated pod security admission.
 
-* Manually set the catalog security mode to legacy in your catalog source definition. This action ensures your catalog runs with legacy permissions even if the default catalog security mode changes to restricted.
-* Label the catalog source namespace for baseline or privileged pod security enforcement.
+* Manually setting the catalog security mode to legacy in your catalog source definition ensures your catalog runs with legacy permissions even if the default catalog security mode changes to restricted.
+* Labeling the catalog source namespace for baseline or privileged pod security enforcement ensures your catalog runs with the elevated pod security admission standard.
 
 [NOTE]
 ====

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -13,6 +13,7 @@ endif::[]
 [id="olm-updating-index-image_{context}"]
 = Updating a SQLite-based index image
 
+[role="_abstract"]
 After configuring the software catalog to use a catalog source that references a custom index image,
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrators

--- a/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
+++ b/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
@@ -6,7 +6,8 @@
 [id="olm-updating-sqlite-catalog-to-a-new-opm-version_{context}"]
 = Rebuilding SQLite database catalog images
 
-You can rebuild your SQLite database catalog image with the latest version of the `opm` CLI tool that is released with your version of {product-title}.
+[role="_abstract"]
+To rebuild a SQLite-based catalog image with a supported `opm` release for your {product-title} version, you can use the `opm index add` command with an updated binary image.
 
 .Prerequisites
 

--- a/modules/sd-olm-removing-catalogs.adoc
+++ b/modules/sd-olm-removing-catalogs.adoc
@@ -8,7 +8,8 @@
 [id="sd-olm-removing-catalogs_{context}"]
 = Removing custom catalogs
 
-As an administrator with the `dedicated-admin` role, you can remove custom Operator catalogs that have been previously added to your cluster by deleting the related catalog source.
+[role="_abstract"]
+To remove a custom Operator catalog from {product-title}, you can delete the related `CatalogSource` object from the web console as an administrator with the `dedicated-admin` role.
 
 .Prerequisites
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/operators/admin/olm-config.adoc
+++ b/operators/admin/olm-config.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Operator Lifecycle Manager (OLM) controller is configured by an `OLMConfig` custom resource (CR) named `cluster`. Cluster administrators can modify this resource to enable or disable certain features.
-
-This document outlines the features currently supported by OLM that are configured by the `OLMConfig` resource.
+[role="_abstract"]
+You can enable or disable Operator Lifecycle Manager (OLM) cluster features by editing the `OLMConfig` custom resource named `cluster` in {product-title}.
 
 include::modules/olm-disabling-copied-csvs.adoc[leveloffset=+1]
 

--- a/operators/admin/olm-configuring-proxy-support.adoc
+++ b/operators/admin/olm-configuring-proxy-support.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-If a global proxy is configured on your {product-title} cluster, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. However, you can also configure installed Operators to override the global proxy or inject a custom CA certificate.
+[role="_abstract"]
+When a cluster-wide proxy is configured, Operator Lifecycle Manager (OLM) applies those settings to managed Operators in {product-title}. You can override proxy configuration per Operator or inject a custom CA certificate.
 
 [role="_additional-resources"]
 .Additional resources

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-For {product-title} clusters in disconnected environments, Operator Lifecycle Manager (OLM) by default cannot access the Red{nbsp}Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity.
-
-However, as a cluster administrator you can still enable your cluster to use OLM in a disconnected environment if you have a workstation that has full internet access. The workstation, which requires full internet access to pull the remote OperatorHub content, is used to prepare local mirrors of the remote sources, and push the content to a mirror registry.
+[role="_abstract"]
+On disconnected {product-title} clusters, Operator Lifecycle Manager (OLM) cannot reach remote OperatorHub sources by default. You can mirror catalog content locally and configure OLM to install Operators from those mirrors.
 
 The mirror registry can be located on a bastion host, which requires connectivity to both your workstation and the disconnected cluster, or a completely disconnected, or _airgapped_, host, which requires removable media to physically move the mirrored content to the disconnected environment.
 

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat provides several Operator catalogs that are included with {product-title} by default.
+[role="_abstract"]
+{product-title} includes Red Hat-provided Operator catalogs by default for use with Operator Lifecycle Manager (OLM). These catalogs deliver Red Hat, certified, and community Operators through index images in the software catalog.
 
 [IMPORTANT]
 ====

--- a/operators/understanding/olm-understanding-software-catalog.adoc
+++ b/operators/understanding/olm-understanding-software-catalog.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+The software catalog in {product-title} provides a web console interface for discovering, installing, and managing Operators through Operator Lifecycle Manager (OLM).
+
 include::modules/olm-software-catalog-overview.adoc[leveloffset=+1]
 
 include::modules/olm-software-catalog-architecture.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
Rewrites DITA short descriptions (`[role="_abstract"]`) for 28 OLM catalog, config, and software-catalog topics from [OSDOCS-16941](https://redhat.atlassian.net/browse/OSDOCS-16941) attachments. Removes duplicative intro paragraphs where the new abstract covers the same intent.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16941

## Versions
4.20+

## Merge order
Independent branch from main (abstracts only). Preferred merge order: first in series (abstracts → callouts #115365 → other-vale). Rebase later PRs if same-file conflicts.

## Files changed
- 28 files across `operators/admin/`, `operators/understanding/`, and `modules/` (see PR Files changed)

## Vale rules addressed
- AsciiDocDITA.ShortDescription

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted

Made with [Cursor](https://cursor.com)