### PR TITLE
[OSDOCS#20290]: Added files for zstream release notes 4.21.21

### DIFF
--- a/modules/zstream-4-21-21.adoc
+++ b/modules/zstream-4-21-21.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-21_{context}"]
+= RHSA-2026:27044 - {product-title} {product-version}.21 fixed issues advisory
+
+Issued: 23 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.21 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:27044[RHSA-2026:27044] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:27041[RHBA-2026:27041] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.21 --pullspecs
+----
+
+[id="zstream-4-21-21-enhancements_{context}"]
+== Enhancements
+
+* With this update, the `chrony-wait.service` systemd service has been optimized to reduce node boot times. The service now creates a flag file when shutting down and checks its timestamp on startup. If the file was modified within the last hour, the service assumes minimal clock skew has occurred and skips the synchronization wait. As a result, nodes reach the `Ready` state approximately 24 seconds faster on Azure and 11 seconds faster on other platforms during reboots, improving cluster scaling and recovery times. (link:https://redhat.atlassian.net/browse/OCPBUGS-88334[OCPBUGS-88334])
+
+
+[id="zstream-4-21-21-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, `NodeNetworkConfigurationPolicy` (NNCP) policies with captured names based on matched rules could erroneously capture and overwrite transient network profiles created by the `configure-ovs.sh` script in `/run/NetworkManager/system-connections/`. As a consequence, applying NNCP policies could break existing network configurations, particularly for bond interfaces, leaving nodes in a degraded state that would fail after reboot. With this release, NNCP policies only capture and modify network connections from `/etc/NetworkManager/system-connections/`, excluding transient runtime profiles. As a result, NNCP policies no longer interfere with Open vSwitch bridge configurations or other transient network setups. (link:https://redhat.atlassian.net/browse/OCPBUGS-86998[OCPBUGS-86998])
+
+
+* Before this update, the Machine Config Daemon (MCD) unnecessarily pulled and extracted the extensions container image during every operating system update, including initial node bootstrap, regardless of whether extensions were configured. As a consequence, this caused unnecessary network traffic and increased update times even when no extensions were in use. With this release, the MCD only pulls the extensions image when extensions are actually configured in the `MachineConfig` object. As a result, operating system updates complete more quickly and use less network bandwidth when extensions are not in use. (link:https://redhat.atlassian.net/browse/OCPBUGS-88335[OCPBUGS-88335])
+
+* Before this update, restoring a `VolumeSnapshot` request from the {product-title} web console failed if the parent persistent volume claim (PVC) was deleted. This issue occurred because of the incomplete rendering of form fields. As a consequence, users could not restore a `VolumeSnapshot` request through the user interface after the parent PVC was removed. With this update, the console correctly renders the restore form fields regardless of the status of the parent PVC. As a result, users can successfully restore a `VolumeSnapshot` request from the {product-title} web console even after deleting the parent PVC.(link:https://redhat.atlassian.net/browse/OCPBUGS-88358[OCPBUGS-88358])
+
+
+[id="zstream-4-21-21-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -50,6 +50,9 @@ include::modules/zstream-4-21-23.adoc[leveloffset=+2]
 // 4.21.22 RNs and updating
 include::modules/zstream-4-21-22.adoc[leveloffset=+2]
 
+// 4.21.21 RNs and updating
+include::modules/zstream-4-21-21.adoc[leveloffset=+2]
+
 // 4.21.20 RNs and updating
 include::modules/zstream-4-21-20.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20290

Link to docs preview:
https://115449--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-21_release-notes


