### PR TITLE
CNV-87842: Update docs for disableContainerInterface

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -13,7 +13,7 @@ The NAD and the VM must be in the same namespace.
 
 [WARNING]
 ====
-Configuring IP address management (IPAM) in a network attachment definition for virtual machines is not supported.
+Configuring IP address management (IPAM) in a network attachment definition for VMs is not supported.
 ====
 
 .Prerequisites
@@ -58,6 +58,7 @@ OSA interfaces on {ibm-z-name} do not support VLAN filtering and VLAN-tagged tra
 ** `spec.config.bridge` defines the name of the Linux bridge configured on the node. The name should match the interface bridge name defined in the `NodeNetworkConfigurationPolicy` manifest.
 ** `spec.config.macspoofchk` is optional and defines a flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
 ** `spec.config.vlan` is optional and defines the VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
+** `spec.config.disableContainerInterface` is optional. When set to `true`, the Bridge CNI plug-in skips creating a standard container virtual ethernet (`veth`) interface inside the pod's network namespace. This enables the virtualization networking backend to attach the layer-2 interface directly to the guest VM instead of a standard container.
 ** `spec.config.preserveDefaultVlan` is optional and defines whether the VM connects to the bridge through the default VLAN. The default value is `true`.
 
 . Optional: If you want to connect a VM to the native network, configure the Linux bridge `NetworkAttachmentDefinition` manifest without specifying any VLAN:

--- a/modules/virt-creating-linux-bridge-nad-web.adoc
+++ b/modules/virt-creating-linux-bridge-nad-web.adoc
@@ -39,4 +39,25 @@ Open Systems Adapter (OSA) interfaces on {ibm-z-name} do not support VLAN filter
 +
 endif::openshift-dedicated[]
 . Optional: Select *MAC Spoof Check* to enable MAC spoof filtering. This feature provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
+. Optional: In the *YAML* tab, add the `spec.config.disableContainerInterface` field. When set to `true`, the Bridge CNI plug-in skips creating a standard container virtual ethernet (`veth`) interface inside the pod's network namespace. This enables the virtualization networking backend to attach the layer-2 interface directly to the guest VM instead of a standard container.
++
+Example YAML:
++
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-network
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br1
+spec:
+  config: |
+    {
+# ...
+      "disableContainerInterface": true,
+# ...
+    }
+----
+
 . Click *Create*.


### PR DESCRIPTION
Version(s):
From Jira: `4.12 all the way to 4.21` but this is also marked as 4.22.z, so I will fix it in all supported branches (4.16+)

Issue:
https://redhat.atlassian.net/browse/CNV-87842

Link to docs preview:
https://115690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
