### PR TITLE
[OCPBUGS#56411]: Document creating an IPPool for static IP machine scaling

### DIFF
--- a/modules/nodes-vsphere-creating-ippool-static-ip.adoc
+++ b/modules/nodes-vsphere-creating-ippool-static-ip.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/node-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-vsphere-creating-ippool-static-ip_{context}"]
+= Creating an IP pool for static IP addresses
+
+[role="_abstract"]
+Before you use a machine set to scale machines with static IP addresses, create an `IPPool` custom resource (CR). The `IPPool` CR defines the static IP addresses that an external IP address management (IPAM) controller can allocate to machines in the machine set.
+
+[IMPORTANT]
+====
+* The Machine API does not include a built-in IPAM service. Your organization must deploy an external IPAM controller that can reconcile `IPAddressClaim` resources and bind static IP addresses from an `IPPool` resource.
+* The `apiVersion` and schema of the `IPPool` resource depend on the IPAM controller that you deploy. The following example uses the `ipamcontroller.example.io` API group to match the machine set configuration that is shown later in this section.
+* Do not use the Whereabouts `IPPool` resource (`whereabouts.cni.cncf.io/v1alpha1`) for Machine API static IP address allocation. The Whereabouts `IPPool` resource is used by the Whereabouts IPAM Container Network Interface (CNI) plugin to allocate IP addresses to pods on secondary networks.
+====
+
+.Prerequisites
+
+* You deployed a cluster that runs at least one node with a configured static IP address.
+* You deployed an external IPAM controller that can manage `IPPool` resources and bind IP addresses to `IPAddressClaim` resources.
+
+.Procedure
+
+. Create a file named `ippool.yaml` that defines an `IPPool` resource:
++
+[source,yaml]
+----
+apiVersion: ipamcontroller.example.io/v1
+kind: IPPool
+metadata:
+  name: static-ci-pool <1>
+  namespace: openshift-machine-api
+spec:
+  addresses: <2>
+  - 192.168.204.128/29
+  gateway: 192.168.204.1 <3>
+  prefix: 24 <4>
+----
+<1> The name of the IP pool. You must specify this name in the `network.devices.addressesFromPools` section of the machine set.
+<2> A list of static IP addresses or CIDR ranges that the IPAM controller can allocate to machines. Modify these values for your network.
+<3> The default gateway for the network interface.
+<4> The prefix length for the network.
+
+. Create the `IPPool` resource by entering the following command:
++
+[source,terminal]
+----
+$ oc create -f ippool.yaml
+----
+
+. Verify that the `IPPool` resource exists by entering the following command:
++
+[source,terminal]
+----
+$ oc get ippool.ipamcontroller.example.io -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME             AGE
+static-ci-pool   30s
+----
+
+[NOTE]
+====
+To add more static IP addresses later, update the `IPPool` resource, and then scale the machine set. You can also scale machine sets that use Dynamic Host Configuration Protocol (DHCP) independently from machine sets that use static IP addresses.
+====

--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -8,13 +8,15 @@
 
 You can use a machine set to scale machines with configured static IP addresses.
 
-After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.
+To enable this configuration, create an `IPPool` resource that defines the static IP addresses available for allocation. Then configure a machine set to request a static IP address from that pool. After you configure the machine set, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. An external IP address management (IPAM) controller then creates an `IPAddress` resource and binds a static IP address from the pool to the `IPAddressClaim` resource.
 
 [IMPORTANT]
 ====
-Your organization might use numerous types of IP address management (IPAM) services. If you want to enable a particular IPAM service on {product-title}, you might need to manually create the `IPAddressClaim` resource in a YAML definition and then bind a static IP address to this resource by entering the following command in your `oc` CLI:
+* Your organization might use numerous types of IPAM services. The Machine API does not include a built-in IPAM service, so you must deploy an external controller that can manage `IPPool` resources and bind IP addresses to `IPAddressClaim` resources.
+* The Whereabouts `IPPool` resource (`whereabouts.cni.cncf.io/v1alpha1`) is not used for Machine API static IP address allocation. That resource is used by the Whereabouts IPAM Container Network Interface (CNI) plugin to allocate IP addresses to pods on secondary networks.
+* If you want to enable a particular IPAM service on {product-title}, you might need to manually create the `IPAddressClaim` resource in a YAML definition and then bind a static IP address to this resource by entering the following command in your `oc` CLI:
 
-[source, terminal]
+[source,terminal]
 ----
 $ oc create -f <ipaddressclaim_filename>
 ----
@@ -38,4 +40,4 @@ spec:
 status: {}
 ----
 
-The machine controller updates the machine with a status of `IPAddressClaimed` to indicate that a static IP address has successfully bound to the `IPAddressClaim` resource. The machine controller applies the same status to a machine with multiple `IPAddressClaim` resources that each contain a bound static IP address.The machine controller then creates a virtual machine and applies static IP addresses to any nodes listed in the `providerSpec` of a machine's configuration.
+The machine controller updates the machine with a status of `IPAddressClaimed` to indicate that a static IP address has successfully bound to the `IPAddressClaim` resource. The machine controller applies the same status to a machine with multiple `IPAddressClaim` resources that each contain a bound static IP address. The machine controller then creates a virtual machine and applies static IP addresses to any nodes listed in the `providerSpec` of a machine's configuration.

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -13,6 +13,7 @@ The example in the procedure demonstrates the use of controllers for scaling mac
 .Prerequisites
 
 * You deployed a cluster that runs at least one node with a configured static IP address.
+* You created an `IPPool` resource that defines the static IP addresses for the machine set. For more information, see "Creating an IP pool for static IP addresses".
 
 .Procedure
 . Configure a machine set by specifying IP pool information in the `network.devices.addressesFromPools` schema of the machine set's YAML file:

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -186,7 +186,7 @@ include::modules/nodes-nodes-managing-max-pods-proc.adoc[leveloffset=+1]
 [id="nodes-vsphere-scale-static-ip-addresses"]
 == Machine scaling with static IP addresses
 
-After you deployed your cluster to run nodes with static IP addresses, you can scale an instance of a machine or a machine set to use one of these static IP addresses.
+After you deployed your cluster to run nodes with static IP addresses, you can scale an instance of a machine or a machine set to use one of these static IP addresses. To scale a machine set with static IP addresses, create an `IPPool` resource that defines the available addresses, and then configure the machine set to request an address from that pool.
 
 [role="_additional-resources"]
 .Additional resources
@@ -197,6 +197,9 @@ include::modules/nodes-vsphere-scaling-machines-static-ip.adoc[leveloffset=+2]
 
 // Machine set scaling of machines with configured static IP addresses
 include::modules/nodes-vsphere-machine-set-concept-static-ip.adoc[leveloffset=+2]
+
+// Creating an IP pool for static IP addresses
+include::modules/nodes-vsphere-creating-ippool-static-ip.adoc[leveloffset=+2]
 
 // Using a machine set to scale machines with configured static IP addresses
 include::modules/nodes-vsphere-machine-set-scaling-static-ip.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
* Adds a procedure for creating an `IPPool` resource used when scaling machine sets with static IP addresses.
* Clarifies that the Whereabouts `IPPool` API (`whereabouts.cni.cncf.io/v1alpha1`) is for pod secondary-network IPAM and is not used for Machine API static IP allocation.
* Notes that DHCP-backed and static-IP machine sets can be scaled independently.

## Test plan
- [ ] Confirm the new module renders under **Machine scaling with static IP addresses** in the Netlify PR preview.
- [ ] Verify callouts and example YAML for `IPPool` creation are clear and consistent with the existing machine set examples (`ipamcontroller.example.io`).
- [ ] Confirm the Whereabouts distinction note is accurate for QE/docs review.
- [ ] QE review for OCP 4.16+.

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-56411

Link to docs preview:
<!--- Add Netlify preview URL after CI builds --->

QE review:
- [ ] QE has approved this change.


Made with [Cursor](https://cursor.com)