### PR TITLE
ROX-33828: Update install docs for 4.11

### DIFF
--- a/cli/command-reference/roxctl-central.adoc
+++ b/cli/command-reference/roxctl-central.adoc
@@ -37,6 +37,9 @@ $ roxctl central [command] [flags]
 |`generate`
 |Generate the required YAML configuration files containing the orchestrator objects for the deployment of Central.
 
+|`migrate-to-operator`
+|Generate a `Central` custom resource from an existing deployment for Operator management.
+
 |`init-bundles`
 |Initialize bundles for Central.
 
@@ -113,6 +116,9 @@ include::modules/roxctl-central-debug-authz-trace.adoc[leveloffset=+2]
 include::modules/roxctl-central-debug-db-stats-reset.adoc[leveloffset=+2]
 
 include::modules/roxctl-central-debug-download-diagnostics.adoc[leveloffset=+2]
+
+//roxctl central migrate-to-operator
+include::modules/roxctl-central-migrate-to-operator.adoc[leveloffset=+1]
 
 // /roxctl central generate
 include::modules/roxctl-central-generate.adoc[leveloffset=+1]

--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -39,6 +39,8 @@ include::modules/installing-rhacs-on-red-hat-openshift-by-using-the-roxctl-cli.a
 
 include::modules/installing-rhacs-kubernetes-steps.adoc[leveloffset=+1]
 
+include::modules/installing-rhacs-on-kubernetes-by-using-the-operator.adoc[leveloffset=+2]
+
 include::modules/installing-rhacs-on-kubernetes-platforms-by-using-helm-charts.adoc[leveloffset=+2]
 
 include::modules/installing-rhacs-on-kubernetes-platforms-by-using-the-roxctl.adoc[leveloffset=+2]

--- a/installing/installing_other/install-central-other.adoc
+++ b/installing/installing_other/install-central-other.adoc
@@ -12,10 +12,25 @@ Central is the resource that contains the {product-title-short} application mana
 
 You can install Central by using one of the following methods:
 
-* Install using Helm charts
-* Install using the `roxctl` CLI (do not use this method unless you have a specific installation need that requires using it)
+* Install by using the Operator (recommended)
+* Install by using Helm charts (deprecated)
+* Install by using the `roxctl` CLI (deprecated)
 
-// Install using Helm
+// Install by using Operator
+
+include::modules/install-operator-using-helm-chart-other-concept.adoc[leveloffset=+1]
+
+include::modules/install-operator-using-helm-chart-other.adoc[leveloffset=+2]
+
+include::modules/install-central-operator-other.adoc[leveloffset=+2]
+
+// Migrate existing deployments to Operator
+
+include::modules/migrate-to-operator-overview.adoc[leveloffset=+1]
+
+include::modules/migrate-to-operator-procedure.adoc[leveloffset=+2]
+
+// Install by using Helm
 
 include::modules/install-central-using-helm-charts-other.adoc[leveloffset=+1]
 
@@ -75,7 +90,7 @@ include::modules/install-central-services-helm-chart.adoc[leveloffset=+3]
 
 include::modules/change-config-options-after-deployment-central-service.adoc[leveloffset=+2]
 
-// Install using roxctl
+// Install by using roxctl
 
 include::modules/install-central-using-the-roxctl-cli-other.adoc[leveloffset=+1]
 

--- a/installing/installing_other/install-rhacs-other.adoc
+++ b/installing/installing_other/install-rhacs-other.adoc
@@ -9,17 +9,24 @@ toc::[]
 [role="_abstract"]
 {product-title} ({product-title-short}) provides security services for self-managed {product-title-short} on platforms such as Amazon Elastic Kubernetes Service (Amazon EKS), Google Kubernetes Engine (Google GKE), and Microsoft Azure Kubernetes Service (Microsoft AKS).
 
-Before you install:
+Before you install, do these steps:
 
-* Understand the installation methods for different platforms.
-* Understand the {product-title-short} architecture.
+* Review the installation methods for different platforms.
+* Review the {product-title-short} architecture.
 * Check the default resource requirements.
 
 The following list provides a high-level overview of installation steps:
 
-. Install Central services on a cluster by using Helm charts or the `roxctl` CLI.
+. Install the {product-title-short} Operator on the Central cluster by using the `rhacs-operator` Helm chart.
+. Create a `Central` custom resource to deploy Central services.
 . Generate and apply a cluster registration secret or an init bundle.
-. Install secured cluster resources on each of your secured clusters.
+. Install the Operator on each secured cluster and create a `SecuredCluster` custom resource.
+
+[IMPORTANT]
+====
+Direct Helm chart and `roxctl` CLI installation methods are deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====
 
 [role="_additional-resources"]
 [id="additional-resources-install-rhacs-other_{context}"]

--- a/installing/installing_other/install-secured-cluster-other.adoc
+++ b/installing/installing_other/install-secured-cluster-other.adoc
@@ -14,6 +14,24 @@ You can install {rh-rhacs-first} on your secured clusters for the following plat
 * Google Kubernetes Engine (GKE)
 * Microsoft Azure Kubernetes Service (Microsoft AKS)
 
+You can install secured cluster services by using one of the following methods:
+
+* Install by using the Operator (recommended)
+* Install by using Helm charts (deprecated)
+* Install by using the `roxctl` CLI (deprecated)
+
+// Install by using Operator
+
+include::modules/install-secured-cluster-operator-other.adoc[leveloffset=+1]
+
+[NOTE]
+====
+If you have existing secured cluster deployments installed by using Helm charts or the `roxctl` CLI, you can migrate them to Operator management.
+For more information, see xref:../../installing/installing_other/install-central-other.adoc#migrate-to-operator-overview_install-central-other[Migrating existing {product-title-short} deployments to Operator management].
+====
+
+// Install by using Helm charts
+
 include::modules/installing-rhacs-on-secured-clusters-by-using-helm-charts.adoc[leveloffset=+1]
 
 include::modules/installing-rhacs-on-secured-clusters-by-using-helm-charts-without-customizations.adoc[leveloffset=+2]

--- a/modules/install-central-operator-other.adoc
+++ b/modules/install-central-operator-other.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-central-other.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="install-central-operator-other_{context}"]
+= Install Central by using the Operator
+
+[role="_abstract"]
+After you install the {product-title-short} Operator, deploy Central by creating a `Central` custom resource.
+You deploy Central only once, and you can monitor multiple separate clusters by using the same Central installation.
+
+[IMPORTANT]
+====
+When you install {product-title} for the first time, you must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
+====
+
+.Prerequisites
+
+* The {product-title-short} Operator is installed on the cluster. For more information, see "Install the {product-title-short} Operator by using a Helm chart".
+
+.Procedure
+
+. Create the `stackrox` namespace:
++
+[source,terminal]
+----
+$ kubectl create namespace stackrox
+----
+
+. If you are deploying directly from the Red Hat image registry and do not have a cluster-wide image pull secret configured, create an image pull secret for the {product-title-short} application images:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl -n stackrox create secret docker-registry _<pull_secret_name>_ \
+  --docker-server=registry.redhat.io \
+  --docker-username=_<username>_ \
+  --docker-password=_<password>_
+----
+
+. Create a YAML file for the `Central` custom resource:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+  namespace: stackrox
+spec:
+  imagePullSecrets:
+    - name: _<pull_secret_name>_
+  central:
+    exposure:
+      loadBalancer:
+        enabled: true
+----
++
+If you have a cluster-wide image pull secret configured, you can omit the `imagePullSecrets` field.
++
+[NOTE]
+====
+The preceding example configures a load balancer for Central access.
+You can also use a node port or other exposure method depending on your cluster configuration.
+For a full list of configuration options, see "Central configuration options for {product-title-short} by using the Operator".
+====
+
+. Apply the custom resource:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl apply -f _<central_cr_file>_.yaml
+----
+
+. Wait for Central to become ready:
++
+[source,terminal]
+----
+$ kubectl -n stackrox rollout status deployment central
+----
+
+.Verification
+
+. Verify the `Central` custom resource status:
++
+[source,terminal]
+----
+$ kubectl get central -n stackrox
+----
+
+. Verify that Central pods are running:
++
+[source,terminal]
+----
+$ kubectl get pods -n stackrox
+----
++
+Confirm that the `central` and `central-db` pods are running. Example output:
++
+[source,terminal]
+----
+NAME                                  READY   STATUS     RESTARTS   AGE
+central-66b49bdbfb-zd67d              1/1     Running    0          88s
+central-db-675db46854-mqsll           2/2     Running    0          88s
+----
+. Retrieve the administrator password:
++
+[source,terminal]
+----
+$ kubectl -n stackrox get secret central-htpasswd -o go-template='{{index .data "password" | base64decode}}'
+----
+
+. Retrieve the external IP address of the Central load balancer:
++
+[source,terminal]
+----
+$ kubectl -n stackrox get svc central-loadbalancer
+----
+
+. Enter the external IP address and port of the Central load balancer into your browser to access the {product-title-short} portal. 
+. Log in with the `admin` account and administrator password.
+
+
+.Next steps
+
+* Generate and apply a cluster registration secret or init bundle.

--- a/modules/install-central-roxctl.adoc
+++ b/modules/install-central-roxctl.adoc
@@ -23,6 +23,11 @@ endif::[]
 [role="_abstract"]
 After you run the interactive installer, you can run the `setup.sh` script to install Central.
 
+[IMPORTANT]
+====
+The `roxctl` CLI installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====
 
 .Procedure
 . Run the `setup.sh` script to configure image registry access:

--- a/modules/install-central-using-helm-charts-other.adoc
+++ b/modules/install-central-using-helm-charts-other.adoc
@@ -8,3 +8,11 @@
 
 [role="_abstract"]
 You can install Central by using Helm charts without any customization, by using the default values, or by using Helm charts with additional customizations of configuration parameters.
+
+[IMPORTANT]
+====
+Direct Helm chart installation of Central is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for other platforms.
+For existing deployments, see the migration to Operator management documentation.
+====

--- a/modules/install-central-using-helm-charts.adoc
+++ b/modules/install-central-using-helm-charts.adoc
@@ -8,3 +8,10 @@
 
 [role="_abstract"]
 You can install Central by using Helm charts without any customization, by using the default values, or by using Helm charts with additional customizations of configuration parameters.
+
+[IMPORTANT]
+====
+Direct Helm chart installation of Central is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation.
+====

--- a/modules/install-central-using-the-roxctl-cli-other.adoc
+++ b/modules/install-central-using-the-roxctl-cli-other.adoc
@@ -7,9 +7,12 @@
 = Install Central by using the roxctl CLI
 
 [role="_abstract"]
-For production environments, Red{nbsp}Hat recommends using Helm charts to install {product-title-short}.
+For production environments, Red{nbsp}Hat recommends using the Operator to install {product-title-short}.
 
-[WARNING]
+[IMPORTANT]
 ====
-Do not use the `roxctl` install method unless you have a specific installation need that requires using this method.
+The `roxctl` CLI installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for other platforms.
+For existing deployments, see the migration to Operator management documentation.
 ====

--- a/modules/install-central-using-the-roxctl-cli.adoc
+++ b/modules/install-central-using-the-roxctl-cli.adoc
@@ -7,9 +7,11 @@
 = Install Central by using the roxctl CLI
 
 [role="_abstract"]
-For production environments, Red{nbsp}Hat recommends using the Operator or Helm charts to install {product-title-short}.
+For production environments, Red{nbsp}Hat recommends using the Operator to install {product-title-short}.
 
-[WARNING]
+[IMPORTANT]
 ====
-Do not use the `roxctl` install method unless you have a specific installation need that requires using this method.
+The `roxctl` CLI installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation.
 ====

--- a/modules/install-operator-using-helm-chart-other-concept.adoc
+++ b/modules/install-operator-using-helm-chart-other-concept.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-central-other.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="install-operator-using-helm-chart-other-concept_{context}"]
+= Install {product-title-short} by using the Operator on other platforms
+
+[role="_abstract"]
+You can install {product-title-short} on non-OpenShift Kubernetes clusters such as Amazon Elastic Kubernetes Service (Amazon EKS), Google Kubernetes Engine (Google GKE), and Microsoft Azure Kubernetes Service (Microsoft AKS) by using the {product-title-short} Operator.
+The Operator provides a Kubernetes-native way to manage the lifecycle of {product-title-short} components through custom resources.
+
+The {product-title-short} Operator is the recommended installation method for all platforms.
+On {osp}, you install the Operator from the Red{nbsp}Hat Ecosystem Catalog.
+On other Kubernetes platforms, you install the Operator by using the `rhacs-operator` Helm chart.
+
+The installation flow for non-OpenShift platforms consists of the following steps:
+
+. Install the {product-title-short} Operator on the cluster where Central will run by using the `rhacs-operator` Helm chart.
+. Create a Central custom resource to deploy Central services.
+. In the {product-title-short} portal, generate and apply a cluster registration secret (CRS) or an init bundle.
+. Create a `SecuredCluster` custom resource on each cluster you want to secure.
+
+After you install the Operator, you configure {product-title-short} by creating and modifying custom resources instead of managing individual Kubernetes objects directly.
+The Operator reconciles the required state defined in the custom resources and manages the underlying deployments, services, and other resources automatically.
+
+[IMPORTANT]
+====
+Direct Helm chart installation of {product-title-short} components by using the `central-services` and `secured-cluster-services` charts is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====

--- a/modules/install-operator-using-helm-chart-other.adoc
+++ b/modules/install-operator-using-helm-chart-other.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-central-other.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="install-operator-using-helm-chart-other_{context}"]
+= Install the {product-title-short} Operator by using a Helm chart
+
+[role="_abstract"]
+You can install the {product-title-short} Operator on non-OpenShift Kubernetes clusters by using the `rhacs-operator` Helm chart.
+After the Operator is running, you can create `Central` and `SecuredCluster` custom resources to deploy {product-title-short} components.
+
+.Prerequisites
+
+* You have Helm version 3.x installed. Migrating a legacy installation requires version 3.18 or later. Users migrating with version 4.x might experience problems.
+* You have `kubectl` installed and configured with cluster administrator access to the target Kubernetes cluster.
+* You have access to `registry.redhat.io`, or you have mirrored the Operator image to an internal registry.
+
+.Procedure
+
+. Create a namespace for the Operator:
++
+[source,terminal]
+----
+$ kubectl create namespace rhacs-operator-system
+----
+
+. If you are deploying directly from the Red Hat image registry and do not have a cluster-wide image pull secret configured, create an image pull secret for the Operator:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl -n rhacs-operator-system create secret docker-registry _<pull_secret_name>_ \
+  --docker-server=registry.redhat.io \
+  --docker-username=_<username>_ \
+  --docker-password=_<password>_
+----
++
+You can generate a registry service account token at link:https://access.redhat.com/terms-based-registry/[Red Hat Container Registry Authentication].
+
+. Add the {product-title-short} Helm chart repository, if it has not been added yet:
++
+[source,terminal]
+----
+$ helm repo add rhacs https://mirror.openshift.com/pub/rhacs/charts/
+----
++
+If you previously added the repository, update the local cache:
++
+[source,terminal]
+----
+$ helm repo update rhacs
+----
+
+. Install the `rhacs-operator` Helm chart:
++
+[source,terminal,subs="+quotes"]
+----
+$ helm install --wait -n rhacs-operator-system rhacs-operator rhacs/rhacs-operator \
+  --set manager.imagePullSecrets[0].name=_<pull_secret_name>_
+----
++
+If you have a cluster-wide image pull secret and do not need to specify a pull secret, you can omit the `--set manager.imagePullSecrets` option.
++
+[NOTE]
+====
+If you are installing the Operator on a cluster where {product-title-short} was previously installed by using a legacy installation method, add `--take-ownership` after `helm install` to avoid conflicts with existing `SecurityPolicies` CustomResourceDefinition.
+====
++
+[NOTE]
+====
+The `manager.imagePullSecrets` value configures the image pull secret for the Operator pod itself.
+This is different from the `spec.imagePullSecrets` field in `Central` or `SecuredCluster` custom resources, which configures image pull secrets for {product-title-short} application component images such as Central, Scanner, and Sensor.
+====
+
+.Verification
+
+* Verify that the Operator pod is running:
++
+[source,terminal]
+----
+$ kubectl get pods -n rhacs-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+rhacs-operator-controller-manager-<hash>     1/1     Running   0          60s
+----
+
+.Next steps
+
+* Install Central by using the Operator.

--- a/modules/install-rhacs-on-secured-clusters-by-using-helm-charts.adoc
+++ b/modules/install-rhacs-on-secured-clusters-by-using-helm-charts.adoc
@@ -8,3 +8,10 @@
 
 [role="_abstract"]
 You can install {product-title-short} on secured clusters by using Helm charts with no customization, using the default values, or with customizations of configuration parameters.
+
+[IMPORTANT]
+====
+Direct Helm chart installation of secured cluster services is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services.
+====

--- a/modules/install-secured-cluster-operator-other.adoc
+++ b/modules/install-secured-cluster-operator-other.adoc
@@ -1,0 +1,99 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-secured-cluster-other.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="install-secured-cluster-operator-other_{context}"]
+= Install secured cluster services by using the Operator
+
+[role="_abstract"]
+You can install secured cluster services on your Kubernetes clusters by using the {product-title-short} Operator, which creates the `SecuredCluster` custom resource.
+You must install the secured cluster services on every cluster in your environment that you want to monitor.
+
+[IMPORTANT]
+====
+When you install {product-title}:
+
+* You must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
+* If you are installing the `SecuredCluster` custom resource on the same cluster as Central, it is recommended to install it in the same namespace as Central. Using a different namespace can result in duplicate Scanner deployments.
+====
+
+.Prerequisites
+
+* The {product-title-short} Operator is installed on the secured cluster. For more information, see "Install the {product-title-short} Operator by using a Helm chart".
+* You have generated a cluster registration secret (CRS) or an init bundle and applied it in the namespace where you will create the `SecuredCluster` custom resource.
+
+.Procedure
+
+. If you are deploying directly from the Red Hat image registry on a different cluster than Central, and you do not have a cluster-wide image pull secret configured, create an image pull secret for the {product-title-short} application images:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl -n stackrox create secret docker-registry _<pull_secret_name>_ \
+  --docker-server=registry.redhat.io \
+  --docker-username=_<username>_ \
+  --docker-password=_<password>_
+----
+
+. Create a YAML file for the `SecuredCluster` custom resource:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: stackrox
+spec:
+  imagePullSecrets:
+    - name: _<pull_secret_name>_
+  clusterName: _<cluster_name>_
+  centralEndpoint: _<central_address>_
+----
++
+If you have a cluster-wide image pull secret configured or you are installing on the same cluster as Central and already created the pull secret, you can omit the `imagePullSecrets` field.
++
+Where:
++
+--
+`_<cluster_name>_`:: Specifies a unique name to identify this cluster, for example, `prod-west`.
+`_<central_address>_`:: Specifies the address of your Central instance, for example, `central.example.com:443`. Use the default value of `central.stackrox.svc:443` only if you are installing secured cluster services on the same cluster as Central, installed in the namespace `stackrox`.
+--
+
+. Apply the custom resource:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl apply -f _<securedcluster_cr_file>_.yaml
+----
+
+.Verification
+
+. Verify that the secured cluster services are running:
++
+[source,terminal]
+----
+$ kubectl get pods -n stackrox
+----
++
+Confirm that the Sensor, Collector, and Admission Controller pods are running. Example output:
++
+[source,terminal]
+----
+NAME                                  READY   STATUS    RESTARTS   AGE
+admission-control-c8bb8f68-lww7c      1/1     Running   0          10m
+admission-control-c8bb8f68-pldp5      1/1     Running   0          86s
+admission-control-c8bb8f68-rm5c9      1/1     Running   0          10m
+collector-j9djk                       0/2     Pending   0          94s
+collector-klr4s                       2/2     Running   0          92s
+collector-ncg86                       2/2     Running   0          92s
+config-controller-6bf4bfd866-zjxr6    1/1     Running   0          31m
+sensor-5d96d7bb96-7xrvv               1/1     Running   0          6m50s
+----
+
+. Verify the `SecuredCluster` custom resource status:
++
+[source,terminal]
+----
+$ kubectl get securedcluster -n stackrox
+----

--- a/modules/install-sensor-roxctl.adoc
+++ b/modules/install-sensor-roxctl.adoc
@@ -13,6 +13,12 @@
 [role="_abstract"]
 Deploy Sensor to a cluster by using the manifest installation method by using the {product-title-short} portal or the `roxctl` CLI.
 
+[IMPORTANT]
+====
+Installing by using the `roxctl CLI`, also known as the manifest installation method, is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====
+
 To monitor a cluster, you must deploy Sensor. You must deploy Sensor into each cluster that you want to monitor. This installation method is also called the manifest installation method.
 
 To perform an installation by using the manifest installation method, follow _only one_ of the following procedures:

--- a/modules/installation-methods-for-different-platforms.adoc
+++ b/modules/installation-methods-for-different-platforms.adoc
@@ -16,7 +16,7 @@ You can perform different types of installations on different platforms. Not all
 
 .7+|Managed service platform
 |{osp} Dedicated (OSD)
-.4+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[1]^
+.4+d|Operator (recommended), Helm charts (deprecated) ^[1]^, or `roxctl` CLI (deprecated) ^[1]^
 .4+| For more information, see Installing Central services for {product-title-short} on {osp} and Installing Secured Cluster services for {product-title-short} on {osp}
 
 |Azure {osp} (ARO)
@@ -26,7 +26,7 @@ You can perform different types of installations on different platforms. Not all
 |{osp} on {ibm-cloud}
 
 |Amazon Elastic Kubernetes Service (Amazon EKS)
-.3+d|Helm charts (recommended), or `roxctl` CLI ^[1]^
+.3+d|Operator by using a Helm chart (recommended), Helm charts (deprecated) ^[1]^, or `roxctl` CLI (deprecated) ^[1]^
 
 .3+| For more information, see Installing Central services for {product-title-short} on other platforms and Installing Secured Cluster services for {product-title-short} on other platforms
 
@@ -36,7 +36,7 @@ You can perform different types of installations on different platforms. Not all
 
 .2+|Self-managed platform
 |Red{nbsp}Hat {ocp} ({ocp-short})
-.2+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[1]^
+.2+d|Operator (recommended), Helm charts (deprecated) ^[1]^, or `roxctl` CLI (deprecated) ^[1]^
 .2+| For more information, see Installing Central services for {product-title-short} on {osp} and Installing Secured Cluster services for {product-title-short} on {osp}
 
 |{osp} Kubernetes Engine (OKE)
@@ -44,5 +44,5 @@ You can perform different types of installations on different platforms. Not all
 
 [.small]
 --
-1. Do not use the `roxctl` installation method unless you have specific requirements for following this installation method.
+1. Direct Helm chart and `roxctl` CLI installation methods are deprecated and will be removed in a future release. Use the Operator-based installation method instead. For existing deployments, see the migration procedure to migrate to Operator management.
 --

--- a/modules/installing-rhacs-kubernetes-steps.adoc
+++ b/modules/installing-rhacs-kubernetes-steps.adoc
@@ -6,4 +6,5 @@
 = Installation steps for RHACS on Kubernetes
 
 [role="_abstract"]
-You can install {product-title-short} on Kubernetes platforms by using Helm charts or the `roxctl` CLI.
+You can install {product-title-short} on Kubernetes platforms by using the {product-title-short} Operator, which is the recommended installation method.
+You can also use Helm charts or the `roxctl` CLI, but these methods are deprecated and will be removed in a future release.

--- a/modules/installing-rhacs-on-kubernetes-by-using-the-operator.adoc
+++ b/modules/installing-rhacs-on-kubernetes-by-using-the-operator.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * installing/acs-high-level-overview.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-kube-operator-steps_{context}"]
+= Installing {product-title-short} on Kubernetes platforms by using the Operator
+
+[role="_abstract"]
+You can install {product-title-short} on Kubernetes platforms by using the {product-title-short} Operator.
+The Operator is the recommended installation method for all platforms.
+
+.Procedure
+
+. Add the {product-title-short} Helm chart repository and install the `rhacs-operator` Helm chart on the cluster that will contain Central, called the Central cluster.
+. Use the Operator to create a `Central` custom resource in the `stackrox` namespace to deploy Central services. One Central cluster can secure many clusters.
+. Log in to the {product-title-short} web console from the Central cluster and generate a cluster registration secret (CRS). You need to apply the CRS to the cluster that you want to secure, called the secured cluster. The CRS has the cryptographic artifacts that {product-title-short} uses to establish trusted connections between Central and secured clusters.
++
+[NOTE]
+====
+Init bundles are still supported, but using a CRS is the preferred method for securing your cluster.
+====
+. For each secured cluster:
+.. Install the `rhacs-operator` Helm chart on the secured cluster.
+.. Apply the CRS or the init bundle that you generated to the secured cluster.
+.. Create a `SecuredCluster` custom resource in the `stackrox` namespace. When creating the custom resource, enter the address of Central in the `centralEndpoint` field so that the secured cluster can communicate with Central.

--- a/modules/installing-rhacs-on-secured-clusters-by-using-helm-charts.adoc
+++ b/modules/installing-rhacs-on-secured-clusters-by-using-helm-charts.adoc
@@ -8,3 +8,10 @@
 
 [role="_abstract"]
 You can install {product-title-short} on secured clusters by using Helm charts with no customization, using the default values, or with customizations of configuration parameters.
+
+[IMPORTANT]
+====
+Direct Helm chart installation of secured cluster services is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services on other platforms.
+====

--- a/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli-other.adoc
+++ b/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli-other.adoc
@@ -8,3 +8,10 @@
 
 [role="_abstract"]
 To install {product-title-short} on secured clusters by using the `roxctl` CLI, you must first install the `roxctl` CLI and then install Sensor by using either the {product-title-short} portal or the `roxctl` CLI.
+
+[IMPORTANT]
+====
+The `roxctl` CLI installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services on other platforms.
+====

--- a/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli.adoc
+++ b/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 To secure your infrastructure, deploy the Sensor component to install {rh-rhacs-first} on your {ocp} secured clusters. Use the `roxctl` CLI to generate the necessary installation files and run the sensor installation script. This method enables you to provision the sensor by creating the required configuration files and running the deployment script manually.
 
+[IMPORTANT]
+====
+The `roxctl` CLI installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services.
+====
+
 .Prerequisites
 
 * If you plan to use the `roxctl` CLI command to generate the files used by the sensor installation script, you have installed the `roxctl` CLI.

--- a/modules/manifest-installation-by-using-the-roxctl-cli.adoc
+++ b/modules/manifest-installation-by-using-the-roxctl-cli.adoc
@@ -17,6 +17,13 @@ endif::[]
 [role="_abstract"]
 To monitor your cluster for policy violations, deploy the required Sensor resources. You can generate the configuration bundle by using the `roxctl` CLI and running the extracted script to connect your cluster to {product-title-short}.
 
+[IMPORTANT]
+====
+Installing by using the `roxctl CLI`, also known as the manifest installation method, is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services on other platforms.
+====
+
 .Procedure
 . Generate the required sensor configuration for your {ocp} cluster and associate it with your Central instance by running the following command:
 +

--- a/modules/manifest-installation-method-by-using-the-web-portal.adoc
+++ b/modules/manifest-installation-method-by-using-the-web-portal.adoc
@@ -17,6 +17,13 @@ endif::[]
 [role="_abstract"]
 To help ensure your cluster reports security information to Central, you can deploy Sensor by installing a manifest by using the {product-title-short} web portal.
 
+[IMPORTANT]
+====
+The manifest installation method is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+For more information, see the Operator installation documentation for secured cluster services on other platforms.
+====
+
 .Procedure
 . On your secured cluster, in the {product-title-short} portal, go to *Platform Configuration* -> *Clusters*.
 . Select *Secure a cluster* -> *Legacy installation method*.

--- a/modules/migrate-to-operator-overview.adoc
+++ b/modules/migrate-to-operator-overview.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-central-other.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="migrate-to-operator-overview_{context}"]
+= Migrating existing {product-title-short} deployments to Operator management
+
+[role="_abstract"]
+If you have existing {product-title-short} deployments installed by using Helm charts or the `roxctl` CLI, you can migrate them to Operator management.
+Migrating to the Operator is recommended because direct Helm chart and manifest installation methods are deprecated and will be removed in a future release.
+
+When you apply a `Central` or `SecuredCluster` custom resource in the same namespace as an existing legacy installation, the Operator adopts the existing Kubernetes resources without requiring data migration and with minimal disruption.
+The Operator detects the running deployment, takes ownership of the managed resources, and begins reconciling them according to the custom resource specification.
+
+You use two `roxctl` CLI commands to generate the custom resources from your existing deployments:
+
+* `roxctl central migrate-to-operator` inspects an existing Central deployment and generates a `Central` custom resource YAML file.
+* `roxctl sensor migrate-to-operator` inspects an existing SecuredCluster deployment and generates a `SecuredCluster` custom resource YAML file.
+
+Each command supports two input modes:
+
+`--namespace`:: Inspects a live deployment running in the specified Kubernetes namespace. This mode reads deployment configurations directly from the cluster by using your current `kubectl` context.
+
+`--from-dir`:: Reads from a directory of exported manifest YAML files. Use this mode when you do not have direct access to the cluster or when you want to generate the custom resource offline.
+
+You must specify one of these two options, but not both.
+
+[IMPORTANT]
+====
+The `migrate-to-operator` commands are not currently aware of every way that a legacy {product-title-short} deployment could have been customized.
+Review the generated custom resource carefully and compare it against your existing configuration before applying it.
+====
+
+The migration commands detect most configuration settings, but the following limitations apply:
+
+* *Non-standard release names*: Installations that used the `allowNonstandardReleaseName` Helm value are not directly supported by the `migrate-to-operator` commands. You can still migrate these installations by changing the `metadata.name` field of the generated custom resource manually before applying it.
+* *Custom images*: If your deployment uses non-default container images, the Operator does not support image overrides in the custom resource. Instead, configure `RELATED_IMAGE_*` environment variables on the Operator deployment.
+* *Server-side cluster configuration*: Certain options that are stored as server-side cluster configuration in Central are not detected from the generated manifests. These include admission controller bypass settings, automatic process baseline locking, and audit log collection settings. Review the generated custom resource and configure these settings manually if needed.
+* *Helm values mapping*: If you installed by using Helm charts, compare your Helm values with the generated custom resource to verify that all customizations are preserved. Run `helm get values -n stackrox <release-name>` to review your current Helm values.
+* *Non-default parameters*: If you specified any non-default parameters when initially deploying a component, make sure that the custom resource spec also specifies the relevant fields if you want to keep the configuration unchanged.

--- a/modules/migrate-to-operator-procedure.adoc
+++ b/modules/migrate-to-operator-procedure.adoc
@@ -1,0 +1,135 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_other/install-central-other.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="migrate-to-operator-procedure_{context}"]
+= Migrate an {product-title-short} installation to Operator management
+
+[role="_abstract"]
+You can migrate existing {product-title-short} deployments to Operator management by generating custom resource YAML files from your current deployment and applying them to the cluster.
+The Operator takes over management of the existing resources without requiring data migration and with minimal disruption.
+
+.Prerequisites
+
+* The {product-title-short} Operator is installed on the target cluster.
+* The Central database is backed up. For more information, see "Backing up {product-title-short}".
+* The `roxctl` CLI matching the target {product-title-short} version is installed.
+* `kubectl` is installed and configured with access to the target cluster.
+* If you use a GitOps-based solution such as ArgoCD to manage your {product-title-short} deployment, disable it before proceeding. The Operator must be able to take ownership of the resources without conflicting with the GitOps controller.
+
+.Procedure
+
+. Verify your current installation method:
++
+* For Helm installations, run the following command:
++
+[source,terminal]
+----
+$ helm list -n stackrox
+----
++
+* For manifest installations, check whether the deployment was created by using `roxctl` generated manifests.
+
+. Optional: If you used Helm to install, export your current Helm values for reference:
++
+[source,terminal,subs="+quotes"]
+----
+$ helm get values -n stackrox _<release_name>_
+----
+
+. Generate a `Central` custom resource from the existing Central deployment:
++
+[source,terminal,subs="+quotes"]
+----
+$ roxctl central migrate-to-operator --namespace stackrox --output _<central_cr_file>_.yaml
+----
++
+Alternatively, to generate the custom resource from a directory of exported manifest files, run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ roxctl central migrate-to-operator --from-dir _<path_to_manifests>_ --output _<central_cr_file>_.yaml
+----
+
+. Review the generated `Central` custom resource YAML file.
+Check for the following items:
++
+* Database persistence settings (PVC claim name, host path)
+* Exposure settings (load balancer, node port, route)
+* Default TLS secret references
+* Declarative configuration mounts
+* Telemetry settings
++
+[IMPORTANT]
+====
+If the command outputs a warning about non-default container images, configure `RELATED_IMAGE_*` environment variables on the Operator Deployment before applying the custom resource.
+====
+
+. Verify that the {product-title-short} Operator is running and ready before applying the custom resource:
++
+[source,terminal]
+----
+$ kubectl get pods -n rhacs-operator
+----
++
+Confirm that the Operator controller manager pod is in a `Running` state and all containers are ready.
+
+. Apply the `Central` custom resource in the same namespace as the existing installation:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl apply -f _<central_cr_file>_.yaml -n stackrox
+----
+
+. Verify that the Operator has taken over management of Central:
++
+[source,terminal]
+----
+$ kubectl get central -n stackrox
+----
++
+The `PROGRESSING` column should be `False` and `AVAILABLE` should be `True`. If necessary, investigate further:
++
+[source,terminal]
+----
+$ kubectl describe central -n stackrox
+----
+
+. For each secured cluster, generate a `SecuredCluster` custom resource:
++
+[source,terminal,subs="+quotes"]
+----
+$ roxctl sensor migrate-to-operator --namespace stackrox --output _<securedcluster_cr_file>_.yaml
+----
+
+. Review the generated `SecuredCluster` custom resource YAML file.
+Check for the following items:
++
+* Cluster name
+* Central endpoint address
+* Admission control settings
+* Collector settings and taint toleration
+
+. Apply the `SecuredCluster` custom resource:
++
+[source,terminal,subs="+quotes"]
+----
+$ kubectl apply -f _<securedcluster_cr_file>_.yaml -n stackrox
+----
+
+. Verify that the Operator has taken over management of the secured cluster:
++
+[source,terminal]
+----
+$ kubectl get securedcluster -n stackrox
+----
++
+The `PROGRESSING` column should be `False` and `AVAILABLE` should be `True`. If necessary, investigate further:
++
+[source,terminal]
+----
+$ kubectl describe securedcluster -n stackrox
+----
+
+. You should keep the legacy Helm release record in case you need to troubleshoot later. The release record has no runtime cost and does not interfere with Operator management.

--- a/modules/roxctl-central-generate.adoc
+++ b/modules/roxctl-central-generate.adoc
@@ -6,7 +6,14 @@
 [id="roxctl-central-generate_{context}"]
 = roxctl central generate
 
+[role="_abstract"]
 Generate the required YAML configuration files that contain the orchestrator objects to deploy Central.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====
 
 .Usage
 [source,terminal]
@@ -23,19 +30,19 @@ $ roxctl central generate [flags]
 |Specify the path to the backup bundle from which you want to restore the keys and certificates.
 
 |`--debug`
-|If set to `true`, templates are read from the local file system. The default value is `false`.
+|If set to `true`, templates are read from the local file system. The default value is `false`. This flag is only available in development builds.
 
 |`--debug-path string`
-|Specify the path to Helm templates on your local file system. For more details, run the `roxctl central generate --help` command.
+|Specify the path to Helm templates on your local file system. This flag is only available in development builds.
 
-|`--default-tls-certfile`
+|`--default-tls-cert`
 |Specify the PEM certificate bundle file that you want to use as the default.
 
-|`--default-tls-keyfile`
+|`--default-tls-key`
 |Specify the PEM private key file that you want to use as the default.
 
 |`--enable-pod-security-policies`
-|If set to `true`, `PodSecurityPolicy` resources are created. The default value is `true`.
+|If set to `true`, `PodSecurityPolicy` resources are created. The default value is `false`.
 
 |`-p`, `--password string`
 |Specify the administrator password. The default value is automatically generated.

--- a/modules/roxctl-central-migrate-to-operator.adoc
+++ b/modules/roxctl-central-migrate-to-operator.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * cli/command-reference/roxctl-central.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="roxctl-central-migrate-to-operator_{context}"]
+= roxctl central migrate-to-operator
+
+[role="_abstract"]
+Inspect an existing Central deployment and generate a `Central` custom resource YAML file that preserves the detected configuration.
+When the generated custom resource is applied in the same namespace as the existing deployment, the {product-title-short} Operator takes over management.
+
+.Usage
+[source,terminal]
+----
+$ roxctl central migrate-to-operator [flags]
+----
+
+.Options
+[cols="4,6",options="header"]
+|===
+|Option |Description
+
+|`--from-dir _<path>_`
+|Path to a directory containing exported manifest YAML files. Mutually exclusive with `--namespace`.
+
+|`-n`, `--namespace _<namespace>_`
+|Kubernetes namespace of the running Central deployment. Mutually exclusive with `--from-dir`.
+
+|`-o`, `--output _<path>_`
+|Path to write the generated custom resource YAML file. If not specified, the output is written to standard output.
+|===
+
+Either `--from-dir` or `--namespace` must be specified, but not both.
+
+If non-default container images are detected, the command outputs a warning.
+Configure `RELATED_IMAGE_*` environment variables on the Operator Deployment to use custom images instead of overriding images in the custom resource.

--- a/modules/roxctl-helm-derive-local-values.adoc
+++ b/modules/roxctl-helm-derive-local-values.adoc
@@ -8,3 +8,10 @@
 
 [role="_abstract"]
 Derive local Helm values from the cluster configuration.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+To migrate existing Helm-based deployments to Operator management, use the `roxctl central migrate-to-operator` and `roxctl sensor migrate-to-operator` commands.
+====

--- a/modules/roxctl-helm-output.adoc
+++ b/modules/roxctl-helm-output.adoc
@@ -8,3 +8,9 @@
 
 [role="_abstract"]
 Output a Helm chart.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====

--- a/modules/roxctl-sensor-generate-certs.adoc
+++ b/modules/roxctl-sensor-generate-certs.adoc
@@ -7,4 +7,12 @@
 = roxctl sensor generate-certs
 
 [role="_abstract"]
+
 Download a YAML file with renewed certificates for Sensor, Collector, and Admission controller.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====
+

--- a/modules/roxctl-sensor-generate.adoc
+++ b/modules/roxctl-sensor-generate.adoc
@@ -7,4 +7,11 @@
 = roxctl sensor generate
 
 [role="_abstract"]
+
 Generate files to deploy {product-title-short} services in secured clusters.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====

--- a/modules/roxctl-sensor-get-bundle.adoc
+++ b/modules/roxctl-sensor-get-bundle.adoc
@@ -7,4 +7,11 @@
 = roxctl sensor get-bundle
 
 [role="_abstract"]
+
 Download a bundle with the files to deploy {product-title-short} services into a cluster.
+
+[IMPORTANT]
+====
+This command is deprecated and will be removed in a future release.
+Use the Operator-based installation method instead.
+====

--- a/modules/roxctl-sensor-migrate-to-operator.adoc
+++ b/modules/roxctl-sensor-migrate-to-operator.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * cli/command-reference/roxctl-sensor.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="roxctl-sensor-migrate-to-operator_{context}"]
+= roxctl sensor migrate-to-operator
+
+[role="_abstract"]
+Inspect an existing `SecuredCluster` deployment and generate a `SecuredCluster` custom resource YAML file that preserves the detected configuration.
+When you apply the generated custom resource in the same namespace as the existing deployment, the {product-title-short} Operator takes over management.
+
+.Usage
+[source,terminal]
+----
+$ roxctl sensor migrate-to-operator [flags]
+----
+
+.Options
+[cols="4,6",options="header"]
+|===
+|Option |Description
+
+|`--from-dir _<path>_`
+|Path to a directory containing exported manifest YAML files. Mutually exclusive with `--namespace`.
+
+|`-n`, `--namespace _<namespace>_`
+|Kubernetes namespace of the running SecuredCluster deployment. Mutually exclusive with `--from-dir`.
+
+|`-o`, `--output _<path>_`
+|Path to write the generated custom resource YAML file. If not specified, the output is written to standard output.
+|===
+
+Specify either `--from-dir` or `--namespace`, but not both.
+
+If the system detects non-default container images, the command outputs a warning.
+Configure `RELATED_IMAGE_*` environment variables on the Operator deployment to use custom images instead of overriding images in the custom resource.
+
+[NOTE]
+====
+Certain server-side cluster configuration options stored in Central, such as admission controller bypass, automatic process baseline locking, and audit log collection, are not detected from the generated manifests.
+Review the generated custom resource and configure these settings manually if needed.
+====


### PR DESCRIPTION
**Please note questions/comments in body of modules**

Version(s): 4.11

Issue: 

https://redhat.atlassian.net/browse/ROX-33828
https://redhat.atlassian.net/browse/ROX-33749

Links to docs previews:

**High-level overview info:**

  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-high-level-overview.html — Updated installation methods table to list operator as recommended, added operator overview under Kubernetes install steps, legacy methods marked as deprecated

**Kubernetes/non-OCP installation:**

  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html — Added operator Helm chart install section (concept + procedure), Central CR creation procedure, and migration-to-operator section (overview + step-by-step procedure)
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html — Added SecuredCluster CR creation procedure via operator, deprecation notices on Helm chart and roxctl install methods
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-rhacs-other.html — Updated high-level overview steps to list operator as the primary install path, added deprecation notice for Helm and roxctl methods

**Command reference - migrate to operator command:**

  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-central.html — Added roxctl central migrate-to-operator command reference, corrected central generate flag names and defaults
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-sensor.html — Added roxctl sensor migrate-to-operator command reference, removed nonexistent --slim-collector flag, updated --istio-support description

**Deprecation notices:**

  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-helm.html — Deprecation notices on helm output and helm derive-local-values commands
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html — Deprecation notices on Helm chart and roxctl CLI install methods
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html — Deprecation notices on Helm chart and roxctl CLI install methods
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html — Deprecation notices on legacy install methods
  - https://115380--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html — Deprecation notices on legacy install methods

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Generated with the assistance of docs-tools plugin and claude code
