### PR TITLE
OSDOCS-20693: adds RHCL 1.4.2 async release note

### DIFF
--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -7,7 +7,7 @@
 = About this release
 
 [role="_abstract"]
-{rh} {prodname} {version}, link:https://access.redhat.com/errata/RHBA-2026:25234[RHBA-2026:25234], is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
+{rh} {prodname} {version} is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
 
 Starting with {prodname} {version}, full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
 

--- a/modules/rhcl-relnotes-1.4.1-z-stream.adoc
+++ b/modules/rhcl-relnotes-1.4.1-z-stream.adoc
@@ -9,7 +9,7 @@
 Issued: 1 July 2026
 
 [role="_abstract"]
-{product-title} release 1.4.1 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:34242[RHBA-2026:34242] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../update/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+{product-title} release 1.4.1 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:34242[RHBA-2026:34242] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../update/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Update Red Hat Connectivity Link].
 
 [id="rhcl-relnotes-1.4.1-z-stream-bug-fixes_{context}"]
 == Bug fixes

--- a/modules/rhcl-relnotes-1.4.2-z-stream.adoc
+++ b/modules/rhcl-relnotes-1.4.2-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/rhcl-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.4.2-z-stream_{context}"]
+= {product-title} 1.4.2 bug fix and security update
+
+Issued: 23 July 2026
+
+[role="_abstract"]
+{product-title} release 1.4.2 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:44389[RHBA-2026:44389] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../update/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Update Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.4.2-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, API requests larger than 1MB could experience intermittent data corruption when {prodname} policies were used alongside additional Envoy filters that process the request body. This was because of the way Envoy handled paused streams while the `allow_on_headers_stop_iteration` flag was enabled. Depending on timing, if an early-chain WebAssembly (WASM) filter paused the stream, the initial 16KB chunk of the request body failed to reach later filters. As a result, broken payloads reached those downstream filters 40-80 percent of the time. This release removes the unnecessary flag, ensuring that Envoy correctly preserves and flushes the entire request buffer. Payload corruption on large API requests no longer occurs. (https://redhat.atlassian.net/browse/CONNLINK-1311[CONNLINK-1311])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -23,4 +23,6 @@ include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
 include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+1]
 
+include::modules/rhcl-relnotes-1.4.2-z-stream.adoc[leveloffset=+2]
+
 include::modules/rhcl-relnotes-1.4.1-z-stream.adoc[leveloffset=+2]

--- a/snippets/rhcl-1-4-0-do-not-install.adoc
+++ b/snippets/rhcl-1-4-0-do-not-install.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: SNIPPET
 
-[WARNING]
+[IMPORTANT]
 ====
-{rh} {prodname} 1.4.0 is deprecated. {ocp} clusters running {prodname} 1.4.0 might experience authentication failures, API key management errors, gateway instability, or gateway pod memory pressure because of integration changes that are not fully compatible on all supported {ocp} and {service-mesh} combinations.
+*Use the latest version*: Install or upgrade to {rh} {prodname} 1.4.1 or later.
 
-Install or upgrade to {rh} {prodname} 1.4.1.
+*Deprecation notice*: {rh} {prodname} 1.4.0 is deprecated. {ocp} clusters running {prodname} 1.4.0 might experience authentication failures, API key management errors, gateway instability, or gateway pod memory pressure because of integration changes that are not fully compatible on all supported {ocp} and {service-mesh} combinations.
 ====
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20693](https://redhat.atlassian.net/browse/OSDOCS-20693)

Link to docs preview:
https://115432--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.4.2-z-stream_rhcl-release-notes
https://115432--ocpdocs-pr.netlify.app/rhcl/latest/install-rhcl/install-guide.html (updated 1.4.0 notice)


QE review:
- [x] QE verified this release

Additional info: hold for released advisory/number

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
