### PR TITLE
[OSDOCS#18992] CQA pre-migration for Scalability and performance index assembly

### DIFF
--- a/modules/scalability-performance-planning-optimization.adoc
+++ b/modules/scalability-performance-planning-optimization.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module,
+// but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-performance-planning-optimization_{context}"]
+= Planning, optimization, and measurement
+
+[role="_abstract"]
+Review the following guidance on planning, optimizing, and measuring the performance of your cluster.
+
+* xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[Planning your environment according to object maximums]
+* xref:../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended practices for {ibm-z-title} and {ibm-linuxone-title}]
+* xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
+* xref:../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[Using CPU Manager and Topology Manager]
+* xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-numa-aware-scheduling[Scheduling NUMA-aware workloads]
+* xref:../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage, routing, networking and CPU usage]
+* xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#managing-bare-metal-hosts[Managing bare metal hosts and events]
+* xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do-and-how-they-are-consumed[What are huge pages and how are they used by apps]
+* xref:../scalability_and_performance/cnf-understanding-low-latency.adoc#cnf-understanding-low-latency[Low latency tuning for improving cluster stability and partitioning workload]
+* xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]
+* xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning]
+* xref:../scalability_and_performance/node-observability-operator.adoc#using-node-observability-operator[Using the Node Observability Operator]

--- a/modules/scalability-performance-recommended-practices.adoc
+++ b/modules/scalability-performance-recommended-practices.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module,
+// but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-performance-recommended-practices_{context}"]
+= Recommended performance and scalability practices
+
+[role="_abstract"]
+Review the following recommended performance and scalability practices for your cluster.
+
+* xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-control-plane-practices[Recommended control plane practices]
+* xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#recommended-infrastructure-practices[Recommended infrastructure practices]

--- a/modules/scalability-performance-telco-rds.adoc
+++ b/modules/scalability-performance-telco-rds.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module,
+// but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-performance-telco-rds_{context}"]
+= Telco reference design specifications
+
+[role="_abstract"]
+Review the following telco reference design specifications.
+
+* xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-ref-design-specs[Telco RAN DU reference design specification for {product-title} {product-version}]
+* xref:../scalability_and_performance/telco-core-rds.adoc#telco-core-ref-design-specs[Telco core reference design specification]

--- a/scalability_and_performance/index.adoc
+++ b/scalability_and_performance/index.adoc
@@ -4,56 +4,23 @@
 include::_attributes/common-attributes.adoc[]
 :context: index
 
-// ifndef::openshift-dedicated,openshift-rosa[]
+[role="_abstract"]
 {product-title} provides best practices and tools to help you optimize the performance and scale of your clusters. The following documentation provides information on recommended performance and scalability practices, reference design specifications, optimization, and low latency tuning.
 
-To contact Red Hat support, see xref:../support/getting-support.adoc#getting-support[Getting support].
-
-// endif::openshift-dedicated,openshift-rosa[]
+To contact Red Hat support, see Getting support.
 
 [NOTE]
 ====
-Some performance and scalability Operators have release cycles that are independent from {product-title} release cycles. For more information, see link:access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operators].
+Some performance and scalability Operators have release cycles that are independent from {product-title} release cycles. For more information, see OpenShift Operators.
 ====
 
+include::modules/scalability-performance-recommended-practices.adoc[leveloffset=+1]
 
-== Recommended performance and scalability practices
+[role="_additional-resources"]
+.Additional resources
+* xref:../support/getting-support.adoc#getting-support[Getting support]
+* link:access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operators]
 
-xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-control-plane-practices[Recommended control plane practices]
+include::modules/scalability-performance-telco-rds.adoc[leveloffset=+1]
 
-xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#recommended-infrastructure-practices[Recommended infrastructure practices]
-
-
-== Telco reference design specifications
-
-xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-ref-design-specs[Telco RAN DU reference design specification for {product-title} {product-version}]
-
-xref:../scalability_and_performance/telco-core-rds.adoc#telco-core-ref-design-specs[Telco core reference design specification]
-
-
-== Planning, optimization, and measurement
-xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[Planning your environment according to object maximums]
-
-xref:../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended practices for {ibm-z-title} and {ibm-linuxone-title}]
-
-xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
-
-xref:../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[Using CPU Manager and Topology Manager]
-
-xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-numa-aware-scheduling[Scheduling NUMA-aware workloads]
-
-xref:../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage, routing, networking and CPU usage]
-
-xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#managing-bare-metal-hosts[Managing bare metal hosts and events]
-
-xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do-and-how-they-are-consumed[What are huge pages and how are they used by apps]
-
-xref:../scalability_and_performance/cnf-understanding-low-latency.adoc#cnf-understanding-low-latency[Low latency tuning for improving cluster stability and partitioning workload]
-
-xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]
-
-xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning]
-
-xref:../scalability_and_performance/node-observability-operator.adoc#using-node-observability-operator[Using the Node Observability Operator]
-
-// endif::[]
+include::modules/scalability-performance-planning-optimization.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989)

Link to docs preview: 4.20+

QE review:
- [ ] QE has approved this change.

Additional information: One of 3 PRs splitting [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989) (index.adoc CQA pre-migration) by assembly.