### PR TITLE
OADP-8331: Add OADP 1.6.1 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,11 +49,11 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.6.0
+:oadp-version: 1.6.1
 :oadp-version-1-3: 1.3.6
 :oadp-version-1-4: 1.4.6
 :oadp-version-1-5: 1.5.5
-:oadp-version-1-6: 1.6.0
+:oadp-version-1-6: 1.6.1
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-6-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-6-release-notes.adoc
@@ -19,6 +19,8 @@ Review new features, resolved issues, known issues, Technology Preview features,
 For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
+include::modules/oadp-1-6-1-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-6-0-release-notes.adoc[leveloffset=+1]
 
 

--- a/modules/oadp-1-6-1-release-notes.adoc
+++ b/modules/oadp-1-6-1-release-notes.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-6-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-6-1-release-notes_{context}"]
+= {oadp-short} 1.6.1 release notes
+
+[role="_abstract"]
+{oadp-first} 1.6.1 release notes list resolved and known issues.
+
+The following Red Hat Security Advisory (RHSA) is available for {oadp-short} 1.6.1:
+
+* link:https://access.redhat.com/errata/RHSA-2026:43692[RHSA-2026:43692 - New version of Red{nbsp}Hat OpenShift API for Data Protection]
+
+
+[id="resolved-issues-1-6-1_{context}"]
+== Resolved issues
+
+{oadp-short} CLI no longer exposes the namespace flag for non-admin operations::
+Before this update, the {oadp-short} command-line interface (CLI) exposed the global `--namespace` or `-n` flag in the help output of all `oc oadp nonadmin` commands, even though non-admin operations do not support namespace selection because of multi-tenancy boundaries. As a consequence, if you specified the namespace flag during a non-admin backup or restore operation, the CLI ignored the provided value and used the active `oc project` context instead, potentially creating resources in an unintended namespace.
++
+With this update, the `--namespace` flag is hidden from all `oc oadp nonadmin` subcommands so that it is no longer displayed in the help output and does not accept user input for non-admin operations. As a result, non-admin CLI commands operate correctly only within your current project context, which eliminates the risk of namespace mismatch.
++
+link:https://redhat.atlassian.net/browse/OADP-7955[OADP-7955]
+
+Wildcard handling for `excludedClusterScopedResources` no longer causes validation failures::
+Before this update, the {oadp-short} Operator incorrectly appended default resources to `excludedClusterScopedResources` in the `NonAdminBackup` custom resource (CR) when a wildcard (`*`) was present. As a consequence, `FailedValidation` errors occurred when you excluded all cluster-scoped resources. With this update, the Operator correctly handles the wildcard without appending default resources. As a result, validation failures no longer occur when you use a wildcard to exclude cluster-scoped resources.
++
+link:https://redhat.atlassian.net/browse/OADP-7897[OADP-7897]
+
+`VolumePolicy` support for phase conditions to allow skipping PVCs::
+Before this update, {oadp-short} volume policies lacked the capability to evaluate and filter persistent volume claims (PVCs) based on their lifecycle status phase. As a consequence, backups could trigger unwanted warnings or errors for unbound or pending PVCs that you excluded, such as in scaled-down serverless environments.
++
+With this update, volume policy actions have been improved to natively support the phase condition of PVCs. As a result, you can define custom volume policies in your `ConfigMap` object to automatically skip pending or unbound PVCs during backup operations. For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-policy
+  namespace: velero
+data:
+  policy.yaml: |
+    version: v1
+    volumePolicies:
+    - conditions:
+        pvcPhase: ["Pending", "Lost"]
+      action:
+        type: skip
+----
++
+link:https://redhat.atlassian.net/browse/OADP-6428[OADP-6428]
+
+
+[id="known-issues-1-6-1_{context}"]
+== Known issues
+
+`CloudStorage` bucket creation fails on {GCP} with WIF authentication::
+When you configure `CloudStorage` on OpenShift clusters on {GCP} by using Workload Identity Federation (WIF) authentication, the `CloudStorage` resource fails to detect that a {GCP} bucket does not exist. As a consequence, the resource returns a `BucketCheckError` condition and prevents automatic bucket creation.
++
+To work around this problem, use an existing {GCP} bucket when configuring `CloudStorage` on OpenShift clusters on {GCP} using Workload Identity Federation (WIF) authentication. As a result, the controller skips bucket creation and proceeds with the existing bucket for backup storage.
++
+link:https://redhat.atlassian.net/browse/OADP-8085[OADP-8085]
+
+Non-admin backups of {odf-short} encrypted volumes fail with {oadp-short}::
+When the {oadp-short} Data Mover backs up an encrypted {odf-first} volume, it creates a temporary persistent volume claim (PVC) in the `openshift-adp` namespace. The ceph-csi driver then attempts to fetch the `ceph-csi-kms-token` secret from the `openshift-adp` namespace instead of the original application namespace that contains the secret. As a consequence, the `NonAdminBackup` custom resource (CR) fails with an error similar to the following output:
++
+----
+openshift-adp   2h11m       Warning   ProvisioningFailed     persistentvolumeclaim/NAMESPACE-rh-cf00000c-0000-0000-0000-22abf391t6dr   failed to provision volume with StorageClass "ocs-storagecluster-ceph-rbd-encrypted": rpc error: code = InvalidArgument desc = invalid encryption kms configuration: failed fetching token from openshift-adp/ceph-csi-kms-token: secrets "ceph-csi-kms-token" not found
+----
++
+To work around this problem, copy `ceph-csi-kms-token` and the associated Key Management Service (KMS) config map from the application namespace to `openshift-adp` before running the backup. As a result, the ceph-csi driver can locate the encryption credentials and the backup completes successfully.
++
+link:https://redhat.atlassian.net/browse/OADP-7972[OADP-7972]


### PR DESCRIPTION
Summary of changes:
Add Release Notes for OADP 1.6.1 and update attributes accordingly.

Version(s):
OCP - main, 4.22, 5.0

Issue:
[OADP-8331](https://redhat.atlassian.net/browse/OADP-8331)

Link to docs preview:
[OADP 1.6.1 release notes](https://115703--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-6-release-notes.html#oadp-1-6-1-release-notes_oadp-1-6-release-notes)

QE review:
- [x] QE has approved this change.