### PR TITLE
[OSDOCS#18992] CQA pre-migration for Windows Containers index assembly

### DIFF
--- a/modules/managing-windows-container-workloads.adoc
+++ b/modules/managing-windows-container-workloads.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="managing-windows-container-workloads_{context}"]
+= Managing Windows container workloads
+
+[role="_abstract"]
+With a Red Hat subscription, you can get support for running Windows workloads in {product-title}.
+
+Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[release notes].
+
+You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Windows instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[ConfigMap].
+
+[NOTE]
+====
+Compute machine sets are not supported for bare metal or provider agnostic clusters.
+====
+
+For workloads including both Linux and Windows, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}. For more information, see xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[getting started with Windows container workloads].
+
+You need the WMCO to run Windows workloads in your cluster. The WMCO orchestrates the process of deploying and managing Windows workloads on a cluster. For more information, see xref:../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[how to enable Windows container workloads].
+
+You can create a Windows `MachineSet` object to create infrastructure Windows machine sets and related machines so that you can move supported Windows workloads to the new Windows machines. You can create a Windows `MachineSet` object on multiple platforms.
+
+You can xref:../windows_containers/scheduling-windows-workloads.adoc#scheduling-windows-workloads[schedule Windows workloads] to Windows compute nodes.
+
+You can xref:../windows_containers/windows-node-upgrades.adoc#windows-node-upgrades[perform Windows Machine Config Operator upgrades] to ensure that your Windows nodes have the latest updates.
+
+You can xref:../windows_containers/removing-windows-nodes.adoc#removing-windows-nodes[remove a Windows node] by deleting a specific machine.
+
+You can xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[use Bring-Your-Own-Host (BYOH) Windows instances] to repurpose Windows Server VMs and bring them to {product-title}. BYOH Windows instances benefit users who are looking to mitigate major disruptions when a Windows server goes offline. You can use BYOH Windows instances as nodes on {product-title} 4.8 and later versions.
+
+You can xref:../windows_containers/disabling-windows-container-workloads.adoc#disabling-windows-container-workloads[disable Windows container workloads] by performing the following:
+
+* Uninstalling the Windows Machine Config Operator
+* Deleting the Windows Machine Config Operator namespace

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,37 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 [role="_abstract"]
-You can use {productwinc} run Windows compute nodes in an {product-title} cluster by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. 
+You can use {productwinc} to run Windows compute nodes in an {product-title} cluster by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes.
 
-With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[release notes].
-
-You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
-
-[NOTE]
-====
-Compute machine sets are not supported for bare metal or provider agnostic clusters.
-====
-
-For workloads including both Linux and Windows, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}. For more information, see xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[getting started with Windows container workloads].
-
-You need the WMCO to run Windows workloads in your cluster. The WMCO orchestrates the process of deploying and managing Windows workloads on a cluster. For more information, see xref:../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[how to enable Windows container workloads].
-
-You can create a Windows `MachineSet` object to create infrastructure Windows machine sets and related machines so that you can move supported Windows workloads to the new Windows machines. You can create a Windows `MachineSet` object on multiple platforms.
-
-You can xref:../windows_containers/scheduling-windows-workloads.adoc#scheduling-windows-workloads[schedule Windows workloads] to Windows compute nodes.
-
-You can xref:../windows_containers/windows-node-upgrades.adoc#windows-node-upgrades[perform Windows Machine Config Operator upgrades] to ensure that your Windows nodes have the latest updates.
-
-You can xref:../windows_containers/removing-windows-nodes.adoc#removing-windows-nodes[remove a Windows node] by deleting a specific machine.
-
-You can xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[use Bring-Your-Own-Host (BYOH) Windows instances] to repurpose Windows Server VMs and bring them to {product-title}. BYOH Windows instances benefit users who are looking to mitigate major disruptions in the event that a Windows server goes offline. You can use BYOH Windows instances as nodes on {product-title} 4.8 and later versions.
-
-You can xref:../windows_containers/disabling-windows-container-workloads.adoc#disabling-windows-container-workloads[disable Windows container workloads] by performing the following:
-
-* Uninstalling the Windows Machine Config Operator
-* Deleting the Windows Machine Config Operator namespace
+include::modules/managing-windows-container-workloads.adoc[leveloffset=+1]
 
 ////
 Replace the above with the following line if WMCO is not available when a new OCP version launches:


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992)

Link to docs preview:
- https://115719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 3 PRs splitting [OSDOCS-18992](https://redhat.atlassian.net/browse/OSDOCS-18992) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.
