### PR TITLE
OSDOCS-20720 created ESO RNs for 1-0-1

### DIFF
--- a/modules/external-secrets-operator-rn-0-1.adoc
+++ b/modules/external-secrets-operator-rn-0-1.adoc
@@ -3,7 +3,7 @@
 = Release notes for {external-secrets-operator} 0.1.0 (Technology Preview)
 
 [role="_abstract"]
-Version `0.1.0` of the {external-secrets-operator} is based on the upstream external-secrets version `0.14.3`. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.14.3[external-secrets project release notes for v0.14.3].
+Version `0.1.0` of the {external-secrets-operator} is based on the upstream external-secrets version `0.14.3`.
 
 Issued: 2025-06-26
 

--- a/modules/external-secrets-operator-rn-1-0-1.adoc
+++ b/modules/external-secrets-operator-rn-1-0-1.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_opperator/external-secrets-operator-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-1-0-1_{context}"]
+= Release notes for {external-secrets-operator} 1.0.1
+
+[role="_abstract"]
+{external-secrets-operator} 1.0.1 is based on the upstream external-secrets version 0.19.2.
+
+Issued: 16 July 2026
+
+[role="_abstract"]
+This release fixes some Common Vulnerabilities and Exposures (CVEs) and provides related Red Hat advisories.
+
+The following advisories are available for the {external-secrets-operator}:
+
+* https://access.redhat.com/errata/RHSA-2026:40924[RHSA-2026:40924]
+* https://access.redhat.com/errata/RHBA-2026:40923[RHBA-2026:40923]
+* https://access.redhat.com/errata/RHBA-2026:40925[RHBA-2026:40925]
+* https://access.redhat.com/errata/RHBA-2026:41014[RHBA-2026:41014]
+
+[is="external-secrets-operator-1-0-1-cves_{context}"]
+== CVEs
+
+* https://access.redhat.com/security/cve/cve-2025-61726[CVE-2025-61726]
+
+* https://access.redhat.com/security/cve/cve-2025-68121[CVE-2025-68121]
+

--- a/modules/external-secrets-operator-rn-1-0.adoc
+++ b/modules/external-secrets-operator-rn-1-0.adoc
@@ -3,7 +3,7 @@
 = Release notes for {external-secrets-operator} 1.0.0 (General Availability)
 
 [role="_abstract"]
-{external-secrets-operator} version 1.0.0 is based on the upstream external-secrets project, version v0.19.0. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.19.0[external-secrets project release notes for v0.19.0].
+{external-secrets-operator} version 1.0.0 is based on the upstream external-secrets project, version v0.19.0.
 
 Issued: 2025-11-03
 

--- a/modules/external-secrets-operator-rn-1-1.adoc
+++ b/modules/external-secrets-operator-rn-1-1.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: REFERENCE
 [id="external-secrets-operator-rn-1-1_{context}"]
-= Release notes for {external-secrets-operator} 1.1.0 (General Availability)
+= Release notes for {external-secrets-operator} 1.1.0
 
 [role="_abstract"]
-{external-secrets-operator} version 1.1.0 is based on the upstream external-secrets project, version v0.20.4. For more information, see the link:https://https://github.com/external-secrets/external-secrets/tree/v0.20.4[external-secrets project release notes for v0.20.4].
+{external-secrets-operator} version 1.1.0 is based on the upstream external-secrets project, version v0.20.4.
 
 Issued: 2026-03-17
 

--- a/modules/external-secrets-operator-rn-1-2.adoc
+++ b/modules/external-secrets-operator-rn-1-2.adoc
@@ -3,7 +3,7 @@
 = Release notes for {external-secrets-operator} 1.2.0
 
 [role="_abstract"]
-{external-secrets-operator} version 1.2.0 is based on the upstream external-secrets project, version v2.5.0. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v2.5.0[external-secrets project release notes for v2.5.0].
+{external-secrets-operator} version 1.2.0 is based on the upstream external-secrets project, version v2.5.0.
 
 Issued: 2026-07-09
 

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -19,6 +19,9 @@ include::modules/external-secrets-operator-rn-1-2.adoc[leveloffset=+1]
 // ESO RN 1.1
 include::modules/external-secrets-operator-rn-1-1.adoc[leveloffset=+1]
 
+// ESO RN 1.0.1
+include::modules/external-secrets-operator-rn-1-0-1.adoc[leveloffset=+1]
+
 // ESO RN 1.0
 include::modules/external-secrets-operator-rn-1-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20720

Link to docs preview:
https://115598--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html#external-secrets-operator-rn-1-0-1_external-secrets-operator-release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
