### PR TITLE
OCPBUGS-99274: Remove scsi- prefix from FC wwids example

### DIFF
--- a/modules/persistent-storage-fibre-provisioning.adoc
+++ b/modules/persistent-storage-fibre-provisioning.adoc
@@ -34,7 +34,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   fc:
-    wwids: [scsi-3600508b400105e210000900000490000] <1>
+    wwids: [3600508b400105e210000900000490000] <1>
     targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <2>
     lun: 2 <2>
     fsType: ext4


### PR DESCRIPTION
## Summary
- Remove incorrect `scsi-` prefix from Fibre Channel PV `wwids` example in `modules/persistent-storage-fibre-provisioning.adoc`
- Kubernetes already prepends `scsi-` when resolving `/dev/disk/by-id/`; including it causes a failed volume lookup

Fixes: https://issues.redhat.com/browse/OCPBUGS-99274

## Test plan
- [ ] Confirm example shows `wwids: [3600508b400105e210000900000490000]` (no `scsi-` prefix)
- [ ] Confirm docs preview renders the updated YAML correctly

Made with [Cursor](https://cursor.com)