### PR TITLE
TELCODOCS-2799: Fix AsciiDocDITA rule violations in ztp-talm-updating-managed-policies-pg assembly

### DIFF
--- a/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+++ b/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ztp-topology-aware-lifecycle-manager-pg"]
-= Updating managed clusters in a disconnected environment with PolicyGenerator resources and TALM
+= Updating managed clusters in a disconnected environment with PolicyGenerator resources and {cgu-operator}
 include::_attributes/common-attributes.adoc[]
 :context: ztp-talm-pg
 :policy-gen-cr: PolicyGenerator
@@ -8,39 +8,36 @@ include::_attributes/common-attributes.adoc[]
 :rangen-yaml-path: policies.manifests
 
 toc::[]
+
+[role="_abstract"]
 You can use the {cgu-operator-first} to manage the software lifecycle of managed clusters that you have deployed using {ztp-first} and {cgu-operator-first}.
 {cgu-operator} uses {rh-rhacm-first} {policy-gen-cr} policies to manage and control changes applied to target clusters.
-
-For more information about the {cgu-operator-full}, see xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}].
 
 include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about how to update {ztp-first}, see xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
-
-* For more information about how to mirror an {product-title} image repository, see xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository].
-
-* For more information about how to mirror Operator catalogs for disconnected clusters, see xref:../../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
-
-* For more information about how to prepare the disconnected environment and mirroring the desired image repository, see xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
-
-* For more information about update channels and releases, see xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases].
+* xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}]
+* xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters]
+* xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment]
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]
 
 include::modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about mirroring the images in a disconnected environment, see xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-acm-adding-images-to-mirror-registry_ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
+* xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-acm-adding-images-to-mirror-registry_ztp-preparing-the-hub-cluster[Preparing the disconnected environment]
 
 include::modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about updating {ztp}, see xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
+* xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}]
 
 include::modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc[leveloffset=+1]
 
@@ -55,7 +52,7 @@ include::modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the {cgu-operator} precaching workflow, see xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-concept_cnf-topology-aware-lifecycle-manager[Using the container image precache feature].
+* xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-concept_cnf-topology-aware-lifecycle-manager[Using the container image precache feature]
 
 include::modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc[leveloffset=+1]
 

--- a/modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc
@@ -6,14 +6,19 @@
 [id="talo-precache-autocreated-cgu-for-ztp_{context}"]
 = About the auto-created ClusterGroupUpgrade CR for {ztp}
 
+[role="_abstract"]
 {cgu-operator} has a controller called `ManagedClusterForCGU` that monitors the `Ready` state of the `ManagedCluster` CRs on the hub cluster and creates the `ClusterGroupUpgrade` CRs for {ztp-first}.
 
 For any managed cluster in the `Ready` state without a `ztp-done` label applied, the `ManagedClusterForCGU` controller automatically creates a `ClusterGroupUpgrade` CR in the `ztp-install` namespace with its associated {rh-rhacm} policies that are created during the {ztp} process. {cgu-operator} then remediates the set of configuration policies that are listed in the auto-created `ClusterGroupUpgrade` CR to push the configuration CRs to the managed cluster.
 
-If there are no policies for the managed cluster at the time when the cluster becomes `Ready`, a `ClusterGroupUpgrade` CR with no policies is created. Upon completion of the `ClusterGroupUpgrade` the managed cluster is labeled as `ztp-done`. If there are policies that you want to apply for that managed cluster, manually create a `ClusterGroupUpgrade` as a day-2 operation.
+If there are no policies for the managed cluster at the time when the cluster becomes `Ready`, a `ClusterGroupUpgrade` CR with no policies is created. Upon completion of the `ClusterGroupUpgrade` the managed cluster is labeled as `ztp-done`. If there are policies that you want to apply for that managed cluster, manually create a `ClusterGroupUpgrade` as a Day 2 operation.
 
-.Example of an auto-created `ClusterGroupUpgrade` CR for {ztp}
+.Procedure
 
+* View the auto-created `ClusterGroupUpgrade` CR for {ztp}:
++
+The following example shows an auto-created `ClusterGroupUpgrade` CR for {ztp}:
++
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -35,13 +40,13 @@ spec:
   actions:
     afterCompletion:
       addClusterLabels:
-        ztp-done: "" <1>
+        ztp-done: ""
       deleteClusterLabels:
         ztp-running: ""
       deleteObjects: true
     beforeEnable:
       addClusterLabels:
-        ztp-running: "" <2>
+        ztp-running: ""
   clusters:
   - spoke1
   enable: true
@@ -56,5 +61,8 @@ spec:
     maxConcurrency: 1
     timeout: 240
 ----
-<1> Applied to the managed cluster when {cgu-operator} completes the cluster configuration.
-<2> Applied to the managed cluster when {cgu-operator} starts deploying the configuration policies.
++
+--
+* `ztp-done: ""` is applied to the managed cluster when {cgu-operator} completes the cluster configuration.
+* `ztp-running: ""` is applied to the managed cluster when {cgu-operator} starts deploying the configuration policies.
+--

--- a/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
@@ -4,11 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="talm-prechache-user-specified-images-preparing-crs_{context}"]
-= Creating the custom resources for pre-caching
+= Creating the custom resources for precaching
 
+[role="_abstract"]
 You must create the `PreCachingConfig` CR before or concurrently with the `ClusterGroupUpgrade` CR.
 
-. Create the `PreCachingConfig` CR with the list of additional images you want to pre-cache.
+.Procedure
+
+. Create the `PreCachingConfig` CR with the list of additional images you want to precache.
 +
 [source,yaml]
 ----
@@ -16,17 +19,20 @@ apiVersion: ran.openshift.io/v1alpha1
 kind: PreCachingConfig
 metadata:
   name: exampleconfig
-  namespace: default <1>
+  namespace: default
 spec:
 [...]
-  spaceRequired: 30Gi <2>
+  spaceRequired: 30Gi
   additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1> The `namespace` must be accessible to the hub cluster.
-<2> It is recommended to set the minimum disk space required field to ensure that there is sufficient storage space for the pre-cached images.
++
+--
+* `namespace` must be accessible to the hub cluster.
+* `spaceRequired` - It is recommended to set the minimum disk space required field to ensure that there is sufficient storage space for the precached images.
+--
 
 . Create a `ClusterGroupUpgrade` CR with the `preCaching` field set to `true` and specify the `PreCachingConfig` CR created in the previous step:
 +
@@ -60,25 +66,24 @@ Once you install the images on the cluster, you cannot change or delete them.
 ====
 
 +
-. When you want to start pre-caching the images, apply the `ClusterGroupUpgrade` CR by running the following command:
+. When you want to start precaching the images, apply the `ClusterGroupUpgrade` CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f cgu.yaml
 ----
-
++
 {cgu-operator} verifies the `ClusterGroupUpgrade` CR.
-
-From this point, you can continue with the {cgu-operator} pre-caching workflow.
-
+From this point, you can continue with the {cgu-operator} precaching workflow.
++
 [NOTE]
 ====
-All sites are pre-cached concurrently.
+All sites are precached concurrently.
 ====
 
 .Verification
 
-. Check the pre-caching status on the hub cluster where the `ClusterUpgradeGroup` CR is applied by running the following command:
+. Check the precaching status on the hub cluster where the `ClusterUpgradeGroup` CR is applied by running the following command:
 +
 [source,terminal]
 ----
@@ -86,7 +91,8 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-.Example output
+The following is example output:
++
 [source,yaml]
 ----
   precaching:
@@ -112,11 +118,12 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-The pre-caching configurations are validated by checking if the managed policies exist.
+The precaching configurations are validated by checking if the managed policies exist.
 Valid configurations of the `ClusterGroupUpgrade` and the `PreCachingConfig` CRs result in the following statuses:
 
 +
-.Example output of valid CRs
+The following example shows the output of valid CRs:
++
 [source,yaml]
 ----
 - lastTransitionTime: "2023-01-01T00:00:01Z"
@@ -142,16 +149,17 @@ Valid configurations of the `ClusterGroupUpgrade` and the `PreCachingConfig` CRs
 ----
 
 +
-.Example of an invalid PreCachingConfig CR
+The following example shows an invalid `PreCachingConfig` CR:
++
 [source,yaml]
 ----
 Type:    "PrecacheSpecValid"
 Status:  False,
 Reason:  "PrecacheSpecIncomplete"
-Message: "Precaching spec is incomplete: failed to get PreCachingConfig resource due to PreCachingConfig.ran.openshift.io "<pre-caching_cr_name>" not found"
+Message: "Precaching spec is incomplete: failed to get PreCachingConfig resource due to PreCachingConfig.ran.openshift.io "<precaching_cr_name>" not found"
 ----
 
-. You can find the pre-caching job by running the following command on the managed cluster:
+. You can find the precaching job by running the following command on the managed cluster:
 +
 [source,terminal]
 ----
@@ -159,14 +167,15 @@ $ oc get jobs -n openshift-talo-pre-cache
 ----
 
 +
-.Example of pre-caching job in progress
+The following example shows a precaching job in progress:
++
 [source,terminal]
 ----
 NAME        COMPLETIONS       DURATION      AGE
 pre-cache   0/1               1s            1s
 ----
 
-. You can check the status of the pod created for the pre-caching job by running the following command:
+. You can check the status of the pod created for the precaching job by running the following command:
 +
 [source,terminal]
 ----
@@ -174,7 +183,8 @@ $ oc describe pod pre-cache -n openshift-talo-pre-cache
 ----
 
 +
-.Example of pre-caching job in progress
+The following example shows a precaching job in progress:
++
 [source,terminal]
 ----
 Type        Reason              Age    From              Message
@@ -188,7 +198,7 @@ Normal      SuccesfulCreate     19s    job-controller    Created pod: pre-cache-
 $ oc logs -f pre-cache-abcd1 -n openshift-talo-pre-cache
 ----
 
-. To verify the pre-cache job is successfully completed, run the following command:
+. To verify the precache job is successfully completed, run the following command:
 +
 [source,terminal]
 ----
@@ -196,7 +206,8 @@ $ oc describe pod pre-cache -n openshift-talo-pre-cache
 ----
 
 +
-.Example of completed pre-cache job
+The following example shows a completed precache job:
++
 [source,terminal]
 ----
 Type        Reason              Age    From              Message
@@ -204,7 +215,7 @@ Normal      SuccesfulCreate     5m19s  job-controller    Created pod: pre-cache-
 Normal      Completed           19s    job-controller    Job completed
 ----
 
-. To verify that the images are successfully pre-cached on the {sno}, do the following:
+. To verify that the images are successfully precached on the {sno}, do the following:
 
 .. Enter into the node in debug mode:
 +
@@ -220,7 +231,7 @@ $ oc debug node/cnfdf00.example.lab
 $ chroot /host/
 ----
 
-.. Search for the desired images:
+.. Search for the required images:
 +
 [source,terminal]
 ----

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-operator-and-platform-update_{context}"]
 = Performing a platform and an Operator update together
 
+[role="_abstract"]
 You can perform a platform and an Operator update at the same time.
 
 .Prerequisites
@@ -68,9 +69,9 @@ metadata:
   namespace: default
 spec:
   managedPolicies:
-  - du-upgrade-platform-upgrade <1>
-  - du-upgrade-operator-catsrc-policy <2>
-  - common-subscriptions-policy <3>
+  - du-upgrade-platform-upgrade
+  - du-upgrade-operator-catsrc-policy
+  - common-subscriptions-policy
   preCaching: true
   clusterSelector:
   - group-du-sno
@@ -78,9 +79,12 @@ spec:
     maxConcurrency: 1
   enable: false
 ----
-<1> This is the platform update policy.
-<2> This is the policy containing the catalog source information for the Operators to be updated. It is needed for the pre-caching feature to determine which Operator images to download to the managed cluster.
-<3> This is the policy to update the Operators.
++
+--
+* `du-upgrade-platform-upgrade` is the platform update policy.
+* `du-upgrade-operator-catsrc-policy` is the policy containing the catalog source information for the Operators to be updated. It is needed for the precaching feature to determine which Operator images to download to the managed cluster.
+* `common-subscriptions-policy` is the policy to update the Operators.
+--
 
 .. Apply the `cgu-platform-operator-upgrade.yml` file to the hub cluster by running the following command:
 +
@@ -89,8 +93,8 @@ spec:
 $ oc apply -f cgu-platform-operator-upgrade.yml
 ----
 
-. Optional: Pre-cache the images for the platform and the Operator update.
-.. Enable pre-caching in the `ClusterGroupUpgrade` CR by running the following command:
+. Optional: Precache the images for the platform and the Operator update.
+.. Enable precaching in the `ClusterGroupUpgrade` CR by running the following command:
 +
 [source,terminal]
 ----
@@ -98,14 +102,14 @@ $ oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-du-upgra
 --patch '{"spec":{"preCaching": true}}' --type=merge
 ----
 
-.. Monitor the update process and wait for the pre-caching to complete. Check the status of pre-caching by running the following command on the managed cluster:
+.. Monitor the update process and wait for the precaching to complete. Check the status of precaching by running the following command on the managed cluster:
 +
 [source,terminal]
 ----
 $ oc get jobs,pods -n openshift-talm-pre-cache
 ----
 
-.. Check if the pre-caching is completed before starting the update by running the following command:
+.. Check if the precaching is completed before starting the update by running the following command:
 +
 [source,terminal]
 ----
@@ -130,7 +134,7 @@ $ oc get policies --all-namespaces
 +
 [NOTE]
 ====
-The CRs for the platform and Operator updates can be created from the beginning by configuring the setting to `spec.enable: true`. In this case, the update starts immediately after pre-caching completes and there is no need to manually enable the CR.
+The CRs for the platform and Operator updates can be created from the beginning by configuring the setting to `spec.enable: true`. In this case, the update starts immediately after precaching completes and there is no need to manually enable the CR.
 
-Both pre-caching and the update create extra resources, such as policies, placement bindings, placement rules, managed cluster actions, and managed cluster view, to help complete the procedures. Setting the `afterCompletion.deleteObjects` field to `true` deletes all these resources after the updates complete.
+Both precaching and the update create extra resources, such as policies, placement bindings, placement rules, managed cluster actions, and managed cluster view, to help complete the procedures. Setting the `afterCompletion.deleteObjects` field to `true` deletes all these resources after the updates complete.
 ====

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -6,6 +6,7 @@
 [id="cnf-topology-aware-lifecycle-manager-operator-troubleshooting-{policy-gen-cr}_{context}"]
 = Troubleshooting missed Operator updates with {policy-gen-cr} CRs
 
+[role="_abstract"]
 In some scenarios, {cgu-operator-first} might miss Operator updates due to an out-of-date policy compliance state.
 
 After a catalog source update, it takes time for the Operator Lifecycle Manager (OLM) to update the subscription status. The status of the subscription policy might continue to show as compliant while {cgu-operator} decides whether remediation is needed. As a result, the Operator specified in the subscription policy does not get upgraded.
@@ -34,7 +35,10 @@ metadata:
   namespace: operator-namspace
 # ...
 spec:
-  source: redhat-operators-disconnected-v2 <1>
+  source: redhat-operators-disconnected-v2
 # ...
 ----
-<1> Enter the name of the additional catalog source configuration that you defined in the `{policy-gen-cr}` resource.
++
+--
+* `redhat-operators-disconnected-v2` specifies the name of the additional catalog source configuration that you defined in the `{policy-gen-cr}` resource.
+--

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-operator-update-{policy-gen-cr}_{context}"]
 = Performing an Operator update with {policy-gen-cr} CRs
 
+[role="_abstract"]
 You can perform an Operator update with the {cgu-operator}.
 
 .Prerequisites
@@ -13,7 +14,7 @@ You can perform an Operator update with the {cgu-operator}.
 * Install the {cgu-operator-first}.
 * Update {ztp-first} to the latest version.
 * Provision one or more managed clusters with {ztp}.
-* Mirror the desired index image, bundle images, and all Operator images referenced in the bundle images.
+* Mirror the required index image, bundle images, and all Operator images referenced in the bundle images.
 * Log in as a user with `cluster-admin` privileges.
 * Create {rh-rhacm} policies in the hub cluster.
 
@@ -29,17 +30,17 @@ ifeval::["{policy-gen-cr}" == "PolicyGenerator"]
 include::snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc[]
 endif::[]
 
-.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators-disconnected` catalog source with the new index images that contain the desired Operators images.
+.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators-disconnected` catalog source with the new index images that contain the required Operators images.
 +
 [NOTE]
 ====
-If you want to use the image pre-caching for Operators and there are Operators from a different catalog source other than `redhat-operators-disconnected`,  you must perform the following tasks:
+If you want to use the image precaching for Operators and there are Operators from a different catalog source other than `redhat-operators-disconnected`, you must perform the following tasks:
 
 * Prepare a separate catalog source policy with the new index image or registry poll interval update for the different catalog source.
-* Prepare a separate subscription policy for the desired Operators that are from the different catalog source.
+* Prepare a separate subscription policy for the required Operators that are from the different catalog source.
 ====
 +
-For example, the desired SRIOV-FEC Operator is available in the `certified-operators` catalog source. To update the catalog source and the Operator subscription, add the following contents to generate two policies, `du-upgrade-fec-catsrc-policy` and `du-upgrade-subscriptions-fec-policy`:
+For example, the required SRIOV-FEC Operator is available in the `certified-operators` catalog source. To update the catalog source and the Operator subscription, add the following contents to generate two policies, `du-upgrade-fec-catsrc-policy` and `du-upgrade-subscriptions-fec-policy`:
 +
 ifeval::["{policy-gen-cr}" == "PolicyGenTemplate"]
 include::snippets/pgt-sriov-fec-cnf-topology-aware-lifecycle-manager-operator-update.adoc[]
@@ -113,8 +114,8 @@ metadata:
   namespace: default
 spec:
   managedPolicies:
-  - du-upgrade-operator-catsrc-policy <1>
-  - common-subscriptions-policy <2>
+  - du-upgrade-operator-catsrc-policy
+  - common-subscriptions-policy
   preCaching: false
   clusters:
   - spoke1
@@ -122,12 +123,15 @@ spec:
     maxConcurrency: 1
   enable: false
 ----
-<1> The policy is needed by the image pre-caching feature to retrieve the operator images from the catalog source.
-<2> The policy contains Operator subscriptions. If you have followed the structure and content of the reference `PolicyGenTemplates`, all Operator subscriptions are grouped into the `common-subscriptions-policy` policy.
++
+--
+* `du-upgrade-operator-catsrc-policy` is needed by the image precaching feature to retrieve the Operator images from the catalog source.
+* `common-subscriptions-policy` contains Operator subscriptions. If you have followed the structure and content of the reference `PolicyGenTemplates`, all Operator subscriptions are grouped into the `common-subscriptions-policy` policy.
+--
 +
 [NOTE]
 ====
-One `ClusterGroupUpgrade` CR can only pre-cache the images of the desired Operators defined in the subscription policy from one catalog source included in the `ClusterGroupUpgrade` CR. If the desired Operators are from different catalog sources, such as in the example of the SRIOV-FEC Operator, another `ClusterGroupUpgrade` CR must be created with `du-upgrade-fec-catsrc-policy` and `du-upgrade-subscriptions-fec-policy` policies for the SRIOV-FEC Operator images pre-caching and update.
+One `ClusterGroupUpgrade` CR can only precache the images of the required Operators defined in the subscription policy from one catalog source included in the `ClusterGroupUpgrade` CR. If the required Operators are from different catalog sources, such as in the example of the SRIOV-FEC Operator, another `ClusterGroupUpgrade` CR must be created with `du-upgrade-fec-catsrc-policy` and `du-upgrade-subscriptions-fec-policy` policies for the SRIOV-FEC Operator images precaching and update.
 ====
 
 .. Apply the `ClusterGroupUpgrade` CR to the hub cluster by running the following command:
@@ -137,16 +141,16 @@ One `ClusterGroupUpgrade` CR can only pre-cache the images of the desired Operat
 $ oc apply -f cgu-operator-upgrade.yml
 ----
 
-. Optional: Pre-cache the images for the Operator update.
+. Optional: Precache the images for the Operator update.
 
-.. Before starting image pre-caching, verify the subscription policy is `NonCompliant` at this point by running the following command:
+.. Before starting image precaching, verify the subscription policy is `NonCompliant` at this point by running the following command:
 +
 [source,terminal]
 ----
 $ oc get policy common-subscriptions-policy -n <policy_namespace>
 ----
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----
@@ -154,7 +158,7 @@ NAME                          REMEDIATION ACTION   COMPLIANCE STATE     AGE
 common-subscriptions-policy   inform               NonCompliant         27d
 ----
 
-.. Enable pre-caching in the `ClusterGroupUpgrade` CR by running the following command:
+.. Enable precaching in the `ClusterGroupUpgrade` CR by running the following command:
 +
 [source,terminal]
 ----
@@ -162,21 +166,21 @@ $ oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-operator
 --patch '{"spec":{"preCaching": true}}' --type=merge
 ----
 
-.. Monitor the process and wait for the pre-caching to complete. Check the status of pre-caching by running the following command on the managed cluster:
+.. Monitor the process and wait for the precaching to complete. Check the status of precaching by running the following command on the managed cluster:
 +
 [source,terminal]
 ----
 $ oc get cgu cgu-operator-upgrade -o jsonpath='{.status.precaching.status}'
 ----
 
-.. Check if the pre-caching is completed before starting the update by running the following command:
+.. Check if the precaching is completed before starting the update by running the following command:
 +
 [source,terminal]
 ----
 $ oc get cgu -n default cgu-operator-upgrade -ojsonpath='{.status.conditions}' | jq
 ----
 +
-.Example output
+The following is example output:
 +
 [source,json]
 ----
@@ -200,7 +204,7 @@ $ oc get cgu -n default cgu-operator-upgrade -ojsonpath='{.status.conditions}' |
 
 . Start the Operator update.
 
-.. Enable the `cgu-operator-upgrade` `ClusterGroupUpgrade` CR and disable pre-caching to start the Operator update by running the following command:
+.. Enable the `cgu-operator-upgrade` `ClusterGroupUpgrade` CR and disable precaching to start the Operator update by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cnf-topology-aware-lifecycle-manager-pao-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-pao-update.adoc
@@ -6,6 +6,7 @@
 [id="talm-pao-update-{policy-gen-cr}_{context}"]
 = Removing Performance Addon Operator subscriptions from deployed clusters with {policy-gen-cr} CRs
 
+[role="_abstract"]
 In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 or later, these functions are part of the Node Tuning Operator.
 
 Do not install the Performance Addon Operator on clusters running {product-title} 4.11 or later. If you upgrade to {product-title} 4.11 or later, the Node Tuning Operator automatically removes the Performance Addon Operator.

--- a/modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-platform-update-{policy-gen-cr}_{context}"]
 = Performing a platform update with {policy-gen-cr} CRs
 
+[role="_abstract"]
 You can perform a platform update with the {cgu-operator}.
 
 .Prerequisites
@@ -13,7 +14,7 @@ You can perform a platform update with the {cgu-operator}.
 * Install the {cgu-operator-first}.
 * Update {ztp-first} to the latest version.
 * Provision one or more managed clusters with {ztp}.
-* Mirror the desired image repository.
+* Mirror the required image repository.
 * Log in as a user with `cluster-admin` privileges.
 * Create {rh-rhacm} policies in the hub cluster.
 
@@ -24,7 +25,8 @@ You can perform a platform update with the {cgu-operator}.
 .. Save the following `{policy-gen-cr}` CR in the `du-upgrade.yaml` file:
 +
 --
-.Example of `{policy-gen-cr}` for platform update
+The following example shows the `{policy-gen-cr}` CR for platform update:
+
 ifeval::["{policy-gen-cr}" == "PolicyGenTemplate"]
 include::snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc[]
 endif::[]
@@ -34,7 +36,7 @@ endif::[]
 
 The `{policy-gen-cr}` CR generates two policies:
 
-* The `du-upgrade-platform-upgrade-prep` policy does the preparation work for the platform update. It creates the `ConfigMap` CR for the desired release image signature, creates the image content source of the mirrored release image repository, and updates the cluster version with the desired update channel and the update graph reachable by the managed cluster in the disconnected environment.
+* The `du-upgrade-platform-upgrade-prep` policy does the preparation work for the platform update. It creates the `ConfigMap` CR for the required release image signature, creates the image content source of the mirrored release image repository, and updates the cluster version with the required update channel and the update graph reachable by the managed cluster in the disconnected environment.
 
 * The `du-upgrade-platform-upgrade` policy is used to perform platform upgrade.
 --
@@ -80,8 +82,8 @@ spec:
 $ oc apply -f cgu-platform-upgrade.yml
 ----
 
-. Optional: Pre-cache the images for the platform update.
-.. Enable pre-caching in the `ClusterGroupUpdate` CR by running the following command:
+. Optional: Precache the images for the platform update.
+.. Enable precaching in the `ClusterGroupUpdate` CR by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
@@ -4,11 +4,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="talm-prechache-user-specified-images-concept_{context}"]
-= Pre-caching user-specified images with {cgu-operator} on {sno} clusters
+= Precaching user-specified images with {cgu-operator} on {sno} clusters
 
-You can pre-cache application-specific workload images on {sno} clusters before upgrading your applications.
+[role="_abstract"]
+You can precache application-specific workload images on {sno} clusters before upgrading your applications.
 
-You can specify the configuration options for the pre-caching jobs using the following custom resources (CR):
+You can specify the configuration options for the precaching jobs by using the following custom resources (CR):
 
 * `PreCachingConfig` CR
 * `ClusterGroupUpgrade` CR
@@ -18,7 +19,8 @@ You can specify the configuration options for the pre-caching jobs using the fol
 All fields in the `PreCachingConfig` CR are optional.
 ====
 
-.Example PreCachingConfig CR
+The following example shows a `PreCachingConfig` CR:
+
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -27,7 +29,7 @@ metadata:
   name: exampleconfig
   namespace: exampleconfig-ns
 spec:
-  overrides: <1>
+  overrides:
     platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     operatorsIndexes:
       - registry.example.com:5000/custom-redhat-operators:1.0.0
@@ -35,21 +37,23 @@ spec:
       - local-storage-operator: stable
       - ptp-operator: stable
       - sriov-network-operator: stable
-  spaceRequired: 30 Gi <2>
-  excludePrecachePatterns: <3>
+  spaceRequired: 30 Gi
+  excludePrecachePatterns:
     - aws
     - vsphere
-  additionalImages: <4>
+  additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1>  By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
-<2> Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
-<3> Specifies the images to exclude from pre-caching based on image name matching.
-<4> Specifies the list of additional images to pre-cache.
 
-.Example ClusterGroupUpgrade CR with PreCachingConfig CR reference
+* `overrides` - By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
+* `spaceRequired` - Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
+* `excludePrecachePatterns` - Specifies the images to exclude from precaching based on image name matching.
+* `additionalImages` - Specifies the list of additional images to precache.
+
+The following example shows a `ClusterGroupUpgrade` CR with a `PreCachingConfig` CR reference:
+
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -57,11 +61,12 @@ kind: ClusterGroupUpgrade
 metadata:
   name: cgu
 spec:
-  preCaching: true <1>
+  preCaching: true
   preCachingConfigRef:
-    name: exampleconfig <2>
-    namespace: exampleconfig-ns <3>
+    name: exampleconfig
+    namespace: exampleconfig-ns
 ----
-<1> The `preCaching` field set to `true` enables the pre-caching job.
-<2> The `preCachingConfigRef.name` field specifies the `PreCachingConfig` CR that you want to use.
-<3> The `preCachingConfigRef.namespace` specifies the namespace of the `PreCachingConfig` CR that you want to use.
+
+* `preCaching` set to `true` enables the precaching job.
+* `preCachingConfigRef.name` specifies the `PreCachingConfig` CR that you want to use.
+* `preCachingConfigRef.namespace` specifies the namespace of the `PreCachingConfig` CR that you want to use.

--- a/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
@@ -6,15 +6,19 @@
 [id="talo-platform-prepare-for-update-env-setup_{context}"]
 = Setting up the disconnected environment
 
+[role="_abstract"]
 {cgu-operator} can perform both platform and Operator updates.
 
-You must mirror both the platform image and Operator images that you want to update to in your mirror registry before you can use {cgu-operator} to update your disconnected clusters. Complete the following steps to mirror the images:
+You must mirror both the platform image and Operator images that you want to update to in your mirror registry before you can use {cgu-operator} to update your disconnected clusters.
+
+.Procedure
 
 * For platform updates, you must perform the following steps:
 +
-. Mirror the desired {product-title} image repository. Ensure that the desired platform image is mirrored by following the "Mirroring the {product-title} image repository" procedure linked in the Additional resources. Save the contents of the `imageContentSources` section in the `imageContentSources.yaml` file:
+. Mirror the required {product-title} image repository. Ensure that the required platform image is mirrored by following the "Mirroring the {product-title} image repository" procedure linked in the Additional resources. Save the contents of the `imageContentSources` section in the `imageContentSources.yaml` file:
 +
-.Example output
+The following is example output:
++
 [source,yaml]
 ----
 imageContentSources:
@@ -26,9 +30,9 @@ imageContentSources:
    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 ----
 
-. Save the image signature of the desired platform image that was mirrored. You must add the image signature to the `{policy-gen-cr}` CR for platform updates. To get the image signature, perform the following steps:
+. Save the image signature of the required platform image that was mirrored. You must add the image signature to the `{policy-gen-cr}` CR for platform updates. To get the image signature, perform the following steps:
 +
-.. Specify the desired {product-title} tag by running the following command:
+.. Specify the required {product-title} tag by running the following command:
 +
 [source,terminal]
 ----
@@ -39,9 +43,12 @@ $ OCP_RELEASE_NUMBER=<release_version>
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<cluster_architecture> <1>
+$ ARCHITECTURE=<cluster_architecture>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
++
+--
+* `<cluster_architecture>` specifies the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
+--
 +
 .. Get the release image digest from Quay by running the following command
 +
@@ -99,4 +106,4 @@ $ curl -s https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-{p
 +
 * For Operator updates, you must perform the following task:
 +
-** Mirror the Operator catalogs. Ensure that the desired operator images are mirrored by following the procedure in the "Mirroring Operator catalogs for use with disconnected clusters" section.
+** Mirror the Operator catalogs. Ensure that the required Operator images are mirrored by following the procedure in the "Mirroring Operator catalogs for use with disconnected clusters" section.

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: SNIPPET
 [source,yaml]
 ----
 manifests:
@@ -17,10 +18,10 @@ manifests:
 - path: source-crs/DefaultCatsrc.yaml
   patches:
     - metadata:
-        name: redhat-operators-disconnected-v2 <1>
+        name: redhat-operators-disconnected-v2
       spec:
-        displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
+        displayName: Red Hat Operators Catalog v2
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version>
         updateStrategy:
             registryPoll:
                 interval: 1h
@@ -28,6 +29,7 @@ manifests:
         connectionState:
             lastObservedState: READY
 ----
-<1> Update the name for the new configuration.
-<2> Update the display name for the new configuration.
-<3> Update the index image URL. This `policies.manifests.patches.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+
+* `name` - Update the name for the new configuration.
+* `displayName` - Update the display name for the new configuration.
+* `image` - Update the index image URL. This `policies.manifests.patches.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -35,14 +35,15 @@ policies:
                 name: redhat-operators-disconnected
               spec:
                 displayName: Red Hat Operators Catalog
-                image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
-                updateStrategy: <2>
+                image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
+                updateStrategy:
                     registryPoll:
                         interval: 1h
               status:
                 connectionState:
-                    lastObservedState: READY <3>
+                    lastObservedState: READY
 ----
-<1> Contains the required Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
-<2> Sets how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this, you can restore `registryPoll.interval` to the default value once the update is complete.
-<3> Displays the observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+
+* `image` - Contains the required Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
+* `updateStrategy` - Sets how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this, you can restore `registryPoll.interval` to the default value once the update is complete.
+* `lastObservedState` - Displays the observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -29,7 +29,7 @@ policies:
       policyAnnotations:
         ran.openshift.io/ztp-deploy-wave: "100"
       manifests:
-        - path: source-crs/ClusterVersion.yaml <1>
+        - path: source-crs/ClusterVersion.yaml
           patches:
             - metadata:
                 name: version
@@ -46,13 +46,13 @@ policies:
       policyAnnotations:
         ran.openshift.io/ztp-deploy-wave: "1"
       manifests:
-        - path: source-crs/ImageSignature.yaml <2>
+        - path: source-crs/ImageSignature.yaml
         - path: source-crs/DisconnectedICSP.yaml
           patches:
             - metadata:
                 name: disconnected-internal-icsp-for-ocp
               spec:
-                repositoryDigestMirrors: <3>
+                repositoryDigestMirrors:
                     - mirrors:
                         - quay-intern.example.com/ocp4/openshift-release-dev
                       source: quay.io/openshift-release-dev/ocp-release
@@ -60,7 +60,8 @@ policies:
                         - quay-intern.example.com/ocp4/openshift-release-dev
                       source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 ----
-<1> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
-<2> `ImageSignature.yaml` contains the image signature of the required release image. The image signature is used to verify the image before applying the platform update.
-<3> Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+
+* `source-crs/ClusterVersion.yaml` - Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image precaching.
+* `source-crs/ImageSignature.yaml` - Contains the image signature of the required release image. The image signature is used to verify the image before applying the platform update.
+* `repositoryDigestMirrors` - Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
 

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -19,10 +19,10 @@
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators-disconnected-v2 <1>
+        name: redhat-operators-disconnected-v2
       spec:
-        displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
+        displayName: Red Hat Operators Catalog v2
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version>
         updateStrategy:
           registryPoll:
             interval: 1h
@@ -30,6 +30,7 @@
         connectionState:
             lastObservedState: READY
 ----
-<1> Update the name for the new configuration.
-<2> Update the display name for the new configuration.
-<3> Update the index image URL. This `fileName.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+
+* `name` - Update the name for the new configuration.
+* `displayName` - Update the display name for the new configuration.
+* `image` - Update the index image URL. This `fileName.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -19,14 +19,15 @@ spec:
         name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
-        updateStrategy: <2>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
+        updateStrategy:
           registryPoll:
             interval: 1h
       status:
         connectionState:
-            lastObservedState: READY <3>
+            lastObservedState: READY
 ----
-<1> The index image URL contains the desired Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
-<2> Set how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this behavior, you can restore `registryPoll.interval` to the default value once the update is complete.
-<3> Last observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+
+* `image` - The index image URL contains the required Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
+* `updateStrategy` - Set how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this behavior, you can restore `registryPoll.interval` to the default value once the update is complete.
+* `lastObservedState` - Last observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -12,23 +12,23 @@ spec:
   mcp: "master"
   remediationAction: inform
   sourceFiles:
-    - fileName: ImageSignature.yaml <1>
+    - fileName: ImageSignature.yaml
       policyName: "platform-upgrade-prep"
       binaryData:
-        ${DIGEST_ALGO}-${DIGEST_ENCODED}: ${SIGNATURE_BASE64} <2>
+        ${DIGEST_ALGO}-${DIGEST_ENCODED}: ${SIGNATURE_BASE64}
     - fileName: DisconnectedICSP.yaml
       policyName: "platform-upgrade-prep"
       metadata:
         name: disconnected-internal-icsp-for-ocp
       spec:
-        repositoryDigestMirrors: <3>
+        repositoryDigestMirrors:
           - mirrors:
             - quay-intern.example.com/ocp4/openshift-release-dev
             source: quay.io/openshift-release-dev/ocp-release
           - mirrors:
             - quay-intern.example.com/ocp4/openshift-release-dev
             source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-    - fileName: ClusterVersion.yaml <4>
+    - fileName: ClusterVersion.yaml
       policyName: "platform-upgrade"
       metadata:
         name: version
@@ -42,7 +42,8 @@ spec:
           - version: {product-version}.4
             state: "Completed"
 ----
-<1> The `ConfigMap` CR contains the signature of the desired release image to update to.
-<2> Shows the image signature of the desired {product-title} release. Get the signature from the `checksum-${OCP_RELEASE_NUMBER}.yaml` file you saved when following the procedures in the "Setting up the environment" section.
-<3> Shows the mirror repository that contains the desired {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
-<4> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
+
+* `ImageSignature.yaml` - The `ConfigMap` CR contains the signature of the required release image to update to.
+* `${DIGEST_ALGO}-${DIGEST_ENCODED}: ${SIGNATURE_BASE64}` - Shows the image signature of the required {product-title} release. Get the signature from the `checksum-${OCP_RELEASE_NUMBER}.yaml` file you saved when following the procedures in the "Setting up the environment" section.
+* `repositoryDigestMirrors` - Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+* `ClusterVersion.yaml` - Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image precaching.


### PR DESCRIPTION
[TELCODOCS-2799]: Fix AsciiDocDITA rule violations in ztp-talm-updating-managed-policies-pg assembly

Version(s): 4.20+

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2799

Link to docs preview: https://115955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html

QE review:
- [ ] QE has approved this change.

Additional information: Resolve all AsciiDocDITA errors across 10 files in the ztp-talm-updating-managed-policies-pg assembly to prepare for DITA conversion.

Note: These are editorial/DITA-prep changes only - no technical content changes.