### PR TITLE
OBSDOCS-3619: Add Logging 6.2.12 z-stream release notes

### DIFF
--- a/modules/logging-release-notes-6-2-12.adoc
+++ b/modules/logging-release-notes-6-2-12.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-12_{context}"]
+= Logging 6.2.12 Release Notes
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:47952[RHSA-2026:47952].
+
+[id="logging-release-notes-6-2-12-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, Vector did not emit component metadata labels (`component_id`, `component_kind`, `component_type`) for the `vector_component_sent_bytes_total` metric when forwarding logs to AWS CloudWatch. This caused some CloudWatch outputs to be missing from the "Log send rate" dashboard, which filters by `component_kind="sink"`. With this update, Vector correctly emits these metadata labels for all CloudWatch outputs, ensuring all collectors appear in the dashboard.
+(https://redhat.atlassian.net/browse/LOG-7893[LOG-7893])
+
+* Before this update, the {clo} hard-coded `terminationGracePeriodSeconds: 10` for collector (Vector) pods. In environments with high log volume and `deliveryMode: AtLeastOnce` enabled, Vector uses a disk buffer to ensure data persistence. During shutdown (SIGTERM), Vector must flush in-memory events to the disk buffer and close connections to remote sinks. Because 10 seconds was insufficient for these operations under load, Kubernetes sent a SIGKILL while a write operation was in progress. This resulted in a corrupted disk buffer, causing the pod to fail its next startup with `InvalidProtobufPayload` errors. With this update, the collector pod receives enough grace period to complete its flush and shut down gracefully without corrupting the on-disk state.
+(https://redhat.atlassian.net/browse/LOG-9636[LOG-9636])
+
+* Before this update, the {clo} did not watch for changes to TLS CA certificates referenced in `ClusterLogForwarder` output configurations. When a ConfigMap referenced by `.spec.outputs.tls.ca.configMapName` was updated, collector pods continued using the old certificate until manually restarted. With this update, the operator watches the referenced ConfigMap and automatically restarts collector pods when the CA certificate changes.
+(https://redhat.atlassian.net/browse/LOG-9685[LOG-9685])
+
+[id="logging-release-notes-6-2-12-deprecated-functionality_{context}"]
+== Deprecated functionality
+
+* The Azure Monitor Logs output type is deprecated. Microsoft has announced that the Azure Monitor Logs Ingestion API will be discontinued. Administrators must migrate to the Azure Log Ingest API. For migration guidance, see the link:https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/migration-guide[Microsoft Azure Monitor migration documentation].
+(https://redhat.atlassian.net/browse/LOG-9193[LOG-9193])
+
+[id="logging-release-notes-6-2-12-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25681[CVE-2026-25681]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-27136[CVE-2026-27136]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32280[CVE-2026-32280]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32281[CVE-2026-32281]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32282[CVE-2026-32282]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33810[CVE-2026-33810]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33811[CVE-2026-33811]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-34986[CVE-2026-34986]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39820[CVE-2026-39820]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39821[CVE-2026-39821]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42151[CVE-2026-42151]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42154[CVE-2026-42154]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42504[CVE-2026-42504]

--- a/release_notes/logging-release-notes-6.2.adoc
+++ b/release_notes/logging-release-notes-6.2.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 The following release notes describe the updates in {LoggingProductName} 6.2. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-2-12.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-11.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-2-10.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Adds release notes for OpenShift Logging 6.2.12 z-stream release
- Includes 1 bug fix and 5 CVEs
- Uses errata placeholder pending actual errata number
- Preview: https://115879--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.2.html#logging-release-notes-6-2-12_loggging-release-notes-6-2

## Changes
- Created `modules/logging-release-notes-6-2-12.adoc` with bug fix and CVE sections
- Updated `release_notes/logging-release-notes-6.2.adoc` to include new module

## Fixed Issues
- [LOG-9636](https://redhat.atlassian.net/browse/LOG-9636): Vector terminationGracePeriodSeconds hardcoded to 10s causes SIGKILL and disk buffer corruption

## CVEs Included
- CVE-2026-25681: golang.org/x/net/html: Arbitrary code execution via Cross-Site Scripting
- CVE-2026-32281: Go crypto/x509: Denial of Service via inefficient certificate chain validation
- CVE-2026-32282: Root.Chmod can follow symlinks out of the root
- CVE-2026-34986: Go JOSE: Denial of Service via crafted JSON Web Encryption (JWE) object
- CVE-2026-39821: golang.org/x/net/idna: Privilege escalation via incorrect Punycode label processing

## Follow-up
Errata number placeholder (`RHSA-YYYY:NNNNN`) will need to be updated once the actual errata is available.

**JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3619

Signed-off-by: John Wilkins <jowilkin@redhat.com>