### PR TITLE
[OSDOCS#18992] CQA pre-migration for Scalability and performance index assembly

### DIFF
--- a/modules/scalability-and-performance-planning-optimization-measurement.adoc
+++ b/modules/scalability-and-performance-planning-optimization-measurement.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-and-performance-planning-optimization-measurement_{context}"]
+= Planning, optimization, and measurement
+
+[role="_abstract"]
+Review guidance for planning, optimizing, and measuring the performance and scalability of your {product-title} cluster.
+
+xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[Planning your environment according to object maximums]
+
+xref:../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended practices for {ibm-z-title} and {ibm-linuxone-title}]
+
+xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
+
+xref:../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[Using CPU Manager and Topology Manager]
+
+xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-numa-aware-scheduling[Scheduling NUMA-aware workloads]
+
+xref:../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage, routing, networking and CPU usage]
+
+xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#managing-bare-metal-hosts[Managing bare-metal hosts and events]
+
+xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do-and-how-they-are-consumed[What are huge pages and how are they used by apps]
+
+xref:../scalability_and_performance/cnf-understanding-low-latency.adoc#cnf-understanding-low-latency[Low latency tuning for improving cluster stability and partitioning workload]
+
+xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]
+
+xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning]
+
+xref:../scalability_and_performance/node-observability-operator.adoc#using-node-observability-operator[Using the Node Observability Operator]

--- a/modules/scalability-and-performance-recommended-practices.adoc
+++ b/modules/scalability-and-performance-recommended-practices.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-and-performance-recommended-practices_{context}"]
+= Recommended performance and scalability practices
+
+[role="_abstract"]
+Review the recommended performance and scalability practices for {product-title}.
+
+xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-control-plane-practices[Recommended control plane practices]
+
+xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#recommended-infrastructure-practices[Recommended infrastructure practices]

--- a/modules/scalability-and-performance-telco-reference-designs.adoc
+++ b/modules/scalability-and-performance-telco-reference-designs.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-and-performance-telco-reference-designs_{context}"]
+= Telco reference design specifications
+
+[role="_abstract"]
+Review the telco reference design specifications for {product-title}.
+
+xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-ref-design-specs[Telco RAN DU reference design specification for {product-title} {product-version}]
+
+xref:../scalability_and_performance/telco-core-rds.adoc#telco-core-ref-design-specs[Telco core reference design specification]

--- a/scalability_and_performance/index.adoc
+++ b/scalability_and_performance/index.adoc
@@ -4,56 +4,31 @@
 include::_attributes/common-attributes.adoc[]
 :context: index
 
+toc::[]
+
 // ifndef::openshift-dedicated,openshift-rosa[]
-{product-title} provides best practices and tools to help you optimize the performance and scale of your clusters. The following documentation provides information on recommended performance and scalability practices, reference design specifications, optimization, and low latency tuning.
+[role="_abstract"]
+{product-title} provides best practices and tools to help you optimize the performance and scale of your clusters.
 
-To contact Red Hat support, see xref:../support/getting-support.adoc#getting-support[Getting support].
-
+The following documentation provides information on recommended performance and scalability practices, reference design specifications, optimization, and low latency tuning.
 // endif::openshift-dedicated,openshift-rosa[]
+
+To contact Red Hat support, see "Getting support".
 
 [NOTE]
 ====
-Some performance and scalability Operators have release cycles that are independent from {product-title} release cycles. For more information, see link:access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operators].
+Some performance and scalability Operators have release cycles that are independent from {product-title} release cycles. For more information, see "OpenShift Operators".
 ====
 
+include::modules/scalability-and-performance-recommended-practices.adoc[leveloffset=+1]
 
-== Recommended performance and scalability practices
+include::modules/scalability-and-performance-telco-reference-designs.adoc[leveloffset=+1]
 
-xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-control-plane-practices[Recommended control plane practices]
+include::modules/scalability-and-performance-planning-optimization-measurement.adoc[leveloffset=+1]
 
-xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#recommended-infrastructure-practices[Recommended infrastructure practices]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-
-== Telco reference design specifications
-
-xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-ref-design-specs[Telco RAN DU reference design specification for {product-title} {product-version}]
-
-xref:../scalability_and_performance/telco-core-rds.adoc#telco-core-ref-design-specs[Telco core reference design specification]
-
-
-== Planning, optimization, and measurement
-xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[Planning your environment according to object maximums]
-
-xref:../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended practices for {ibm-z-title} and {ibm-linuxone-title}]
-
-xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
-
-xref:../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[Using CPU Manager and Topology Manager]
-
-xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-numa-aware-scheduling[Scheduling NUMA-aware workloads]
-
-xref:../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage, routing, networking and CPU usage]
-
-xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#managing-bare-metal-hosts[Managing bare metal hosts and events]
-
-xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do-and-how-they-are-consumed[What are huge pages and how are they used by apps]
-
-xref:../scalability_and_performance/cnf-understanding-low-latency.adoc#cnf-understanding-low-latency[Low latency tuning for improving cluster stability and partitioning workload]
-
-xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]
-
-xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning]
-
-xref:../scalability_and_performance/node-observability-operator.adoc#using-node-observability-operator[Using the Node Observability Operator]
-
-// endif::[]
+* xref:../support/getting-support.adoc#getting-support[Getting support]
+* link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operators]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992)

Link to docs preview:
- https://115718--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 3 PRs splitting [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.
