### PR TITLE
CNV#87875: Add web console procedure for hot swapping VM secondary network

### DIFF
--- a/modules/virt-hot-swapping-vm-secondary-network-web-console.adoc
+++ b/modules/virt-hot-swapping-vm-secondary-network-web-console.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-hot-swap-vm-secondary-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-hot-swapping-vm-secondary-network-web-console_{context}"]
+= Hot swapping a virtual machine secondary network by using the web console
+
+[role="_abstract"]
+You can hot swap the secondary network of a running virtual machine (VM) by using the {product-title} web console. Hot swapping the secondary network preserves the workload and avoids the need for a VM reboot.
+
+.Prerequisites
+
+* The VM is running and is live migratable.
+* The target `NetworkAttachmentDefinition` object exists in the same namespace as the VM. If you created a `ClusterUserDefinedNetwork` object, verify that the cluster user-defined network controller has created the corresponding `NetworkAttachmentDefinition` object.
+
+.Procedure
+
+. Navigate to *Virtualization* -> *VirtualMachines* in the web console.
+. Click a running VM to view the *VirtualMachine details* page.
+. Click the *Configuration* tab and then click the *Network interfaces* tab.
+. Click the Options menu {kebab} beside the network interface that you want to modify and select *Edit*.
+. Select the target network from the *Network* list.
+. Click *Save*.
++
+The network interface row displays a *Pending* label. A warning banner indicates that the VM has pending network changes. The pending changes are applied during the next live migration or reboot.
+
+.Verification
+
+. On the *VirtualMachine details* page, click the *Diagnostics* tab.
+. Check the *Status conditions* table and verify that the `MigrationRequired` condition is listed with the reason `AutoMigrationDueToLiveUpdate`.
++
+After the live migration completes, the `MigrationRequired` condition disappears and the *Pending* label is removed from the network interface.

--- a/virt/vm_networking/virt-hot-swap-vm-secondary-network.adoc
+++ b/virt/vm_networking/virt-hot-swap-vm-secondary-network.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]    
 
 [role="_abstract"]
-You can change the secondary network of a virtual machine (VM) without rebooting your VM. The change is transparent to the guest operating system, preserving properties like the MAC address. 
+You can change the secondary network of a virtual machine (VM) without rebooting your VM. The change is transparent to the guest operating system, preserving properties such as the MAC address. 
 
 By hot swapping the secondary network, you can move a running VM to a different network segment or VLAN and apply new network policies or reconfigure network topology without interrupting the workload. {VirtProductName} supports hot swapping for VMs that are connected to an OVN-Kubernetes localnet and a Linux bridge secondary network.
 
@@ -16,6 +16,8 @@ To hot swap a VM secondary network, you must edit the network configuration of t
 include::modules/virt-vm-nw-hot-swap-limitations.adoc[leveloffset=+1]
 
 include::modules/virt-live-updating-vm-nad-udn.adoc[leveloffset=+1]
+
+include::modules/virt-hot-swapping-vm-secondary-network-web-console.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
5.0+

Issue:
https://redhat.atlassian.net/browse/CNV-87875

Link to docs preview:
https://115681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-hot-swap-vm-secondary-network.html#virt-hot-swapping-vm-secondary-network-web-console_virt-hot-swap-vm-secondary-network

QE review:
- [x] QE has approved this change.

Additional information:
Add a web console procedure for hot swapping a VM secondary network.

- Created new module `virt-hot-swapping-vm-secondary-network-web-console.adoc` because the existing assembly only had a CLI procedure and was missing the web console path
- Added the new module include to the `virt-hot-swap-vm-secondary-network` assembly