### PR TITLE
OSDOCS#20663: Update the OPP compatibility matrix for OCP 4.21

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -40,32 +40,32 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 // These variable are the current product release versions for the OPP products
-:ocp-supported-version: 4.20
-:rhacs-version: 4.9
-:quay-version: 3.16
-:rhacm-version: 2.15
-:odf-version: 4.20
+:ocp-supported-version: 4.21
+:rhacs-version: 4.10
+:quay-version: 3.17
+:rhacm-version: 2.16
+:odf-version: 4.21
 // These variables are for the immediate past 4 OPP product versions that are in the compatibility table
-:ocp-supported-version-1: 4.19
-:rhacs-version-1: 4.8
-:quay-version-1: 3.15
-:rhacm-version-1: 2.14
-:odf-version-1: 4.19
-:ocp-supported-version-2: 4.18
-:rhacs-version-2: 4.7
-:quay-version-2: 3.14
-:rhacm-version-2: 2.13
-:odf-version-2: 4.18
-:ocp-supported-version-3: 4.17
-:rhacs-version-3: 4.6
-:quay-version-3: 3.13
-:rhacm-version-3: 2.12
-:odf-version-3: 4.17
-:ocp-supported-version-4: 4.16
-:rhacs-version-4: 4.5
-:quay-version-4: 3.12
-:rhacm-version-4: 2.11
-:odf-version-4: 4.16
+:ocp-supported-version-1: 4.20
+:rhacs-version-1: 4.9
+:quay-version-1: 3.16
+:rhacm-version-1: 2.15
+:odf-version-1: 4.20
+:ocp-supported-version-2: 4.19
+:rhacs-version-2: 4.8
+:quay-version-2: 3.15
+:rhacm-version-2: 2.14
+:odf-version-2: 4.19
+:ocp-supported-version-3: 4.18
+:rhacs-version-3: 4.7
+:quay-version-3: 3.14
+:rhacm-version-3: 2.13
+:odf-version-3: 4.18
+:ocp-supported-version-4: 4.17
+:rhacs-version-4: 4.6
+:quay-version-4: 3.13
+:rhacm-version-4: 2.12
+:odf-version-4: 4.17
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -9,8 +9,8 @@
 [role="_abstract"]
 Learn about new features, known issues, and fixed bugs in the latest {product-title} release. This information helps you plan your upgrade and understand how changes to the platform affect your existing environment.
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/ocp-4-20-release-notes[{ocp}]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/release_notes/acm-release-notes[Release notes for {rh-rhacm}]
-* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.16/html/red_hat_quay_release_notes/release-notes-316[{quay} Release Notes]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.9/html/release_notes/release-notes-49[{acs} for Kubernetes 4.9]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.20/html/4.20_release_notes/index[{rh-storage-data-foundation}]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/release_notes/ocp-4-21-release-notes[{ocp}]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/release_notes/acm-release-notes[Release notes for {rh-rhacm}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.17/html/red_hat_quay_release_notes/index[{quay} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.10/html/release_notes/release-notes-410[{acs} for Kubernetes 4.10]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.21/html/4.21_release_notes/index[{rh-storage-data-foundation} 4.21]


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo, and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
OSDOCS-20663

Link to docs preview:
[Compatibility matrix](https://115393--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html#opp-architecture-compatibility-matrix_opp-architecture)

QE review:
- [x ] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.
