### PR TITLE
OSDOCS-16996: DITA callouts — Azure Stack Hub install-config sample

### DIFF
--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -29,70 +29,68 @@ ifdef::ash[]
 ----
 apiVersion: v1
 baseDomain: example.com
-controlPlane: <1>
+controlPlane:
   name: master
   platform:
     azure:
       osDisk:
-        diskSizeGB: 1024 <2>
+        diskSizeGB: 1024
         diskType: premium_LRS
   replicas: 3
-compute: <1>
+compute:
 - name: worker
   platform:
     azure:
       osDisk:
-        diskSizeGB: 512 <2>
+        diskSizeGB: 512
         diskType: premium_LRS
   replicas: 0
 metadata:
-  name: test-cluster <3>
+  name: test-cluster
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <4>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   azure:
-    armEndpoint: azurestack_arm_endpoint <5>
-    baseDomainResourceGroupName: resource_group <6>
-    region: azure_stack_local_region <7>
-    resourceGroupName: existing_resource_group <8>
+    armEndpoint: azurestack_arm_endpoint
+    baseDomainResourceGroupName: resource_group
+    region: azure_stack_local_region
+    resourceGroupName: existing_resource_group
     outboundType: Loadbalancer
-    cloudName: AzureStackCloud <9>
-pullSecret: '{"auths": ...}' <10>
+    cloudName: AzureStackCloud
+pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <11>
-additionalTrustBundle: | <12>
+fips: false
+endif::openshift-origin[]
+additionalTrustBundle: |
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-sshKey: ssh-ed25519 AAAA... <13>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <11>
-    -----BEGIN CERTIFICATE-----
-    <MY_TRUSTED_CA_CERT>
-    -----END CERTIFICATE-----
-sshKey: ssh-ed25519 AAAA... <12>
-endif::openshift-origin[]
+sshKey: ssh-ed25519 AAAA...
 ----
-<1> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<2> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
-<3> Specify the name of the cluster.
-<4> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<5> Specify the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
-<6> Specify the name of the resource group that contains the DNS zone for your base domain.
-<7> Specify the name of your Azure Stack Hub local region.
-<8> Specify the name of an already existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
-<9> Specify the Azure Stack Hub environment as your target platform.
-<10> Specify the pull secret required to authenticate your cluster.
+
+where:
+
+`controlPlane`:: Specifies the configuration for the machines that form the control plane. The `controlPlane` section is a single mapping. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
+`compute`:: Specifies the configuration for the machines that form the compute plane. The `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not.
+`controlPlane.platform.azure.osDisk.diskSizeGB`:: Specifies the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
+`compute.platform.azure.osDisk.diskSizeGB`:: Specifies the size of the disk to use in GB.
+`metadata.name`:: Specifies the name of the cluster.
+`networking.networkType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`platform.azure.armEndpoint`:: Specifies the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
+`platform.azure.baseDomainResourceGroupName`:: Specifies the name of the resource group that contains the DNS zone for your base domain.
+`platform.azure.region`:: Specifies the name of your Azure Stack Hub local region.
+`platform.azure.resourceGroupName`:: Specifies the name of an already existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
+`platform.azure.cloudName`:: Specifies the Azure Stack Hub environment as your target platform.
+`pullSecret`:: Specifies the pull secret required to authenticate your cluster.
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+`fips`:: Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 --
 [IMPORTANT]
@@ -102,13 +100,9 @@ To enable FIPS mode for your cluster, you must run the installation program from
 When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
 --
-<12> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
-<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<11> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
-<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
+`additionalTrustBundle`:: Specifies the certificate trust bundle. If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
+`sshKey`:: Specifies the `sshKey` value that you use to access the machines in your cluster. This parameter is optional.
 +
 [NOTE]
 ====
@@ -120,97 +114,86 @@ ifdef::ash-default,ash-network[]
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
+baseDomain: example.com
 credentialsMode: Manual
-controlPlane: <2> <3>
+controlPlane:
   name: master
   platform:
     azure:
       osDisk:
-        diskSizeGB: 1024 <4>
+        diskSizeGB: 1024
         diskType: premium_LRS
   replicas: 3
-compute: <2>
+compute:
 - name: worker
   platform:
     azure:
       osDisk:
-        diskSizeGB: 512 <4>
+        diskSizeGB: 512
         diskType: premium_LRS
   replicas: 3
 metadata:
-  name: test-cluster <1> <5>
+  name: test-cluster
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <6>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   azure:
-    armEndpoint: azurestack_arm_endpoint <1> <7>
-    baseDomainResourceGroupName: resource_group <1> <8>
-    region: azure_stack_local_region <1> <9>
-    resourceGroupName: existing_resource_group <10>
+    armEndpoint: azurestack_arm_endpoint
+    baseDomainResourceGroupName: resource_group
+    region: azure_stack_local_region
+    resourceGroupName: existing_resource_group
     outboundType: Loadbalancer
-    cloudName: AzureStackCloud <1>
-    clusterOSimage: https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd <1> <11>
-pullSecret: '{"auths": ...}' <1> <12>
+    cloudName: AzureStackCloud
+    clusterOSimage: https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd
+pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <13>
-sshKey: ssh-ed25519 AAAA... <14>
+fips: false
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA...<13>
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-additionalTrustBundle: | <15>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <14>
-endif::openshift-origin[]
+sshKey: ssh-ed25519 AAAA...
+additionalTrustBundle: |
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
 ----
-<1> Required.
-<2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<4> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
-<5> The name of the cluster.
-<6> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<7> The Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
-<8> The name of the resource group that contains the DNS zone for your base domain.
-<9> The name of your Azure Stack Hub local region.
-<10> The name of an existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
-<11> The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
-<12> The pull secret required to authenticate your cluster.
+
+where:
+
+`baseDomain`:: Specifies the base domain for your cluster. This parameter is required.
+`controlPlane`:: Specifies the configuration for the machines that form the control plane. The `controlPlane` section is a single mapping. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used. If you do not provide these parameter, the installation program provides the default value.
+`compute`:: Specifies the configuration for the machines that form the compute plane. The `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. If you do not provide these parameter, the installation program provides the default value.
+`controlPlane.platform.azure.osDisk.diskSizeGB`:: Specifies the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
+`compute.platform.azure.osDisk.diskSizeGB`:: Specifies the size of the disk to use in GB.
+`metadata.name`:: Specifies the name of the cluster. This parameter is required.
+`networking.networkType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`platform.azure.armEndpoint`:: Specifies the Azure Resource Manager endpoint that your Azure Stack Hub operator provides. This parameter is required.
+`platform.azure.baseDomainResourceGroupName`:: Specifies the name of the resource group that contains the DNS zone for your base domain. This parameter is required.
+`platform.azure.region`:: Specifies the name of your Azure Stack Hub local region. This parameter is required.
+`platform.azure.resourceGroupName`:: Specifies the name of an existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
+`platform.azure.cloudName`:: Specifies the `platform.azure.cloudName` parameter. This parameter is required.
+`platform.azure.clusterOSimage`:: Specifies the URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
+`pullSecret`:: Specifies the pull secret required to authenticate your cluster. This parameter is required.
 ifndef::openshift-origin[]
-<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+`fips`:: Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
-<14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
+`sshKey`:: Specifies the `sshKey` value that you use to access the machines in your cluster. This parameter is optional.
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-ifndef::openshift-origin[]
-<15> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<14> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
-endif::openshift-origin[]
+`additionalTrustBundle`:: Specifies the certificate trust bundle. If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
 
 endif::ash-default,ash-network[]
 


### PR DESCRIPTION
## Summary
Rewrites numbered callouts in `installation-azure-stack-hub-config-yaml.adoc` to DITA-safe `where:` description lists (Pattern E) for both `ash` and `ash-default`/`ash-network` conditional blocks. Addresses AsciiDocDITA.CalloutList for [OSDOCS-16996](https://redhat.atlassian.net/browse/OSDOCS-16996) Azure Stack Hub pre-migration scope.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-16996

## Versions
4.20+

## Previews
[115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default.html](https://115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-default.html)
[115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.html](https://115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.html)
[115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.html](https://115462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.html)

## Merge order
Independent branch from main (callouts only). Preferred merge order after #115461 (abstracts) if same-file conflicts; rebase if needed.

## Files changed
- `modules/installation-azure-stack-hub-config-yaml.adoc`

## Vale rules addressed
- AsciiDocDITA.CalloutList

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted
- `cli-installing-cli.adoc` omitted from scope (stale attachment path)

Made with [Cursor](https://cursor.com)