### PR TITLE
[OSDOCS#17010] CQA 2.1 for Nutanix installer-provisioned assemblies

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -7,24 +7,31 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} version {product-version}, you can choose one of the following options to install a cluster on your Nutanix instance:
 
 **Using installer-provisioned infrastructure**: Use the procedures in the following sections to use installer-provisioned infrastructure. Installer-provisioned infrastructure is ideal for installing in connected or disconnected network environments. The installer-provisioned infrastructure includes an installation program that provisions the underlying infrastructure for the cluster.
 
-**Using the Assisted Installer**: The link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}] hosted at link:http://console.redhat.com[console.redhat.com]. The {ai-full} cannot be used in disconnected environments. The {ai-full} does not provision the underlying infrastructure for the cluster, so you must provision the infrastructure before you run the {ai-full}. Installing with the {ai-full} also provides integration with Nutanix, enabling autoscaling. See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
+**Using the Assisted Installer**: The {ai-full} is hosted at console.redhat.com. The {ai-full} cannot be used in disconnected environments. The {ai-full} does not provision the underlying infrastructure for the cluster, so you must provision the infrastructure before you run the {ai-full}. Installing with the {ai-full} also provides integration with Nutanix, enabling autoscaling.
 
-**Using user-provisioned infrastructure**: Complete the relevant steps outlined in the xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[Installing a cluster on any platform] documentation.
+**Using user-provisioned infrastructure**: You provision the underlying infrastructure yourself and then complete the relevant installation steps.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}]
+* xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}]
+* xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[Installing a cluster on any platform]
 
 == Prerequisites
 
-* You have reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have reviewed details about the {product-title} installation and update processes.
 * The installation program requires access to port 9440 on Prism Central and Prism Element. You verified that port 9440 is accessible.
 * If you use a firewall, you have met these prerequisites:
 ** You confirmed that port 9440 is accessible. Control plane nodes must be able to reach Prism Central and Prism Element on port 9440 for the installation to succeed.
-** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
-* If your Nutanix environment is using the default self-signed SSL certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
+** You configured the firewall to grant access to the sites that {product-title} requires. This includes the use of Telemetry.
+* If your Nutanix environment is using the default self-signed SSL certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the Nutanix AOS Security Guide.
 +
-If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see xref:../../networking/configuring_network_settings/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI].
+If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see "Configuring a custom PKI".
 +
 [IMPORTANT]
 ====
@@ -81,8 +88,10 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall to grant required access]
+* link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide]
+* xref:../../networking/configuring_network_settings/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
 * xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
-
-== Next steps
 * xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]

--- a/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
@@ -6,25 +6,26 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} {product-version}, you can install a cluster on Nutanix infrastructure in a restricted network by creating an internal mirror of the installation release content.
 
 == Prerequisites
 
-* You have reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have reviewed details about the {product-title} installation and update processes.
 * The installation program requires access to port 9440 on Prism Central and Prism Element. You verified that port 9440 is accessible.
 * If you use a firewall, you have met these prerequisites:
 ** You confirmed that port 9440 is accessible. Control plane nodes must be able to reach Prism Central and Prism Element on port 9440 for the installation to succeed.
-** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
-* If your Nutanix environment is using the default self-signed SSL/TLS certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
+** You configured the firewall to grant access to the sites that {product-title} requires. This includes the use of Telemetry.
+* If your Nutanix environment is using the default self-signed SSL/TLS certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the Nutanix AOS Security Guide.
 +
-If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see xref:../../networking/configuring_network_settings/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI].
+If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see "Configuring a custom PKI".
 +
 [IMPORTANT]
 ====
 Use 2048-bit certificates. The installation fails if you use 4096-bit certificates with Prism Central 2022.x.
 ====
-* You have a container image registry, such as {quay}. If you do not already have a registry, you can create a mirror registry using  xref:../../disconnected/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[_mirror registry for Red{nbsp}Hat OpenShift_].
-* You have used the xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror OpenShift CLI (oc) plugin] to mirror all of the required {product-title} content and other images, including the Nutanix CSI Operator, to your mirror registry.
+* You have a container image registry, such as {quay}. If you do not already have a registry, you can create a mirror registry using the _mirror registry for Red{nbsp}Hat OpenShift_.
+* You have used the oc-mirror OpenShift CLI (oc) plugin to mirror all of the required {product-title} content and other images, including the Nutanix CSI Operator, to your mirror registry.
 +
 [IMPORTANT]
 ====
@@ -64,28 +65,29 @@ include::modules/manually-configure-iam-nutanix.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-== Post installation
-Complete the following steps to complete the configuration of your cluster.
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
 
-include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
-
-include::modules/oc-mirror-updating-restricted-cluster-manifests.adoc[leveloffset=+2]
+include::modules/oc-mirror-updating-restricted-cluster-manifests.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../extensions/catalogs/managing-catalogs.adoc#olmv1-adding-a-catalog-to-a-cluster_managing-catalogs[Adding a catalog to a cluster] in "Extensions"
+* xref:../../extensions/catalogs/managing-catalogs.adoc#olmv1-adding-a-catalog-to-a-cluster_managing-catalogs[Adding a catalog to a cluster in Extensions]
 
-include::modules/registry-configuring-storage-nutanix.adoc[leveloffset=+2]
+include::modules/registry-configuring-storage-nutanix.adoc[leveloffset=+1]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
 
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall to grant required access]
+* link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide]
+* xref:../../networking/configuring_network_settings/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
+* xref:../../disconnected/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[_mirror registry for Red{nbsp}Hat OpenShift_]
+* xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror OpenShift CLI (oc) plugin]
 * xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
-
-== Next steps
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]

--- a/modules/installation-adding-nutanix-root-certificates.adoc
+++ b/modules/installation-adding-nutanix-root-certificates.adoc
@@ -7,6 +7,7 @@
 [id="installation-adding-nutanix-root-certificates_{context}"]
 = Adding Nutanix root CA certificates to your system trust
 
+[role="_abstract"]
 Because the installation program requires access to the Prism Central API, you must add your Nutanix trusted root CA certificates to your system trust before you install an {product-title} cluster.
 
 .Procedure

--- a/modules/installation-configuring-nutanix-failure-domains.adoc
+++ b/modules/installation-configuring-nutanix-failure-domains.adoc
@@ -7,6 +7,7 @@
 [id="installation-configuring-nutanix-failure-domains_{context}"]
 = Configuring failure domains
 
+[role="_abstract"]
 Failure domains improve the fault tolerance of an {product-title} cluster by distributing control plane and compute machines across multiple Nutanix Prism Elements (clusters).
 
 [TIP]
@@ -53,7 +54,6 @@ where:
 ** If compute and control plane machines can share the same set of failure domains, add the failure domain names under the cluster's default machine configuration.
 +
 .Example of control plane and compute machines sharing a set of failure domains
-+
 [source,yaml]
 ----
 apiVersion: v1
@@ -72,7 +72,6 @@ platform:
 ** If compute and control plane machines must use different failure domains, add the failure domain names under the respective machine pools.
 +
 .Example of control plane and compute machines using different failure domains
-+
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/installation-nutanix-ccm.adoc
+++ b/modules/installation-nutanix-ccm.adoc
@@ -6,6 +6,7 @@
 [id="nutanix-ccm-config_{context}"]
 = Adding config map and secret resources required for Nutanix CCM
 
+[role="_abstract"]
 Installations on Nutanix require additional `ConfigMap` and `Secret` resources to integrate with the Nutanix Cloud Controller Manager (CCM).
 
 .Prerequisites
@@ -33,7 +34,7 @@ metadata:
 data:
   cloud.conf: "{
       \"prismCentral\": {
-          \"address\": \"<prism_central_FQDN/IP>\", <1>
+          \"address\": \"<prism_central_FQDN/IP>\",
           \"port\": 9440,
             \"credentialRef\": {
                 \"kind\": \"Secret\",
@@ -48,7 +49,8 @@ data:
        \"enableCustomLabeling\": true
      }"
 ----
-<1> Specify the Prism Central FQDN/IP.
++
+For `<prism_central_FQDN/IP>`, specify the Prism Central FQDN or IP address.
 
 . Verify that the file `cluster-infrastructure-02-config.yml` exists and has the following information:
 +

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -14,6 +14,7 @@ endif::[]
 [id="installation-nutanix-config-yaml_{context}"]
 = Sample customized install-config.yaml file for Nutanix
 
+[role="_abstract"]
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [IMPORTANT]
@@ -25,67 +26,67 @@ ifdef::default[]
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
-compute: <2>
-- hyperthreading: Enabled <3>
+baseDomain: example.com
+compute:
+- hyperthreading: Enabled
   name: worker
   replicas: 3
   platform:
-    nutanix: <4>
+    nutanix:
       cpus: 2
       coresPerSocket: 2
       memoryMiB: 8196
       osDisk:
         diskSizeGiB: 120
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
-controlPlane: <2>
-  hyperthreading: Enabled <3>
+controlPlane:
+  hyperthreading: Enabled
   name: master
   replicas: 3
   platform:
-    nutanix: <4>
+    nutanix:
       cpus: 4
       coresPerSocket: 2
       memoryMiB: 16384
       osDisk:
         diskSizeGiB: 120
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
 metadata:
   creationTimestamp: null
-  name: test-cluster <1>
+  name: test-cluster
 networking:
   clusterNetwork:
     - cidr: 10.128.0.0/14
       hostPrefix: 23
   machineNetwork:
     - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <6>
+  networkType: OVNKubernetes
   serviceNetwork:
     - 172.30.0.0/16
 platform:
   nutanix:
     apiVIPs:
-      - 10.40.142.7 <1>
+      - 10.40.142.7
     defaultMachinePlatform:
       bootType: Legacy
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
-      project: <7>
+      project:
         type: name
         name: <project_name>
     ingressVIPs:
-      - 10.40.142.8 <1>
+      - 10.40.142.8
     prismCentral:
       endpoint:
-        address: your.prismcentral.domainname <1>
-        port: 9440 <1>
-      password: <password> <1>
-      username: <username> <1>
+        address: your.prismcentral.domainname
+        port: 9440
+      password: <password>
+      username: <username>
     prismElements:
     - endpoint:
         address: your.prismelement.domainname
@@ -93,44 +94,46 @@ platform:
       uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
     subnetUUIDs:
     - c7938dc6-7659-453e-a688-e26020c68e43
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <8>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
 credentialsMode: Manual
 publish: External
-pullSecret: '{"auths": ...}' <1>
+pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
+fips: false
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
-endif::openshift-origin[]
+sshKey: ssh-ed25519 AAAA...
 ----
-<1> Required. The installation program prompts you for this value.
-<2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+
+The installation program prompts you for the values of `baseDomain`, `metadata.name`, `platform.nutanix.apiVIPs`, `platform.nutanix.ingressVIPs`, `platform.nutanix.prismCentral.endpoint.address`, `platform.nutanix.prismCentral.endpoint.port`, `platform.nutanix.prismCentral.password`, `platform.nutanix.prismCentral.username`, and `pullSecret`.
+
+where:
+
+`compute`:: The `compute` section is a sequence of mappings. The first line of the `compute` section must begin with a hyphen, `-`. Although this section currently defines a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation.
+`hyperthreading`:: Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
-<4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
-<5> Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
-<6> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`platform.nutanix`:: Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
+`categories`:: Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
+`controlPlane`:: The `controlPlane` section is a single mapping. The first line of the `controlPlane` section must not begin with a hyphen. Only one control plane pool is used.
+`networkType`:: The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
 ifndef::openshift-origin[]
-<7> Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
-<8> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+`project`:: Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
+endif::openshift-origin[]
+`<password>`:: Required. The installation program prompts you for this value.
+`<username>`:: Required. The installation program prompts you for this value.
+`clusterOSImage`:: Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
+ifndef::openshift-origin[]
+`fips`:: Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
-<10> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<7> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-<8> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
+`sshKey`:: Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [NOTE]
 ====
@@ -142,65 +145,65 @@ ifdef::restricted[]
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
-compute: <2>
-- hyperthreading: Enabled <3>
+baseDomain: example.com
+compute:
+- hyperthreading: Enabled
   name: worker
   replicas: 3
   platform:
-    nutanix: <4>
+    nutanix:
       cpus: 2
       coresPerSocket: 2
       memoryMiB: 8196
       osDisk:
         diskSizeGiB: 120
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
-controlPlane: <2>
-  hyperthreading: Enabled <3>
+controlPlane:
+  hyperthreading: Enabled
   name: master
   replicas: 3
   platform:
-    nutanix: <4>
+    nutanix:
       cpus: 4
       coresPerSocket: 2
       memoryMiB: 16384
       osDisk:
         diskSizeGiB: 120
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
 metadata:
   creationTimestamp: null
-  name: test-cluster <1>
+  name: test-cluster
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <6>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   nutanix:
-    apiVIP: 10.40.142.7 <1>
-    ingressVIP: 10.40.142.8 <1>
+    apiVIP: 10.40.142.7
+    ingressVIP: 10.40.142.8
     defaultMachinePlatform:
       bootType: Legacy
-      categories: <5>
+      categories:
       - key: <category_key_name>
         value: <category_value>
-      project: <7>
+      project:
         type: name
         name: <project_name>
     prismCentral:
       endpoint:
-        address: your.prismcentral.domainname <1>
-        port: 9440 <1>
-      password: <password> <1>
-      username: <username> <1>
+        address: your.prismcentral.domainname
+        port: 9440
+      password: <password>
+      username: <username>
     prismElements:
     - endpoint:
         address: your.prismelement.domainname
@@ -208,89 +211,64 @@ platform:
       uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
     subnetUUIDs:
     - c7938dc6-7659-453e-a688-e26020c68e43
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <8>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
 credentialsMode: Manual
 publish: External
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}'
 ifndef::openshift-origin[]
-fips: false <10>
-sshKey: ssh-ed25519 AAAA... <11>
+fips: false
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <10>
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-additionalTrustBundle: | <12>
+sshKey: ssh-ed25519 AAAA...
+additionalTrustBundle: |
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <13>
+imageContentSources:
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <11>
-  -----BEGIN CERTIFICATE-----
-  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-  -----END CERTIFICATE-----
-imageContentSources: <12>
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-release
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-endif::openshift-origin[]
 ----
-<1> Required. The installation program prompts you for this value.
-<2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+
+The installation program prompts you for the values of `baseDomain`, `metadata.name`, `platform.nutanix.apiVIP`, `platform.nutanix.ingressVIP`, `platform.nutanix.prismCentral.endpoint.address`, `platform.nutanix.prismCentral.endpoint.port`, `platform.nutanix.prismCentral.password`, and `platform.nutanix.prismCentral.username`.
+
+where:
+
+`compute`:: The `compute` section is a sequence of mappings. The first line of the `compute` section must begin with a hyphen, `-`. Although this section currently defines a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation.
+`hyperthreading`:: Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
-<4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
-<5> Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
-<6> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<7> Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
-<8> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server or Nutanix Objects and pointing the installation program to the image.
-<9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
+`platform.nutanix`:: Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
+`categories`:: Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
+`controlPlane`:: The `controlPlane` section is a single mapping. The first line of the `controlPlane` section must not begin with a hyphen. Only one control plane pool is used.
+`networkType`:: The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`project`:: Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
+`<password>`:: Required. The installation program prompts you for this value.
+`<username>`:: Required. The installation program prompts you for this value.
+`clusterOSImage`:: Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server or Nutanix Objects and pointing the installation program to the image.
+`<local_registry>`:: Specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`.
+`<credentials>`:: Specify the base64-encoded user name and password for your mirror registry.
 ifndef::openshift-origin[]
-<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+`fips`:: Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
-<11> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+`sshKey`:: Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<10> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
-+
-[NOTE]
-====
-For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
-====
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-<12> Provide the contents of the certificate file that you used for your mirror registry.
-<13> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
-endif::openshift-origin[]
+`additionalTrustBundle`:: Provide the contents of the certificate file that you used for your mirror registry.
+`imageContentSources`:: Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
 endif::restricted[]
 
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]

--- a/modules/installation-nutanix-download-rhcos.adoc
+++ b/modules/installation-nutanix-download-rhcos.adoc
@@ -5,6 +5,7 @@
 [id="installation-nutanix-download-rhcos_{context}"]
 = Downloading the RHCOS cluster image
 
+[role="_abstract"]
 Prism Central requires access to the {op-system-first} image to install the cluster. You can use the installation program to locate and download the {op-system} image and make it available through an internal HTTP server or Nutanix Objects.
 
 .Prerequisites
@@ -37,9 +38,8 @@ $ ./openshift-install coreos print-stream-json
 . Make the image available through an internal HTTP server or Nutanix Objects.
 
 . Note the location of the downloaded image. You update the `platform` section in the installation configuration file (`install-config.yaml`) with the image's location before deploying the cluster.
-
++
 .Snippet of an `install-config.yaml` file that specifies the {op-system} image
-
 [source,yaml]
 ----
 platform:

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -7,6 +7,7 @@
 [id="manually-create-iam-nutanix_{context}"]
 = Configuring IAM for Nutanix
 
+[role="_abstract"]
 Installing the cluster requires that the Cloud Credential Operator (CCO) operate in manual mode. While the installation program configures the CCO for manual mode, you must specify the identity and access management secrets.
 
 .Prerequisites
@@ -23,19 +24,22 @@ Installing the cluster requires that the Cloud Credential Operator (CCO) operate
 [source,yaml]
 ----
 credentials:
-- type: basic_auth <1>
+- type: basic_auth
   data:
-    prismCentral: <2>
+    prismCentral:
       username: <username_for_prism_central>
       password: <password_for_prism_central>
-    prismElements: <3>
+    prismElements:
     - name: <name_of_prism_element>
       username: <username_for_prism_element>
       password: <password_for_prism_element>
 ----
-<1> Specify the authentication type. Only basic authentication is supported.
-<2> Specify the Prism Central credentials.
-<3> Optional: Specify the Prism Element credentials.
++
+where:
+
+`type`:: Specifies the authentication type. Only basic authentication is supported.
+`prismCentral`:: Specifies the Prism Central credentials.
+`prismElements`:: Optional: Specifies the Prism Element credentials.
 
 . Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
@@ -51,13 +55,16 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
++
+where:
+
+`--included`:: Includes only the manifests that your specific cluster configuration requires.
+`<path_to_directory_with_installation_configuration>`:: Specifies the location of the `install-config.yaml` file.
+`<path_to_directory_for_credentials_requests>`:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 .Sample `CredentialsRequest` object
 [source,yaml]
@@ -85,14 +92,16 @@ $ oc adm release extract \
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <1>
-  --output-dir=<ccoctl_output_dir> \// <2>
-  --credentials-source-filepath=<path_to_credentials_file> <3>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<ccoctl_output_dir> \
+  --credentials-source-filepath=<path_to_credentials_file>
 ----
 +
-<1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
-<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<3> Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
+where:
+
+`<path_to_credentials_requests_directory>`:: Specifies the path to the directory that contains the files for the component `CredentialsRequests` objects.
+`<ccoctl_output_dir>`:: Optional: Specifies the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+`<path_to_credentials_file>`:: Optional: Specifies the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
 
 . Edit the `install-config.yaml` configuration file so that the `credentialsMode` parameter is set to `Manual`.
 +
@@ -101,18 +110,20 @@ $ ccoctl nutanix create-shared-secrets \
 ----
 apiVersion: v1
 baseDomain: cluster1.example.com
-credentialsMode: Manual <1>
+credentialsMode: Manual
 ...
 ----
-<1> Add this line to set the `credentialsMode` parameter to `Manual`.
++
+Add the `credentialsMode` line to set the parameter to `Manual`.
 
 . Create the installation manifests by running the following command:
 +
 [source,terminal]
 ----
-$ openshift-install create manifests --dir <installation_directory> <1>
+$ openshift-install create manifests --dir <installation_directory>
 ----
-<1> Specify the path to the directory that contains the `install-config.yaml` file for your cluster.
++
+For `<installation_directory>`, specify the path to the directory that contains the `install-config.yaml` file for your cluster.
 
 . Copy the generated credential files to the target manifests directory by running the following command:
 +

--- a/modules/nutanix-entitlements.adoc
+++ b/modules/nutanix-entitlements.adoc
@@ -5,5 +5,6 @@
 [id="nutanix-entitlements_{context}"]
 = Internet access for Prism Central
 
+[role="_abstract"]
 Prism Central requires internet access to obtain the {op-system-first} image that is required to install the cluster. The {op-system} image for Nutanix is available at `rhcos.mirror.openshift.com`.
 

--- a/modules/oc-mirror-updating-restricted-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-restricted-cluster-manifests.adoc
@@ -6,6 +6,7 @@
 [id="oc-mirror-updating-cluster-manifests_{context}"]
 = Installing the policy resources into the cluster
 
+[role="_abstract"]
 Mirroring the {product-title} content using the oc-mirror OpenShift CLI (oc) plugin creates resources, which include `catalogSource-certified-operator-index.yaml` and `imageContentSourcePolicy.yaml`.
 
 * The `ImageContentSourcePolicy` resource associates the mirror registry with the source registry and redirects image pull requests from the online registries to the mirror registry.

--- a/modules/registry-configuring-storage-nutanix.adoc
+++ b/modules/registry-configuring-storage-nutanix.adoc
@@ -3,10 +3,14 @@
 // * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="registry-configuring-storage-nutanix_{context}"]
 = Configuring the default storage container
 
+[role="_abstract"]
 After you install the cluster, you must install the Nutanix CSI Operator and configure the default storage container for the cluster.
 
-For more information, see the Nutanix documentation for link:https://opendocs.nutanix.com/openshift/operators/csi/[installing the CSI Operator] and link:https://opendocs.nutanix.com/openshift/post-install/[configuring registry storage].
+[role="_additional-resources"]
+== Additional resources
+* link:https://opendocs.nutanix.com/openshift/operators/csi/[Installing the CSI Operator]
+* link:https://opendocs.nutanix.com/openshift/post-install/[Configuring registry storage]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-17010](https://redhat.atlassian.net/browse/OSDOCS-17010)

Link to docs preview:
- https://115692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.html
- https://115692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html
- https://115692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: Split from #115209 to keep size manageable. Kept with the restricted-networks assembly since they share 5 modules.

