### PR TITLE
Update nodes-cluster-worker-latency-profiles-about.adoc

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -53,7 +53,7 @@ If a pod is on a node that has the `NoExecute` taint, the pod runs according to 
 
 | Kubelet Controller Manager
 | `node-monitor-grace-period`
-| 40s
+| 50s
 
 | Kubernetes API Server Operator
 | `default-not-ready-toleration-seconds`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[Doc] Update default node-monitor-grace-period to 50s in Nodes guide

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.19, 4.20, 4.21


Issue:
The OpenShift 4.20 "Nodes" documentation incorrectly references a 40-second
  default for the node-monitor-grace-period parameter. This value was increased to
  50 seconds in OpenShift 4.19 to improve cluster resilience against transient
  network latency.

  This discrepancy causes confusion for customers who observe 50s in their logs
  (via FLAG: --node-monitor-grace-period="50s") but read 40s in the official
  documentation.

 https://redhat.atlassian.net/browse/OCPBUGS-99006


Link to docs preview:



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


