### PR TITLE
OSDOCS-20772: Add 4.21.25 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-25.adoc
+++ b/modules/zstream-4-21-25.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-25_{context}"]
+= RHSA-2026:40792 - {product-title} {product-version}.25 bug fix and security update
+
+Issued: 21 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.25 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40792[RHSA-2026:40792] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40778[RHBA-2026:40778] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.25 --pullspecs
+----
+
+[id="zstream-4-21-25-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `nested-container` Security Context Constraint (SCC) used an incorrect specification for UID ranges, causing the UID ranges to be completely missing. As a consequence, pods using the `nested-container` SCC did not have the expected UID range constraints applied. With this release, the SCC correctly uses `uidRangeMin` and `uidRangeMax` fields to specify the UID range from `0` to `65534` so that the `nested-container` SCC properly enforces UID range constraints. (link:https://redhat.atlassian.net/browse/OCPBUGS-81747[OCPBUGS-81747])
+
+* Before this update, the Cluster API image overrides logic did not detect registry configuration. As a consequence, images were always pulled from `quay.io`, and registry overrides had no effect. The rest of the payload properly applied the overrides. With this release, the Cluster API image override logic detects the registry configuration and follows it. As a result, images are downloaded from the correct registry. For this feature to work as intended in environments where registry overrides are applied, 4.20.10 images must be mirrored to the target registry. Otherwise, images are not pulled and clusters are not created. (link:https://redhat.atlassian.net/browse/OCPBUGS-86295[OCPBUGS-86295])
+
+* Before this update, in Telecom Boundary Clock (T-BC) configurations, the `cloud-event-proxy` parameter previously derived the `CLOCK_REALTIME` (E3) sync state incorrectly due to conflicting code paths and race conditions. As a consequence, status inconsistencies and inaccurate reporting occurred. With this release, the `phc2sys` service is the sole publisher of E3, which uses the `worst_of(phc2sys_state, E1_state)` logic and removes the unstable `masterOffsetSource` check. As a result, the `CLOCK_REALTIME` state now accurately reflects the `phc2sys` service offset and upstream PTP lock status. (link:https://redhat.atlassian.net/browse/OCPBUGS-88704[OCPBUGS-88704])
+
+* Before this update, when you provisioned machines on an OpenStack cloud provider that does not support the optional Standard Attributes Tag extension, the Machine API Provider for OpenStack (MAPO) attempted to apply port tags during network port creation. As a consequence, network port creation failed and machine provisioning did not complete. With this release, MAPO checks whether the OpenStack Neutron `standard-attr-tag` extension is available before applying port tags. If the extension is not supported, MAPO skips tag assignment during provisioning. If you explicitly configure port tags on an unsupported OpenStack deployment, MAPO returns an error that prompts you to remove the port tags configuration. As a result, machine provisioning completes successfully on OpenStack deployments that do not support the tag extension. (link:https://redhat.atlassian.net/browse/OCPBUGS-97825[OCPBUGS-97825])
+
+[id="zstream-4-21-25-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -45,6 +45,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
 // 4.21.24 RNs and updating
+// 4.21.25 RNs and updating
+include::modules/zstream-4-21-25.adoc[leveloffset=+2]
+
 include::modules/zstream-4-21-24.adoc[leveloffset=+2]
 
 // 4.21.23 RNs and updating


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20772

Link to docs preview:
https://115963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-25_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/655
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:40792 / RHBA-2026:40778
