### PR TITLE
OSDOCS-20692: adds RHCL 1.3.6 release note

### DIFF
--- a/modules/ref-relnotes-1.3.6-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.6-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/rhcl-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.6-z-stream_{context}"]
+= {product-title} 1.3.6 bug fix and security update
+
+Issued: 3 August 2026
+
+[role="_abstract"]
+{product-title} release 1.3.6 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:xxxxx[RHBA-2026:xxxxx] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.6-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* There are no bug fixes of notable technical impact in included in this release.

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -17,6 +17,8 @@ include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-z-streams.adoc[leveloffset=+1]
 
+include::modules/ref-relnotes-1.3.6-z-stream.adoc[leveloffset=+2]
+
 include::modules/ref-relnotes-1.3.5-z-stream.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-1.3.4-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.3

Issue:
[OSDOCS-20692](https://redhat.atlassian.net/browse/OSDOCS-20692)

Link to docs preview:
https://115431--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.3.6-z-stream_rhcl-release-notes

QE review:
- N/A sync release note

Additional info: hold for released advisory/number

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
