### PR TITLE
[enterprise-4.21] OCPBUGS-98585: Added kubectl to the cli-tools-list.adoc

### DIFF
--- a/modules/cli-tools-list.adoc
+++ b/modules/cli-tools-list.adoc
@@ -9,11 +9,11 @@
 = List of CLI tools
 
 [role="_abstract"]
-Review the primary command-line interface (CLI) tools available for {product-title}, including tools for cluster administration, application development, and Operator management.
+Manage your {product-title} cluster, applications, and Operators from the terminal by using primary command-line interface (CLI) tools.
 
-Use the following tools to manage your cluster from the terminal:
+The following list details these primary CLI tools:
 
-* xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (`oc`)]:
+* xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[{oc-first}]:
 ifndef::openshift-rosa[]
 This is the most commonly used CLI tool by {product-title} users.
 endif::openshift-rosa[]
@@ -21,6 +21,8 @@ ifdef::openshift-rosa[]
 This is one of the more commonly used developer CLI tools.
 endif::openshift-rosa[]
 It helps both cluster administrators and developers to perform end-to-end operations across {product-title} using the terminal. Unlike the web console, it allows the user to work directly with the project source code using command scripts.
+
+* Kubernetes CLI (`kubectl`): {product-title} is conformant with Cloud Native Computing Foundation (CNCF) Kubernetes and fully supports `kubectl` as a client. The {oc-first} is a superset of `kubectl`, where both CLI tools are included in the {product-title} clients download. You can use the standard `kubectl` commands against {product-title} clusters without any compatibility issues.
 
 * xref:../cli_reference/kn-cli-tools.adoc#kn-cli-tools[Knative CLI (kn)]: The Knative (`kn`) CLI tool provides simple and intuitive terminal commands that can be used to interact with OpenShift Serverless components, such as Knative Serving and Eventing.
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/115520