### PR TITLE
OSDOCS-17040: removing links from install module

### DIFF
--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -121,8 +121,8 @@ your cluster.
 
 You must have internet access to perform the following actions:
 
-* Access {cluster-manager-url} to download the installation program and perform subscription management. If the cluster has internet access and you do not disable Telemetry, that service automatically entitles your cluster.
-* Access link:http://quay.io[Quay.io] to obtain the packages that are required to install your cluster.
+* Access {hybrid-console} to download the installation program and perform subscription management. If the cluster has internet access and you do not disable Telemetry, that service automatically entitles your cluster.
+* Access Quay.io to obtain the packages that are required to install your cluster.
 * Obtain the packages that are required to perform cluster updates.
 ifdef::openshift-enterprise,openshift-webscale[]
 


### PR DESCRIPTION
[OSDOCS-17040](https://redhat.atlassian.net/browse/OSDOCS-17040)

Version(s): 4.20+

CQA for platform agnostic install docs

QE review: QE review not required IMO, let me know if you see anything that makes you disagree.

Preview: [Internet access for OpenShift Container Platform](https://115389--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#cluster-entitlements_installing-platform-agnostic)