### PR TITLE
OSDOCS-17172-user-provided-certs-api-server CQA

### DIFF
--- a/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
+++ b/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
@@ -6,24 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Review user-provided TLS certificates for the API server in {product-title} to understand their purpose, location, management, and expiration for external client access.
+
+[id="user-provided-certificates-for-api-server-purpose_{context}"]
 == Purpose
 
 The API server is accessible by clients external to the cluster at `api.<cluster_name>.<base_domain>`. You might want clients to access the API server at a different hostname or without the need to distribute the cluster-managed certificate authority (CA) certificates to the clients. The administrator must set a custom default certificate to be used by the API server when serving content.
 
+[id="user-provided-certificates-for-api-server-location_{context}"]
 == Location
 
 The user-provided certificates must be provided in a `kubernetes.io/tls` type `Secret` in the `openshift-config` namespace. Update the API server cluster configuration, the `apiserver/cluster` resource, to enable the use of the user-provided certificate.
 
+[id="user-provided-certificates-for-api-server-management_{context}"]
 == Management
 
 User-provided certificates are managed by the user.
 
+[id="user-provided-certificates-for-api-server-expiration_{context}"]
 == Expiration
 
 API server client certificate expiration is less than five minutes.
 
-User-provided certificates are managed by the user.
-
+[id="user-provided-certificates-for-api-server-customization_{context}"]
 == Customization
 
 Update the secret containing the user-managed certificate as needed.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://115883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/user-provided-certificates-for-api-server.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
