### PR TITLE
[OSDOCS#18992] CQA pre-migration for Backup and restore index assembly

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -73,7 +73,7 @@ include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[Application backup and restore operations]
+* xref:../../../backup_and_restore/index.adoc#application-backup-restore-operations-overview_backup-restore-overview[Application backup and restore operations]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic]
 * xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -7,80 +7,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[id="control-plane-backup-restore-operations-overview"]
-== Control plane backup and restore operations
+[role="_abstract"]
+Learn how to back up and restore your {product-title} cluster's control plane and how to back up and restore applications running on the cluster.
 
-As a cluster administrator, you might need to stop an {product-title} cluster for a period and restart it later. Some reasons for restarting a cluster are that you need to perform maintenance on a cluster or want to reduce resource costs. In {product-title}, you can perform a xref:../backup_and_restore/graceful-cluster-shutdown.adoc#graceful-shutdown-cluster[graceful shutdown of a cluster] so that you can easily restart the cluster later.
-
-You must xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[back up etcd data] before shutting down a cluster; etcd is the key-value store for {product-title}, which persists the state of all resource objects. An etcd backup plays a crucial role in disaster recovery. In {product-title}, you can also xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[replace an unhealthy etcd member].
-
-When you want to get your cluster running again, xref:../backup_and_restore/graceful-cluster-restart.adoc#graceful-restart-cluster[restart the cluster gracefully].
-
-[NOTE]
-====
-A cluster's certificates expire one year after the installation date. You can shut down a cluster and expect it to restart gracefully while the certificates are still valid. Although the cluster automatically retrieves the expired control plane certificates, you must still xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[approve the certificate signing requests (CSRs)].
-====
-
-You might run into several situations where {product-title}  does not work as expected, such as:
-
-* You have a cluster that is not functional after the restart because of unexpected conditions, such as node failure or network connectivity issues.
-* You have deleted something critical in the cluster by mistake.
-* You have lost the majority of your control plane hosts, leading to etcd quorum loss.
-
-You can always recover from a disaster situation by xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restoring your cluster to its previous state] using the saved etcd snapshots.
+include::modules/control-plane-backup-restore-operations-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-etcd_deleting-machine[Quorum protection with machine lifecycle hooks]
 
-[id="application-backup-restore-operations-overview"]
-== Application backup and restore operations
-
-As a cluster administrator, you can back up and restore applications running on {product-title} by using the OpenShift API for Data Protection (OADP).
-
-OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using the version of Velero that is appropriate for the version of OADP you install, according to the table in xref:../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#velero-obtaining-by-downloading_velero-cli-tool[Downloading the Velero CLI tool].  OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
-
-[id="oadp-requirements"]
-=== OADP requirements
-
-OADP has the following requirements:
-
-* You must be logged in as a user with a `cluster-admin` role.
-* You must have object storage for storing backups, such as one of the following storage types:
-
-** OpenShift Data Foundation
-** Amazon Web Services
-** Microsoft Azure
-** {gcp-full}
-** S3-compatible object storage
-** {ibm-cloud-name} Object Storage S3
-
-include::snippets/oadp-ocp-compat.adoc[]
-
-* To back up PVs with snapshots, you must have cloud storage that has a native snapshot API or supports Container Storage Interface (CSI) snapshots, such as the following providers:
-
-** Amazon Web Services
-** Microsoft Azure
-** {gcp-full}
-** CSI snapshot-enabled cloud storage, such as Ceph RBD or Ceph FS
-
-[NOTE]
-====
-If you do not want to back up PVs by using snapshots, you can use link:https://restic.net/[Restic], which is installed by the OADP Operator by default.
-====
-
-[id="backing-up-and-restoring-applications"]
-=== Backing up and restoring applications
-
-You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR]. You can configure the following backup options:
-
-* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[Creating backup hooks] to run commands before or after the backup operation
-
-* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[Scheduling backups]
-
-* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic]
-
-* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[Creating a Restore CR].
-* You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.
+include::modules/application-backup-restore-operations-overview.adoc[leveloffset=+1]
 
 :backup-restore-overview!:

--- a/modules/application-backup-restore-operations-overview.adoc
+++ b/modules/application-backup-restore-operations-overview.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="application-backup-restore-operations-overview_{context}"]
+= Application backup and restore operations
+
+[role="_abstract"]
+As a cluster administrator, you can back up and restore applications running on {product-title} by using the OpenShift API for Data Protection (OADP).
+
+OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using the version of Velero that is appropriate for the version of OADP you install, according to the table in xref:../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#velero-obtaining-by-downloading_velero-cli-tool[Downloading the Velero CLI tool].  OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
+
+[id="oadp-requirements_{context}"]
+== OADP requirements
+
+OADP has the following requirements:
+
+* You must be logged in as a user with a `cluster-admin` role.
+* You must have object storage for storing backups, such as one of the following storage types:
+
+** {rh-storage}
+** Amazon Web Services
+** Microsoft Azure
+** {gcp-full}
+** S3-compatible object storage
+** {ibm-cloud-name} Object Storage S3
+
+include::snippets/oadp-ocp-compat.adoc[]
+
+* To back up PVs with snapshots, you must have cloud storage that has a native snapshot API or supports Container Storage Interface (CSI) snapshots, such as the following providers:
+
+** Amazon Web Services
+** Microsoft Azure
+** {gcp-full}
+** CSI snapshot-enabled cloud storage, such as Ceph RBD or Ceph FS
+
+[NOTE]
+====
+If you do not want to back up PVs by using snapshots, you can use link:https://restic.net/[Restic], which is installed by the OADP Operator by default.
+====
+
+[id="backing-up-and-restoring-applications_{context}"]
+== Backing up and restoring applications
+
+You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR]. You can configure the following backup options:
+
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[Creating backup hooks] to run commands before or after the backup operation
+
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[Scheduling backups]
+
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic]
+
+* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[Creating a Restore CR].
+* You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.

--- a/modules/control-plane-backup-restore-operations-overview.adoc
+++ b/modules/control-plane-backup-restore-operations-overview.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="control-plane-backup-restore-operations-overview_{context}"]
+= Control plane backup and restore operations
+
+[role="_abstract"]
+As a cluster administrator, you might need to stop an {product-title} cluster for a period and restart it later.
+
+Some reasons for restarting a cluster are that you need to perform maintenance on a cluster or want to reduce resource costs. In {product-title}, you can perform a xref:../backup_and_restore/graceful-cluster-shutdown.adoc#graceful-shutdown-cluster[graceful shutdown of a cluster] so that you can easily restart the cluster later.
+
+You must xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[back up etcd data] before shutting down a cluster; etcd is the key-value store for {product-title}, which persists the state of all resource objects. An etcd backup plays a crucial role in disaster recovery. In {product-title}, you can also xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[replace an unhealthy etcd member].
+
+When you want to get your cluster running again, xref:../backup_and_restore/graceful-cluster-restart.adoc#graceful-restart-cluster[restart the cluster gracefully].
+
+[NOTE]
+====
+A cluster's certificates expire one year after the installation date. You can shut down a cluster and expect it to restart gracefully while the certificates are still valid. Although the cluster automatically retrieves the expired control plane certificates, you must still xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[approve the certificate signing requests (CSRs)].
+====
+
+You might run into several situations where {product-title}  does not work as expected, such as:
+
+* You have a cluster that is not functional after the restart because of unexpected conditions, such as node failure or network connectivity issues.
+* You have deleted something critical in the cluster by mistake.
+* You have lost the majority of your control plane hosts, leading to etcd quorum loss.
+
+You can always recover from a disaster situation by xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restoring your cluster to its previous state] using the saved etcd snapshots.

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -26,7 +26,7 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[Application backup and restore operations]
+* xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview_backup-restore-overview[Application backup and restore operations]
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic]
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plug-ins]
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[Backing up applications]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992)

Link to docs preview:
- https://115717--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/backup_restore/virt-backup-restore-overview.html
- https://115717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html
- https://115717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html
- https://115717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-overview.html
- https://115717--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/backup_restore/virt-backup-restore-overview.html
- https://115717--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/backup_restore/virt-backup-restore-overview.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 3 PRs splitting [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.
