### PR TITLE
MIG-1934: Add MTC 1.8.16 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -90,7 +90,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.15
+:mtc-version-z: 1.8.16
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-16.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-15.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-14.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-16.adoc
+++ b/modules/migration-mtc-release-notes-1-8-16.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-16_{context}"]
+= {mtc-full} 1.8.16 release notes
+
+[role="_abstract"]
+{mtc-first} 1.8.16 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.8.15. {mtc-short} 1.8.16 fixes several Common Vulnerabilities and Exposures (CVEs).
+
+
+[id="resolved-issues-1-8-16_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.16 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-7783[CVE-2025-7783]
+* link:https://access.redhat.com/security/cve/cve-2025-12816[CVE-2025-12816]
+* link:https://access.redhat.com/security/cve/cve-2025-13465[CVE-2025-13465]
+* link:https://access.redhat.com/security/cve/cve-2025-15284[CVE-2025-15284]
+* link:https://access.redhat.com/security/cve/cve-2025-52881[CVE-2025-52881]
+* link:https://access.redhat.com/security/cve/cve-2025-58183[CVE-2025-58183]
+* link:https://access.redhat.com/security/cve/cve-2025-58754[CVE-2025-58754]
+* link:https://access.redhat.com/security/cve/cve-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/cve-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/cve-2025-62718[CVE-2025-62718]
+* link:https://access.redhat.com/security/cve/cve-2025-66031[CVE-2025-66031]
+* link:https://access.redhat.com/security/cve/cve-2025-66418[CVE-2025-66418]
+* link:https://access.redhat.com/security/cve/cve-2025-66471[CVE-2025-66471]
+* link:https://access.redhat.com/security/cve/cve-2025-66506[CVE-2025-66506]
+* link:https://access.redhat.com/security/cve/cve-2025-68121[CVE-2025-68121]
+* link:https://access.redhat.com/security/cve/cve-2025-69223[CVE-2025-69223]
+* link:https://access.redhat.com/security/cve/cve-2025-69227[CVE-2025-69227]
+* link:https://access.redhat.com/security/cve/cve-2025-69228[CVE-2025-69228]
+* link:https://access.redhat.com/security/cve/cve-2026-4800[CVE-2026-4800]
+* link:https://access.redhat.com/security/cve/cve-2026-6322[CVE-2026-6322]
+* link:https://access.redhat.com/security/cve/cve-2026-9277[CVE-2026-9277]
+* link:https://access.redhat.com/security/cve/cve-2026-9595[CVE-2026-9595]
+* link:https://access.redhat.com/security/cve/cve-2026-12143[CVE-2026-12143]
+* link:https://access.redhat.com/security/cve/cve-2026-13149[CVE-2026-13149]
+* link:https://access.redhat.com/security/cve/cve-2026-13676[CVE-2026-13676]
+* link:https://access.redhat.com/security/cve/cve-2026-21441[CVE-2026-21441]
+* link:https://access.redhat.com/security/cve/cve-2026-22029[CVE-2026-22029]
+* link:https://access.redhat.com/security/cve/cve-2026-23490[CVE-2026-23490]
+* link:https://access.redhat.com/security/cve/cve-2026-23745[CVE-2026-23745]
+* link:https://access.redhat.com/security/cve/cve-2026-25679[CVE-2026-25679]
+* link:https://access.redhat.com/security/cve/cve-2026-25681[CVE-2026-25681]
+* link:https://access.redhat.com/security/cve/cve-2026-27136[CVE-2026-27136]
+* link:https://access.redhat.com/security/cve/cve-2026-27137[CVE-2026-27137]
+* link:https://access.redhat.com/security/cve/cve-2026-29063[CVE-2026-29063]
+* link:https://access.redhat.com/security/cve/cve-2026-30922[CVE-2026-30922]
+* link:https://access.redhat.com/security/cve/cve-2026-32280[CVE-2026-32280]
+* link:https://access.redhat.com/security/cve/cve-2026-32281[CVE-2026-32281]
+* link:https://access.redhat.com/security/cve/cve-2026-32283[CVE-2026-32283]
+* link:https://access.redhat.com/security/cve/cve-2026-33186[CVE-2026-33186]
+* link:https://access.redhat.com/security/cve/cve-2026-33810[CVE-2026-33810]
+* link:https://access.redhat.com/security/cve/cve-2026-33811[CVE-2026-33811]
+* link:https://access.redhat.com/security/cve/cve-2026-34986[CVE-2026-34986]
+* link:https://access.redhat.com/security/cve/cve-2026-39820[CVE-2026-39820]
+* link:https://access.redhat.com/security/cve/cve-2026-39821[CVE-2026-39821]
+* link:https://access.redhat.com/security/cve/cve-2026-40895[CVE-2026-40895]
+* link:https://access.redhat.com/security/cve/cve-2026-42264[CVE-2026-42264]
+* link:https://access.redhat.com/security/cve/cve-2026-42338[CVE-2026-42338]
+* link:https://access.redhat.com/security/cve/cve-2026-42499[CVE-2026-42499]
+* link:https://access.redhat.com/security/cve/cve-2026-44486[CVE-2026-44486]
+* link:https://access.redhat.com/security/cve/cve-2026-44487[CVE-2026-44487]
+* link:https://access.redhat.com/security/cve/cve-2026-44488[CVE-2026-44488]
+* link:https://access.redhat.com/security/cve/cve-2026-44492[CVE-2026-44492]
+* link:https://access.redhat.com/security/cve/cve-2026-44494[CVE-2026-44494]
+* link:https://access.redhat.com/security/cve/cve-2026-44495[CVE-2026-44495]
+* link:https://access.redhat.com/security/cve/cve-2026-44496[CVE-2026-44496]
+* link:https://access.redhat.com/security/cve/cve-2026-45736[CVE-2026-45736]
+* link:https://access.redhat.com/security/cve/cve-2026-45822[CVE-2026-45822]
+* link:https://access.redhat.com/security/cve/cve-2026-48779[CVE-2026-48779]


### PR DESCRIPTION
Summary of changes: Update MTC attribute and add a new module for MTC 1.8.16 release.

Version(s):
OCP 4.14-4.20

Issue:
[MIG-1934](https://redhat.atlassian.net/browse/MIG-1934)

Link to docs preview:
[Migration Toolkit for Containers 1.8.16 release notes](https://115507--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-16_mtc-release-notes)

QE review:
- [x] QE has approved this change.
