### PR TITLE
OSDOCS-20687: Add 4.19.38 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-38.adoc
+++ b/modules/zstream-4-19-38.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-38_{context}"]
+= RHSA-2026:37580 - {product-title} {product-version}.38 bug fix and security update
+
+Issued: 15 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.38 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37580[RHSA-2026:37580] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:37578[RHBA-2026:37578] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.38 --pullspecs
+----
+
+[id="zstream-4-19-38-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, deleting a BareMetalHost (BMH) that referenced a pre-provisioning network data Secret, through the `spec.preprovisioningNetworkDataName` parameter, could report a `RegistrationError` if the Secret was removed before the BMH finished deleting. As a consequence, the BMH deletion would take minutes to complete before an eventual force-delete by the controller. With this release, the Bare Metal Operator (BMO) manages the lifecycle of that Secret in the same way as the BMC credential Secrets. The BMO now protects the Secret using a finalizer while the host is active, which prevents the Secret deletion until the finalizer is removed by the controller. As a result, the BMH is removed successfully before the Secret is allowed to be deleted. (link:https://redhat.atlassian.net/browse/OCPBUGS-87966[OCPBUGS-87966])
+
+* Before this update, when you provisioned machines on an OpenStack cloud provider that does not support the optional Standard Attributes Tag extension, the Machine API Provider for OpenStack (MAPO) attempted to apply port tags during network port creation. As a consequence, network port creation failed and machine provisioning did not complete. With this release, MAPO checks whether the OpenStack Neutron `standard-attr-tag` extension is available before applying port tags. If the extension is not supported, MAPO skips tag assignment during provisioning. If you explicitly configure port tags on an unsupported OpenStack deployment, MAPO returns an error that prompts you to remove the port tags configuration. As a result, machine provisioning completes successfully on OpenStack deployments that do not support the tag extension. (link:https://redhat.atlassian.net/browse/OCPBUGS-94015[OCPBUGS-94015])
+
+* Before this update, the `ironic-agent` container image was missing the `iproute` package, which provides the `ip` command. As a consequence, the Ironic Python Agent (IPA) failed during network configuration and could not send heartbeats to Ironic, which caused bare-metal node cleaning to time out. With this release, the `iproute` package is available in the `ironic-agent` container image. As a result, IPA completes network configuration and heartbeats to Ironic as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-95065[OCPBUGS-95065])
+
+[id="zstream-4-19-38-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.38 RNs and updating
+include::modules/zstream-4-19-38.adoc[leveloffset=+2]
+
 // 4.19.37 z-stream RNs full document
 include::modules/zstream-4-19-37.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.19.38
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20687
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/637
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:37580 / RHBA-2026:37578

## Version
4.19

## Doc preview link
https://115399--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-38_release-notes

## Documented
- OCPBUGS-87966

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-60277 | Internal |
| OCPBUGS-80400 | CVE-only |
| OCPBUGS-82794 | CVE-only |
| OCPBUGS-86716 | CVE-only |
| OCPBUGS-91984 | Internal |
| OCPBUGS-94015 | Incomplete Bug Fix RN |
| OCPBUGS-95065 | Incomplete Bug Fix RN |
| OCPBUGS-95085 | Internal |
| OCPBUGS-95273 | Release Note Not Required |
| OCPBUGS-95589 | Release Note Not Required |
| OCPBUGS-96167 | Release Note Not Required |
| OCPBUGS-97966 | Release Note Not Required |

## Test plan
- [x] Title and issued date match shipment/errata metadata
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files
