### PR TITLE
OSDOCS-20068 [ROSA] New Feature: Karpenter section to log forwarding

### DIFF
--- a/modules/rosa-determine-log-groups.adoc
+++ b/modules/rosa-determine-log-groups.adoc
@@ -1,14 +1,14 @@
 // Module included in the following assemblies:
 //
-// * observability/logging/rosa-configuring-the-log-forwarder.adoc
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
 :_mod-docs-content-type: REFERENCE
 [id="rosa-determine-log-groups_{context}"]
 = Determining what log groups to use
 
 [role="_abstract"]
-When you forward control plane logs to Amazon CloudWatch or S3, you must decide on what log groups you want to use. Because of the existing AWS pricing for the respective services, you can expect additional costs associated with forwarding and storing your logs in S3 and CloudWatch. When you determine what log group to use, consider these additional costs along with other factors, such as your log retention requirements.
+When you forward control plane logs to Amazon CloudWatch or S3, you must decide on what log groups you want to use. Because of the existing AWS pricing for these services, you can expect additional costs associated with forwarding and storing your logs in S3 and CloudWatch. When you decide what log group to use, consider these additional costs along with other factors, such as your log retention requirements.
 
-For each log group, you have access to different applications, and these applications can change depending on what you choose to enable and disable with your logs.
+For each log group, you have access to different applications, and these applications can change depending on what you select to enable and disable with your logs.
 
 When you forward log groups, you must specify a group or application. When you specify a group, the log forwarder collects all the applications in that group. Instead of selecting a group, you can select individual applications. When you set up your log forwarder, you must specify at least one group or application, but you do not need to specify both.
 
@@ -69,6 +69,12 @@ a|
 | Records the placement of each pod on every node. Shows why pods are in a `Running` or `Pending` state.
 a|
 * `kube-scheduler`
+
+| autoscaling
+| Tracks the node provisioning and scaling decisions made by Karpenter workloads. This group records why nodes were created, deleted, or consolidated. It also helps administrators troubleshoot pod scheduling failures caused by insufficient compute resources.
+a|
+* `karpenter`
+* `karpenter-operator`
 
 | not applicable
 | These applications do not belong to a defined log group. To forward their logs, set these applications in the `applications` array.

--- a/modules/rosa-verify-karpenter-log-forwarding.adoc
+++ b/modules/rosa-verify-karpenter-log-forwarding.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-verify-karpenter-log-forwarding_{context}"]
+= Verify Karpenter setup for log forwarding
+
+[role="_abstract"]
+After you configure the {product-title} cluster to use a log forwarder, such as `S3` or `CloudWatch`, verify that Karpenter logs are arriving at your specified destination to confirm that your cluster captures node provisioning and scaling decisions for troubleshooting and capacity planning.
+
+.Prerequisites
+
+* You have configured a control plane log forwarder for your cluster.
+
+.Procedure
+
+. Verify that you have control plane log forwarders configured for your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa list log-forwarder -c <cluster_name|cluster_id>
+----
++
+. Confirm that the expected forwarder has the configuration correctly set to forward logs for Karpenter by running the following command:
++
+[source,terminal]
+----
+$ rosa describe log-forwarder -c <cluster_name|cluster_id> <log_fwd_id>
+----
++
+. Go to your specified logging destination, and confirm that the output includes the data from your application. The output should resemble the following sample:
++
+[source,json]
+----
+{"application": "karpenter", "message": "Node provisioning triggered"}
+{"application": "karpenter-operator", "message": "Reconciliation loop successful"}
+----

--- a/observability/logging/rosa-forwarding-control-plane-logs.adoc
+++ b/observability/logging/rosa-forwarding-control-plane-logs.adoc
@@ -23,6 +23,8 @@ include::modules/rosa-set-up-s3-bucket.adoc[leveloffset=+1]
 
 include::modules/rosa-manage-control-plane-log-forwarding.adoc[leveloffset=+1]
 
+include::modules/rosa-verify-karpenter-log-forwarding.adoc[leveloffset=+1]
+
 include::modules/rosa-create-cluster-ui-log-groups.adoc[leveloffset=+1]
 
 include::modules/rosa-create-cluster-log-forwarding-ui.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20068

Link to docs preview:
https://115388--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/rosa-forwarding-control-plane-logs.html#rosa-verify-karpenter-log-forwarding_rosa-configuring-the-log-forwarder

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
