### PR TITLE
[SRVCOM-4796, SRVCOM-4799] Fix attr rendering in install and transport encryption

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -16,6 +16,8 @@
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system-version: 8.x
 
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
+
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]
 

--- a/install/preparing-serverless-install.adoc
+++ b/install/preparing-serverless-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-serverless-install"]
-= Preparing to install {ServerlessProductName}
+= Preparing to install OpenShift Serverless
 include::_attributes/common-attributes.adoc[]
 :context: preparing-serverless-install
 


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.36`
- `serverless-docs-1.37`
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVCOM-4796
- https://redhat.atlassian.net/browse/SRVCOM-4799

Link to docs preview:
- [preparing-serverless-install](https://115894--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/preparing-serverless-install.html)
- [setting-up_serving-transport-encryption](https://115894--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/serving-transport-encryption#serving-transport-encryption-setting-up_serving-transport-encryption)

QE review:
- [ ] QE approval not needed.

Additional info: 
The first issue is caused by the attribute preceding the attribute definition include. To align with the rest of the OSS documentation, the PR replaces the attribute with the hard-coded product name.
The second is caused by missing attribute definition. The PR adds this definition.