### PR TITLE
OSDOCS WMCO remove HPA from RN

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-limitations.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-limitations.adoc
@@ -16,7 +16,6 @@ Note the following limitations when working with Windows nodes:
 ** OpenShift Service Mesh
 ** OpenShift monitoring of user-defined projects
 ** {ServerlessProductName}
-** Horizontal Pod Autoscaling
 ** Vertical Pod Autoscaling
 ** Hosted Control Planes
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-13174

Per Slack, removing HPA from list of known limitations. I made the change in the [4.18 release notes](https://github.com/openshift/openshift-docs/pull/87287/changes#diff-e0310c2391bf9e1c8c0293f7c5414a68ae29f1308e960a951d0306af8342b9c7) when the limitation was removed, but didn't get the change to main and subsequent release note versions. This PR should fix that. 

Release notes only. This is essentially an after-the-fact cherrypick. No QE needed. 