### PR TITLE
TELCODOCS-2766: DITA rewrite for ztp-updating-gitops

### DIFF
--- a/edge_computing/ztp-updating-gitops.adoc
+++ b/edge_computing/ztp-updating-gitops.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can update the {ztp-first} infrastructure independently from the hub cluster, {rh-rhacm-first}, and the managed {product-title} clusters.
 
 [NOTE]
@@ -46,6 +47,6 @@ include::modules/ztp-roll-out-the-configuration-changes.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For information about the {cgu-operator-first}, see xref:../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full} configuration].
+* xref:../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full} configuration]
 
-* For information about creating `ClusterGroupUpgrade` CRs, see xref:../edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc#talo-precache-autocreated-cgu-for-ztp_ztp-talm[About the auto-created ClusterGroupUpgrade CR for {ztp}].
+* xref:../edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc#talo-precache-autocreated-cgu-for-ztp_ztp-talm[About the auto-created ClusterGroupUpgrade CR for {ztp}]

--- a/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
+++ b/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
@@ -6,6 +6,7 @@
 [id="ztp-installing-the-new-gitops-ztp-applications_{context}"]
 = Installing the new {ztp} applications
 
+[role="_abstract"]
 Using the extracted `argocd/deployment` directory, and after ensuring that the applications point to your site Git repository, apply the full contents of the deployment directory. Applying the full contents of the directory ensures that all necessary resources for the applications are correctly configured.
 
 .Procedure

--- a/modules/ztp-labeling-the-existing-clusters.adoc
+++ b/modules/ztp-labeling-the-existing-clusters.adoc
@@ -6,6 +6,7 @@
 [id="ztp-labeling-the-existing-clusters_{context}"]
 = Labeling the existing clusters
 
+[role="_abstract"]
 To ensure that existing clusters remain untouched by the tool updates, label all existing managed clusters with the `ztp-done` label.
 
 [NOTE]

--- a/modules/ztp-preparing-for-the-gitops-ztp-upgrade.adoc
+++ b/modules/ztp-preparing-for-the-gitops-ztp-upgrade.adoc
@@ -6,6 +6,7 @@
 [id="ztp-preparing-for-the-gitops-ztp-upgrade_{context}"]
 = Preparing for the upgrade
 
+[role="_abstract"]
 Use the following procedure to prepare your site for the {ztp-first} upgrade.
 
 .Procedure

--- a/modules/ztp-pulling-ocp-images.adoc
+++ b/modules/ztp-pulling-ocp-images.adoc
@@ -6,6 +6,7 @@
 [id="ztp-pulling-ocp-images_{context}"]
 = Pulling ISO images for the desired {product-title} version
 
+[role="_abstract"]
 To pull ISO images for the desired {product-title} version, update the `AgentServiceConfig` custom resource (CR) with references to the desired ISO and RootFS images that are hosted on the mirror registry HTTP server.
 
 .Prerequisites

--- a/modules/ztp-required-changes-to-the-git-repository.adoc
+++ b/modules/ztp-required-changes-to-the-git-repository.adoc
@@ -6,6 +6,7 @@
 [id="ztp-required-changes-to-the-git-repository_{context}"]
 = Required changes to the Git repository
 
+[role="_abstract"]
 When upgrading the `ztp-site-generate` container from an earlier release of {ztp-first} to 4.10 or later, there are additional requirements for the contents of the Git repository. Existing content in the repository must be updated to reflect these changes.
 
 [NOTE]

--- a/modules/ztp-roll-out-the-configuration-changes.adoc
+++ b/modules/ztp-roll-out-the-configuration-changes.adoc
@@ -6,6 +6,7 @@
 [id="ztp-roll-out-the-configuration-changes_{context}"]
 = Rolling out the {ztp} configuration changes
 
+[role="_abstract"]
 If any configuration changes were included in the upgrade due to implementing recommended changes, the upgrade process results in a set of policy CRs on the hub cluster in the `Non-Compliant` state. With the {ztp-first} version 4.10 and later `ztp-site-generate` container, these policies are set to `inform` mode and are not pushed to the managed clusters without an additional step by the user. This ensures that potentially disruptive changes to the clusters can be managed in terms of when the changes are made, for example, during a maintenance window, and how many clusters are updated concurrently.
 
 To roll out the changes, create one or more `ClusterGroupUpgrade` CRs as detailed in the {cgu-operator} documentation. The CR must contain the list of `Non-Compliant` policies that you want to push out to the managed clusters as well as a list or selector of which clusters should be included in the update.

--- a/modules/ztp-stopping-the-existing-gitops-ztp-applications.adoc
+++ b/modules/ztp-stopping-the-existing-gitops-ztp-applications.adoc
@@ -6,6 +6,7 @@
 [id="ztp-stopping-the-existing-gitops-ztp-applications_{context}"]
 = Stopping the existing {ztp} applications
 
+[role="_abstract"]
 Removing the existing applications ensures that any changes to existing content in the Git repository are not rolled out until the new version of the tools is available.
 
 Use the application files from the `deployment` directory. If you used custom names for the applications, update the names in these files first.

--- a/modules/ztp-updating-gitops-ztp.adoc
+++ b/modules/ztp-updating-gitops-ztp.adoc
@@ -2,10 +2,11 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-updating-gitops.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="ztp-updating-gitops-ztp_{context}"]
 = Overview of the {ztp} update process
 
+[role="_abstract"]
 You can update {ztp-first} for a fully operational hub cluster running an earlier version of the {ztp} infrastructure. The update process avoids impact on managed clusters.
 
 [NOTE]

--- a/snippets/ztp-patch-argocd-hub-cluster.adoc
+++ b/snippets/ztp-patch-argocd-hub-cluster.adoc
@@ -25,12 +25,12 @@ Click `[Expand for Operator list]` in the "Platform Aligned Operators" table in 
 {
   "args": [
     "-c",
-    "mkdir -p /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator && cp /policy-generator/PolicyGenerator-not-fips-compliant /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator" <1>
+    "mkdir -p /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator && cp /policy-generator/PolicyGenerator-not-fips-compliant /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator"
   ],
   "command": [
     "/bin/bash"
   ],
-  "image": "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.10", <2> <3>
+  "image": "<multicluster_operators_subscription_image>",
   "name": "policy-generator-install",
   "imagePullPolicy": "Always",
   "volumeMounts": [
@@ -41,9 +41,9 @@ Click `[Expand for Operator list]` in the "Platform Aligned Operators" table in 
   ]
 }
 ----
-<1> Optional: For RHEL 9 images, copy the required universal executable in the `/policy-generator/PolicyGenerator-not-fips-compliant` folder for the ArgoCD version.
-<2> Match the `multicluster-operators-subscription` image to the {rh-rhacm} version.
-<3> In disconnected environments, replace the URL for the `multicluster-operators-subscription` image with the disconnected registry equivalent for your environment.
+
+* Optional: For RHEL 9 images, in the `args` field, change the executable path from `/policy-generator/PolicyGenerator-not-fips-compliant` to match the required universal executable for your ArgoCD version.
+* In the `image` field, replace `<multicluster_operators_subscription_image>` with the `multicluster-operators-subscription` image that matches your {rh-rhacm} version, for example `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.10`. In disconnected environments, replace the URL with the disconnected registry equivalent for your environment.
 --
 
 .. Patch the ArgoCD instance.


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to the `ztp-updating-gitops` assembly and all 8 included modules for DITA conversion compatibility
- Change content type of `ztp-updating-gitops-ztp` module from PROCEDURE to CONCEPT (it is an informational overview, not executable steps)
- Clean up final Additional resources section in the assembly to remove explanatory text per DITA RelatedLinks requirements

## Test plan
- [ ] Verify `asciibinder build` completes without errors
- [ ] Verify all `[role="_abstract"]` attributes are correctly placed after module titles
- [ ] Verify content type change on `ztp-updating-gitops-ztp.adoc` is appropriate (overview content, not a procedure)
- [ ] Verify Additional resources links still resolve correctly after text cleanup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)