### PR TITLE
OCPBUGS-98977: Swapped --platform to metal in bare-metal-vsphere-iso.…

### DIFF
--- a/modules/bare-metal-vsphere-iso.adoc
+++ b/modules/bare-metal-vsphere-iso.adoc
@@ -46,7 +46,7 @@ $ curl -I http://<http_server>/worker.ign
 $ sudo coreos-installer install /dev/sda \
     --ignition-url=http://<http_server>/worker.ign \
     --insecure-ignition \
-    --platform=none
+    --platform=metal
 ----
 +
 where:


### PR DESCRIPTION
## Version(s):
4.21+

## Issue:

[OCPBUGS-98977](https://redhat.atlassian.net/browse/OCPBUGS-98977)

Link to docs preview:

*  https://115646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.html#bare-metal-vsphere-iso_adding-bare-metal-compute-vsphere-user-infra

## Summary of Changes

  **File**: `modules/bare-metal-vsphere-iso.adoc`

  **Changes**:
  - Updated `coreos-installer` platform parameter from `--platform=none` to `--platform=metal`
  - Added missing newline at end of file

  **Technical impact**: Ensures proper platform detection for bare metal worker nodes in vSphere environments.

  ## Approvals

  [x] **SME**: Approved (Jerry Zhang) 
  [x] **QE**: Approved (Neil Girard)

