### PR TITLE
OSDOCS-20690: Add 4.14.69 z-stream release notes

### DIFF
--- a/modules/zstream-4-14-69.adoc
+++ b/modules/zstream-4-14-69.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-69-bug-fixes_{context}"]
+= RHSA-2026:36611 - {product-title} {product-version}.69 bug fix and security update
+
+Issued: 16 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.69 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:36611[RHSA-2026:36611] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.69 --pullspecs
+----
+
+[id="zstream-4-14-69-fixed_issues_{context}"]
+== Fixed issues
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-96901[OCPBUGS-96901])
+
+[id="zstream-4-14-69-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.69 RNs and updating
+include::modules/zstream-4-14-69.adoc[leveloffset=+2]
+
 // 4.14.68 Rns and updating
 include::modules/zstream-4-14-68.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.14.69
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20690
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/632
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14
- Errata: RHSA-2026:36611 / RHBA-2026:36609

## Version
4.14

## Doc preview link

https://115402--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-69-bug-fixes_release-notes

## Documented
- Advisory-only release (no documentable OCPBUGS bullets passed filters)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-79841 | CVE-only |
| OCPBUGS-79856 | CVE-only |
| OCPBUGS-86878 | CVE-only |
| OCPBUGS-88373 | CVE-only |
| OCPBUGS-88389 | CVE-only |
| OCPBUGS-88393 | CVE-only |
| OCPBUGS-88405 | CVE-only |
| OCPBUGS-88409 | CVE-only |
| OCPBUGS-88422 | CVE-only |
| OCPBUGS-88440 | CVE-only |
| OCPBUGS-95080 | Internal |
| OCPBUGS-96901 | Incomplete Bug Fix RN |

## Test plan
- [x] Title and issued date match shipment/errata metadata
- [x] Primary + RPM advisory links correct
- [ ] Vale clean on touched files
