### PR TITLE
CNV#92898: Add official download link for VirtIO drivers

### DIFF
--- a/virt/creating_vms_advanced/virt-creating-vms-uploading-images.adoc
+++ b/virt/creating_vms_advanced/virt-creating-vms-uploading-images.adoc
@@ -13,9 +13,9 @@ You can create a Windows VM by uploading a Windows image to a PVC. Then you clon
 
 [IMPORTANT]
 ====
-You must install the QEMU guest agent on VMs created from operating system images that are not provided by Red Hat.
+You must install the QEMU guest agent on VMs created from operating system images that are not provided by Red{nbsp}Hat.
 
-You must also install VirtIO drivers on Windows VMs.
+You must also install VirtIO drivers on Windows VMs. Download VirtIO drivers only from official Red{nbsp}Hat sources. For more information, see "Additional resources".
 ====
 
 include::modules/virt-creating-vm-uploaded-image-web.adoc[leveloffset=+1]
@@ -38,6 +38,9 @@ include::modules/virt-uploading-image-virtctl.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../virt/managing_vms/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[Installing the QEMU guest agent]
 * xref:../../virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc#virt-install-virtio-drivers-on-windows-vms[Installing VirtIO drivers on Windows VMs]
+* link:https://access.redhat.com/downloads/content/479/virtio-win/noarch/package-latest[Red{nbsp}Hat VirtIO drivers download page]
+* link:https://access.redhat.com/solutions/764103[How to check virtio-win drivers version on Windows guest]
+* link:https://access.redhat.com/solutions/6957701[Installing and updating VirtIO drivers for Windows virtual machines]
 * xref:../../virt/creating_vms_advanced/virt-cloning-vms.adoc#virt-cloning-vms[Cloning VMs]
 * xref:../../virt/creating_vms_advanced/virt-creating-vms-by-cloning-pvcs.adoc#virt-cloning-pvc-to-dv-cli_virt-creating-vms-by-cloning-pvcs[Cloning a PVC to a data volume]
 * link:https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation[Sysprep (Generalize) a Windows installation]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/CNV-92898

Link to docs preview:
https://115615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/virt-creating-vms-uploading-images.html#additional-resources_virt-creating-vms-uploading-images

QE review:
- [x] QE has approved this change.

Additional information:

- Added sentence to IMPORTANT box directing users to download VirtIO drivers only from official Red Hat sources, because customers were using unapproved drivers and experiencing issues
- Added link to the Red Hat VirtIO drivers download page in Additional resources because users need a direct path to the approved drivers
- Added link to KCS article on installing and updating VirtIO drivers for Windows VMs in Additional resources for supplemental guidance
- Fixed pre-existing missing `{nbsp}` in "Red Hat" references to match style conventions