### PR TITLE
TELCODOCS-2762: Fix DITA TaskStep error in preparing-ocp-images module

### DIFF
--- a/modules/ztp-precaching-preparing-ocp-images.adoc
+++ b/modules/ztp-precaching-preparing-ocp-images.adoc
@@ -65,7 +65,7 @@ $ cp config.json /root/.docker/config.json
 ----
 +
 `/root/.docker/config.json` is the default path where `podman` checks for the login credentials for the registry.
-
++
 [NOTE]
 ====
 If you use a different registry to pull the required artifacts, you need to copy the proper pull secret.


### PR DESCRIPTION
Follow-up fix for PR #115642.

Attaches the NOTE block to the last procedure step with a `+` connector to resolve the `AsciiDocDITA.TaskStep` Vale error.

**Error:** Content other than a single list cannot be mapped to DITA steps.

Made with [Cursor](https://cursor.com)