### PR TITLE
OSDOCS-20724: Add 4.18.48 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-48.adoc
+++ b/modules/zstream-4-18-48.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-48_{context}"]
+= RHSA-2026:37192 - {product-title} {product-version}.48 fixed issues and security update
+
+Issued: 15 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.48 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:37192[RHSA-2026:37192] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:37189[RHBA-2026:37189] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.48 --pullspecs
+----
+
+[id="zstream-4-18-48-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, the `ironic-agent` container image was missing the `iproute` package, which provides the `ip` command. As a consequence, the Ironic Python Agent (IPA) failed during network configuration and could not send heartbeats to Ironic, which caused bare metal node cleaning to time out. With this release, the `iproute` package is available in the `ironic-agent` container image. As a result, IPA completes network configuration and heartbeats to Ironic as expected. (link:https://issues.redhat.com/browse/OCPBUGS-95066[OCPBUGS-95066])
+
+[id="zstream-4-18-48-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.48 RNs and updating
+include::modules/zstream-4-18-48.adoc[leveloffset=+2]
+
 // 4.18.47 RNs and updating
 include::modules/zstream-4-18-47.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20724

Link to docs preview:
_Pending preview bot comment after CI builds. Update this field with the preview-bot issue comment URL or Netlify preview link once available._

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/636
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:37192 / RHBA-2026:37189