### PR TITLE
[OSDOCS#17010] CQA 2.1 for Nutanix failure-domains and preparing-to-install assemblies

### DIFF
--- a/installing/installing_nutanix/nutanix-failure-domains.adoc
+++ b/installing/installing_nutanix/nutanix-failure-domains.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 By default, the installation program installs control plane and compute machines into a single Nutanix Prism Element (cluster). To improve the fault tolerance of your {product-title} cluster, you can specify that these machines be distributed across multiple Nutanix clusters by configuring failure domains.
 
 A failure domain represents an additional Prism Element instance that is available to {product-title} machine pools during and after installation.
@@ -15,9 +16,9 @@ A failure domain represents an additional Prism Element instance that is availab
 
 The {product-title} installation method determines how and when you configure failure domains:
 
-* If you deploy using installer-provisioned infrastructure, you can configure failure domains in the installation configuration file before deploying the cluster. For more information, see xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuring-nutanix-failure-domains_installing-nutanix-installer-provisioned[Configuring failure domains].
+* If you deploy using installer-provisioned infrastructure, you can configure failure domains in the installation configuration file before deploying the cluster.
 +
-You can also configure failure domains after the cluster is deployed. For more information about configuring failure domains post-installation, see xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#nutanix-failure-domains-adding-to-existing-cluster_nutanix-failure-domains[Adding failure domains to an existing Nutanix cluster].
+You can also configure failure domains after the cluster is deployed, as described in the following section.
 
 * If you deploy using infrastructure that you manage (user-provisioned infrastructure) no additional configuration is required. After the cluster is deployed, you can manually distribute control plane and compute machines across failure domains.
 
@@ -39,13 +40,12 @@ include::modules/post-installation-adding-nutanix-failure-domains-control-planes
 * xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[Checking the control plane machine set custom resource state]
 * xref:../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-replace_cpmso-managing-machines[Replacing a control plane machine]
 
-[id="nutanix-failure-domains-compute-machines_{context}"]
-=== Distributing compute machines across failure domains
+include::modules/nutanix-failure-domains-compute-machines-reference.adoc[leveloffset=+2]
 
-You can distribute compute machines across Nutanix failure domains one of the following ways:
-
-* xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#post-installation-adding-nutanix-failure-domains-compute-machines-edit_nutanix-failure-domains[Editing existing compute machine sets] allows you to distribute compute machines across Nutanix failure domains as a minimal configuration update.
-* xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#post-installation-adding-nutanix-failure-domains-compute-machines-replace_nutanix-failure-domains[Replacing existing compute machine sets] ensures that the specification is immutable and all your machines are the same.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#post-installation-adding-nutanix-failure-domains-compute-machines-edit_nutanix-failure-domains[Editing existing compute machine sets to implement failure domains]
+* xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#post-installation-adding-nutanix-failure-domains-compute-machines-replace_nutanix-failure-domains[Replacing existing compute machine sets to implement failure domains]
 
 include::modules/post-installation-adding-nutanix-failure-domains-compute-machines-edit.adoc[leveloffset=+3]
 
@@ -61,3 +61,9 @@ include::modules/post-installation-adding-nutanix-failure-domains-compute-machin
 
 //Improving reliability for multiple subnet configurations on Nutanix
 include::modules/cpmso-ts-nutanix-multiple-subnet.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuring-nutanix-failure-domains_installing-nutanix-installer-provisioned[Configuring failure domains]
+* xref:../../installing/installing_nutanix/nutanix-failure-domains.adoc#nutanix-failure-domains-adding-to-existing-cluster_nutanix-failure-domains[Adding failure domains to an existing Nutanix cluster]

--- a/installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
+++ b/installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
@@ -6,15 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can install an {product-title} cluster on Nutanix by using a variety of different installation methods. Each method has qualities that can make the method more suitable for different use cases, such as installing a cluster in a disconnected environment or installing a cluster that requires minimal configuration and provisioning. Before you install {product-title}, ensure that your Nutanix environment meets specific requirements.
 
 include::modules/installation-nutanix-infrastructure.adoc[leveloffset=+1]
 
-[id="preparing-to-install-on-nutanix-agent_{context}"]
-== Agent-based Installer
+include::modules/preparing-to-install-on-nutanix-agent-based-installer-reference.adoc[leveloffset=+1]
 
-You can install an {product-title} cluster on Nutanix by using the Agent-based Installer.
-For example, the Agent-based Installer can be used to install a three-node cluster, which is a smaller, more resource efficient cluster for testing, development, and production. See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer] for additional details.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
 
 include::modules/installation-nutanix-installer-infra-reqs.adoc[leveloffset=+1]
 

--- a/modules/installation-nutanix-failure-domains-req.adoc
+++ b/modules/installation-nutanix-failure-domains-req.adoc
@@ -7,7 +7,8 @@
 [id="installation-nutanix-failure-domains-req_{context}"]
 = Failure domain requirements
 
-When planning to use failure domains, consider the following requirements:
+[role="_abstract"]
+When planning to use failure domains, you must meet several Nutanix Prism Central, networking, and subnet requirements.
 
 * All Nutanix Prism Element instances must be managed by the same instance of Prism Central. A deployment that is comprised of multiple Prism Central instances is not supported.
 * The machines that make up the Prism Element clusters must reside on the same Ethernet network for failure domains to be able to communicate with each other.

--- a/modules/installation-nutanix-infrastructure.adoc
+++ b/modules/installation-nutanix-infrastructure.adoc
@@ -6,7 +6,8 @@
 [id="installation-nutanix-infrastructure_{context}"]
 = Nutanix version requirements
 
-You must install the {product-title} cluster to a Nutanix environment that meets the following requirements:
+[role="_abstract"]
+You must install the {product-title} cluster to a Nutanix environment that meets specific version requirements.
 
 
 .Version requirements for Nutanix virtual environments

--- a/modules/installation-nutanix-installer-infra-reqs.adoc
+++ b/modules/installation-nutanix-installer-infra-reqs.adoc
@@ -6,14 +6,13 @@
 [id="installation-nutanix-installer-infra-reqs_{context}"]
 = Environment requirements
 
-Before you install an {product-title} cluster, review the following Nutanix AOS environment requirements.
+[role="_abstract"]
+Before you install an {product-title} cluster, verify that your infrastructure, account privileges, and network configuration meet the Nutanix AOS environment requirements needed for a successful installation.
 
 [id="installation-nutanix-installer-infrastructure-reqs_{context}"]
 == Infrastructure requirements
 
 You can install {product-title} on on-premise Nutanix clusters, Nutanix Cloud Clusters (NC2) on {aws-first}, or NC2 on {azure-first}.
-
-For more information, see link:https://www.nutanix.com/products/nutanix-cloud-clusters/aws[Nutanix Cloud Clusters on AWS] and link:https://www.nutanix.com/products/nutanix-cloud-clusters/azure[Nutanix Cloud Clusters on Microsoft Azure].
 
 [id="installation-nutanix-installer-infra-reqs-account_{context}"]
 == Required account privileges
@@ -28,11 +27,7 @@ Consider the following when managing this user account:
 * When assigning entities to the role, ensure that the user can access only the Prism Element and subnet that are required to deploy the virtual machines.
 * Ensure that the user is a member of the project to which it needs to assign virtual machines.
 
-For more information, see the Nutanix documentation about creating a link:https://opendocs.nutanix.com/guides/cloud_native_role/[Custom Cloud Native role], link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:ssp-ssp-role-assignment-pc-t.html[assigning a role], and link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Admin-Center-Guide-vpc_2023_1_0_1:ssp-projects-add-users-t.html[adding a user to a project].
-
 .Required permissions for creating a Custom Cloud Native role
-[%collapsible]
-====
 [cols="3a,3a,3a,3a",options="header"]
 |===
 |Nutanix Object
@@ -43,35 +38,32 @@ For more information, see the Nutanix documentation about creating a link:https:
 |Categories
 |Always
 |
-[%hardbreaks]
-`Create_Category_Mapping`
-`Create_Or_Update_Name_Category`
-`Create_Or_Update_Value_Category`
-`Delete_Category_Mapping`
-`Delete_Name_Category`
-`Delete_Value_Category`
-`View_Category_Mapping`
-`View_Name_Category`
-`View_Value_Category`
+* `Create_Category_Mapping`
+* `Create_Or_Update_Name_Category`
+* `Create_Or_Update_Value_Category`
+* `Delete_Category_Mapping`
+* `Delete_Name_Category`
+* `Delete_Value_Category`
+* `View_Category_Mapping`
+* `View_Name_Category`
+* `View_Value_Category`
 |Create, read, and delete categories that are assigned to the {product-title} machines.
 
 
 |Images
 |Always
 |
-[%hardbreaks]
-`Create_Image`
-`Delete_Image`
-`View_Image`
+* `Create_Image`
+* `Delete_Image`
+* `View_Image`
 |Create, read, and delete the operating system images used for the {product-title} machines.
 
 |Virtual Machines
 |Always
 |
-[%hardbreaks]
-`Create_Virtual_Machine`
-`Delete_Virtual_Machine`
-`View_Virtual_Machine`
+* `Create_Virtual_Machine`
+* `Delete_Virtual_Machine`
+* `View_Virtual_Machine`
 |Create, read, and delete the {product-title} machines.
 
 |Clusters
@@ -86,26 +78,19 @@ For more information, see the Nutanix documentation about creating a link:https:
 
 |Projects
 |If you will associate a project with compute machines, control plane machines, or all machines.
-|
-[%hardbreaks]
-`View_Project`
+|`View_Project`
 |View the projects defined in Prism Central and allow a project to be assigned to the {product-title} machines.
 
 |Tasks
 |Always
-|
-[%hardbreaks]
-`View_Task`
+|`View_Task`
 |Fetch and view tasks on the Prism Element that contain {product-title} machines and nodes.
 
 |Hosts
 |If you use GPUs with compute machines.
-|
-[%hardbreaks]
-`View_Host`
+|`View_Host`
 |Fetch and view hosts on the Prism Element that have GPUs attached.
 |===
-====
 
 [id="installation-nutanix-installer-infra-reqs-limits_{context}"]
 == Cluster limits
@@ -136,7 +121,7 @@ You must use either AHV IP Address Management (IPAM) or Dynamic Host Configurati
 * IP addresses
 * DNS records
 
-Nutanix Flow Virtual Networking is supported for new cluster installations. To use this feature, enable Flow Virtual Networking on your AHV cluster before installing. For more information, see link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Flow-Virtual-Networking-Guide-vpc_2024_1:ear-flow-nw-overview-pc.html[Flow Virtual Networking overview].
+Nutanix Flow Virtual Networking is supported for new cluster installations. To use this feature, enable Flow Virtual Networking on your AHV cluster before installing.
 
 [NOTE]
 ====
@@ -144,7 +129,7 @@ It is recommended that each {product-title} node in the cluster have access to a
 ====
 
 [id="installation-nutanix-installer-infra-reqs-_{context}"]
-=== Required IP Addresses
+== Required IP Addresses
 An installer-provisioned installation requires two static virtual IP (VIP) addresses:
 
 * A VIP address for the API is required. This address is used to access the cluster API.
@@ -153,7 +138,7 @@ An installer-provisioned installation requires two static virtual IP (VIP) addre
 You specify these IP addresses when you install the {product-title} cluster.
 
 [id="installation-nutanix-installer-infra-reqs-dns-records_{context}"]
-=== DNS records
+== DNS records
 You must create DNS records for two static IP addresses in the appropriate DNS server for the Nutanix instance that hosts your {product-title} cluster. In each record, `<cluster_name>` is the cluster name and `<base_domain>` is the cluster base domain that you specify when you install the cluster.
 
 If you use your own DNS or DHCP server, you must also create records for each node, including the bootstrap, control plane, and compute nodes.
@@ -170,14 +155,18 @@ A complete DNS record takes the form: `<component>.<cluster_name>.<base_domain>.
 
 |API VIP
 |`api.<cluster_name>.<base_domain>.`
-|This DNS A/AAAA or CNAME record must point to the load balancer
-for the control plane machines. This record must be resolvable by both clients
-external to the cluster and from all the nodes within the cluster.
+|This DNS A/AAAA or CNAME record must point to the load balancer for the control plane machines. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
 
 |Ingress VIP
 |`*.apps.<cluster_name>.<base_domain>.`
-|A wildcard DNS A/AAAA or CNAME record that points to the load balancer that targets the
-machines that run the Ingress router pods, which are the worker nodes by
-default. This record must be resolvable by both clients external to the cluster
-and from all the nodes within the cluster.
+|A wildcard DNS A/AAAA or CNAME record that points to the load balancer that targets the machines that run the Ingress router pods, which are the worker nodes by default. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
 |===
+
+[role="_additional-resources"]
+== Additional resources
+* link:https://www.nutanix.com/products/nutanix-cloud-clusters/aws[Nutanix Cloud Clusters on AWS]
+* link:https://www.nutanix.com/products/nutanix-cloud-clusters/azure[Nutanix Cloud Clusters on Microsoft Azure]
+* link:https://opendocs.nutanix.com/guides/cloud_native_role/[Custom Cloud Native role]
+* link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:ssp-ssp-role-assignment-pc-t.html[Assigning a role]
+* link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Admin-Center-Guide-vpc_2023_1_0_1:ssp-projects-add-users-t.html[Adding a user to a project]
+* link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Flow-Virtual-Networking-Guide-vpc_2024_1:ear-flow-nw-overview-pc.html[Flow Virtual Networking overview]

--- a/modules/nutanix-failure-domains-compute-machines-reference.adoc
+++ b/modules/nutanix-failure-domains-compute-machines-reference.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_nutanix/nutanix-failure-domains.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nutanix-failure-domains-compute-machines_{context}"]
+= Distributing compute machines across failure domains
+
+[role="_abstract"]
+You can distribute compute machines across Nutanix failure domains by editing or replacing existing compute machine sets.
+
+* Editing existing compute machine sets allows you to distribute compute machines across Nutanix failure domains as a minimal configuration update.
+* Replacing existing compute machine sets ensures that the specification is immutable and all your machines are the same.

--- a/modules/post-installation-adding-nutanix-failure-domains-compute-machines-edit.adoc
+++ b/modules/post-installation-adding-nutanix-failure-domains-compute-machines-edit.adoc
@@ -6,6 +6,7 @@
 [id="post-installation-adding-nutanix-failure-domains-compute-machines-edit_{context}"]
 = Editing compute machine sets to implement failure domains
 
+[role="_abstract"]
 To distribute compute machines across Nutanix failure domains by using an existing compute machine set, you update the compute machine set with your configuration and then use scaling to replace the existing compute machines.
 
 .Prerequisites
@@ -116,11 +117,12 @@ $ oc annotate machine/<machine_name_original_1> \
 +
 [source,terminal]
 ----
-$ oc scale --replicas=<twice_the_number_of_replicas> \// <1>
+$ oc scale --replicas=<twice_the_number_of_replicas> \
   machineset <machine_set_name_1> \
   -n openshift-machine-api
 ----
-<1> For example, if the original number of replicas in the compute machine set is `2`, scale the replicas to `4`.
++
+For example, if the original number of replicas in the compute machine set is `2`, scale the replicas to `4`.
 
 . List the machines that are managed by the updated compute machine set by running the following command:
 +
@@ -135,10 +137,11 @@ When the new machines are in the `Running` phase, you can scale the compute mach
 +
 [source,terminal]
 ----
-$ oc scale --replicas=<original_number_of_replicas> \// <1>
+$ oc scale --replicas=<original_number_of_replicas> \
   machineset <machine_set_name_1> \
   -n openshift-machine-api
 ----
-<1> For example, if the original number of replicas in the compute machine set was `2`, scale the replicas to `2`.
++
+For example, if the original number of replicas in the compute machine set was `2`, scale the replicas to `2`.
 
 . As required, continue to modify machine sets to reference the additional failure domains that are available to the deployment.

--- a/modules/post-installation-adding-nutanix-failure-domains-compute-machines-replace.adoc
+++ b/modules/post-installation-adding-nutanix-failure-domains-compute-machines-replace.adoc
@@ -6,6 +6,7 @@
 [id="post-installation-adding-nutanix-failure-domains-compute-machines-replace_{context}"]
 = Replacing compute machine sets to implement failure domains
 
+[role="_abstract"]
 To distribute compute machines across Nutanix failure domains by replacing a compute machine set, you create a new compute machine set with your configuration, wait for the machines that it creates to start, and then delete the old compute machine set.
 
 .Prerequisites
@@ -63,15 +64,16 @@ $ oc get machineset <original_machine_set_name_1> \
 ----
 +
 --
-.Example output
+The command returns output similar to the following example:
+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-  name: <infrastructure_id>-<role> <2>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-<role>
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -87,17 +89,20 @@ spec:
         machine.openshift.io/cluster-api-machine-type: <role>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
     spec:
-      providerSpec: <3>
+      providerSpec:
         ...
 ----
-<1> The cluster infrastructure ID.
-<2> A default node label.
-+
+
+where:
+
+`<infrastructure_id>`::  Specifies the cluster infrastructure ID.
+`<role>`:: Specifies a default node label.
+`providerSpec`:: Specifies the values in the `providerSpec` section of the compute machine set CR are platform-specific. For more information about `providerSpec` parameters in the CR, see the sample compute machine set CR configuration for your provider.
+
 [NOTE]
 ====
 For clusters that have user-provisioned infrastructure, a compute machine set can only create machines with a `worker` or `infra` role.
 ====
-<3> The values in the `<providerSpec>` section of the compute machine set CR are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
 --
 
 . Configure the new compute machine set to use the first failure domain by updating or adding the following to the `spec.template.spec.providerSpec.value` stanza in the `<new_machine_set_name_1>.yaml` file.

--- a/modules/post-installation-adding-nutanix-failure-domains-control-planes.adoc
+++ b/modules/post-installation-adding-nutanix-failure-domains-control-planes.adoc
@@ -6,6 +6,7 @@
 [id="post-installation-adding-nutanix-failure-domains-control-planes_{context}"]
 = Distributing control planes across failure domains
 
+[role="_abstract"]
 You distribute control planes across Nutanix failure domains by modifying the control plane machine set custom resource (CR).
 
 .Prerequisites
@@ -51,4 +52,5 @@ spec:
 ----
 . Save your changes.
 
-By default, the control plane machine set propagates changes to your control plane configuration automatically. If the cluster is configured to use the `OnDelete` update strategy, you must replace your control planes manually. For more information, see "Additional resources".
+.Result
+By default, the control plane machine set propagates changes to your control plane configuration automatically. If the cluster is configured to use the `OnDelete` update strategy, you must replace your control planes manually.

--- a/modules/post-installation-configuring-nutanix-failure-domains.adoc
+++ b/modules/post-installation-configuring-nutanix-failure-domains.adoc
@@ -6,6 +6,7 @@
 [id="post-installation-configuring-nutanix-failure-domains_{context}"]
 = Adding failure domains to the Infrastructure CR
 
+[role="_abstract"]
 You add failure domains to an existing Nutanix cluster by modifying its Infrastructure custom resource (CR) (`infrastructures.config.openshift.io`).
 
 [TIP]

--- a/modules/preparing-to-install-on-nutanix-agent-based-installer-reference.adoc
+++ b/modules/preparing-to-install-on-nutanix-agent-based-installer-reference.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="preparing-to-install-on-nutanix-agent-based-installer-reference_{context}"]
+= Agent-based Installer
+
+[role="_abstract"]
+You can install an {product-title} cluster on Nutanix by using the Agent-based Installer.
+The Agent-based Installer can be used to install a three-node cluster, which is a smaller, more resource efficient cluster for testing, development, and production.


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-17010](https://redhat.atlassian.net/browse/OSDOCS-17010)

Link to docs preview:
- https://115693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/nutanix-failure-domains.html
- https://115693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/preparing-to-install-on-nutanix.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: Split from #115209 to keep size manageable.

