### PR TITLE
OSDOCS-17043_a_420#CQA BM only

### DIFF
--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -19,6 +19,8 @@ endif::[]
 ifdef::aws[= Machine sets that deploy machines as Spot Instances]
 ifdef::azure[= Machine sets that deploy machines as Spot VMs]
 ifdef::gcp[= Machine sets that deploy machines as preemptible VM instances]
+
+[role="_abstract"]
 ifdef::aws[]
 You can save on costs by creating a compute machine set running on {aws-first} that deploys machines as non-guaranteed Spot Instances. Spot Instances utilize unused {aws-short} EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::aws[]

--- a/modules/machineset-osp-adding-bare-metal.adoc
+++ b/modules/machineset-osp-adding-bare-metal.adoc
@@ -5,10 +5,10 @@
 // TODO
 // Mothballed
 // Reintroduce when feature is available.
-You can add bare-metal compute machines to an {product-title} cluster after you deploy it
-on {rh-openstack-first}. In this configuration, all machines are attached to an
-existing, installer-provisioned network, and traffic between control plane and
-compute machines is routed between subnets.
+[role="_abstract"]
+You can provision bare-metal hosts in your {rh-openstack-first} environment as compute machines to provide dedicated physical resources alongside virtual machine nodes.
+
+In this configuration, all machines are attached to an existing,installer-provisioned network, and traffic between control plane and compute machines is routed between subnets.
 
 .Prerequisites
 
@@ -18,14 +18,12 @@ compute machines is routed between subnets.
 
 * You deployed an {product-title} cluster on installer-provisioned infrastructure.
 
-* Your {rh-openstack} cloud provider is configured to route traffic between the installer-created VM
-subnet and the pre-existing bare metal subnet.
+* Your {rh-openstack} cloud provider is configured to route traffic between the installation program-created VM subnet and the pre-existing bare metal subnet.
 
 .Procedure
 . Create a file called `baremetalMachineSet.yaml`, and then add the bare metal flavor to it:
 +
 FIXME: May require update before publication.
-.A sample bare metal MachineSet file
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -86,5 +84,3 @@ spec:
 ----
 $ oc create -v baremetalMachineSet.yaml
 ----
-
-You can now use bare-metal compute machines in your {product-title} cluster.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.20 only

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17043

Link to docs preview:
[Machine sets that deploy machines as Spot Instances](https://115755--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-non-guaranteed-instance_creating-machineset-aws)



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
`modules/machineset-osp-adding-bare-metal.adoc` ('Adding bare-metal compute machines to an OpenStack cluster ') is commented out in two assemblies, so it's not displaying in the  preview. But the module might be reintroduced when the feature is available. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
