### PR TITLE
CQA Fix topic map II

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -787,6 +787,29 @@ Topics:
       File: update-completing-the-y-stream-update
     - Name: Completing the z-stream update
       File: update-completing-the-z-stream-update
+  - Name: Upgrading OpenShift Container Platform clusters with RHACM and TALM
+    Dir: updating
+    Topics:
+    - Name: About cluster updates with RHACM and TALM
+      File: update-rhacm-talm-overview
+    - Name: Prepare RHACM policies and TALM for cluster updates
+      File: update-rhacm-talm-preparing-policies
+    - Name: Prepare worker node pools before a cluster update with TALM
+      File: update-rhacm-talm-worker-batching
+    - Name: Perform health checks before a cluster update with TALM
+      File: update-rhacm-talm-health-checks
+    - Name: Manage worker nodes during a cluster update with TALM
+      File: update-rhacm-talm-worker-management
+    - Name: Coordinate OLM-managed Operator updates with TALM
+      File: update-rhacm-talm-operator-coordination
+    - Name: Complete a z-stream cluster update with TALM
+      File: update-rhacm-talm-z-stream
+    - Name: Complete a y-stream cluster update with TALM
+      File: update-rhacm-talm-y-stream
+    - Name: Complete an EUS-to-EUS cluster update with TALM
+      File: update-rhacm-talm-eus
+    - Name: Troubleshoot cluster updates with TALM
+      File: update-rhacm-talm-troubleshooting 
   - Name: Troubleshooting and maintaining OpenShift Container Platform clusters
     Dir: troubleshooting
     Topics:
@@ -1283,6 +1306,22 @@ Topics:
     File: nbde-tang-server-operator-identifying-url
 - Name: Understanding secrets management
   File: understanding-secrets-management
+- Name: External Secrets Management Console Plug-in
+  Dir: external_secrets_management_console_plugin
+  Distros: openshift-enterprise
+  Topics:
+  - Name: External Secrets Management Console Plug-in overview
+    File: index
+  - Name: External Secrets Management Console Plug-in release notes
+    File: external-secrets-console-plugin-release-notes
+  - Name: Installing the External Secrets Management Console Plug-in
+    File: external-secrets-console-plugin-install
+  - Name: Monitoring the External Secrets Management Console Plug-in
+    File: external-secrets-console-plugin-monitor
+  - Name: Uninstalling the External Secrets Management Console Plug-in
+    File: external-secrets-console-plugin-uninstall
+  - Name: Deleting certificates and secrets with External Secrets Management Console Plug-in
+    File: external-secrets-console-plugin-delete
 - Name: cert-manager Operator for Red Hat OpenShift
   Dir: cert_manager_operator
   Distros: openshift-enterprise
@@ -1827,6 +1866,8 @@ Topics:
       File: assigning-network-addresses-gateways
     - Name: Routing HTTP requests to services
       File: routing-http-requests-to-services
+    - Name: Securing HTTPRoutes
+      File: securing-httproutes
     - Name: Routing gRPC requests to services
       File: routing-grpc-requests-to-services
     - Name: Verifying Gateway infrastructure status
@@ -2795,7 +2836,7 @@ Topics:
   File: hcp-authentication-authorization
 - Name: Handling machine configuration for hosted control planes
   File: hcp-machine-config
-- Name: Using feature gates in a hosted cluster
+- Name: Feature gates in a hosted cluster
   File: hcp-using-feature-gates
 - Name: Observability for hosted control planes
   File: hcp-observability
@@ -3134,6 +3175,8 @@ Topics:
   File: removing-windows-nodes
 - Name: Disabling Windows container workloads
   File: disabling-windows-container-workloads
+- Name: Troubleshooting Windows container workloads
+  File: windows-containers-troubleshooting
 ---
 Name: OpenShift sandboxed containers
 Dir: sandboxed_containers


### PR DESCRIPTION
Made some erroneous changes to the topic map when merging https://github.com/openshift/openshift-docs/pull/115126/changes, I only inteded to make the changes to [some CCO titles](https://github.com/openshift/openshift-docs/pull/115126/changes#diff-7c09a5ccc63f204d75ed89dd359a340a43551a4a790ae36fb9c64f6c5149211bL1525-R1493). This is a manual reversion of those other changes. Merge to main only as the changes were not cherrypicked.