### PR TITLE
OCPBUGS-98585: Added kubectl to the cli-tools-list.adoc

### DIFF
--- a/modules/cli-tools-list.adoc
+++ b/modules/cli-tools-list.adoc
@@ -9,9 +9,11 @@
 = List of CLI tools
 
 [role="_abstract"]
-Manage your {product-title} cluster, applications, and Operators from the terminal using these primary command-line interface (CLI) tools:
+Manage your {product-title} cluster, applications, and Operators from the terminal by using primary command-line interface (CLI) tools.
 
-* OpenShift CLI (`oc`):
+The following list details these primary CLI tools:
+
+* {oc-first}:
 ifndef::openshift-rosa[]
 This is the most commonly used CLI tool by {product-title} users.
 endif::openshift-rosa[]
@@ -19,6 +21,7 @@ ifdef::openshift-rosa[]
 This is one of the more commonly used developer CLI tools.
 endif::openshift-rosa[]
 Cluster administrators and developers can use it to perform end-to-end operations across {product-title} from the terminal, including working directly with project source code using command scripts.
+* Kubernetes CLI (`kubectl`): {product-title} is conformant with Cloud Native Computing Foundation (CNCF) Kubernetes and fully supports `kubectl` as a client. The {oc-first} is a superset of `kubectl`, where both CLI tools are included in the {product-title} clients download. You can use the standard `kubectl` commands against {product-title} clusters without any compatibility issues.
 * Helm CLI (`helm`): Helm is a package manager for Kubernetes. The `helm` CLI provides commands to install, upgrade, and manage Helm charts on a cluster.
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 * ROSA CLI (`rosa`): Use the `rosa` CLI to create, update, manage, and delete {product-title} clusters and resources.
@@ -26,7 +29,6 @@ endif::[]
 * opm CLI: The `opm` CLI tool helps Operator developers and cluster administrators create and maintain catalogs of Operators.
 * Knative CLI: The Knative (`kn`) CLI tool provides commands to interact with {ServerlessProductName} components, such as Knative Serving and Eventing.
 * Pipelines CLI (tkn): {pipelines-shortname} is a continuous integration and delivery (CI/CD) solution in {product-title}, which internally uses Tekton. The `tkn` CLI tool provides commands to interact with {pipelines-shortname}.
-
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OCPBUGS-98585](https://redhat.atlassian.net/browse/OCPBUGS-98585)

Link to docs preview:

* https://115520--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cli_reference/index.html
* https://115520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/index.html
* https://115520--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/index.html
* https://115520--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/index.html

Steve Gordan (Senior Director, Product Management_Global)  approval on the [Jira](https://redhat.atlassian.net/browse/OCPBUGS-98585?atlOrigin=eyJpIjoiY2ExYzBhNTE4MDg4NGQzNDkxM2RiZjJiYzI1NTQ1OTUiLCJwIjoiaiJ9).

