### PR TITLE
OSDOCS-16996: DITA abstracts — Azure Stack Hub

### DIFF
--- a/installing/installing_azure_stack_hub/installation-config-parameters-ash.adoc
+++ b/installing/installing_azure_stack_hub/installation-config-parameters-ash.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you deploy an {product-title} cluster on Azure Stack Hub, you provide a customized `install-config.yaml` installation configuration file that describes the details for your environment.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you can install {product-title}, you must configure a Microsoft Azure account.
 
 [IMPORTANT]

--- a/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default.adoc
+++ b/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on Microsoft Azure Stack Hub with an installer-provisioned infrastructure. However, you must manually configure the `install-config.yaml` file to specify values that are specific to Azure Stack Hub.
+[role="_abstract"]
+You can install a cluster on Microsoft Azure Stack Hub with installer-provisioned infrastructure. You must manually configure the `install-config.yaml` file to specify values that are specific to Azure Stack Hub.
 
 [NOTE]
 ====
@@ -18,7 +19,7 @@ While you can select `azure` when using the installation program to deploy a clu
 
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You have installed Azure Stack Hub version 2008 or later. 
+* You have installed Azure Stack Hub version 2008 or later.
 * You xref:../../../installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc#installing-azure-stack-hub-account[configured an Azure Stack Hub account] to host the cluster.
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You verified that you have approximately 16 GB of local disk space. Installing the cluster requires that you download the {op-system} virtual hard drive (VHD) cluster image and upload it to your Azure Stack Hub environment so that it is accessible during deployment. Decompressing the VHD files requires this amount of local disk space.

--- a/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install.adoc
+++ b/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You prepare to install an {product-title} cluster on Azure Stack Hub by completing the following steps:
+[role="_abstract"]
+Prepare to install an {product-title} cluster on Azure Stack Hub by verifying connectivity, configuring your account, generating SSH keys, downloading the installation program, installing the CLI, and setting up cloud credentials.
 
 * Verifying internet connectivity for your cluster.
 

--- a/installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc
+++ b/installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
+[role="_abstract"]
+You can install {product-title} on Azure Stack Hub using installer-provisioned or user-provisioned infrastructure.
+
+The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
 

--- a/installing/installing_azure_stack_hub/uninstalling-cluster-azure-stack-hub.adoc
+++ b/installing/installing_azure_stack_hub/uninstalling-cluster-azure-stack-hub.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can remove a cluster that you deployed to Azure Stack Hub.
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.adoc
+++ b/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on Microsoft Azure Stack Hub by using infrastructure that you provide.
+[role="_abstract"]
+You can install a cluster on Microsoft Azure Stack Hub by using infrastructure that you provide.
 
 Several link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview[Azure Resource Manager] (ARM) templates are provided to assist in completing these steps or to help model your own.
 
@@ -20,7 +21,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You have installed Azure Stack Hub version 2008 or later. 
+* You have installed Azure Stack Hub version 2008 or later.
 * You xref:../../../installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc#installing-azure-stack-hub-account[configured an Azure Stack Hub account] to host the cluster.
 * You downloaded the Azure CLI and installed it on your computer. See link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest[Install the Azure CLI] in the Azure documentation. The documentation below was tested using version `2.28.0` of the Azure CLI. Azure CLI commands might perform differently based on the version you use.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.

--- a/installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install.adoc
+++ b/installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You prepare to install an {product-title} cluster on Azure Stack Hub by completing the following steps:
+[role="_abstract"]
+Prepare to install an {product-title} cluster on Azure Stack Hub by verifying connectivity, configuring your account, generating SSH keys, downloading the installation program, and installing the CLI.
 
 * Verifying internet connectivity for your cluster.
 

--- a/modules/azure-stack-hub-internal-ca.adoc
+++ b/modules/azure-stack-hub-internal-ca.adoc
@@ -6,7 +6,8 @@
 [id="internal-certificate-authority_{context}"]
 = Configuring the cluster to use an internal CA
 
-If the Azure Stack Hub environment is using an internal Certificate Authority (CA), update the `cluster-proxy-01-config.yaml file` to configure the cluster to use the internal CA.
+[role="_abstract"]
+If the Azure Stack Hub environment is using an internal Certificate Authority (CA), update the `cluster-proxy-01-config.yaml` file to configure the cluster to use the internal CA.
 
 .Prerequisites
 

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -17,6 +17,7 @@ endif::[]
 [id="installation-azure-stack-hub-config-yaml_{context}"]
 = Sample customized install-config.yaml file for Azure Stack Hub
 
+[role="_abstract"]
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [IMPORTANT]

--- a/modules/installation-azure-stack-hub-network-config.adoc
+++ b/modules/installation-azure-stack-hub-network-config.adoc
@@ -7,4 +7,7 @@
 [id="installation-azure-stack-hub-network-config_{context}"]
 = Configuring a DNS zone in Azure Stack Hub
 
-To successfully install {product-title} on Azure Stack Hub, you must create DNS records in an Azure Stack Hub DNS zone. The DNS zone must be authoritative for the domain. To delegate a registrar's DNS zone to Azure Stack Hub, see Microsoft's documentation for link:https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-integrate-dns?view=azs-2102[Azure Stack Hub datacenter DNS integration].
+[role="_abstract"]
+To successfully install {product-title} on Azure Stack Hub, you must create DNS records in an Azure Stack Hub DNS zone. The DNS zone must be authoritative for the domain.
+
+To delegate a registrar's DNS zone to Azure Stack Hub, see Microsoft's documentation for link:https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-integrate-dns?view=azs-2102[Azure Stack Hub datacenter DNS integration].

--- a/modules/installation-azure-stack-hub-permissions.adoc
+++ b/modules/installation-azure-stack-hub-permissions.adoc
@@ -6,8 +6,7 @@
 [id="installation-azure-stack-hub-permissions_{context}"]
 = Required Azure Stack Hub roles
 
-Your Microsoft Azure Stack Hub account must have the following roles for the subscription that you use:
-
-* `Owner`
+[role="_abstract"]
+Your Microsoft Azure Stack Hub account must have the `Owner` role for the subscription that you use.
 
 To set roles on the Azure portal, see the link:https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-manage-permissions?view=azs-2102[Manage access to resources in Azure Stack Hub with role-based access control] in the Microsoft documentation.

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -14,6 +14,7 @@
 [id="logging-in-by-using-the-web-console_{context}"]
 = Logging in to the cluster by using the web console
 
+[role="_abstract"]
 The `kubeadmin` user exists by default after an {product-title} installation. You can log in to your cluster as the `kubeadmin` user by using the {product-title} web console.
 
 .Prerequisites


### PR DESCRIPTION
## Summary
Adds `[role="_abstract"]` short descriptions for 13 Azure Stack Hub assemblies and modules in scope for [OSDOCS-16996](https://redhat.atlassian.net/browse/OSDOCS-16996) (abstracts series only).

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16996

## Versions
4.20+

## Previews
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installation-config-parameters-ash
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-account
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install
https://115461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/uninstalling-cluster-azure-stack-hub

## Merge order
Independent branch from `main` (abstracts only). Rebase `osdocs-16996-dita-callouts-1` and `osdocs-16996-dita-other-vale-1` after merge if same-file conflicts occur.

## Files changed
- `installing/installing_azure_stack_hub/installation-config-parameters-ash.adoc`
- `installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc`
- `installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default.adoc`
- `installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install.adoc`
- `installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc`
- `installing/installing_azure_stack_hub/uninstalling-cluster-azure-stack-hub.adoc`
- `installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.adoc`
- `installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install.adoc`
- `modules/azure-stack-hub-internal-ca.adoc`
- `modules/installation-azure-stack-hub-config-yaml.adoc`
- `modules/installation-azure-stack-hub-network-config.adoc`
- `modules/installation-azure-stack-hub-permissions.adoc`
- `modules/logging-in-by-using-the-web-console.adoc`

## Vale rules addressed
- AsciiDocDITA.ShortDescription

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes
- Omitted stale Jira path `modules/cli-installing-cli.adoc` (file no longer exists)

Made with [Cursor](https://cursor.com)