### PR TITLE
OCPBUGS-92192: Fix incorrect must-gather image for NUMA Resources Operator

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -70,7 +70,7 @@ Use this image if your NHC Operator version is *0.9.0. or later*.
 
 For more information, see the "Gathering data" section for the specific Operator in https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/latest/html/remediation_fencing_and_maintenance/index[Remediation, fencing, and maintenance] (Workload Availability for Red Hat OpenShift documentation).
 
-|`registry.redhat.io/numaresources/numaresources-must-gather-rhel9:v<installed-version-nro>`
+|`registry.redhat.io/openshift4/numaresources-must-gather-rhel9:v<installed-version-nro>`
 |Data collection for the NUMA Resources Operator (NRO).
 
 |`registry.redhat.io/openshift4/ptp-must-gather-rhel8:v<installed-version-ptp>`


### PR DESCRIPTION
## Version: 4.20+

## Summary
- Fixed the must-gather image path for the NUMA Resources Operator from `registry.redhat.io/numaresources/numaresources-must-gather-rhel9` to `registry.redhat.io/openshift4/numaresources-must-gather-rhel9`

## Test plan
- [ ] Verify the corrected image path matches the actual registry location for the NRO must-gather image

Bug: https://issues.redhat.com/browse/OCPBUGS-92192

🤖 Generated with [Claude Code](https://claude.com/claude-code)