### PR TITLE
OSDOCS-20684: Add 4.22.5 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-5.adoc
+++ b/modules/zstream-4-22-5.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-5_{context}"]
+= RHSA-2026:37585 - {product-title} {product-version}.5 bug fix and security update
+
+Issued: 14 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.5 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37585[RHSA-2026:37585] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:37583[RHBA-2026:37583] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.5 --pullspecs
+----
+
+[id="zstream-4-22-5-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when deploying a hosted cluster on AWS in non-commercial ISO or classified regions, the Cluster Network Operator (CNO) assumed a maximum transmission unit (MTU) of `9001` for hosted cluster nodes. Because some of these regions do not support jumbo frames at this MTU value, and the setting could not be overridden during cluster creation, networking for hosted clusters in these regions could fail to configure correctly. With this release, you can specify an OVN-Kubernetes tunnel interface MTU between `576` and `9216` at cluster creation time. You can configure this setting by using the optional, immutable `mtu` field in the `ovnKubernetesConfig` configuration of the `HostedCluster` custom resource (CR) or by using the `--ovn-kubernetes-mtu` hosted control planes CLI flag. As a result, you can successfully deploy hosted clusters in AWS regions that do not support jumbo frames, and the CNO applies the correct MTU value. (link:https://redhat.atlassian.net/browse/OCPBUGS-77078[OCPBUGS-77078])
+
+* Before this update, when you filtered projects on the *Projects* list page in the {product-title} web console, the filter matched only the project `metadata.name` value and not the display name stored in the `openshift.io/display-name` annotation. As a consequence, typing a project display name in the filter toolbar returned no results even when a matching project existed. With this release, the *Projects* list filter includes the display name in its matching logic for both fuzzy and exact search modes. As a result, you can filter projects by either their technical name or their display name. (link:https://redhat.atlassian.net/browse/OCPBUGS-90495[OCPBUGS-90495])
+
+* Before this update, on Secure Boot-enabled clusters with nodes originally installed on {product-title} 4.15 or earlier, the Machine Config Operator (MCO) verified the shim version in the node operating system image rather than in the EFI System Partition (ESP). Nodes that were updated in place could have outdated shim and GRand Unified Bootloader (GRUB) binaries on the ESP while the operating system image contained newer versions. As a consequence, the MCO incorrectly skipped the boot loader update workaround for those nodes during a cluster update, and the nodes could fail to boot after the update. With this release, when a node runs Red Hat Enterprise Linux (RHEL) 9.6 or later, the MCO runs a node-level boot loader update by using `bootupctl` before it pulls the new node image container, and falls back to the existing container-based update path if the node-level update fails. As a result, nodes with stale boot loader files on the ESP are updated correctly and boot successfully after updating to this release. (link:https://redhat.atlassian.net/browse/OCPBUGS-93743[OCPBUGS-93743])
+
+* Before this update, when Prometheus compacted time series data, it attempted to enable direct input/output on files that were already open. Some file systems, such as IBM Storage Scale, do not support this operation. As a consequence, compaction failed with a `cannot enable Direct IO: invalid argument` error, Prometheus could not write chunks to disk, and memory usage in Prometheus pods increased until the pods hit their memory limits and restarted or affected other workloads on the node. With this release, Prometheus detects when a file system does not support direct input/output on open files and handles the condition gracefully. As a result, Prometheus writes chunks to disk and completes compaction successfully on these storage back ends. (link:https://redhat.atlassian.net/browse/OCPBUGS-93919[OCPBUGS-93919])
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-95061[OCPBUGS-95061])
+
+* Before this update, when you provisioned machines on an OpenStack cloud provider that does not support the optional Standard Attributes Tag extension, the Machine API Provider for OpenStack (MAPO) attempted to apply port tags during network port creation. As a consequence, network port creation failed and machine provisioning did not complete. With this release, MAPO checks whether the OpenStack Neutron `standard-attr-tag` extension is available before applying port tags. If the extension is not supported, MAPO skips tag assignment during provisioning. If you explicitly configure port tags on an unsupported OpenStack deployment, MAPO returns an error that prompts you to remove the port tags configuration. As a result, machine provisioning completes successfully on OpenStack deployments that do not support the tag extension. (link:https://redhat.atlassian.net/browse/OCPBUGS-97826[OCPBUGS-97826])
+
+[id="zstream-4-22-5-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.5 RNs and updating
+include::modules/zstream-4-22-5.adoc[leveloffset=+2]
+
 // 4.22.4 RNs and updating
 include::modules/zstream-4-22-4.adoc[leveloffset=+2]
 
@@ -55,5 +58,4 @@ include::modules/zstream-4-22-2.adoc[leveloffset=+2]
 
 // zstream 4.22.1 RNs full document
 include::modules/zstream-4-22-1.adoc[leveloffset=+2]
-
 


### PR DESCRIPTION
## Version
4.22

## Summary
- Adds z-stream release notes for OpenShift 4.22.5
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20684
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/638
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
- Errata: RHSA-2026:37585 / RHBA-2026:37583

## Documentation Preview URL 

https://115396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-5_release-notes

## Documented
- Advisory-only release (no documentable OCPBUGS bullets passed filters)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-77078 | Incomplete Bug Fix RN |
| OCPBUGS-83742 | Invalid RN type |
| OCPBUGS-83883 | CVE-only |
| OCPBUGS-84739 | Internal |
| OCPBUGS-87838 | Release Note Not Required |
| OCPBUGS-87866 | Release Note Not Required |
| OCPBUGS-88325 | Internal |
| OCPBUGS-88330 | Release Note Not Required |
| OCPBUGS-90495 | Incomplete Bug Fix RN |
| OCPBUGS-91642 | Release Note Not Required |
| OCPBUGS-91954 | Release Note Not Required |
| OCPBUGS-92022 | Release Note Not Required |
| OCPBUGS-92031 | Invalid RN type |
| OCPBUGS-92193 | Internal |
| OCPBUGS-93743 | Incomplete Bug Fix RN |
| OCPBUGS-93786 | Release Note Not Required |
| OCPBUGS-93799 | Internal |
| OCPBUGS-93919 | Incomplete Bug Fix RN |
| OCPBUGS-93921 | Internal |
| OCPBUGS-94000 | Invalid RN type |
| OCPBUGS-94005 | CVE-only |
| OCPBUGS-94177 | Internal |
| OCPBUGS-94187 | Release Note Not Required |
| OCPBUGS-94188 | Release Note Not Required |
| OCPBUGS-95061 | Incomplete Bug Fix RN |
| OCPBUGS-96145 | Release Note Not Required |
| OCPBUGS-96898 | CVE-only |
| OCPBUGS-97826 | Incomplete Bug Fix RN |
| OCPBUGS-97829 | Internal |
| OCPBUGS-97940 | Release Note Not Required |
| OCPBUGS-97963 | Invalid RN type |
| OCPBUGS-97984 | Internal |

## Scope notes
- Shipment YAML keys: 32
- Errata Fixes keys: 15
- In YAML but not errata Fixes: OCPBUGS-84739, OCPBUGS-88325, OCPBUGS-90495, OCPBUGS-91642, OCPBUGS-91954, OCPBUGS-92022, OCPBUGS-92031, OCPBUGS-92193, OCPBUGS-93786, OCPBUGS-93799, OCPBUGS-93921, OCPBUGS-94005, OCPBUGS-94177, OCPBUGS-94187, OCPBUGS-94188, OCPBUGS-97829, OCPBUGS-97984

## Test plan
- [x] Title and issued date match access.redhat.com
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files (local Vale config missing `NoGerundsInTitles.tengo` script)


Made with [Cursor](https://cursor.com)