### PR TITLE
OSDOCS-20685: Add 4.21.24 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-24.adoc
+++ b/modules/zstream-4-21-24.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-24_{context}"]
+= RHSA-2026:37186 - {product-title} {product-version}.24 bug fix and security update
+
+Issued: 14 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.24 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37186[RHSA-2026:37186] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.24 --pullspecs
+----
+
+[id="zstream-4-21-24-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when you filtered projects on the *Projects* list page in the {product-title} web console, the filter matched only the project `metadata.name` value and not the display name stored in the `openshift.io/display-name` annotation. As a consequence, typing a project's display name in the filter toolbar returned no results even when a matching project existed. With this release, the *Projects* list filter includes the display name in its matching logic for both fuzzy and exact search modes. As a result, you can filter projects by either their technical name or their display name. (link:https://redhat.atlassian.net/browse/OCPBUGS-90498[OCPBUGS-90498])
+
+* Before this update, when Prometheus compacted time series data, it attempted to enable direct I/O on files that were already open. Some file systems, such as IBM Storage Scale, do not support this operation. As a consequence, compaction failed with a `cannot enable Direct IO: invalid argument` error, Prometheus could not write chunks to disk, and memory usage in Prometheus pods increased until the pods hit their memory limits and restarted or affected other workloads on the node. With this release, Prometheus detects when a file system does not support direct I/O on open files and handles the condition gracefully. As a result, Prometheus writes chunks to disk and completes compaction successfully on these storage back ends. (link:https://redhat.atlassian.net/browse/OCPBUGS-93920[OCPBUGS-93920])
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-95062[OCPBUGS-95062])
+
+[id="zstream-4-21-24-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.24 RNs and updating
+include::modules/zstream-4-21-24.adoc[leveloffset=+2]
+
 // 4.21.23 RNs and updating
 include::modules/zstream-4-21-23.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.21.24
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20685
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/635
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:37186

## Version
4.21

## Doc preview link
https://115397--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-24_release-notes

## Documented
- Advisory-only release (no documentable OCPBUGS bullets passed filters)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-78765 | Internal |
| OCPBUGS-81618 | CVE-only |
| OCPBUGS-86743 | CVE-only |
| OCPBUGS-87090 | CVE-only |
| OCPBUGS-87868 | Release Note Not Required |
| OCPBUGS-88323 | Release Note Not Required |
| OCPBUGS-88481 | Internal |
| OCPBUGS-88564 | Release Note Not Required |
| OCPBUGS-88749 | CVE-only |
| OCPBUGS-90498 | Incomplete Bug Fix RN |
| OCPBUGS-91759 | Internal |
| OCPBUGS-91985 | Release Note Not Required |
| OCPBUGS-92375 | Release Note Not Required |
| OCPBUGS-93920 | Incomplete Bug Fix RN |
| OCPBUGS-94011 | CVE-only |
| OCPBUGS-94108 | Internal |
| OCPBUGS-95062 | Incomplete Bug Fix RN |
| OCPBUGS-95068 | Internal |
| OCPBUGS-95544 | Internal |
| OCPBUGS-95588 | Release Note Not Required |
| OCPBUGS-96153 | Release Note Not Required |

## Test plan
- [x] Title and issued date match shipment/errata metadata
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files
