### PR TITLE
RHDEVDOCS-7715: release notes-Errata update placeholder for GitOps 1.20.6

### DIFF
--- a/modules/gitops-release-notes-1-20-6.adoc
+++ b/modules/gitops-release-notes-1-20-6.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-20-6_{context}"]
+= Release notes for Red Hat OpenShift GitOps 1.20.6
+
+Red Hat OpenShift GitOps 1.20.6 is now available on OpenShift Container Platform [INSERT OCP VERSIONS].
+
+== Errata updates
+
+=== [ENTER ERRATA NUMBER, e.g., RHSA-2026:XXXX] - Red Hat OpenShift GitOps 1.20.6 security update advisory
+Issued: [ENTER DATE, e.g., 2026-MM-DD]
+
+The list of security fixes that are included in this release is documented in the following advisory:
+* [ENTER ERRATA NUMBER, e.g., RHSA-2026:XXXX]
+
+If you have installed the Red Hat OpenShift GitOps Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----

--- a/release_notes/gitops-release-notes-1-20.adoc
+++ b/release_notes/gitops-release-notes-1-20.adoc
@@ -30,6 +30,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.20.6
+include::modules/gitops-release-notes-1-20-6.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.20.5
 include::modules/gitops-release-notes-1-20-5.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Jira**
https://redhat.atlassian.net/browse/RHDEVDOCS-7715 

**Preview link:**
https://115474--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-20.html


**QE Review**
@svghadi 

