### PR TITLE
OSDOCS-17172-service-ca-certs CQA

### DIFF
--- a/security/certificate_types_descriptions/service-ca-certificates.adoc
+++ b/security/certificate_types_descriptions/service-ca-certificates.adoc
@@ -6,21 +6,26 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Review service certificate authority (CA) certificate rotation, expiration, and Operator-managed signing in {product-title} to plan maintenance for internal service serving certificates.
+
+[id="cert-types-service-ca-certificates-purpose_{context}"]
 == Purpose
 
 `service-ca` is an Operator that creates a self-signed CA when an {product-title} cluster is deployed.
 
+[id="cert-types-service-ca-certificates-expiration_{context}"]
 == Expiration
 
-A custom expiration term is not supported. The self-signed CA is stored in a secret with qualified name `service-ca/signing-key` in fields `tls.crt` (certificate(s)), `tls.key` (private key), and `ca-bundle.crt` (CA bundle).
+A custom expiration term is not supported. The self-signed CA is stored in the `service-ca/signing-key` secret. The certificate is in `tls.crt`, the private key is in `tls.key`, and the CA bundle is in `ca-bundle.crt`.
 
-Other services can request a service serving certificate by annotating a service resource with `service.beta.openshift.io/serving-cert-secret-name: <secret name>`. In response, the Operator generates a new certificate, as `tls.crt`, and private key, as `tls.key` to the named secret. The certificate is valid for two years.
+Other services can request a service serving certificate by annotating a service resource with `service.beta.openshift.io/serving-cert-secret-name: <secret name>`. In response, the Operator generates a new certificate as `tls.crt`, and a private key as `tls.key`, in the named secret. The certificate is valid for two years.
 
-Other services can request that the CA bundle for the service CA be injected into API service or config map resources by annotating with `service.beta.openshift.io/inject-cabundle: true` to support validating certificates generated from the service CA. In response, the Operator writes its current CA bundle to the `CABundle` field of an API service or as `service-ca.crt` to a config map.
+Other services can request that the CA bundle for the service CA be injected into API service or config map resources by annotating with `service.beta.openshift.io/inject-cabundle: true` to support validating certificates generated from the service CA. In response, the Operator writes the current CA bundle to the `CABundle` field of an API service or as `service-ca.crt` to a config map.
 
 As of {product-title} 4.3.5, automated rotation is supported and is backported to some 4.2.z and 4.3.z releases. For any release supporting automated rotation, the service CA is valid for 26 months and is automatically refreshed when there is less than 13 months validity left. If necessary, you can manually refresh the service CA.
 
-The service CA expiration of 26 months is longer than the expected upgrade interval for a supported {product-title} cluster, such that non-control plane consumers of service CA certificates will be refreshed after CA rotation and prior to the expiration of the pre-rotation CA.
+The 26-month service CA validity period is longer than the expected upgrade interval for a supported {product-title} cluster. Non-control plane consumers of service CA certificates are refreshed after CA rotation and before the expiration of the pre-rotation CA.
 
 [WARNING]
 ====
@@ -29,35 +34,37 @@ A manually-rotated service CA does not maintain trust with the previous service 
 
 [IMPORTANT]
 ====
-Applications using the `service-ca` certificate must be capable of dynamically reloading CA certificates. Otherwise, when automated rotation occurs, the application pods might require a restart in order to rebuild certificate trust.
+Applications using the `service-ca` certificate must be capable of dynamically reloading CA certificates. When automated rotation occurs, pods that cannot reload CA certificates dynamically might require a restart to rebuild certificate trust.
 ====
 
+[id="cert-types-service-ca-certificates-management_{context}"]
 == Management
 
 These certificates are managed by the system and not the user.
 
+[id="cert-types-service-ca-certificates-services_{context}"]
 == Services
 
 Services that use service CA certificates include:
 
-* cluster-autoscaler-operator
-* cluster-monitoring-operator
-* cluster-authentication-operator
-* cluster-image-registry-operator
-* cluster-ingress-operator
-* cluster-kube-apiserver-operator
-* cluster-kube-controller-manager-operator
-* cluster-kube-scheduler-operator
-* cluster-networking-operator
-* cluster-openshift-apiserver-operator
-* cluster-openshift-controller-manager-operator
-* cluster-samples-operator
-* cluster-storage-operator
-* machine-config-operator
-* console-operator
-* insights-operator
-* machine-api-operator
-* operator-lifecycle-manager
+* `cluster-autoscaler-operator`
+* `cluster-monitoring-operator`
+* `cluster-authentication-operator`
+* `cluster-image-registry-operator`
+* `cluster-ingress-operator`
+* `cluster-kube-apiserver-operator`
+* `cluster-kube-controller-manager-operator`
+* `cluster-kube-scheduler-operator`
+* `cluster-networking-operator`
+* `cluster-openshift-apiserver-operator`
+* `cluster-openshift-controller-manager-operator`
+* `cluster-samples-operator`
+* `cluster-storage-operator`
+* `machine-config-operator`
+* `console-operator`
+* `insights-operator`
+* `machine-api-operator`
+* `operator-lifecycle-manager`
 * CSI driver operators
 
 This is not a comprehensive list.
@@ -66,5 +73,5 @@ This is not a comprehensive list.
 [role="_additional-resources"]
 == Additional resources
 
-* xref:../../security/certificates/service-serving-certificate.adoc#add-service-serving[Manually rotate service serving certificates]
+* xref:../../security/certificates/service-serving-certificate.adoc#manually-rotate-service-ca_service-serving-certificate[Manually rotate the service CA certificate]
 * xref:../../security/certificates/service-serving-certificate.adoc#add-service-serving[Securing service traffic using service serving certificate secrets]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://115881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/service-ca-certificates.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
