### PR TITLE
OSDOCS-17172-user-provided-certs CQA

### DIFF
--- a/modules/user-provided-certificates-ingress-ref.adoc
+++ b/modules/user-provided-certificates-ingress-ref.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="user-provided-certificates-ingress-ref_{context}"]
+= User-provided certificates for default ingress reference
+
+[role="_abstract"]
+Use user-provided default ingress certificates to allow applications on the default apps domain to present a custom TLS certificate to clients, so clients do not need to have cluster-managed certificate authority (CA) certificates installed.
+
+[id="cert-types-user-provided-default-ingress-purpose_{context}"]
+== Purpose
+
+Applications are usually exposed at `<route_name>.apps.<cluster_name>.<base_domain>`. The `<cluster_name>` and `<base_domain>` come from the installation config file. `<route_name>` is the host field of the route, if specified, or the route name. For example, `hello-openshift-default.apps.username.devcluster.openshift.com`. `hello-openshift` is the name of the route and the route is in the default namespace. You might want clients to access the applications without distributing cluster-managed CA certificates to the clients. Cluster administrators must set a custom default certificate when serving application content.
+
+[WARNING]
+====
+The Ingress Operator generates a default certificate for an `IngressController` CR to serve as a placeholder until you configure a custom default certificate. Do not use Operator-generated default certificates in production clusters.
+====
+
+[id="cert-types-user-provided-default-ingress-location_{context}"]
+== Location
+
+Store user-provided certificates in a `tls` type `Secret` resource in the `openshift-ingress` namespace. Update the `IngressController` CR in the `openshift-ingress-operator` namespace to enable the use of the user-provided certificate. For more information, see "Setting a custom default certificate".
+
+[id="cert-types-user-provided-default-ingress-management_{context}"]
+== Management
+
+User-provided certificates are managed by the user.
+
+[id="cert-types-user-provided-default-ingress-expiration_{context}"]
+== Expiration
+
+Expiration and renewal are managed by the user.
+
+[id="cert-types-user-provided-default-ingress-services_{context}"]
+== Services
+
+Applications deployed on the cluster use user-provided certificates for default ingress.
+
+[id="cert-types-user-provided-default-ingress-customization_{context}"]
+== Customization
+
+Update the secret containing the user-managed certificate as needed.

--- a/security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.adoc
+++ b/security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.adoc
@@ -6,37 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-== Purpose
+[role="_abstract"]
+Review user-provided ingress certificates in {product-title}, including transport layer security (TLS) secret storage, `IngressController` references, and replacing Operator-generated defaults.
 
-Applications are usually exposed at `<route_name>.apps.<cluster_name>.<base_domain>`. The `<cluster_name>` and `<base_domain>` come from the installation config file. `<route_name>` is the host field of the route, if specified, or the route name. For example, `hello-openshift-default.apps.username.devcluster.openshift.com`. `hello-openshift` is the name of the route and the route is in the default namespace. You might want clients to access the applications without the need to distribute the cluster-managed CA certificates to the clients. The administrator must set a custom default certificate when serving application content.
+Use user-provided certificates for the default `IngressController` CR to complete the following tasks:
 
-[WARNING]
-====
-The Ingress Operator generates a default certificate for an Ingress Controller to serve as a placeholder until you configure a custom default certificate. Do not use operator-generated default certificates in production clusters.
-====
+* Replace Operator-generated default certificates before production use.
+* Store TLS secrets in the correct namespace.
+* Reference the secret in the `IngressController` CR.
 
-== Location
 
-The user-provided certificates must be provided in a `tls` type `Secret` resource in the `openshift-ingress` namespace. Update the `IngressController` CR in the `openshift-ingress-operator` namespace to enable the use of the user-provided certificate. For more information on this process, see xref:../../networking/networking_operators/ingress-operator.adoc#nw-ingress-setting-a-custom-default-certificate_configuring-ingress[Setting a custom default certificate].
 
-== Management
-
-User-provided certificates are managed by the user.
-
-== Expiration
-
-User-provided certificates are managed by the user.
-
-== Services
-
-Applications deployed on the cluster use user-provided certificates for default ingress.
-
-== Customization
-
-Update the secret containing the user-managed certificate as needed.
+include::modules/user-provided-certificates-ingress-ref.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Replacing the default ingress certificate]
+* xref:../../networking/networking_operators/ingress-operator.adoc#nw-ingress-setting-a-custom-default-certificate_configuring-ingress[Setting a custom default certificate]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://115554--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
