### PR TITLE
[RHDEVDOCS-7711]: Add Red Hat OpenShift GitOps 1.21.2 release notes Errata updates placeholder

### DIFF
--- a/modules/gitops-release-notes-1-21-2.adoc
+++ b/modules/gitops-release-notes-1-21-2.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-21-2_{context}"]
+= Release notes for Red Hat OpenShift GitOps 1.21.2
+
+Red Hat OpenShift GitOps 1.21.2 is now available on OpenShift Container Platform [INSERT OCP VERSIONS, e.g., 4.15, 4.16].
+
+== Errata updates
+
+=== [ENTER ERRATA NUMBER, e.g., RHSA-2026:XXXX] - Red Hat OpenShift GitOps 1.21.2 security update advisory
+Issued: [ENTER DATE, e.g., 2026-MM-DD]
+
+The list of security fixes that are included in this release is documented in the following advisory:
+[ENTER ERRATA NUMBER, e.g., RHSA-2026:XXXX]
+
+If you have installed the Red Hat OpenShift GitOps Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----

--- a/release_notes/gitops-release-notes-1-21.adoc
+++ b/release_notes/gitops-release-notes-1-21.adoc
@@ -30,6 +30,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.21.2
+include::modules/gitops-release-notes-1-21-2.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift GitOps 1.21.1
 include::modules/gitops-release-notes-1-21-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
* GitOps 1.21.2

Issue:
* [RHDEVDOCS-7711](https://redhat.atlassian.net/browse/RHDEVDOCS-7711)

Link to docs preview:
https://115410--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-21.html 

QE review:
@svghadi 

Additional information:
Adds the standard z-stream errata advisory placeholder module and include reference for the upcoming GitOps 1.21.2 release. Content structure matches prior 1.21.x releases.