### PR TITLE
[serverless-docs-1.36] [SRVCOM-4796, SRVCOM-4799] Fix attr rendering in install and transport encryption

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -16,6 +16,8 @@
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system-version: 8.x
 
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
+
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]
 


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/115894 into `serverless-docs-1.36`