### PR TITLE
OSDOCS-20689: Add 4.16.66 z-stream release notes

### DIFF
--- a/modules/zstream-4-16-66.adoc
+++ b/modules/zstream-4-16-66.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-66_{context}"]
+= RHSA-2026:36621 - {product-title} {product-version}.66 bug fix and security update
+
+Issued: 16 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.66 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:36621[RHSA-2026:36621] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:36619[RHBA-2026:36619] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.66 --pullspecs
+----
+
+[id="zstream-4-16-66-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-95070[OCPBUGS-95070])
+
+[id="zstream-4-16-66-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,10 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+
+// 4.16.66 RNs and updating
+include::modules/zstream-4-16-66.adoc[leveloffset=+2]
+
 // 4.16.65 Rns and updating
 include::modules/zstream-4-16-65.adoc[leveloffset=+2]
 
@@ -3402,13 +3406,11 @@ include::modules/zstream-4-16-63.adoc[leveloffset=+2]
 // 4.16.62 Rns and updating
 include::modules/zstream-4-16-62.adoc[leveloffset=+2]
 
-
 // 4.16.61 Rns and updating
 include::modules/zstream-4-16-61.adoc[leveloffset=+2]
 
 // 4.16.60 Rns and updating
 include::modules/zstream-4-16-60.adoc[leveloffset=+2]
-
 
 // 4.16.59 Rns and updating
 include::modules/zstream-4-16-59.adoc[leveloffset=+2]


### PR DESCRIPTION
## Version
4.16

## Doc preview link
https://115401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-66_release-notes

## Summary
- Adds z-stream release notes for OpenShift 4.16.66
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20689
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/633
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16
- Errata: RHSA-2026:36621 / RHBA-2026:36619

