### PR TITLE
[OSDOCS#18986] CQA pre-migration for Compliance Operator overview navigation file

### DIFF
--- a/modules/co-overview-concepts.adoc
+++ b/modules/co-overview-concepts.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/co-overview.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="co-overview-operator-concepts_{context}"]
+= Compliance Operator concepts
+
+[role="_abstract"]
+Learn about the Compliance Operator and the custom resource definitions it uses.
+
+xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
+
+xref:../../security/compliance_operator/co-concepts/compliance-operator-crd.adoc#custom-resource-definitions[Understanding the Custom Resource Definitions]

--- a/modules/co-overview-management.adoc
+++ b/modules/co-overview-management.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/co-overview.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="co-overview-operator-mgmt_{context}"]
+= Compliance Operator management
+
+[role="_abstract"]
+You can install, update, manage, and uninstall the Compliance Operator on your cluster.
+
+xref:../../security/compliance_operator/co-management/compliance-operator-installation.adoc#compliance-operator-installation[Installing the Compliance Operator]
+
+xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#compliance-operator-updating[Updating the Compliance Operator]
+
+xref:../../security/compliance_operator/co-management/compliance-operator-manage.adoc#compliance-operator-understanding[Managing the Compliance Operator]
+
+xref:../../security/compliance_operator/co-management/compliance-operator-uninstallation.adoc#compliance-operator-uninstallation[Uninstalling the Compliance Operator]

--- a/modules/co-overview-scan-management.adoc
+++ b/modules/co-overview-scan-management.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/co-overview.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="co-overview-operator-scan-mgmt_{context}"]
+= Compliance Operator scan management
+
+[role="_abstract"]
+You can configure, run, tailor, and troubleshoot Compliance Operator scans, and retrieve and manage their results.
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]
+
+xref:../../security/compliance_operator/co-scans/compliance-scans.adoc#compliance-operator-scans[Compliance Operator scans]
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-tailor.adoc#compliance-operator-tailor[Tailoring the Compliance Operator]
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-raw-results.adoc#compliance-operator-raw-results[Retrieving Compliance Operator raw results]
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-remediation.adoc#compliance-operator-remediation[Managing Compliance Operator remediation]
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-advanced.adoc#compliance-operator-advanced[Performing advanced Compliance Operator tasks]
+
+xref:../../security/compliance_operator/co-scans/compliance-operator-troubleshooting.adoc#compliance-operator-troubleshooting[Troubleshooting the Compliance Operator]
+
+xref:../../security/compliance_operator/co-scans/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[Using the oc-compliance plugin]

--- a/security/compliance_operator/co-overview.adoc
+++ b/security/compliance_operator/co-overview.adoc
@@ -4,6 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: co-overview
 
+[role="_abstract"]
 The {product-title} Compliance Operator assists users by automating the
 inspection of numerous technical implementations and compares those against
 certain aspects of industry standards, benchmarks, and baselines; the
@@ -15,45 +16,19 @@ industry recognized regulatory authority to assess your environment.
 The Compliance Operator makes recommendations based on generally available
 information and practices regarding such standards and may assist with
 remediations, but actual compliance is your responsibility. You are required to
-work with an authorized auditor to achieve compliance with a standard. For the
-latest updates, see the
-xref:../../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance
-Operator release notes]. For more information on compliance support for all Red{nbsp}Hat products, see link:https://access.redhat.com/compliance[Product Compliance].
+work with an authorized auditor to achieve compliance with a standard. For more
+information on compliance support for all Red{nbsp}Hat products, see "Product
+Compliance".
 
-[id="co-overview-operator-concepts"]
-== Compliance Operator concepts
+include::modules/co-overview-concepts.adoc[leveloffset=+1]
 
-xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
+include::modules/co-overview-management.adoc[leveloffset=+1]
 
-xref:../../security/compliance_operator/co-concepts/compliance-operator-crd.adoc#custom-resource-definitions[Understanding the Custom Resource Definitions]
-//[new page] Quick start?
+include::modules/co-overview-scan-management.adoc[leveloffset=+1]
 
-[id="co-overview-operator-mgmt"]
-== Compliance Operator management
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-xref:../../security/compliance_operator/co-management/compliance-operator-installation.adoc#compliance-operator-installation[Installing the Compliance Operator]
-
-xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#compliance-operator-updating[Updating the Compliance Operator]
-
-xref:../../security/compliance_operator/co-management/compliance-operator-manage.adoc#compliance-operator-understanding[Managing the Compliance Operator]
-
-xref:../../security/compliance_operator/co-management/compliance-operator-uninstallation.adoc#compliance-operator-uninstallation[Uninstalling the Compliance Operator]
-
-[id="co-overview-operator-scan-mgmt"]
-== Compliance Operator scan management
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]
-
-xref:../../security/compliance_operator/co-scans/compliance-scans.adoc#compliance-operator-scans[Compliance Operator scans]
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-tailor.adoc#compliance-operator-tailor[Tailoring the Compliance Operator]
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-raw-results.adoc#compliance-operator-raw-results[Retrieving Compliance Operator raw results]
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-remediation.adoc#compliance-operator-remediation[Managing Compliance Operator remediation]
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-advanced.adoc#compliance-operator-advanced[Performing advanced Compliance Operator tasks]
-
-xref:../../security/compliance_operator/co-scans/compliance-operator-troubleshooting.adoc#compliance-operator-troubleshooting[Troubleshooting the Compliance Operator]
-
-xref:../../security/compliance_operator/co-scans/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[Using the oc-compliance plugin]
+* xref:../../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator release notes]
+* link:https://access.redhat.com/compliance[Product Compliance]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986)

Link to docs preview:
- https://115742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-overview.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 4 PRs splitting [OSDOCS-18986](https://redhat.atlassian.net/browse/OSDOCS-18986) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.
