### PR TITLE
[6.4] OBSDOCS-1807: Document LokiStack resource limits (Technology Preview)

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -334,6 +334,8 @@ endif::openshift-origin[]
 :sts-first: Security Token Service (STS)
 :sts-full: Security Token Service
 :sts-short: STS
+//Microsoft Entra ID (FKA Azure Active Directory)
+:entra-id: Microsoft Entra ID
 //Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
 :entra-first: Microsoft Entra Workload ID
 :entra-short: Workload ID

--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -102,6 +102,8 @@ include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset
 
 include::modules/cluster-logging-collector-log-forward-gcp.adoc[leveloffset=+2]
 
+include::modules/cluster-logging-collector-log-forward-gcp-wif.adoc[leveloffset=+2]
+
 include::modules/configuring-otlp-output.adoc[leveloffset=+2]
 
 [id="forwarding-logs-to-splunk_{context}"]
@@ -116,6 +118,26 @@ include::modules/logging-http-forward.adoc[leveloffset=+2]
 include::modules/cluster-logging-collector-log-forward-loki.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-collector-log-forward-kafka.adoc[leveloffset=+2]
+
+include::modules/about-azure-logs-ingestion-api.adoc[leveloffset=+2]
+
+include::modules/azure-logs-ingestion-dcr-requirements.adoc[leveloffset=+2]
+
+include::modules/azure-dcr-components.adoc[leveloffset=+3]
+
+include::modules/azure-dcr-required-information.adoc[leveloffset=+3]
+
+include::modules/azure-dcr-authentication-permissions.adoc[leveloffset=+3]
+
+include::modules/azure-logs-ingestion-authentication.adoc[leveloffset=+2]
+
+include::modules/azure-auth-client-secret.adoc[leveloffset=+3]
+
+include::modules/azure-auth-workload-identity.adoc[leveloffset=+3]
+
+include::modules/azure-auth-permissions.adoc[leveloffset=+3]
+
+include::modules/logging-forwarding-azure-logs-ingestion.adoc[leveloffset=+2]
 
 include::modules/logging-forwarding-azure.adoc[leveloffset=+2]
 

--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -55,6 +55,7 @@ include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+2]
 include::modules/logging-loki-retention.adoc[leveloffset=+2]
 include::modules/loki-memberlist-ip.adoc[leveloffset=+2]
 include::modules/loki-restart-hardening.adoc[leveloffset=+2]
+include::modules/loki-resource-limits.adoc[leveloffset=+2]
 //include::modules/enabling-automatic-stream-sharding.adoc[leveloffset=+2]
 
 //Advanced deployment and scalability

--- a/modules/about-azure-logs-ingestion-api.adoc
+++ b/modules/about-azure-logs-ingestion-api.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-azure-logs-ingestion-api_{context}"]
+= About the Azure Monitor Logs Ingestion API
+
+[role="_abstract"]
+The Azure Monitor Logs Ingestion API provides a modern, secure method for forwarding logs to Azure Monitor. This API uses Data Collection Rules (DCR) to define log schemas and routing, replacing the Data Collector API.
+
+[IMPORTANT]
+====
+Microsoft will disable the Data Collector API on September 14, 2026. If you currently use the `azureMonitor` output type, you must migrate to `azureLogsIngestion` before this date to avoid service disruption.
+====
+
+The `azureLogsIngestion` output type implements this API and offers the following advantages over the deprecated `azureMonitor` output:
+
+Enhanced security:: Support for {entra-id} Workload Identity allows pod-based authentication without managing shared secrets. Service principal authentication with client secrets remains available for environments that require it.
+
+Schema flexibility:: DCRs allow you to define custom log schemas that match your organization's requirements. You can specify which field receives the timestamp, supporting standard schemas such as `TimeGenerated` or specialized schemas such as ASIM that use `EventStartTime`.
+
+Improved reliability:: The Logs Ingestion API provides better error handling and status reporting compared to the Data Collector API.
+
+Azure integration:: DCRs integrate with Azure's monitoring and compliance frameworks, providing centralized management of log ingestion rules across your organization.
+
+The deprecated `azureMonitor` output type uses the Data Collector API. Microsoft will disable this API on September 14, 2026. Existing deployments using `azureMonitor` should migrate to `azureLogsIngestion` before this date.
+
+Both output types can coexist during the migration period. You can configure both outputs in the same `ClusterLogForwarder` custom resource (CR) to validate the new configuration before removing the deprecated output.

--- a/modules/azure-auth-client-secret.adoc
+++ b/modules/azure-auth-client-secret.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-auth-client-secret_{context}"]
+= Client secret authentication
+
+[role="_abstract"]
+Client secret authentication uses a {entra-id} service principal with a client ID and secret. You create a secret in the `openshift-logging` namespace containing the client secret value, then reference this secret in the `ClusterLogForwarder` custom resource (CR).
+
+This authentication method works in all Azure environments and does not require additional {entra-id} configuration beyond creating the service principal. However, you must manage and rotate the client secret according to your organization's security policies.
+
+Use client secret authentication when:
+
+* Your organization's security policies permit storing credentials in cluster secrets
+* You need a straightforward authentication method without additional Azure infrastructure
+* You already manage service principal credentials for other Azure integrations

--- a/modules/azure-auth-permissions.adoc
+++ b/modules/azure-auth-permissions.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-auth-permissions_{context}"]
+= Authentication permissions
+
+[role="_abstract"]
+Regardless of which authentication method you choose, the {entra-id} application (client ID) must have the **Monitoring Metrics Publisher** role assigned to the Data Collection Rule. This role grants permission to send log data through the specified DCR to Azure Monitor.
+
+You configure this role assignment in Azure, not in {product-title}. The role assignment applies to the {entra-id} application identified by the client ID, whether you authenticate using a client secret or workload identity.

--- a/modules/azure-auth-workload-identity.adoc
+++ b/modules/azure-auth-workload-identity.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-auth-workload-identity_{context}"]
+= Workload identity authentication
+
+[role="_abstract"]
+Workload identity authentication uses {entra-id} Workload Identity to obtain tokens automatically from the pod environment. This method does not require storing credentials in cluster secrets. Instead, {product-title} uses pod-injected service account tokens to authenticate with {entra-id}.
+
+{entra-id} Workload Identity requires additional configuration in your Azure environment. This includes establishing a federated identity credential that trusts your {product-title} cluster's OIDC issuer. The service account running the log collector must include specific annotations that Azure uses to request tokens.
+
+Use workload identity authentication when:
+
+* Your organization's security policies prohibit storing cloud credentials in cluster secrets
+* Your Azure environment supports {entra-id} Workload Identity
+* You prefer Azure to manage credential rotation automatically
+* You run {product-title} on Azure infrastructure

--- a/modules/azure-dcr-authentication-permissions.adoc
+++ b/modules/azure-dcr-authentication-permissions.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-dcr-authentication-permissions_{context}"]
+= Authentication and permissions
+
+[role="_abstract"]
+The {entra-id} service principal or workload identity you configure for authentication must have the **Monitoring Metrics Publisher** role assigned to the DCR. This role grants permission to send data through the specified Data Collection Rule.
+
+You configure authentication credentials in {entra-id} separately from the DCR creation. The credentials do not need access to the Log Analytics workspace directly. The DCR controls data routing and access.

--- a/modules/azure-dcr-components.adoc
+++ b/modules/azure-dcr-components.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-dcr-components_{context}"]
+= Data Collection Rule components
+
+[role="_abstract"]
+A Data Collection Rule for log ingestion requires the following components:
+
+Data collection endpoint:: The HTTPS endpoint that receives log data. Azure provides this endpoint URL when you create or view your DCR. The `ClusterLogForwarder` custom resource (CR) requires this endpoint URL.
+
+Stream declaration:: A custom stream definition that specifies the structure of incoming log data. The stream name typically follows the pattern `Custom-<StreamName>_CL`. The `ClusterLogForwarder` CR requires this stream name.
+
+Transformation rule:: An optional Kusto Query Language (KQL) transformation that processes or enriches log data before storage. If you do not specify a transformation, Azure stores the data directly as received.
+
+Destination workspace:: The Log Analytics workspace where Azure stores the processed logs. The DCR associates the stream with a specific table in this workspace.

--- a/modules/azure-dcr-required-information.adoc
+++ b/modules/azure-dcr-required-information.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="azure-dcr-required-information_{context}"]
+= Required information for log forwarding configuration
+
+[role="_abstract"]
+After creating your DCR in Azure, you need the following information to configure the `azureLogsIngestion` output:
+
+DCR immutable ID:: A unique identifier for the Data Collection Rule that {product-title} uses to route log data. You can find this ID in the Azure portal under the DCR JSON view or by using the Azure CLI. The immutable ID format is `dcr-` followed by a hexadecimal string.
+
+Stream name:: The exact name of the custom stream you defined in the DCR, for example, `Custom-MyApplicationLogs_CL`.
+
+Data collection endpoint URL:: The HTTPS URL for the data collection endpoint associated with your DCR. This URL typically uses the pattern `\https://<endpoint-name>.<region>.monitor.azure.com`.
+
+[role="_additional-resources"]
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://learn.microsoft.com/en-us/azure/azure-monitor/logs/tutorial-logs-ingestion-portal[Create a Data Collection Rule for logs ingestion]
+* link:https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview[Logs Ingestion API overview]

--- a/modules/azure-logs-ingestion-authentication.adoc
+++ b/modules/azure-logs-ingestion-authentication.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-logs-ingestion-authentication_{context}"]
+= Azure Logs Ingestion API authentication methods
+
+[role="_abstract"]
+The `azureLogsIngestion` output supports two authentication methods for {entra-id}: service principal credentials with a client secret, or {entra-id} Workload Identity. Your choice depends on your security requirements and Azure environment configuration.

--- a/modules/azure-logs-ingestion-dcr-requirements.adoc
+++ b/modules/azure-logs-ingestion-dcr-requirements.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="azure-logs-ingestion-dcr-requirements_{context}"]
+= Azure Data Collection Rule requirements
+
+[role="_abstract"]
+Before you can forward logs to Azure Monitor by using the Logs Ingestion API, you must create a Data Collection Rule (DCR) in your Azure environment. The DCR defines the schema for your logs and controls which Log Analytics workspace receives the data.

--- a/modules/clf-outputs-reference.adoc
+++ b/modules/clf-outputs-reference.adoc
@@ -9,11 +9,15 @@
 [role="_abstract"]
 Output types define the destination where the collector forwards log records. Each output type has specific configuration requirements for authentication, connection parameters, and data formatting.
 
-`azureMonitor`:: Forwards logs to Azure Monitor Logs service. This output requires a customer ID and shared key for authentication. You can specify a custom log type and associate logs with a specific Azure resource ID.
+`azureLogsIngestion`:: Forwards logs to Azure Monitor Logs by using the Logs Ingestion API with Data Collection Rules (DCR). This output supports two authentication methods: service principal credentials with client secrets, or {entra-id} Workload Identity. You must configure a Data Collection Rule in Azure and specify the DCR immutable ID, stream name, and data collection endpoint URL. The Logs Ingestion API provides improved security, flexible schema mapping, and integration with Azure's monitoring frameworks.
++
+**Use case**: Organizations use Azure Monitor Logs for centralized log analysis, alerting, and integration with Azure services. The Logs Ingestion API replaces the Data Collector API, which Microsoft is retiring on September 14, 2026, and provides support for managed identities and custom log schemas through Data Collection Rules.
+
+`azureMonitor`:: Forwards logs to Azure Monitor Logs service by using the Data Collector API. This output requires a customer ID and shared key for authentication. You can specify a custom log type and associate logs with a specific Azure resource ID.
 +
 [WARNING]
 ====
-The `azureMonitor` output type is deprecated and will be removed in a future release. This output type will become obsolete in September 2026.
+The `azureMonitor` output type is deprecated and will be removed in a future release. Microsoft will disable the Data Collector API on September 14, 2026. Use the `azureLogsIngestion` output type instead.
 ====
 
 `cloudwatch`:: Forwards logs to Amazon CloudWatch. This output supports two authentication methods: AWS access keys or IAM roles with Security Token Service (STS). You must specify the AWS region and a group name pattern for organizing log streams. CloudWatch outputs support cross-account log forwarding using the AssumeRole feature.

--- a/modules/cluster-logging-collector-log-forward-gcp-wif.adoc
+++ b/modules/cluster-logging-collector-log-forward-gcp-wif.adoc
@@ -1,0 +1,215 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-logging-collector-log-forward-gcp-wif_{context}"]
+= Forward logs to Google Cloud Platform with Workload Identity Federation
+
+[role="_abstract"]
+Forward logs to link:https://cloud.google.com/logging/docs/basic-concepts[Google Cloud Logging] using Workload Identity Federation (WIF) for authentication. WIF provides short-lived credentials instead of long-lived service account keys. This approach improves security by eliminating the need to manage and rotate service account key files.
+
+[IMPORTANT]
+====
+Forwarding logs to GCP with Workload Identity Federation is only supported on Red{nbsp}Hat OpenShift on GCP.
+====
+
+.Prerequisites
+
+* You have installed the {clo}.
+* Your {product-title} cluster is installed on GCP in manual credentials mode with Workload Identity Federation (WIF) enabled.
+* You have access to the `ccoctl` utility that was used during cluster installation.
+* You have `gcloud` CLI installed and configured for your GCP project.
+* You have the GCP project number, not the project ID. To get this value, run: `gcloud projects describe <PROJECT_ID> --format="value(projectNumber)"`
+
+[IMPORTANT]
+====
+Workload Identity Federation must be enabled during cluster installation. You cannot retrofit WIF onto an existing cluster that was not installed with WIF support. If your cluster was not installed with WIF, use service account keys instead.
+====
+
+.Procedure
+
+. Set environment variables for your GCP project and cluster configuration:
++
+[source,terminal]
+----
+$ export PROJECT_ID="<your_gcp_project_id>"
+$ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
+$ export LOGGING_NS="openshift-logging"
+$ export SA_NAME="logcollector"
+$ export SECRET_NAME="gcp-wif-secret"
+$ export POOL_ID="<your_cluster_name>"  # <1>
+$ export PROVIDER_ID="<your_cluster_name>"  # <2>
+$ export GCP_SA_NAME="openshift-logging-writer"
+$ export SERVICE_ACCOUNT_EMAIL="${GCP_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+----
++
+<1> The workload identity pool ID created during cluster installation. This typically matches your cluster name.
+<2> The workload identity provider ID created during cluster installation. This typically matches the pool ID.
++
+[WARNING]
+====
+The `audience` field in the CredentialsRequest must use your GCP project *number*, not your project ID. Using the project ID instead of the project number causes HTTP 403 Forbidden errors.
+====
+
+. Create a `CredentialsRequest` custom resource YAML file named `credrequest.yaml`:
++
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: gcp-wif-credrequest
+  namespace: openshift-cloud-credential-operator  # <1>
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+      - roles/logging.logWriter  # <2>
+    skipServiceCheck: true
+    audience: "//iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"  # <3>
+    serviceAccountEmail: ${SERVICE_ACCOUNT_EMAIL}  # <4>
+  cloudTokenPath: /var/run/ocp-collector/serviceaccount  # <5>
+  secretRef:
+    name: ${SECRET_NAME}
+    namespace: ${LOGGING_NS}  # <6>
+  serviceAccountNames:
+    - ${SA_NAME}  # <7>
+----
++
+<1> The standard namespace for CredentialsRequest resources.
+<2> The GCP IAM role granting permissions to write log entries to Google Cloud Logging.
+<3> The WIF audience. This must use the project *number*, not the project ID.
+<4> The email address of the GCP service account that `ccoctl` will create or use.
+<5> The path where the OpenShift service account token is mounted in the collector pod.
+<6> The namespace where the secret will be created. This should match the namespace where you will deploy the `ClusterLogForwarder`.
+<7> The name of the OpenShift service account that the collector pods will use.
+
+. Use the `ccoctl` utility to create the GCP service account and IAM bindings:
++
+[source,terminal]
+----
+$ mkdir -p credreqs
+$ cp credrequest.yaml credreqs/
+$ ccoctl gcp create-all \
+  --name="${POOL_ID}" \
+  --project="${PROJECT_ID}" \
+  --region="us-east1" \
+  --credentials-requests-dir=credreqs \
+  --output-dir=output
+----
++
+This command creates:
++
+--
+* A GCP service account with the specified email address
+* IAM policy bindings granting the `roles/logging.logWriter` role
+* A workload identity binding between the OpenShift service account and the GCP service account
+* An OpenShift secret manifest containing the external account credentials
+--
+
+. Apply the generated secret manifest:
++
+[source,terminal]
+----
+$ oc apply -f output/manifests/${LOGGING_NS}-${SECRET_NAME}-credentials.yaml
+----
+
+. Update the secret to fix the `cloudTokenPath` for the collector:
++
+[IMPORTANT]
+====
+The `ccoctl` utility does not respect the `cloudTokenPath` setting in the CredentialsRequest. You must manually update the generated secret to use the correct token path for the logging collector.
+====
++
+[source,terminal]
+----
+$ oc get secret ${SECRET_NAME} -n ${LOGGING_NS} -o jsonpath='{.data.service_account\.json}' | base64 -d > /tmp/creds.json
+$ jq '.credential_source.file = "/var/run/ocp-collector/serviceaccount/token"' /tmp/creds.json > /tmp/external_account.json
+$ oc delete secret ${SECRET_NAME} -n ${LOGGING_NS}
+$ oc create secret generic ${SECRET_NAME} -n ${LOGGING_NS} \
+  --from-file=external_account.json=/tmp/external_account.json
+----
+
+. Verify the secret was updated correctly:
++
+[source,terminal]
+----
+$ oc get secret ${SECRET_NAME} -n ${LOGGING_NS} -o jsonpath='{.data.external_account\.json}' | base64 -d | jq .credential_source
+----
++
+The output should show:
++
+[source,json]
+----
+{
+  "file": "/var/run/ocp-collector/serviceaccount/token"
+}
+----
+
+. Create a `ClusterLogForwarder` custom resource that uses WIF authentication:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: <log_forwarder_name>
+  namespace: openshift-logging  # <1>
+spec:
+  serviceAccount:
+    name: logcollector  # <2>
+  outputs:
+    - name: gcp-wif
+      type: googleCloudLogging
+      googleCloudLogging:
+        authentication:
+          credentials:
+            secretName: gcp-wif-secret
+            key: external_account.json  # <3>
+          token:
+            from: serviceAccount  # <4>
+        id:
+          type: project
+          value: <your_project_id>
+        logId: openshift-logs
+  pipelines:
+    - name: send-to-gcp
+      inputRefs:
+        - application
+        - infrastructure
+        - audit
+      outputRefs:
+        - gcp-wif
+----
++
+<1> The namespace where the `ClusterLogForwarder` is deployed. This should match the namespace specified in the `CredentialsRequest` secret reference.
+<2> The OpenShift service account name. This must match the `serviceAccountNames` value in the `CredentialsRequest`.
+<3> The secret key containing the external account configuration file. Note that this is `external_account.json`, not `service_account.json`, because you manually recreated the secret in the previous step.
+<4> Specifies that the bearer token comes from the service account. The collector uses the service account token as the subject token for WIF token exchange with GCP.
+
+.Verification
+
+. Check the log collector pods to verify that they are running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging -l app.kubernetes.io/component=collector
+----
+
+. Review the collector pod logs to confirm successful authentication and log forwarding:
++
+[source,terminal]
+----
+$ oc logs -n openshift-logging <collector_pod_name> | grep -i gcp
+----
+
+. In the GCP console, navigate to *Logging* > *Logs Explorer* and verify that logs from your OpenShift cluster are appearing.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://cloud.google.com/iam/docs/workload-identity-federation[GCP Workload Identity Federation documentation]
+* link:https://docs.openshift.com/container-platform/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html[Using manual mode with STS]
+* link:https://cloud.google.com/logging/docs[Cloud Logging documentation]

--- a/modules/cluster-logging-collector-log-forward-gcp.adoc
+++ b/modules/cluster-logging-collector-log-forward-gcp.adoc
@@ -4,10 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-log-forward-gcp_{context}"]
-= Forwarding logs to Google Cloud Platform (GCP)
+= Forward logs to Google Cloud Platform with service account keys
 
 [role="_abstract"]
-You can forward logs to link:https://cloud.google.com/logging/docs/basic-concepts[Google Cloud Logging].
+Forward logs to link:https://cloud.google.com/logging/docs/basic-concepts[Google Cloud Logging] using a Google service account key for authentication.
+
+[NOTE]
+====
+For improved security, consider using Workload Identity Federation instead of long-lived service account keys. See "Forwarding logs to Google Cloud Platform with Workload Identity Federation".
+====
 
 [IMPORTANT]
 ====
@@ -66,6 +71,7 @@ spec:
 
 [role="_additional-resources"]
 .Additional resources
+* link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys[Creating and managing service account keys]
 * link:https://cloud.google.com/billing/docs/concepts[Google Cloud Billing Documentation]
 * link:https://cloud.google.com/logging/docs[Cloud Logging documentation]
 * link:https://cloud.google.com/logging/docs/view/logging-query-language[Google Cloud Logging Query Language Documentation]

--- a/modules/logging-delivery-tuning.adoc
+++ b/modules/logging-delivery-tuning.adoc
@@ -70,18 +70,18 @@ spec:
     lokiStack:
       tuning:
         deliveryMode: AtLeastOnce
-        compression: gzip
-        maxWrite: 3Mi
-        minRetryDuration: 2
-        maxRetryDuration: 300
+        compression: none
+        maxWrite: <integer>
+        minRetryDuration: 1s
+        maxRetryDuration: 1s
 ----
 `deliveryMode`:: Specify the delivery mode for log forwarding. When left unset, the system defaults to using an in-memory buffer, which offers the highest performance due to low latency but does not provide durability. Buffered data is lost on process termination or failure.
 ** `AtLeastOnce` delivery means that if the log forwarder crashes or restarts, the collector re-sends any logs it read before the crash but did not send to their destination. The collector might duplicate some logs after a crash.
 ** `AtMostOnce` delivery means that the log forwarder makes no effort to recover logs lost during a crash. This mode gives better throughput, but might result in greater log loss.
-`compression`:: Specifying a `compression` configuration causes the collector to compress data before sending it over the network. Note that not all output types support compression, and if the specified compression type is not supported by the output, this results in an error. For more information, see "Supported compression types for tuning outputs". When left unset, the collector does not apply compression.
-`maxWrite`:: Specifies a limit for the maximum payload in bytes of a single send operation to the output. You can specify this value as an integer or as a string with units such as `Ki` (kibibyte), `Mi` (mebibyte), or `Gi` (gibibyte). For example: `1048576`, `"1Mi"`, or `"3Mi"`. For `LokiStack` outputs, the default value is `3Mi` when not specified.
-`minRetryDuration`:: Specifies a minimum duration in seconds to wait between attempts before retrying delivery after a failure. This value is an integer representing seconds. For example, `2` means 2 seconds.
-`maxRetryDuration`:: Specifies a maximum duration in seconds to wait between attempts before retrying delivery after a failure. This value is an integer representing seconds. For example, `300` means 300 seconds (5 minutes).
+`compression`:: Specifying a `compression` configuration causes the collector to compress data before sending it over the network. Note that not all output types support compression, and if the specified compression type is not supported by the output, this results in an error. For more information, see "Supported compression types for tuning outputs".
+`maxWrite`:: Specifies a limit for the maximum payload of a single send operation to the output.
+`minRetryDuration`:: Specifies a minimum duration to wait between attempts before retrying delivery after a failure. This value is a string, and you can specify it as milliseconds (`ms`), seconds (`s`), or minutes (`m`).
+`maxRetryDuration`:: Specifies a maximum duration to wait between attempts before retrying delivery after a failure. This value is a string, and you can specify it as milliseconds (`ms`), seconds (`s`), or minutes (`m`).
 
 [id="supported-compression-types_{context}"]
 .Supported compression types for tuning outputs

--- a/modules/logging-forwarding-azure-logs-ingestion.adoc
+++ b/modules/logging-forwarding-azure-logs-ingestion.adoc
@@ -1,0 +1,185 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="logging-forwarding-azure-logs-ingestion_{context}"]
+= Forward logs to Azure Monitor using the Logs Ingestion API
+
+[role="_abstract"]
+Forward logs to Azure Monitor using the Logs Ingestion API with Data Collection Rules. This procedure shows how to configure the `azureLogsIngestion` output type with client secret authentication. For workload identity authentication, see the example at the end of this procedure.
+
+.Prerequisites
+
+* You have an Azure account with permissions to create and manage Azure Monitor resources.
+* You created a Data Collection Rule (DCR) in your Azure Log Analytics workspace.
+* You obtained the following information from your DCR:
+** DCR immutable ID
+** Stream name
+** Data collection endpoint URL
+* You created a {entra-id} service principal with the **Monitoring Metrics Publisher** role assigned to your DCR.
+* You obtained the following {entra-id} credentials:
+** Tenant ID
+** Client ID
+** Client secret (for client secret authentication)
+* You installed the {clo}.
+* You installed the {oc-first}.
+* You have administrator access.
+
+.Procedure
+
+. Create a secret containing your {entra-id} client secret:
++
+[source,terminal]
+----
+$ oc create secret generic azure-entra-secret \
+  --from-literal=client-secret=<your_client_secret> \
+  -n openshift-logging
+----
+
+. Create a `ClusterLogForwarder` custom resource (CR) or edit your existing CR. Replace the following values with your Azure configuration:
++
+--
+* Replace `<data_collection_endpoint>` and `<region>` with your data collection endpoint URL. Find this URL in the Azure portal under your DCR details or run `az monitor data-collection endpoint show`.
+* Replace the `dcrImmutableId` value with your DCR immutable ID. Find this ID in the Azure portal under the DCR JSON view or run `az monitor data-collection rule show`.
+* Replace the `streamName` value with the stream name you defined in your DCR. The stream name must match exactly, including the `Custom-` prefix and `_CL` suffix if your DCR uses them.
+* Replace the `tenantId` value with your {entra-id} tenant ID.
+* Replace the `clientId` value with your {entra-id} application (client) ID.
+* The `secretName` value should match the name of the secret you created in step 1.
+--
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-MyApplicationLogs_CL"
+      authentication:
+        type: clientSecret
+        clientSecret:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+          secret:
+            secretName: azure-entra-secret
+            key: client-secret
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----
+
+. Apply the CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Check the `ClusterLogForwarder` status:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging -o jsonpath='{.status.conditions}' | jq
+----
++
+Look for conditions indicating successful configuration and log delivery.
+
+. Verify that logs appear in your Azure Log Analytics workspace:
+.. Log in to the Azure portal.
+.. Navigate to your Log Analytics workspace.
+.. Run a query against your custom log table to verify that logs are being ingested:
++
+[source,text]
+----
+MyApplicationLogs_CL
+| take 10
+----
+
+*Using workload identity authentication*
+
+If your environment supports {entra-id} Workload Identity, you can configure authentication without storing credentials in cluster secrets. Replace the values with your Azure configuration as described in the main procedure.
+
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-MyApplicationLogs_CL"
+      authentication:
+        type: workloadIdentity
+        workloadIdentity:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----
++
+Workload identity authentication requires additional {entra-id} configuration, including a federated identity credential that trusts your {product-title} cluster's OIDC issuer.
+
+*Configuring custom timestamp field*
+
+Some Azure Monitor schemas use different timestamp field names. For example, ASIM (Azure Sentinel Information Model) schemas use `EventStartTime` instead of the default `TimeGenerated`. Replace the values with your Azure configuration as described in the main procedure. The `timestampField` specifies the destination field for the timestamp in your DCR table schema. Common values are `TimeGenerated` (default), `Timestamp` (previous versions), or `EventStartTime` (ASIM).
+
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-AsimStream_CL"
+      timestampField: "EventStartTime"
+      authentication:
+        type: clientSecret
+        clientSecret:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+          secret:
+            secretName: azure-entra-secret
+            key: client-secret
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----

--- a/modules/loki-resource-limits.adoc
+++ b/modules/loki-resource-limits.adoc
@@ -1,0 +1,161 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="loki-resource-limits_{context}"]
+= Setting resource limits for LokiStack components
+
+:FeatureName: Setting resource limits equal to resource requests for LokiStack components
+include::snippets/technology-preview.adoc[]
+
+[role="_abstract"]
+By default, LokiStack components specify resource requests but have no resource limits set. Without limits, components can use additional node resources when available. You can configure LokiStack to set resource limits equal to resource requests. This configuration imposes a hard limit on resource usage. This prevents node memory exhaustion.
+
+[id="understanding-resource-limits_{context}"]
+= Understanding resource limits and their impact
+
+Kubernetes resource requests and limits control pod resource allocation:
+
+Resource requests:: The minimum amount of CPU and memory guaranteed to a pod. The scheduler uses requests to determine pod placement on nodes.
+
+Resource limits:: The maximum amount of CPU and memory a pod can consume. When a container's memory usage exceeds its `limits.memory`, the Linux kernel Out-of-Memory (OOM) killer terminates the container process (Exit Code 137). When a container tries to use more CPU than its `limits.cpu` allows, the kernel Completely Fair Scheduler (CFS) limits its access to CPU cycles. This causes CPU throttling. Performance degradation results: latency spikes, timeouts, and sluggishness for CPU throttling, and container restarts for OOMKilled events.
+
+By default, LokiStack components have resource requests configured but have no resource limits set. Components can burst above their requested resources when the node has available capacity. Bursting helps components handle temporary load spikes.
+
+[id="when-to-set-limits_{context}"]
+= When to set resource limits equal to requests
+
+Setting resource limits equal to requests (`spec.template.useRequestsAsLimits: true`) is useful in the following scenarios:
+
+Preventing node memory exhaustion::
+On nodes that run multiple workloads, unconstrained LokiStack components can consume all available memory during load spikes. This affects other workloads. Setting resource limits prevents this problem.
+
+Predictable resource consumption::
+When you need guaranteed resource boundaries for capacity planning and cost control, setting limits ensures components never exceed their allocated resources.
+
+Shared node environments::
+On nodes that run multiple workloads (such as in multitenant clusters or clusters with many diverse applications), setting resource limits prevents any single workload from consuming all available resources during load spikes. Without limits, LokiStack components can burst and consume resources needed by other workloads on the same node. Resource limits enforce hard boundaries that ensure predictable resource allocation across all workloads.
+
+[IMPORTANT]
+====
+Setting resource limits equal to requests reduces LokiStack ability to handle load spikes. Components cannot burst above their requested resources even when the node has available capacity. This can result in:
+
+* Query timeouts during peak load
+* Ingestion backpressure and log loss
+* Component restarts due to OOMKilled events
+
+Only enable this setting if node resource exhaustion is a confirmed problem. Monitor component resource usage after enabling to ensure limits are not too restrictive.
+====
+
+[id="checking-current-resource-usage_{context}"]
+= Checking current resource usage
+
+Before you enable resource limits, verify that peak CPU and memory usage over time is below the limits for your LokiStack size. Log workload patterns change throughout the day and across days. Reviewing historical usage over a time range is more reliable than checking current values. If peak usage exceeds the limits from the sizing tables, enabling `useRequestsAsLimits` causes pods to be OOMKilled and enter CrashLoopBackOff.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You know your current LokiStack size (for example, `1x.small`).
+
+.Procedure
+
+. In the {ocp-product-title} web console, navigate to *Observe* → *Metrics*.
+
+. Set the time range to *1w* (1 week) to view historical usage patterns.
+
+. Query CPU usage for all LokiStack components:
++
+[NOTE]
+====
+These queries assume that your LokiStack custom resource is named `logging-loki`. If you used a different name, replace `logging-loki.{asterisk}` with `<your-lokistack-name>.{asterisk}` in the queries.
+====
++
+[source,promql]
+----
+pod:container_cpu_usage:sum{pod=~"logging-loki.*",namespace="openshift-logging"}
+----
++
+Observe the peak CPU usage for each component over the past week.
+
+. Query memory usage for all LokiStack components:
++
+[source,promql]
+----
+sum(container_memory_working_set_bytes{pod=~"logging-loki.*",namespace="openshift-logging",container=""}) BY (pod, namespace)
+----
++
+Observe the peak memory usage for each component over the past week.
+
+. Compare the peak usage values (not current values) against the resource requests for your LokiStack size in the sizing tables:
++
+--
+* For CPU: Peak usage should be below the CPU request per pod for each component.
+* For memory: Peak memory (in bytes) should be below the memory request per pod for each component.
+
+For per-component resource tables for your size, see the additional resources at the end of this topic.
+
+If the current usage of any component exceeds its resource request, do not enable `useRequestsAsLimits` until you complete one of the following actions:
+
+* Increase the LokiStack size to one with higher resource allocations.
+* Reduce log ingestion volume to decrease resource consumption.
+* Investigate why components are consuming more resources than expected.
+--
+
+[id="configuring-resource-limits_{context}"]
+= Configuring resource limits
+
+After you verify that current resource usage is below the limits, enable resource limits.
+
+To set resource limits equal to requests for all LokiStack components, set `spec.template.useRequestsAsLimits` to `true`:
+
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small
+  template:
+    useRequestsAsLimits: true
+----
+
+`spec.template.useRequestsAsLimits`:: Sets resource limits equal to resource requests for all LokiStack components (distributor, ingester, querier, query-frontend, compactor, index-gateway, ruler, and gateway). This setting applies to all components. You cannot set limits for individual components.
+
+[id="verifying-resource-limits_{context}"]
+= Verifying resource limits
+
+After you enable `useRequestsAsLimits`, verify that resource limits are set correctly:
+
+. Check a LokiStack pod's resource configuration:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-logging -l app.kubernetes.io/component=ingester -o jsonpath='{.items[0].spec.containers[0].resources}' | jq
+----
++
+.Example output
+[source,json]
+----
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "1",
+    "memory": "2Gi"
+  }
+}
+----
+
+. Verify that the values for `requests` and `limits` are identical for both CPU and memory.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]
+* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes resource management for pods and containers]
+* link:https://access.redhat.com/solutions/7039657[How to set resource limits for LokiStack components]


### PR DESCRIPTION
## Cherry-pick from main

This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/114436 to the `standalone-logging-docs-6.4` branch.

The automatic cherry-pick failed due to merge conflicts, which have been resolved.

## Summary

Documents the `useRequestsAsLimits` field in LokiStack, which sets resource limits equal to resource requests for all components. This feature is in Technology Preview.

## Changes

**New module: modules/loki-resource-limits.adoc**
- Explains when to use resource limits (node exhaustion, predictable consumption, shared node environments)
- Important warning about reduced load spike handling ability
- Procedure for checking current resource usage before enabling
- Configuration example using definition list (DITA-compatible)
- Verification steps

**Assembly update: configuring/configuring-the-log-store.adoc**
- Added module to "Enhanced reliability and performance" section

**Technical accuracy improvements (SME review):**
- Corrected description of OOM killer and CPU throttling mechanisms (kernel-level operations, not Kubernetes-level)
- Added specific technical details: Exit Code 137, CFS mechanism
- Clarified impacts for CPU throttling and OOMKilled events
- Improved multitenant scenario explanation

**Style and clarity improvements (peer review):**
- Applied 21 style guide fixes for conciseness, active voice, clarity
- Changed "Current usage" to "Peak usage" for technical accuracy
- Split compound sentences, broke "which" clauses
- Used restrictive clauses, removed possessives and redundant phrases

**DITA compliance:**
- All subsections use level 1 (=) headings per modular docs standard
- Assembly uses leveloffset=+2 for proper nesting
- Replaced callout with definition list for DITA compatibility

## Conflict Resolution

Merge conflict in `.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt` was resolved by merging the vocabulary lists (6.4 branch already contained most terms from the cherry-pick).

## References
- JIRA: https://redhat.atlassian.net/browse/OBSDOCS-1807
- KCS: https://access.redhat.com/solutions/7039657

Signed-off-by: John Wilkins <jowilkin@redhat.com>