### PR TITLE
OSDOCS-20688: Add 4.18.48 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-48.adoc
+++ b/modules/zstream-4-18-48.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-48_{context}"]
+= RHSA-2026:37192 - {product-title} {product-version}.48 bug fix and security update
+
+Issued: 15 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.48 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37192[RHSA-2026:37192] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.48 --pullspecs
+----
+
+[id="zstream-4-18-48-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `ironic-agent` container image was missing the `iproute` package, which provides the `ip` command. As a consequence, the Ironic Python Agent (IPA) failed during network configuration and could not send heartbeats to Ironic, which caused bare-metal node cleaning to time out. With this release, the `iproute` package is available in the `ironic-agent` container image. As a result, IPA completes network configuration and heartbeats to Ironic as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-95066[OCPBUGS-95066])
+
+
+[id="zstream-4-18-48-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.48 RNs and updating
+include::modules/zstream-4-18-48.adoc[leveloffset=+2]
+
 // 4.18.47 RNs and updating
 include::modules/zstream-4-18-47.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.18.48
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20688
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/636
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: No RPM/ RHBA-2026:37189

## Version
4.18

## Preview link
https://115400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-48_release-notes

## Documented
- Advisory-only release (no documentable OCPBUGS bullets passed filters)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-77125 | CVE-only |
| OCPBUGS-80335 | CVE-only |
| OCPBUGS-95066 | Incomplete Bug Fix RN |
| OCPBUGS-97588 | Release Note Not Required |

## Test plan
- [x] Title and issued date match shipment/errata metadata
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files
