### PR TITLE
[OSDOCS-16926]: CQA: etcd performance (3 of 4)

### DIFF
--- a/etcd/etcd-performance.adoc
+++ b/etcd/etcd-performance.adoc
@@ -64,6 +64,8 @@ include::modules/etcd-database-size.adoc[leveloffset=+1]
 //Increasing the database size for etcd
 include::modules/etcd-increase-db.adoc[leveloffset=+1]
 
+include::modules/etcd-increase-db-troubleshooting.adoc[leveloffset=+1]
+
 // Measuring network jitter between control plane nodes
 include::modules/etcd-network-latency-jitter.adoc[leveloffset=+1]
 

--- a/modules/etcd-database-size.adoc
+++ b/modules/etcd-database-size.adoc
@@ -6,6 +6,9 @@
 [id="etcd-database-size_{context}"]
 = Determining the size of the etcd database and understanding its effects
 
+[role="_abstract"]
+etcd database size affects defragmentation duration, resync time after network partitions, and transaction rates. Plan capacity so maintenance and recovery do not degrade cluster stability.
+
 The size of the etcd database has a direct impact on the time to complete the etcd defragmentation process. {product-title} automatically runs the etcd defragmentation on one etcd member at a time when it detects at least 45% fragmentation. During the defragmentation process, the etcd member cannot process any requests. On small etcd databases, the defragmentation process happens in less than a second. With larger etcd databases, the disk latency directly impacts the fragmentation time, causing additional latency, as operations are blocked while defragmentation happens.
 
 The size of the etcd database is a factor to consider when network partitions isolate a control plane node for a period and the control plane needs to resync after communication is re-established.
@@ -16,7 +19,7 @@ The magnitude of the effects is specific to the deployment. The time to complete
 
 Consider the following two examples for the type of impacts to plan for.
 
-Example of the effect of etcd defragementation based on database size:: Writing an etcd database of 1 GB to a slow 7200 RPMs disk at 80 Mbit/s takes about 1 minute and 40 seconds. In such a scenario, the defragmentation process takes at least this long, if not longer, to complete the defragmentation.
+Example of the effect of etcd defragmentation based on database size:: Writing an etcd database of 1 GB to a slow 7200 RPMs disk at 80 Mbits/sec takes about 1 minute and 40 seconds. In such a scenario, the defragmentation process takes at least this long, if not longer, to complete the defragmentation.
 
 Example of the effect of database size on etcd synchronization:: If there is a change of 10% of the etcd database during the disconnection of one of the control plane nodes, the resync needs to transfer at least 100 MB. Transferring 100 MB over a 1 Gbps link takes 800 ms. On clusters with regular transactions with the Kubernetes API, the larger the etcd database size, the more network instabilities will cause control plane instabilities.
 
@@ -24,9 +27,9 @@ You can determine the size of an etcd database by using the {product-title} cons
 
 .Procedure
 
-* To find the database size in the {product-title} console, go to the *etcd* dashboard to view a plot that reports the size of the etcd database. 
+* To find the database size in the {product-title} console, go to the *etcd* dashboard to view a plot that reports the size of the etcd database.
 
-* To find the database size by using the etcdctl tool, you can enter two commands:
+* To find the database size by using the `etcdctl` tool, enter the following commands:
 
 .. Enter the following command to list the pods:
 +

--- a/modules/etcd-increase-db-troubleshooting.adoc
+++ b/modules/etcd-increase-db-troubleshooting.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * etcd/etcd-performance.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="etcd-increase-db-troubleshooting_{context}"]
+= Troubleshooting etcd database size increases
+
+[role="_abstract"]
+Resolve common errors when increasing the etcd disk quota, including values that are too small, too large, or lower than the current setting.
+
+If you encounter issues when you try to increase the database size for etcd, the following examples might help.
+
+[id="etcd-ts-db-small_{context}"]
+== Value is too small
+
+If the value that you specify is less than `8`, you see an error message. For example, if you enter the following command:
+
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 5}}'
+----
+
+The following error message is displayed:
+
+.Example error message
+[source,terminal]
+----
+The Etcd "cluster" is invalid:
+* spec.backendQuotaGiB: Invalid value: 5: spec.backendQuotaGiB in body should be greater than or equal to 8
+* spec.backendQuotaGiB: Invalid value: "integer": etcd backendQuotaGiB may not be decreased
+----
+
+To resolve this issue, specify an integer between `8` and `32`.
+
+[id="etcd-ts-db-large_{context}"]
+== Value is too large
+
+If the value that you specify is greater than `32`, you see an error message. For example, if you enter the following command:
+
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 64}}'
+----
+
+The following error message is displayed:
+
+.Example error message
+[source,terminal]
+----
+The Etcd "cluster" is invalid: spec.backendQuotaGiB: Invalid value: 64: spec.backendQuotaGiB in body should be less than or equal to 32
+----
+
+To resolve this issue, specify an integer between `8` and `32`.
+
+[id="etcd-ts-db-decrease_{context}"]
+== Value is decreasing
+
+If the value is set to a valid value between `8` and `32`, you cannot decrease the value. Otherwise, you see an error message.
+
+For example, check the current value by entering the following command:
+
+[source,terminal]
+----
+$ oc describe etcd/cluster | grep "Backend Quota"
+----
+
+.Example output
+[source,terminal]
+----
+Backend Quota Gi B: 10
+----
+
+If you decrease the disk quota value by entering the following command, an error message is displayed.
+
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 8}}'
+----
+
+.Example error message
+[source,terminal]
+----
+The Etcd "cluster" is invalid: spec.backendQuotaGiB: Invalid value: "integer": etcd backendQuotaGiB may not be decreased
+----
+
+To resolve this issue, specify an integer greater than `10`.

--- a/modules/etcd-increase-db.adoc
+++ b/modules/etcd-increase-db.adoc
@@ -6,23 +6,21 @@
 [id="etcd-increase-db_{context}"]
 = Increasing the database size for etcd
 
+[role="_abstract"]
+Increase the etcd disk quota when low space or excessive growth alerts appear. Expanding the quota before etcd runs out of space prevents write failures and cluster instability.
+
 You can set the disk quota in gibibytes (GiB) for each etcd instance. If you set a disk quota for your etcd instance, you can specify integer values from 8 to 32. The default value is 8. You can specify only increasing values.
 
 You might want to increase the disk quota if you encounter a `low space` alert. This alert indicates that the cluster is too large to fit in etcd despite automatic compaction and defragmentation. If you see this alert, you need to increase the disk quota immediately because after etcd runs out of space, writes fail.
 
-Another scenario where you might want to increase the disk quota is if you encounter an `excessive database growth` alert. This alert is a warning that the database might grow too large in the next four hours. In this scenario, consider increasing the disk quota so that you do not eventually encounter a `low space` alert and possible write fails. 
+Another scenario where you might want to increase the disk quota is if you encounter an `excessive database growth` alert. This alert is a warning that the database might grow too large in the next four hours. In this scenario, consider increasing the disk quota so that you do not eventually encounter a `low space` alert and possible write fails.
 
-If you increase the disk quota, the disk space that you specify is not immediately reserved. Instead, etcd can grow to that size if needed. Ensure that etcd is running on a dedicated disk that is larger than the value that you specify for the disk quota. 
+If you increase the disk quota, the disk space that you specify is not immediately reserved. Instead, etcd can grow to that size if needed. Ensure that etcd is running on a dedicated disk that is larger than the value that you specify for the disk quota.
 
 For large etcd databases, the control plane nodes must have additional memory and storage. Because you must account for the API server cache, the minimum memory required is at least three times the configured size of the etcd database.
 
 :FeatureName: Increasing the database size for etcd
 include::snippets/technology-preview.adoc[]
-
-[id="etcd-change-db-size_{context}"]
-== Changing the etcd database size
-
-To change the database size for etcd, complete the following steps.
 
 .Procedure
 
@@ -61,7 +59,7 @@ etcd.operator.openshift.io/cluster patched
 $ oc describe etcd/cluster | grep "Backend Quota"
 ----
 +
-The etcd Operator automatically rolls out the etcd instances with the new values. 
+The etcd Operator automatically rolls out the etcd instances with the new values.
 
 . Verify that the etcd pods are up and running by entering the following command:
 +
@@ -104,7 +102,7 @@ revision-pruner-8-ci-ln-b6kfsw2-72292-mzwbq-master-2   0/1     Completed   0    
 $ oc describe -n openshift-etcd pod/<etcd_podname> | grep "ETCD_QUOTA_BACKEND_BYTES"
 ----
 +
-The value might not have changed from the default value of `8`. 
+The value might not have changed from the default value of `8`.
 +
 .Example output
 [source,terminal]
@@ -113,83 +111,6 @@ ETCD_QUOTA_BACKEND_BYTES:                               8589934592
 ----
 +
 [NOTE]
-=====
+====
 While the value that you set is an integer in GiB, the value shown in the output is converted to bytes.
-=====
-
-
-[id="etcd-change-db-size-troubleshooting_{context}"]
-== Troubleshooting
-
-If you encounter issues when you try to increase the database size for etcd, the following troubleshooting steps might help.
-
-[id="etcd-troubleshoot-small-value_{context}"]
-=== Value is too small
-
-If the value that you specify is less than `8`, you see the following error message:
-
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 5}}'
-----
-
-.Example error message
-[source,terminal]
-----
-The Etcd "cluster" is invalid: 
-* spec.backendQuotaGiB: Invalid value: 5: spec.backendQuotaGiB in body should be greater than or equal to 8
-* spec.backendQuotaGiB: Invalid value: "integer": etcd backendQuotaGiB may not be decreased
-----
-
-To resolve this issue, specify an integer between `8` and `32`.
-
-[id="etcd-troubleshoot-large-value_{context}"]
-=== Value is too large
-
-If the value that you specify is greater than `32`, you see the following error message:
-
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 64}}'
-----
-
-.Example error message
-[source,terminal]
-----
-The Etcd "cluster" is invalid: spec.backendQuotaGiB: Invalid value: 64: spec.backendQuotaGiB in body should be less than or equal to 32
-----
-
-To resolve this issue, specify an integer between `8` and `32`.
-
-[id="etcd-troubleshoot-decreasing-value_{context}"]
-=== Value is decreasing
-
-If the value is set to a valid value between `8` and `32`, you cannot decrease the value. Otherwise, you see an error message.
-
-. Check to see the current value by entering the following command:
-+
-[source,terminal]
-----
-$ oc describe etcd/cluster | grep "Backend Quota"
-----
-+
-.Example output
-[source,terminal]
-----
-Backend Quota Gi B: 10
-----
-
-. Decrease the disk quota value by entering the following command:
-+
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"backendQuotaGiB": 8}}'
-----
-+
-.Example error message
-[source,terminal]
-----
-The Etcd "cluster" is invalid: spec.backendQuotaGiB: Invalid value: "integer": etcd backendQuotaGiB may not be decreased
-----
-
-. To resolve this issue, specify an integer greater than `10`.
+====

--- a/modules/etcd-timer-tunables.adoc
+++ b/modules/etcd-timer-tunables.adoc
@@ -6,6 +6,9 @@
 [id="etcd-timer-tunables_{context}"]
 = {product-title} timer tunables for etcd
 
+[role="_abstract"]
+{product-title} sets platform-specific etcd election timeout and heartbeat interval values. Knowing these tunables helps you align network and disk requirements with expected cluster behavior.
+
 {product-title} maintains etcd timers that are optimized for each platform. {product-title} has prescribed validated values that are optimized for each platform provider. The default etcd timers with `platform=none` or `platform=metal` are as follows:
 
 [source,terminal]

--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -6,16 +6,14 @@
 [id="etcd-tuning-parameters_{context}"]
 = Setting tuning parameters for etcd
 
-You can set the control plane hardware speed to `"Standard"`, `"Slower"`, or the default, which is `""`.
+[role="_abstract"]
+Configure the control plane hardware speed setting for etcd to match your environment's latency.
 
-The default setting allows the system to decide which speed to use. This value enables upgrades from versions where this feature does not exist, as the system can select values from previous versions.
+You can set the control plane hardware speed to `"Standard"` or `"Slower"`, or use the default, which is `""`.
 
-By selecting one of the other values, you are overriding the default. If you see many leader elections due to timeouts or missed heartbeats and your system is set to `""` or `"Standard"`, set the hardware speed to `"Slower"` to make the system more tolerant to the increased latency.
+The default setting allows the system to decide the speed to use. This value enables upgrades from versions where this feature does not exist, as the system can select values from previous versions.
 
-[id="etcd-changing-hardware-speed-tolerance_{context}"]
-== Changing hardware speed tolerance
-
-To change the hardware speed tolerance for etcd, complete the following steps.
+By selecting one of the other values, you are overriding the default. If you see many leader elections due to timeouts or missed heartbeats, and your system is set to `""` or `"Standard"`, set the hardware speed to `"Slower"`. This change makes the system more tolerant to the increased latency.
 
 .Procedure
 
@@ -46,6 +44,7 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"controlPlaneHardwareSpeed": 
 +
 The following table indicates the heartbeat interval and leader election timeout for each profile. These values are subject to change.
 +
+.Heartbeat interval and leader election timeout by hardware speed profile
 |===
 | Profile | ETCD_HEARTBEAT_INTERVAL | ETCD_LEADER_ELECTION_TIMEOUT
 | `""` | Varies depending on platform | Varies depending on platform
@@ -89,30 +88,30 @@ Control Plane Hardware Speed:  ""
 $ oc get pods -n openshift-etcd -w
 ----
 +
-The following output shows the expected entries for master-0. Before you continue, wait until all masters show a status of `4/4 Running`.
+The following output shows the expected entries for the `main-0` control plane node. Before you continue, wait until all control plane nodes show a status of `4/4 Running`.
 +
 .Example output
 [source,terminal]
 ----
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Pending             0          0s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Pending             0          0s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     ContainerCreating   0          0s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     ContainerCreating   0          1s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           1/1     Running             0          2s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          34s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          36s
-installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          36s
-etcd-guard-ci-ln-qkgs94t-72292-9clnd-master-0            0/1     Running             0          26m
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Terminating         0          11m
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Terminating         0          11m
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Pending             0          0s
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Init:1/3            0          1s
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Init:2/3            0          2s
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     PodInitializing     0          3s
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  3/4     Running             0          4s
-etcd-guard-ci-ln-qkgs94t-72292-9clnd-master-0            1/1     Running             0          26m
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  3/4     Running             0          20s
-etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Running             0          20s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     Pending             0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     Pending             0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     ContainerCreating   0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     ContainerCreating   0          1s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           1/1     Running             0          2s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     Completed           0          34s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     Completed           0          36s
+installer-9-ci-ln-qkgs94t-72292-9clnd-main-0           0/1     Completed           0          36s
+etcd-guard-ci-ln-qkgs94t-72292-9clnd-main-0            0/1     Running             0          26m
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  4/4     Terminating         0          11m
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  4/4     Terminating         0          11m
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  0/4     Pending             0          0s
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  0/4     Init:1/3            0          1s
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  0/4     Init:2/3            0          2s
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  0/4     PodInitializing     0          3s
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  3/4     Running             0          4s
+etcd-guard-ci-ln-qkgs94t-72292-9clnd-main-0            1/1     Running             0          26m
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  3/4     Running             0          20s
+etcd-ci-ln-qkgs94t-72292-9clnd-main-0                  4/4     Running             0          20s
 ----
 
 . Enter the following command to review to the values:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-16926
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Setting tuning parameters for etcd: https://115687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-performance.html#etcd-tuning-parameters_etcd-performance
- OCP timer tunables for etcd: https://115687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-performance.html#etcd-timer-tunables_etcd-performance
- Determining the size of the etcd database and understanding its effects: https://115687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-performance.html#etcd-database-size_etcd-performance
- Increasing the database size for etcd: https://115687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-performance.html#etcd-increase-db_etcd-performance
- Troubleshooting etcd database size increases: https://115687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-performance.html#etcd-increase-db-troubleshooting_etcd-performance
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Do not merge until https://github.com/openshift/openshift-docs/pull/115682 is merged
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
