### PR TITLE
OSDOCS-17171-3:CQA 2.0-Security-Certificates-Attachment4

### DIFF
--- a/modules/customize-certificates-add-service-serving-apiservice.adoc
+++ b/modules/customize-certificates-add-service-serving-apiservice.adoc
@@ -6,7 +6,8 @@
 [id="add-service-certificate-apiservice_{context}"]
 = Add the service CA bundle to an API service
 
-You can annotate an `APIService` object with `service.beta.openshift.io/inject-cabundle=true` to have its `spec.caBundle` field populated with the service CA bundle. This allows the Kubernetes API server to validate the service CA certificate used to secure the targeted endpoint.
+[role="_abstract"]
+To allow the Kubernetes API server in {product-title} to validate the service Certificate Authority (CA) certificate that secures an API service endpoint, you can annotate an `APIService` object to inject the service CA bundle into the `spec.caBundle` field.
 
 .Procedure
 
@@ -14,10 +15,11 @@ You can annotate an `APIService` object with `service.beta.openshift.io/inject-c
 +
 [source,terminal]
 ----
-$ oc annotate apiservice <api_service_name> \//<1>
+$ oc annotate apiservice <api_service_name> \
      service.beta.openshift.io/inject-cabundle=true
 ----
-<1> Replace `<api_service_name>` with the name of the API service to annotate.
++
+* Replace `<api_service_name>` with the name of the API service to annotate.
 +
 For example, use the following command to annotate the API service `test1`:
 +

--- a/modules/customize-certificates-add-service-serving-configmap.adoc
+++ b/modules/customize-certificates-add-service-serving-configmap.adoc
@@ -6,7 +6,8 @@
 [id="add-service-certificate-configmap_{context}"]
 = Add the service CA bundle to a config map
 
-A pod can access the service Certificate Authority (CA) certificate by mounting a `ConfigMap` object that has the `service.beta.openshift.io/inject-cabundle=true` annotation. After annotating the config map, the cluster automatically injects the service CA certificate into the `service-ca.crt` key on the config map. Access to this CA certificate allows TLS clients to verify connections to services by using service serving certificates.
+[role="_abstract"]
+To verify TLS connections to services that use serving certificates in {product-title}, you can inject the service Certificate Authority (CA) certificate into a config map. Annotate the config map so that pods can mount the CA bundle from the `service-ca.crt` key.
 
 [IMPORTANT]
 ====
@@ -19,10 +20,11 @@ After adding this annotation to a config map, the OpenShift Service CA Operator 
 +
 [source,terminal]
 ----
-$ oc annotate configmap <config_map_name> \//<1>
+$ oc annotate configmap <config_map_name> \
      service.beta.openshift.io/inject-cabundle=true
 ----
-<1> Replace `<config_map_name>` with the name of the config map to annotate.
++
+* Replace `<config_map_name>` with the name of the config map to annotate.
 +
 [NOTE]
 ====
@@ -70,13 +72,18 @@ spec:
       volumes:
       - name: trusted-ca
         configMap:
-          name: <config_map_name> <1>
+          name: <config_map_name>
           items:
-            - key: ca-bundle.crt <2>
-              path: tls-ca-bundle.pem <3>
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
 # ...
 ----
-<1> Specify the name of the config map that you annotated in an earlier step of the procedure.
-<2> `ca-bundle.crt` is required as the ConfigMap key.
-<3> `tls-ca-bundle.pem` is required as the ConfigMap path.
++
+where:
++
+--
+`<config_map_name>`:: Specifies the name of the config map that you annotated in an earlier step of the procedure.
+ca-bundle.crt:: Specifies the `ConfigMap` key. This is required.
+tls-ca-bundle.pem:: Specifies the `ConfigMap` path. This is required.
+--
 

--- a/modules/customize-certificates-add-service-serving-crd.adoc
+++ b/modules/customize-certificates-add-service-serving-crd.adoc
@@ -6,7 +6,8 @@
 [id="add-service-certificate-crd_{context}"]
 = Add the service CA bundle to a custom resource definition
 
-You can annotate a `CustomResourceDefinition` (CRD) object with `service.beta.openshift.io/inject-cabundle=true` to have its `spec.conversion.webhook.clientConfig.caBundle` field populated with the service CA bundle. This allows the Kubernetes API server to validate the service CA certificate used to secure the targeted endpoint.
+[role="_abstract"]
+You can annotate a `CustomResourceDefinition` (CRD) object with `service.beta.openshift.io/inject-cabundle=true` to have its `spec.conversion.webhook.clientConfig.caBundle` field populated with the service Certificate Authority (CA) bundle. This allows the Kubernetes API server to validate the service CA certificate used to secure the targeted endpoint.
 
 [NOTE]
 ====
@@ -19,10 +20,11 @@ The service CA bundle will only be injected into the CRD if the CRD is configure
 +
 [source,terminal]
 ----
-$ oc annotate crd <crd_name> \//<1>
+$ oc annotate crd <crd_name> \
      service.beta.openshift.io/inject-cabundle=true
 ----
-<1> Replace `<crd_name>` with the name of the CRD to annotate.
++
+* Replace `<crd_name>` with the name of the CRD to annotate.
 +
 For example, use the following command to annotate the CRD `test1`:
 +

--- a/modules/customize-certificates-add-service-serving-mutating-webhook.adoc
+++ b/modules/customize-certificates-add-service-serving-mutating-webhook.adoc
@@ -6,7 +6,8 @@
 [id="add-service-certificate-mutating-webhook_{context}"]
 = Add the service CA bundle to a mutating webhook configuration
 
-You can annotate a `MutatingWebhookConfiguration` object with `service.beta.openshift.io/inject-cabundle=true` to have the `clientConfig.caBundle` field of each webhook populated with the service CA bundle. This allows the Kubernetes API server to validate the service CA certificate used to secure the targeted endpoint.
+[role="_abstract"]
+To allow the Kubernetes API server in {product-title} to validate the service Certificate Authority (CA) certificate that secures a mutating webhook endpoint, you can annotate a `MutatingWebhookConfiguration` object to inject the service CA bundle into each webhook `clientConfig.caBundle` field.
 
 [NOTE]
 ====
@@ -19,10 +20,11 @@ Do not set this annotation for admission webhook configurations that need to spe
 +
 [source,terminal]
 ----
-$ oc annotate mutatingwebhookconfigurations <mutating_webhook_name> \//<1>
+$ oc annotate mutatingwebhookconfigurations <mutating_webhook_name> \
      service.beta.openshift.io/inject-cabundle=true
 ----
-<1> Replace `<mutating_webhook_name>` with the name of the mutating webhook configuration to annotate.
++
+* Replace `<mutating_webhook_name>` with the name of the mutating webhook configuration to annotate.
 +
 For example, use the following command to annotate the mutating webhook configuration `test1`:
 +

--- a/modules/customize-certificates-add-service-serving-validating-webhook.adoc
+++ b/modules/customize-certificates-add-service-serving-validating-webhook.adoc
@@ -6,7 +6,8 @@
 [id="add-service-certificate-validating-webhook_{context}"]
 = Add the service CA bundle to a validating webhook configuration
 
-You can annotate a `ValidatingWebhookConfiguration` object with `service.beta.openshift.io/inject-cabundle=true` to have the `clientConfig.caBundle` field of each webhook populated with the service CA bundle. This allows the Kubernetes API server to validate the service CA certificate used to secure the targeted endpoint.
+[role="_abstract"]
+To allow the Kubernetes API server in {product-title} to validate the service Certificate Authority (CA) certificate that secures a validating webhook endpoint, you can annotate a `ValidatingWebhookConfiguration` object to inject the service CA bundle into each webhook `clientConfig.caBundle` field.
 
 [NOTE]
 ====
@@ -19,10 +20,11 @@ Do not set this annotation for admission webhook configurations that need to spe
 +
 [source,terminal]
 ----
-$ oc annotate validatingwebhookconfigurations <validating_webhook_name> \//<1>
+$ oc annotate validatingwebhookconfigurations <validating_webhook_name> \
      service.beta.openshift.io/inject-cabundle=true
 ----
-<1> Replace `<validating_webhook_name>` with the name of the validating webhook configuration to annotate.
++
+* Replace `<validating_webhook_name>` with the name of the validating webhook configuration to annotate.
 +
 For example, use the following command to annotate the validating webhook configuration `test1`:
 +

--- a/modules/customize-certificates-add-service-serving.adoc
+++ b/modules/customize-certificates-add-service-serving.adoc
@@ -6,13 +6,14 @@
 [id="add-service-certificate_{context}"]
 = Add a service certificate
 
-To secure communication to your service, generate a signed serving certificate and key pair into a secret in the same namespace as the service.
+[role="_abstract"]
+To secure internal communication to a service in {product-title}, you can annotate the service to generate a signed serving certificate and key pair into a secret in the same namespace.
 
 The generated certificate is only valid for the internal service DNS name `<service.name>.<service.namespace>.svc`, and is only valid for internal communications. If your service is a headless service (no `clusterIP` value set), the generated certificate also contains a wildcard subject in the format of `*.<service.name>.<service.namespace>.svc`.
 
 [IMPORTANT]
 ====
-Because the generated certificates contain wildcard subjects for headless services, you must not use the service CA if your client must differentiate between individual pods. In this case:
+Because the generated certificates contain wildcard subjects for headless services, you must not use the service Certificate Authority (CA) if your client must differentiate between individual pods. In this case:
 
 * Generate individual TLS certificates by using a different CA.
 * Do not accept the service CA as a trusted CA for connections that are directed to individual pods and must not be impersonated by other pods. These connections must be configured to trust the CA that was used to generate the individual TLS certificates.
@@ -28,19 +29,17 @@ Because the generated certificates contain wildcard subjects for headless servic
 +
 [source,terminal]
 ----
-$ oc annotate service <service_name> \//<1>
-     service.beta.openshift.io/serving-cert-secret-name=<secret_name> //<2>
+$ oc annotate service <service_name> \
+     service.beta.openshift.io/serving-cert-secret-name=<secret_name>
 ----
 +
---
-<1> Replace `<service_name>` with the name of the service to secure.
-<2> `<secret_name>` will be the name of the generated secret containing the certificate and key pair.
+* Replace `<service_name>` with the name of the service to secure.
+* `<secret_name>` will be the name of the generated secret containing the certificate and key pair.
 +
 [NOTE]
 ====
 For convenience, it is recommended that this value be the same as `<service_name>`.
 ====
---
 +
 For example, use the following command to annotate the service `test1`:
 +

--- a/modules/customize-certificates-manually-rotate-service-ca.adoc
+++ b/modules/customize-certificates-manually-rotate-service-ca.adoc
@@ -6,9 +6,10 @@
 [id="manually-rotate-service-ca_{context}"]
 = Manually rotate the service CA certificate
 
-The service CA is valid for 26 months and is automatically refreshed when there is less than 13 months validity left.
+[role="_abstract"]
+To refresh the service Certificate Authority (CA) certificate in {product-title} outside the automatic renewal cycle, you can delete the `signing-key` secret in the `openshift-service-ca` namespace. Restart pods so that services use certificates signed by the new CA.
 
-If necessary, you can manually refresh the service CA by using the following procedure.
+The service CA is valid for 26 months and is automatically refreshed when less than 13 months of validity remain.
 
 [WARNING]
 ====

--- a/modules/customize-certificates-rotate-service-serving.adoc
+++ b/modules/customize-certificates-rotate-service-serving.adoc
@@ -6,9 +6,8 @@
 [id="rotate-service-serving_{context}"]
 = Manually rotate the generated service certificate
 
-You can rotate the service certificate by deleting the
-associated secret. Deleting the secret results in a new one
-being automatically created, resulting in a new certificate.
+[role="_abstract"]
+To replace a generated service serving certificate in {product-title}, you can delete the TLS secret named in the service `serving-cert-secret-name` annotation. A new secret and certificate pair are created automatically.
 
 .Prerequisites
 
@@ -39,10 +38,10 @@ will automatically recreate the secret.
 +
 [source,terminal]
 ----
-$ oc delete secret <secret> //<1>
+$ oc delete secret <secret>
 ----
-<1> Replace `<secret>` with the name of the secret from the previous
-step.
++
+* Replace `<secret>` with the name of the secret from the previous step.
 
 . Confirm that the certificate has been recreated
 by obtaining the new secret and examining the `AGE`.

--- a/modules/customize-certificates-understanding-service-serving.adoc
+++ b/modules/customize-certificates-understanding-service-serving.adoc
@@ -6,9 +6,8 @@
 [id="understanding-service-serving_{context}"]
 = Understanding service serving certificates
 
-Service serving certificates are intended to support complex
-middleware applications that require encryption. These certificates are
-issued as TLS web server certificates.
+[role="_abstract"]
+Service serving certificates are TLS web server certificates that {product-title} issues for middleware applications that require encryption. The `service-ca` controller stores the certificate and key in a secret and automatically replaces them near expiration.
 
 The `service-ca` controller uses the `x509.SHA256WithRSA` signature
 algorithm to generate service certificates.
@@ -18,7 +17,7 @@ and `tls.key` respectively, within a created secret. The
 certificate and key are automatically replaced when they get close to
 expiration.
 
-The service CA certificate, which issues the service certificates, is valid for 26 months and is automatically rotated when there is less than 13 months validity left. After rotation, the previous service CA configuration is still trusted until its expiration. This allows a grace period for all affected services to refresh their key material before the expiration. If you do not upgrade your cluster during this grace period, which restarts services and refreshes their key material, you might need to manually restart services to avoid failures after the previous service CA expires.
+The service Certificate Authority (CA) certificate, which issues the service certificates, is valid for 26 months and is automatically rotated when there is less than 13 months validity left. After rotation, the previous service CA configuration is still trusted until its expiration. This allows a grace period for all affected services to refresh their key material before the expiration. If you do not upgrade your cluster during this grace period, which restarts services and refreshes their key material, you might need to manually restart services to avoid failures after the previous service CA expires.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17171

Link to docs preview:
https://115884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html