### PR TITLE
[RHDEVDOCS-7728] rm unsupported 11214 entry from 1.22 RNs

### DIFF
--- a/modules/op-release-notes-1-22-0.adoc
+++ b/modules/op-release-notes-1-22-0.adoc
@@ -48,11 +48,6 @@ With this update, step objects support a `displayName` field, helping improve pi
 +
 link:https://issues.redhat.com/browse/SRVKP-11214[SRVKP-11214]
 
-Pipelines can execute embedded pipelines::
-With this update, pipelines can execute embedded pipelines directly using the `PipelineSpec` field under tasks, enabling pipelines-in-pipelines functionality.
-+
-link:https://issues.redhat.com/browse/SRVKP-11214[SRVKP-11214]
-
 Concurrent StepAction resolution reduces TaskRun startup time::
 With this update, `StepActions` in a `TaskRun` are resolved concurrently instead of sequentially, reducing startup time when using multiple remote `StepActions`.
 +


### PR DESCRIPTION
Version(s):
- none for cherry-picking

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7728

Link to docs preview:
- [1.22 RNs](https://redhat.atlassian.net/browse/RHDEVDOCS-7729)

QE review:
- [x] QE approval not needed.

