### PR TITLE
HCCDOC-4522 [CHERRYPICK] RH Lightspeed - Fix incorrect UI label in health UI 

### DIFF
--- a/modules/displaying-the-insights-status-in-the-web-console.adoc
+++ b/modules/displaying-the-insights-status-in-the-web-console.adoc
@@ -5,14 +5,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="displaying-the-insights-status-in-the-web-console_{context}"]
-= Displaying the {red-hat-lightspeed} status in the web console
+= Display the {red-hat-lightspeed} advisor status in the web console
 
 [role="_abstract"]
-{red-hat-lightspeed} repeatedly analyzes your cluster and you can display the status of identified potential issues of your cluster in the {product-title} web console. This status shows the number of issues in the different categories and, for further details, links to the reports in {cluster-manager-url}.
+View the health status of your cluster and potential issues identified by the {red-hat-lightspeed} advisor service in the {product-title} web console. Issues are grouped by risk category with links to detailed reports in the {hybrid-console-second}.
 
 .Prerequisites
 
-* Your cluster is registered in {cluster-manager-url}.
+* Your cluster is registered with {cluster-manager}.
 * Remote health reporting is enabled, which is the default.
 * You are logged in to the {product-title} web console.
 
@@ -20,6 +20,12 @@
 
 . Navigate to *Home* -> *Overview* in the {product-title} web console.
 
-. Click *{red-hat-lightspeed}* on the *Status* card.
+. Click *Insights* on the *Status* card.
 +
-The pop-up window lists potential issues grouped by risk. Click the individual categories or *View all recommendations in {red-hat-lightspeed} Advisor* to display more details.
+A list of potential issues that are grouped by risk is displayed.
+. Click *View all recommendations in {red-hat-lightspeed} Advisor* or click a specific category to view detailed reports in the {hybrid-console-second}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://console.redhat.com/openshift/insights/advisor/recommendations[{red-hat-lightspeed} Advisor recommendations]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

[P2/3] CQA Fix outdated steps in the HCC console for OpenShift Advisor GUI following the rebranding from Red Hat Insights to Red Hat Lightspeed.

See https://github.com/openshift/openshift-docs/pull/114882

_Note:  In Red Hat Lightspeed, the advisor service is always in lowercase, and the UI Page for the user view of information produced by the advisor service is capitalized as Advisor. Lowercase a is not a typo!_

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/HCCDOC-4522
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


https://115426--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html
https://115426--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
