### PR TITLE
CNV-93077: Documentation missing Jira link

### DIFF
--- a/modules/virt-feedback-on-openshift-virtualization.adoc
+++ b/modules/virt-feedback-on-openshift-virtualization.adoc
@@ -11,7 +11,7 @@ To report an error or request an enhancement in the documentation, log in to you
 
 .Procedure
 
-. Create a Jira issue for {VirtProductName} and in the *Component* field, select *CNV Documentation*.
+. Create a link:https://redhat.atlassian.net/secure/CreateIssueDetails!init.jspa?priority=1003&summary=%5BDoc%5D&pid=10270&issuetype=10016&components=13563[Jira issue] and in the *Component* field, select *CNV Documentation*.
 . Enter a brief description of the issue in the *Summary*.
 . Provide a detailed description of the issue or requested enhancement in the *Description*. Include a URL to where the issue occurs in the documentation.
 . Click *Create*.

--- a/virt/support/virt-support-overview.adoc
+++ b/virt/support/virt-support-overview.adoc
@@ -4,7 +4,6 @@ include::_attributes/common-attributes.adoc[]
 = Support overview
 :context: virt-support-overview
 
-
 toc::[]
 
 [role="_abstract"]
@@ -32,5 +31,4 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Using the `must-gather` tool for {VirtProductName}]
 * link:https://access.redhat.com/labs/rhir/?product=cnv[Red{nbsp}Hat Issue Router]
 * link:https://redhat.atlassian.net/jira[Red{nbsp}Hat Jira account]
-* link:https://redhat.atlassian.net/secure/CreateIssueDetails!init.jspa?priority=1003&summary=%5BDoc%5D&pid=10270&issuetype=10016&components=13563[Jira issue tracker for {VirtProductName}]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
v4.20, v4.21, v4.22 + main for 5.0.

Issue:
https://redhat.atlassian.net/browse/CNV-93077

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
No QE & Peer review required


