### PR TITLE
OSDOCS-20752: Add 4.22.6 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-6.adoc
+++ b/modules/zstream-4-22-6.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-6_{context}"]
+= RHSA-2026:40768 - {product-title} {product-version}.6 bug fix and security update
+
+Issued: 21 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.6 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40768[RHSA-2026:40768] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40763[RHBA-2026:40763] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.6 --pullspecs
+----
+
+[id="zstream-4-22-6-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, vSphere Container Storage Interface (CSI) volume provisioning could fail when new ESXi hosts in maintenance mode lacked datastore access. With this release, volume provisioning skips ESXi hosts that are in maintenance mode, and the CSI driver is updated to version 3.6.2. As a result, volume provisioning succeeds when hosts are in maintenance mode. (link:https://redhat.atlassian.net/browse/OCPBUGS-92190[OCPBUGS-92190])
+
+* Before this update, when you navigated to *Compute* -> *Nodes* -> *[node]* -> *Terminal* in the {product-title} web console, the component checked for the debug pod while the pod was still being created. As a consequence, a `Debug pod not found or was deleted.` error briefly flashed before the terminal loaded successfully. With this release, a loading spinner is shown while the debug pod is being created, and the cleanup logic guards against an undefined namespace to prevent errors on early unmount. As a result, the node *Terminal* tab loads without displaying a false error message. (link:https://redhat.atlassian.net/browse/OCPBUGS-95580[OCPBUGS-95580])
+
+* Before this update, the Cluster Ingress Operator migrated Gateway API from Operator Life Management (OLM) to the Sail Library. As a consequence, the subscription persisted with the `ingress.operator.openshift.io/owned` annotation and {SMProductName} users did not know whether to retain or delete these subscriptions. With this release, an `OrphanedOSSMSubscription` Prometheus alert, gauge metric, and `ClusterOperator` status condition identify these orphaned {SMProductShortName} subscriptions and provide remediation guidance. As a result, the metric resets after the annotation is removed. (link:https://redhat.atlassian.net/browse/OCPBUGS-97563[OCPBUGS-97563])
+
+* Before this update, the oc-mirror plugin failed to find signatures for multi-architecture {product-title} payloads. As a consequence, the mirror-to-disk process failed when writing the `tar` archive file. With this release, oc-mirror correctly handles multi-architecture {product-title} payloads that have unsigned manifest lists. As a result, mirror-to-disk operations complete successfully for multi-architecture payloads. (link:https://redhat.atlassian.net/browse/OCPBUGS-97946[OCPBUGS-97946])
+
+[id="zstream-4-22-6-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.6 RNs and updating
+include::modules/zstream-4-22-6.adoc[leveloffset=+2]
+
 // 4.22.5 RNs and updating
 include::modules/zstream-4-22-5.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20752

Link to docs preview:
https://115871--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-6_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/654
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
- Errata: RHSA-2026:40768 / RHBA-2026:40763 (from shipment YAML live_id; not yet published on access.redhat.com — Issued date is a placeholder)
- Ship date (MR): 2026-Jul-21

Made with [Cursor](https://cursor.com)