### PR TITLE
OSDOCS-20686: Add 4.20.29 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-29.adoc
+++ b/modules/zstream-4-20-29.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-29_{context}"]
+= RHSA-2026:37628 - {product-title} {product-version}.29 bug fix and security update
+
+Issued: 14 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.29 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37628[RHSA-2026:37628] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.29 --pullspecs
+----
+
+[id="zstream-4-20-29-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, deleting a BareMetalHost (BMH) that referenced a pre-provisioning network data Secret through the `spec.preprovisioningNetworkDataName` parameter could report a `RegistrationError` if the Secret was removed before the BMH finished deleting. As a consequence, the BMH deletion would take minutes to complete before an eventual force-delete by the controller. With this release, the Bare Metal Operator (BMO) manages the lifecycle of that Secret in the same way as the BMC credential Secrets. The BMO now protects the Secret using a finalizer while the host is active, which prevents the Secret deletion until the finalizer is removed by the controller. As a result, the BMH is removed successfully before the Secret is allowed to be deleted. (link:https://redhat.atlassian.net/browse/OCPBUGS-87965[OCPBUGS-87965])
+
+* Before this update, when you provisioned machines on an OpenStack cloud provider that does not support the optional Standard Attributes Tag extension, the Machine API Provider for OpenStack (MAPO) attempted to apply port tags during network port creation. As a consequence, network port creation failed and machine provisioning did not complete. With this release, MAPO checks whether the OpenStack Neutron `standard-attr-tag` extension is available before applying port tags. If the extension is not supported, MAPO skips tag assignment during provisioning. If you explicitly configure port tags on an unsupported OpenStack deployment, MAPO returns an error that prompts you to remove the port tags configuration. As a result, machine provisioning completes successfully on OpenStack deployments that do not support the tag extension. (link:https://redhat.atlassian.net/browse/OCPBUGS-94016[OCPBUGS-94016])
+
+* Before this update, role based access control (RBAC) permissions were insufficient for the Secrets Store Container Storage Interface (CSI) driver in the Control Plane Operator (CPO) on the management cluster. As a consequence, users could not create hosted clusters with the Secrets Store CSI driver and the CPO on versions later than 4.19.19. With this release, the CPO now checks the accessibility of resource types before creation, granting access to the Secrets Store CSI driver and enabling successful hosted cluster creation. (link:https://redhat.atlassian.net/browse/OCPBUGS-94175[OCPBUGS-94175])
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-95063[OCPBUGS-95063])
+
+[id="zstream-4-20-29-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.29 RNs and updating
+include::modules/zstream-4-20-29.adoc[leveloffset=+2]
+
 // 4.20.28 release notes
 include::modules/zstream-4-20-28.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Version
4.20

## Summary
- Adds z-stream release notes for OpenShift 4.20.29
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20686
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/639
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:37628

## Doc preview link
https://115398--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-29_release-notes

## Documented
- OCPBUGS-87965, OCPBUGS-94175

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-72402 | Internal |
| OCPBUGS-76473 | Release Note Not Required |
| OCPBUGS-85523 | Internal |
| OCPBUGS-86746 | CVE-only |
| OCPBUGS-87089 | CVE-only |
| OCPBUGS-88753 | CVE-only |
| OCPBUGS-91732 | Release Note Not Required |
| OCPBUGS-92706 | Release Note Not Required |
| OCPBUGS-93896 | Release Note Not Required |
| OCPBUGS-94012 | CVE-only |
| OCPBUGS-94016 | Incomplete Bug Fix RN |
| OCPBUGS-94227 | Release Note Not Required |
| OCPBUGS-95063 | Incomplete Bug Fix RN |
| OCPBUGS-96160 | Release Note Not Required |
| OCPBUGS-97586 | Internal |
| OCPBUGS-97788 | Internal |
| OCPBUGS-98095 | Release Note Not Required |

## Test plan
- [x] Title and issued date match shipment/errata metadata
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files
