### PR TITLE
OCPBUGS-90094: vtysh moved to openshift-frrk8s pods in OCP 4.20+

### DIFF
--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -147,10 +147,10 @@ spec:
     spec:
       containers:
       - name: server
-        image: nginx
+        image: registry.access.redhat.com/ubi9/httpd-24
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -162,7 +162,7 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: server
   type: LoadBalancer
@@ -178,32 +178,32 @@ $ oc apply -f deploy-service.yaml
 
 .Verification
 
-. Identify a MetalLB speaker pod by running the following command:
+. Identify a `frr-k8s` pod by running the following command:
 +
 [source,terminal]
 ----
-$ oc get -n metallb-system pods -l component=speaker
+$ oc get -n openshift-frr-k8s pods -l app=frr-k8s
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME            READY   STATUS    RESTARTS   AGE
-speaker-c6c5f   6/6     Running   0          69m
+frr-k8s-abcde   7/7     Running   0          69m
 ----
 
-. Verify that the state of the BGP session is `Established` in the speaker pod by running the following command, replacing the variables to match your configuration:
+. Verify that the state of the BGP session is `Established` in the `frr-k8s` pod by running the following command, replacing the variables to match your configuration:
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system <speaker_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> neigh"
+$ oc exec -n openshift-frr-k8s <frr_k8s_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> neigh"
 ----
 +
 .Example output
 [source,terminal]
 ----
-BGP neighbor is 192.168.30.1, remote AS 200, local AS 100, external link
-  BGP version 4, remote router ID 192.168.30.1, local router ID 192.168.30.71
+BGP neighbor is 192.168.130.1, remote AS 200, local AS 100, external link
+  BGP version 4, remote router ID 192.168.130.1, local router ID 192.168.130.71
   BGP state = Established, up for 04:20:09
 
 ...
@@ -213,5 +213,5 @@ BGP neighbor is 192.168.30.1, remote AS 200, local AS 100, external link
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system <speaker_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> ipv4"
+$ oc exec -n openshift-frr-k8s <frr_k8s_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> ipv4"
 ----


### PR DESCRIPTION
## Summary

Backport of https://github.com/openshift/openshift-docs/pull/114119 to enterprise-4.20.

Updates MetalLB BGP peer configuration procedure to reflect FRR architecture change where `vtysh` moved to `openshift-frrk8s` pods in OCP 4.20+.

## Files

1 file included, 0 files excluded.

- `modules/nw-metallb-configure-vrf-bgppeer.adoc`

## Test plan

- [ ] Preview renders correctly
- [ ] No broken includes or cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)