### PR TITLE
[OSDOCS#18986] CQA pre-migration for Security and compliance index assembly

### DIFF
--- a/modules/security-compliance-capabilities.adoc
+++ b/modules/security-compliance-capabilities.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * security/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="compliance-overview_{context}"]
+= Compliance overview
+
+[role="_abstract"]
+For many {product-title} customers, regulatory readiness, or compliance, on some level is required before any systems can be put into production. That regulatory readiness can be imposed by national standards, industry standards, or the organization's corporate governance framework.
+
+[id="compliance-checking_{context}"]
+== Compliance checking
+
+Administrators can use the xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance-operator[Compliance Operator] to run compliance scans and recommend remediations for any issues found. The xref:../security/compliance_operator/co-scans/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[`oc-compliance` plugin] is an OpenShift CLI (`oc`) plugin that provides a set of utilities to easily interact with the Compliance Operator.
+
+[id="file-integrity-checking_{context}"]
+== File integrity checking
+
+Administrators can use the xref:../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[File Integrity Operator] to continually run file integrity checks on cluster nodes and provide a log of files that have been modified.

--- a/modules/security-overview-capabilities.adoc
+++ b/modules/security-overview-capabilities.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * security/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="security-overview_{context}"]
+= Security overview
+
+[role="_abstract"]
+It is important to understand how to properly secure various aspects of your {product-title} cluster.
+
+[id="container-security_{context}"]
+== Container security
+
+A good starting point to understanding {product-title} security is to review the concepts in xref:../security/container_security/security-understanding.adoc#security-understanding[Understanding container security]. This and subsequent sections provide a high-level walkthrough of the container security measures available in {product-title}, including solutions for the host layer, the container and orchestration layer, and the build and application layer. These sections also include information on the following topics:
+
+* Why container security is important and how it compares with existing security standards.
+* Which container security measures are provided by the host ({op-system} and {op-system-base}) layer and
+which are provided by {product-title}.
+* How to evaluate your container content and sources for vulnerabilities.
+* How to design your build and deployment process to proactively check container content.
+* How to control access to containers through authentication and authorization.
+* How networking and attached storage are secured in {product-title}.
+* Containerized solutions for API management and SSO.
+
+[id="auditing_{context}"]
+== Auditing
+
+{product-title} auditing provides a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system. Administrators can xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[configure the audit log policy] and xref:../security/audit-log-view.adoc#audit-log-view[view audit logs].
+
+[id="certificates_{context}"]
+== Certificates
+
+Certificates are used by various components to validate access to the cluster. Administrators can xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[replace the default ingress certificate], xref:../security/certificates/api-server.adoc#api-server-certificates[add API server certificates], or xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[add a service certificate].
+
+You can also review more details about the types of certificates used by the cluster:
+
+* xref:../security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc#cert-types-user-provided-certificates-for-the-api-server[User-provided certificates for the API server]
+* xref:../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-certificates[Proxy certificates]
+* xref:../security/certificate_types_descriptions/service-ca-certificates.adoc#cert-types-service-ca-certificates[Service CA certificates]
+* xref:../security/certificate_types_descriptions/node-certificates.adoc#cert-types-node-certificates[Node certificates]
+* xref:../security/certificate_types_descriptions/bootstrap-certificates.adoc#cert-types-bootstrap-certificates[Bootstrap certificates]
+* xref:../security/certificate_types_descriptions/etcd-certificates.adoc#cert-types-etcd-certificates[etcd certificates]
+* xref:../security/certificate_types_descriptions/olm-certificates.adoc#cert-types-olm-certificates[OLM certificates]
+* xref:../security/certificate_types_descriptions/aggregated-api-client-certificates.adoc#cert-types-aggregated-api-client-certificates[Aggregated API client certificates]
+* xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates]
+* xref:../security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.adoc#cert-types-user-provided-certificates-for-default-ingress[User-provided certificates for default ingress]
+* xref:../security/certificate_types_descriptions/ingress-certificates.adoc#cert-types-ingress-certificates[Ingress certificates]
+* xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and cluster logging Operator component certificates]
+* xref:../security/certificate_types_descriptions/control-plane-certificates.adoc#cert-types-control-plane-certificates[Control plane certificates]
+
+[id="encrypting-data_{context}"]
+== Encrypting data
+
+You can xref:../etcd/etcd-encrypt.adoc#etcd-encrypt[enable etcd encryption] for your cluster to provide an additional layer of data security. For example, it can help protect the loss of sensitive data if an etcd backup is exposed to the incorrect parties.
+
+[id="vulnerability-scanning_{context}"]
+== Vulnerability scanning
+
+Administrators can use the {rhq-cso} to run xref:../security/pod-vulnerability-scan.adoc#pod-vulnerability-scan[vulnerability scans] and review information about detected vulnerabilities.

--- a/security/index.adoc
+++ b/security/index.adoc
@@ -6,88 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// TODO: Need some help with an intro blurb
+[role="_abstract"]
+Review the security and compliance capabilities available in {product-title}, and learn how to secure your cluster.
 
-[id="security-overview"]
-== Security overview
+include::modules/security-overview-capabilities.adoc[leveloffset=+1]
 
-It is important to understand how to properly secure various aspects of your {product-title} cluster.
+include::modules/security-compliance-capabilities.adoc[leveloffset=+1]
 
-
-[id="container-security"]
-=== Container security
-
-A good starting point to understanding {product-title} security is to review the concepts in xref:../security/container_security/security-understanding.adoc#security-understanding[Understanding container security]. This and subsequent sections provide a high-level walkthrough of the container security measures available in {product-title}, including solutions for the host layer, the container and orchestration layer, and the build and application layer. These sections also include information on the following topics:
-
-* Why container security is important and how it compares with existing security standards.
-* Which container security measures are provided by the host ({op-system} and {op-system-base}) layer and
-which are provided by {product-title}.
-* How to evaluate your container content and sources for vulnerabilities.
-* How to design your build and deployment process to proactively check container content.
-* How to control access to containers through authentication and authorization.
-* How networking and attached storage are secured in {product-title}.
-* Containerized solutions for API management and SSO.
-
-
-[id="auditing"]
-=== Auditing
-
-{product-title} auditing provides a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system. Administrators can xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[configure the audit log policy] and xref:../security/audit-log-view.adoc#audit-log-view[view audit logs].
-
-
-[id="certificates"]
-=== Certificates
-
-Certificates are used by various components to validate access to the cluster. Administrators can xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[replace the default ingress certificate], xref:../security/certificates/api-server.adoc#api-server-certificates[add API server certificates], or xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[add a service certificate].
-
-You can also review more details about the types of certificates used by the cluster:
-
-// TODO: there isn't a cert description landing page. Consider adding one instead of all of these links?
-* xref:../security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc#cert-types-user-provided-certificates-for-the-api-server[User-provided certificates for the API server]
-* xref:../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-certificates[Proxy certificates]
-* xref:../security/certificate_types_descriptions/service-ca-certificates.adoc#cert-types-service-ca-certificates[Service CA certificates]
-* xref:../security/certificate_types_descriptions/node-certificates.adoc#cert-types-node-certificates[Node certificates]
-* xref:../security/certificate_types_descriptions/bootstrap-certificates.adoc#cert-types-bootstrap-certificates[Bootstrap certificates]
-* xref:../security/certificate_types_descriptions/etcd-certificates.adoc#cert-types-etcd-certificates[etcd certificates]
-* xref:../security/certificate_types_descriptions/olm-certificates.adoc#cert-types-olm-certificates[OLM certificates]
-* xref:../security/certificate_types_descriptions/aggregated-api-client-certificates.adoc#cert-types-aggregated-api-client-certificates[Aggregated API client certificates]
-* xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates]
-* xref:../security/certificate_types_descriptions/user-provided-certificates-for-default-ingress.adoc#cert-types-user-provided-certificates-for-default-ingress[User-provided certificates for default ingress]
-* xref:../security/certificate_types_descriptions/ingress-certificates.adoc#cert-types-ingress-certificates[Ingress certificates]
-* xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and cluster logging Operator component certificates]
-* xref:../security/certificate_types_descriptions/control-plane-certificates.adoc#cert-types-control-plane-certificates[Control plane certificates]
-
-
-[id="encrypting-data"]
-=== Encrypting data
-
-You can xref:../etcd/etcd-encrypt.adoc#etcd-encrypt[enable etcd encryption] for your cluster to provide an additional layer of data security. For example, it can help protect the loss of sensitive data if an etcd backup is exposed to the incorrect parties.
-
-
-[id="vulnerability-scanning"]
-=== Vulnerability scanning
-
-Administrators can use the {rhq-cso} to run xref:../security/pod-vulnerability-scan.adoc#pod-vulnerability-scan[vulnerability scans] and review information about detected vulnerabilities.
-
-[id="compliance-overview"]
-== Compliance overview
-
-For many {product-title} customers, regulatory readiness, or compliance, on some level is required before any systems can be put into production. That regulatory readiness can be imposed by national standards, industry standards, or the organization's corporate governance framework.
-
-
-[id="compliance-checking"]
-=== Compliance checking
-
-Administrators can use the xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance-operator[Compliance Operator] to run compliance scans and recommend remediations for any issues found. The xref:../security/compliance_operator/co-scans/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[`oc-compliance` plugin] is an OpenShift CLI (`oc`) plugin that provides a set of utilities to easily interact with the Compliance Operator.
-
-
-[id="file-integrity-checking"]
-=== File integrity checking
-
-Administrators can use the xref:../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[File Integrity Operator] to continually run file integrity checks on cluster nodes and provide a log of files that have been modified.
-
-[id="additional-resources_security-compliance-overview"]
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986)

Link to docs preview:
- https://115741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 4 PRs splitting [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.
