### PR TITLE
OSDOCS-17079-final: CQA 2.0 for SUPP-1: Remote Health Monitoring (Ins…

### DIFF
--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -7,11 +7,10 @@
 = Information collected by Telemetry
 
 [role="_abstract"]
-The following information is collected by Telemetry:
+Telemetry collects specific information, such as system, sizing, and usage information.
 
-[id="system-information_{context}"]
-== System information
-
+System information::
++
 * Version information, including the {product-title} cluster version and installed update details that are used to determine update version availability
 * Update information, including the number of updates available per cluster, the channel and image repository used for an update, update progress information, and the number of errors that occur in an update
 * The unique random identifier that is generated during an installation
@@ -22,9 +21,8 @@ The following information is collected by Telemetry:
 * Information about the validity of certificates
 * The name of the provider platform that {product-title} is deployed on and the data center location
 
-[id="sizing-information_{context}"]
-== Sizing Information
-
+Sizing Information::
++
 * Sizing information about clusters, machine types, and machines, including the number of CPU cores and the amount of RAM used for each
 ifdef::virt-cluster[]
 * The number of running virtual machine instances in a cluster
@@ -34,10 +32,9 @@ ifndef::openshift-dedicated[]
 * Number of application builds by build strategy type
 endif::openshift-dedicated[]
 
-[id="usage-information_{context}"]
-== Usage information
-
+Usage information::
++
 * Usage information about components, features, and extensions
 * Usage details about Technology Previews and unsupported configurations
-
++
 Telemetry does not collect identifying information such as usernames or passwords. Red Hat does not intend to collect personal information. If Red Hat discovers that personal information has been inadvertently received, Red Hat will delete such information. To the extent that any telemetry data constitutes personal data, please refer to the link:https://www.redhat.com/en/about/privacy-policy[Red Hat Privacy Statement] for more information about Red Hat's privacy practices.

--- a/modules/understanding-insights-operator-alerts.adoc
+++ b/modules/understanding-insights-operator-alerts.adoc
@@ -2,17 +2,12 @@
 //
 // * support/remote_health_monitoring/using-insights-operator.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="understanding-insights-operator-alerts_{context}"]
-= {insights-operator} alerts
+= Viewing {insights-operator} alerts
 
 [role="_abstract"]
 The {insights-operator} declares alerts through the Prometheus monitoring system to the Alertmanager. You can view these alerts in the Alerting UI in the {product-title} web console.
-
-To view these alerts in the Alerting UI in the {product-title} web console, choose one of the following methods:
-
-* In the *Administrator* perspective, click *Observe* -> *Alerting*.
-* In the *Developer* perspective, click *Observe* -> <project_name> -> *Alerts* tab.
 
 Currently, {insights-operator} sends the following alerts when the conditions are met:
 
@@ -24,3 +19,10 @@ Currently, {insights-operator} sends the following alerts when the conditions ar
 |`SimpleContentAccessNotAvailable`|Simple content access is not enabled in Red Hat Subscription Management.
 |`InsightsRecommendationActive`|{red-hat-lightspeed} has an active recommendation for the cluster.
 |====
+
+.Procedure
+
+* To view these alerts in the Alerting UI in the {product-title} web console, choose one of the following methods:
++
+** In the *Administrator* perspective, click *Observe* -> *Alerting*.
+** In the *Developer* perspective, click *Observe* -> <project_name> -> *Alerts* tab.

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -15,9 +15,9 @@ toc::[]
 
 A cluster that reports data to Red Hat through Telemetry and the {insights-operator} is considered a _connected cluster_.
 
-*Telemetry* is the term that Red Hat uses to describe the information being sent to Red Hat by the {product-title} Telemeter Client. Lightweight attributes are sent from connected clusters to Red Hat to enable subscription management automation, monitor the health of clusters, assist with support, and improve customer experience.
+Telemetry is the term that Red Hat uses to describe the information being sent to Red Hat by the {product-title} Telemeter Client. Lightweight attributes are sent from connected clusters to Red Hat to enable subscription management automation, monitor the health of clusters, assist with support, and improve customer experience.
 
-The *{insights-operator}* gathers {product-title} configuration data and sends it to Red{nbsp}Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on {cluster-manager-url}.
+The {insights-operator} gathers {product-title} configuration data and sends it to Red{nbsp}Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on {cluster-manager-url}.
 
 More information is provided in this document about these two processes.
 

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -10,16 +10,17 @@ toc::[]
 [role="_abstract"]
 You can manually gather and upload {insights-operator} archives to diagnose issues from a restricted network.
 
-To use the {insights-operator} in a restricted network, you must:
+To use the {insights-operator} in a restricted network, you must complete the following tasks:
 
 * Create a copy of your {insights-operator} archive.
-* Upload the {insights-operator} archive to link:https://console.redhat.com[console.redhat.com].
+* Upload the {insights-operator} archive to the {hybrid-console}.
 
 Additionally, you can select to obfuscate the {insights-operator} data before data upload.
 
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://console.redhat.com[{hybrid-console}]
 * xref:../../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network[Enabling {insights-operator} data obfuscation]
 
 include::modules/insights-operator-one-time-gather.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17079](https://redhat.atlassian.net/browse/OSDOCS-17079)

Link to docs preview:

  1. modules/telemetry-what-information-is-collected.adoc
  - Changed: Converted section headings to definition list format
  - Preview link (appears in about-remote-health-monitoring.html):
    - https://115643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/about-remote-health-monitoring.html#telemetry-what-information-is-collected_about-remote-health-monitoring

  2. modules/understanding-insights-operator-alerts.adoc
  - Changed: Module type from CONCEPT to PROCEDURE, title changed, moved navigation to procedure steps
  - Preview link (appears in using-insights-operator.html):
    - https://115643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#understanding-insights-operator-alerts_using-insights-operator

  3. support/remote_health_monitoring/about-remote-health-monitoring.adoc
  - Changed: Removed bold formatting from "Insights Operator"
  - Preview link:
    - https://115643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/about-remote-health-monitoring.html

  4. support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
  - Changed: Text clarification and link formatting updates
  - Preview link:
    - https://115643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.html