### PR TITLE
[OSDOCS#18986] CQA pre-migration for Understanding identity provider configuration navigation file

### DIFF
--- a/authentication/understanding-identity-provider.adoc
+++ b/authentication/understanding-identity-provider.adoc
@@ -15,64 +15,7 @@ The {product-title} master includes a built-in OAuth server.
 
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
 
-[id="supported-identity-providers"]
-== Supported identity providers
-
-You can configure the following types of identity providers:
-
-[cols="2a,8a",options="header"]
-|===
-
-|Identity provider
-|Description
-
-|xref:../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#configuring-htpasswd-identity-provider[htpasswd]
-|Configure the `htpasswd` identity provider to validate user names and passwords
-against a flat file generated using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
-
-|xref:../authentication/identity_providers/configuring-keystone-identity-provider.adoc#configuring-keystone-identity-provider[Keystone]
-|Configure the `keystone` identity provider to integrate
-your {product-title} cluster with Keystone to enable shared authentication with
-an OpenStack Keystone v3 server configured to store users in an internal
-database.
-
-|xref:../authentication/identity_providers/configuring-ldap-identity-provider.adoc#configuring-ldap-identity-provider[LDAP]
-|Configure the `ldap` identity provider to validate user names and passwords
-against an LDAPv3 server, using simple bind authentication.
-
-|xref:../authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc#configuring-basic-authentication-identity-provider[Basic authentication]
-|Configure a `basic-authentication` identity provider for users to log in to
-{product-title} with credentials validated against a remote identity provider.
-Basic authentication is a generic backend integration mechanism.
-
-|xref:../authentication/identity_providers/configuring-request-header-identity-provider.adoc#configuring-request-header-identity-provider[Request header]
-|Configure a `request-header` identity provider to identify users from request
-header values, such as `X-Remote-User`. It is typically used in combination with
-an authenticating proxy, which sets the request header value.
-
-|xref:../authentication/identity_providers/configuring-github-identity-provider.adoc#configuring-github-identity-provider[GitHub or GitHub Enterprise]
-|Configure a `github` identity provider to validate user names and passwords
-against GitHub or GitHub Enterprise's OAuth authentication server.
-
-|xref:../authentication/identity_providers/configuring-gitlab-identity-provider.adoc#configuring-gitlab-identity-provider[GitLab]
-|Configure a `gitlab` identity provider to use
-link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity
-provider.
-
-|xref:../authentication/identity_providers/configuring-google-identity-provider.adoc#configuring-google-identity-provider[Google]
-|Configure a `google` identity provider using
-link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
-
-|xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc#configuring-oidc-identity-provider[OpenID Connect]
-|Configure an `oidc` identity provider to integrate with an OpenID Connect
-identity provider using an
-link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].
-
-|===
-
-Once an identity provider has been defined, you can
-xref:../authentication/using-rbac.adoc#authorization-overview_using-rbac[use RBAC to define and apply permissions].
+include::modules/identity-provider-supported-types.adoc[leveloffset=+1]
 
 include::modules/authentication-remove-kubeadmin.adoc[leveloffset=+1]
 

--- a/modules/identity-provider-supported-types.adoc
+++ b/modules/identity-provider-supported-types.adoc
@@ -5,7 +5,7 @@
 // This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
 
 :_mod-docs-content-type: REFERENCE
-[id="identity-provider-supported-types_{context}"]
+[id="supported-identity-providers"]
 = Supported identity providers
 
 [role="_abstract"]

--- a/modules/identity-provider-supported-types.adoc
+++ b/modules/identity-provider-supported-types.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * authentication/understanding-identity-provider.adoc
+//
+// This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
+
+:_mod-docs-content-type: REFERENCE
+[id="identity-provider-supported-types_{context}"]
+= Supported identity providers
+
+[role="_abstract"]
+You can configure the following types of identity providers:
+
+[cols="2a,8a",options="header"]
+|===
+
+|Identity provider
+|Description
+
+|xref:../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#configuring-htpasswd-identity-provider[htpasswd]
+|Configure the `htpasswd` identity provider to validate user names and passwords
+against a flat file generated using
+link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+
+|xref:../authentication/identity_providers/configuring-keystone-identity-provider.adoc#configuring-keystone-identity-provider[Keystone]
+|Configure the `keystone` identity provider to integrate
+your {product-title} cluster with Keystone to enable shared authentication with
+an OpenStack Keystone v3 server configured to store users in an internal
+database.
+
+|xref:../authentication/identity_providers/configuring-ldap-identity-provider.adoc#configuring-ldap-identity-provider[LDAP]
+|Configure the `ldap` identity provider to validate user names and passwords
+against an LDAPv3 server, using simple bind authentication.
+
+|xref:../authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc#configuring-basic-authentication-identity-provider[Basic authentication]
+|Configure a `basic-authentication` identity provider for users to log in to
+{product-title} with credentials validated against a remote identity provider.
+Basic authentication is a generic backend integration mechanism.
+
+|xref:../authentication/identity_providers/configuring-request-header-identity-provider.adoc#configuring-request-header-identity-provider[Request header]
+|Configure a `request-header` identity provider to identify users from request
+header values, such as `X-Remote-User`. It is typically used in combination with
+an authenticating proxy, which sets the request header value.
+
+|xref:../authentication/identity_providers/configuring-github-identity-provider.adoc#configuring-github-identity-provider[GitHub or GitHub Enterprise]
+|Configure a `github` identity provider to validate user names and passwords
+against GitHub or GitHub Enterprise's OAuth authentication server.
+
+|xref:../authentication/identity_providers/configuring-gitlab-identity-provider.adoc#configuring-gitlab-identity-provider[GitLab]
+|Configure a `gitlab` identity provider to use
+link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity
+provider.
+
+|xref:../authentication/identity_providers/configuring-google-identity-provider.adoc#configuring-google-identity-provider[Google]
+|Configure a `google` identity provider using
+link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
+
+|xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc#configuring-oidc-identity-provider[OpenID Connect]
+|Configure an `oidc` identity provider to integrate with an OpenID Connect
+identity provider using an
+link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].
+
+|===
+
+Once an identity provider has been defined, you can
+xref:../authentication/using-rbac.adoc#authorization-overview_using-rbac[use RBAC to define and apply permissions].

--- a/modules/identity-provider-supported-types.adoc
+++ b/modules/identity-provider-supported-types.adoc
@@ -5,7 +5,7 @@
 // This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
 
 :_mod-docs-content-type: REFERENCE
-[id="supported-identity-providers"]
+[id="supported-identity-providers_{context}"]
 = Supported identity providers
 
 [role="_abstract"]

--- a/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
@@ -13,4 +13,4 @@ include::modules/troubleshooting-security-authentication.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]
+* xref:../../../authentication/understanding-identity-provider.adoc#supported-identity-providers_understanding-identity-provider[Supported identity providers]

--- a/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
@@ -13,4 +13,4 @@ include::modules/troubleshooting-security-authentication.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../authentication/understanding-identity-provider.adoc#identity-provider-supported-types_understanding-identity-provider[Supported identity providers]
+* xref:../../../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]

--- a/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-security.adoc
@@ -13,4 +13,4 @@ include::modules/troubleshooting-security-authentication.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]
+* xref:../../../authentication/understanding-identity-provider.adoc#identity-provider-supported-types_understanding-identity-provider[Supported identity providers]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -150,7 +150,7 @@ Managing cluster components::
 | xref:../authentication/impersonating-system-admin.adoc#impersonating-system-admin[Impersonating the system:admin user]
 
 | xref:../authentication/understanding-authentication.adoc#understanding-authentication[Manage authentication]
-| xref:../authentication/understanding-identity-provider.adoc#identity-provider-supported-types_understanding-identity-provider[Supported identity providers]
+| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]
 
 | Manage xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Ingress], xref:../security/certificates/api-server.adoc#api-server-certificates[API server], and xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[service] certificates
 | xref:../networking/network_security/network-policy-apis.adoc#network-policy-apis[Network security]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -150,7 +150,7 @@ Managing cluster components::
 | xref:../authentication/impersonating-system-admin.adoc#impersonating-system-admin[Impersonating the system:admin user]
 
 | xref:../authentication/understanding-authentication.adoc#understanding-authentication[Manage authentication]
-| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]
+| xref:../authentication/understanding-identity-provider.adoc#identity-provider-supported-types_understanding-identity-provider[Supported identity providers]
 
 | Manage xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Ingress], xref:../security/certificates/api-server.adoc#api-server-certificates[API server], and xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[service] certificates
 | xref:../networking/network_security/network-policy-apis.adoc#network-policy-apis[Network security]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -150,7 +150,7 @@ Managing cluster components::
 | xref:../authentication/impersonating-system-admin.adoc#impersonating-system-admin[Impersonating the system:admin user]
 
 | xref:../authentication/understanding-authentication.adoc#understanding-authentication[Manage authentication]
-| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[Supported identity providers]
+| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers_understanding-identity-provider[Supported identity providers]
 
 | Manage xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Ingress], xref:../security/certificates/api-server.adoc#api-server-certificates[API server], and xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[service] certificates
 | xref:../networking/network_security/network-policy-apis.adoc#network-policy-apis[Network security]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986)

Link to docs preview: 4.20+

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: This is 1 of 4 PRs splitting [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986) by assembly. This assembly's "Supported identity providers" section is a navigation file per the Jira ticket. Xrefs are allowed in the resulting reference module, which must only ever be included in one location. The existing anchor ID was preserved (same base string) with `_{context}` appended, matching the pattern used in #108999.

Note: this PR renames the anchor from `supported-identity-providers` to `supported-identity-providers_{context}`. The companion PR (#115739) for `authentication/index.adoc` still links to the old anchor name; that PR should merge together with or before this one to avoid a stale anchor.
