### PR TITLE
OBSDOCS-2747: Reapply syslog receiver verification fix for 6.6

### DIFF
--- a/modules/configuring-the-collector-to-listen-for-connections-as-a-syslog-server.adoc
+++ b/modules/configuring-the-collector-to-listen-for-connections-as-a-syslog-server.adoc
@@ -108,32 +108,11 @@ In this example output, the service name is `collector-syslog-receiver`.
 
 .Verification
 
-. Extract the certificate authority (CA) certificate file by running the following command:
+. Send a test syslog message using the `logger` command by running the following command:
 +
 [source,terminal]
 ----
-$ oc extract cm/openshift-service-ca.crt -n <namespace>
+$ logger --tcp --server collector-syslog-receiver.<namespace>.svc --port 10514 “test message”
 ----
 +
-[NOTE]
-====
-If the CA in the cluster where the collectors are running changes, you must extract the CA certificate file again.
-====
-
-. As an example, use the `curl` command to send logs by running the following command:
-+
-[source,terminal]
-----
-$ curl --cacert <openshift_service_ca.crt> collector-syslog-receiver.<namespace>.svc:10514  “test message”
-----
-+
-Replace <openshift_service_ca.crt> with the extracted CA certificate file.
-
-////
-. As an example, send logs by running the following command:
-+
-[source,terminal]
-----
-$ logger --tcp --server  collector-syslog-receiver.<ns>.svc:10514  “test message”
-----
-////
+Replace `<namespace>` with the namespace where the collector service is running.


### PR DESCRIPTION
## Summary

Reapply the syslog receiver verification fix that was inadvertently reverted by PR #114845 ([OBSDOCS-1639](https://redhat.atlassian.net/browse/OBSDOCS-1639)).

**Problem:** PR #114845 merged on July 8th and reverted the [OBSDOCS-2747](https://redhat.atlassian.net/browse/OBSDOCS-2747) fix that was merged on July 6th. The original fix replaced the incorrect `curl` verification method with the proper `logger` command.

**Changes:**
- Removed curl-based verification including CA certificate extraction
- Replaced with proper `logger` command that uses the syslog protocol
- Simplified verification to a single step with the correct tool

**Why this matters:** The `curl` command sends HTTP requests, not syslog messages, so it cannot properly test a syslog receiver. The `logger` command uses the syslog protocol and is the correct tool.

**Status on other versions:**
- ✅ 6.3: Fixed via PR #114612 (still correct)
- ✅ 6.4: Fixed via PR #114613 (still correct)
- ✅ 6.5: Fixed via PR #114614 (still correct)
- ❌ 6.6: Was fixed via PR #114615, but reverted by PR #114845 (this PR fixes it again)

**JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-2747

Signed-off-by: John Wilkins <jowilkin@redhat.com>