### PR TITLE
[OKD] Fix stale OS attributes: update Fedora CoreOS (FCOS) to CentOS Stream CoreOS (SCOS)

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -23,12 +23,12 @@
 :op-system-version-9: 9
 :op-system-ai: Red{nbsp}Hat Enterprise Linux AI
 ifdef::openshift-origin[]
-:op-system-first: Fedora CoreOS (FCOS)
-:op-system: FCOS
-:op-system-lowercase: fcos
-:op-system-base: Fedora
-:op-system-base-full: Fedora
-:op-system-version: 35
+:op-system-first: CentOS Stream CoreOS (SCOS)
+:op-system: SCOS
+:op-system-lowercase: scos
+:op-system-base: CentOS Stream
+:op-system-base-full: CentOS Stream
+:op-system-version: 9
 endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]
@@ -243,10 +243,10 @@ endif::[]
 :factory-prestaging-tool: factory-precaching-cli tool
 :factory-prestaging-tool-caps: Factory-precaching-cli tool
 :openshift-networking: Red Hat OpenShift Networking
-// TODO - this probably needs to be different for OKD
-//ifdef::openshift-origin[]
-//:openshift-networking: OKD Networking
-//endif::[]
+// OKD Networking attribute
+ifdef::openshift-origin[]
+:openshift-networking: OKD Networking
+endif::[]
 // logical volume manager storage
 :lvms-first: Logical Volume Manager (LVM) Storage
 :lvms: LVM Storage

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -106,7 +106,7 @@ Topics:
 - Name: Understanding OKD development
   File: understanding-development
   Distros: openshift-origin
-- Name: Fedora CoreOS
+- Name: CentOS Stream CoreOS
   File: architecture-rhcos
   Distros: openshift-origin
 - Name: Red Hat Enterprise Linux CoreOS
@@ -896,7 +896,7 @@ Topics:
   - Name: Updating the boot loader on Red Hat Enterprise Linux CoreOS nodes using bootupd
     File: updating-bootloader-rhcos
     Distros: openshift-enterprise
-  - Name: Updating the boot loader on Fedora CoreOS nodes using bootupd
+  - Name: Updating the boot loader on CentOS Stream CoreOS nodes using bootupd
     File: updating-bootloader-rhcos
     Distros: openshift-origin
 - Name: Troubleshooting a cluster update
@@ -1129,7 +1129,7 @@ Topics:
     Distros: openshift-enterprise,openshift-aro
   - Name: Container image signatures
     File: security-container-signature
-  - Name: Hardening Fedora CoreOS
+  - Name: Hardening CentOS Stream CoreOS
     File: security-hardening
     Distros: openshift-origin
   - Name: Understanding compliance


### PR DESCRIPTION
## Summary

Since OKD 4.16, the node operating system has been **CentOS Stream CoreOS (SCOS)**, not Fedora CoreOS (FCOS). The `common-attributes.adoc` file and several topic map entries still reference FCOS, causing all rendered OKD documentation at docs.okd.io to display incorrect OS names.

This PR updates:

### `_attributes/common-attributes.adoc`
- `{op-system-first}`: Fedora CoreOS (FCOS) → **CentOS Stream CoreOS (SCOS)**
- `{op-system}`: FCOS → **SCOS**
- `{op-system-lowercase}`: fcos → **scos**
- `{op-system-base}`: Fedora → **CentOS Stream**
- `{op-system-base-full}`: Fedora → **CentOS Stream**
- `{op-system-version}`: 35 → **9**
- Activated the `openshift-networking` OKD override (was commented out with a TODO)

### `_topic_maps/_topic_map.yml`
- "Fedora CoreOS" → "CentOS Stream CoreOS"
- "Hardening Fedora CoreOS" → "Hardening CentOS Stream CoreOS"  
- "Updating the boot loader on Fedora CoreOS nodes using bootupd" → "...CentOS Stream CoreOS nodes..."

## Context

- OKD transitioned from FCOS to SCOS in version 4.16 (see [OKD blog: Node OS changes](https://okd.io/docs/project/upgrade-notes/from-4-15/fcos-to-scos-migration/))
- The `openshift-networking` attribute for OKD was left as a commented-out TODO; this PR activates it
- These attribute changes affect every page in the rendered OKD documentation that references the node OS

## Verification

Built locally with:
```
podman run --rm -it -v $(pwd):/docs:Z quay.io/openshift-cs/asciibinder asciibinder build --distro openshift-origin
```

Confirmed that rendered output no longer contains FCOS references (only 2 legitimate external links to Fedora project docs remain).