### PR TITLE
OSDOCS-20773: Add 4.20.30 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-30.adoc
+++ b/modules/zstream-4-20-30.adoc
@@ -9,7 +9,7 @@
 Issued: 21 July 2026
 
 [role="_abstract"]
-{product-title} release {product-version}.30 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40795[RHSA-2026:40795] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40780[RHBA-2026:40780] advisory.
+{product-title} release {product-version}.30 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40795[RHSA-2026:40795] advisory. There are no RPM packages for this release.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -24,6 +24,8 @@ $ oc adm release info 4.20.30 --pullspecs
 == Fixed issues
 
 * Before this update, in Telecom Boundary Clock (T-BC) configurations, the `cloud-event-proxy` parameter previously derived the `CLOCK_REALTIME` (E3) sync state incorrectly due to conflicting code paths and race conditions. As a consequence, status inconsistencies and inaccurate reporting occurred. With this release, the `phc2sys` service is the sole publisher of E3, which uses the `worst_of(phc2sys_state, E1_state)` logic and removes the unstable `masterOffsetSource` check. As a result, the `CLOCK_REALTIME` state now accurately reflects the `phc2sys` service offset and upstream PTP lock status. (link:https://redhat.atlassian.net/browse/OCPBUGS-88705[OCPBUGS-88705])
+
+* Before this update, by default, the Vertical Pod Autoscaler (VPA) Operator required a primary node for running the VPA controllers, even on hosted control plane (HCP) clusters where these nodes did not exist in the guest cluster. As a consequence, installation of the VPA on HCP clusters failed. With this release, the VPA controllers can run on any nodes in HCP clusters. As a result, you can install the VPA successfully on HCP clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-92046[OCPBUGS-92046])
 
 [id="zstream-4-20-30-updating_{context}"]
 == Updating

--- a/modules/zstream-4-20-30.adoc
+++ b/modules/zstream-4-20-30.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-30_{context}"]
+= RHSA-2026:40795 - {product-title} {product-version}.30 bug fix and security update
+
+Issued: 21 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.30 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40795[RHSA-2026:40795] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40780[RHBA-2026:40780] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.30 --pullspecs
+----
+
+[id="zstream-4-20-30-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, in Telecom Boundary Clock (T-BC) configurations, the `cloud-event-proxy` parameter previously derived the `CLOCK_REALTIME` (E3) sync state incorrectly due to conflicting code paths and race conditions. As a consequence, status inconsistencies and inaccurate reporting occurred. With this release, the `phc2sys` service is the sole publisher of E3, which uses the `worst_of(phc2sys_state, E1_state)` logic and removes the unstable `masterOffsetSource` check. As a result, the `CLOCK_REALTIME` state now accurately reflects the `phc2sys` service offset and upstream PTP lock status. (link:https://redhat.atlassian.net/browse/OCPBUGS-88705[OCPBUGS-88705])
+
+[id="zstream-4-20-30-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3022,6 +3022,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
 // 4.20.29 RNs and updating
+// 4.20.30 RNs and updating
+include::modules/zstream-4-20-30.adoc[leveloffset=+2]
+
 include::modules/zstream-4-20-29.adoc[leveloffset=+2]
 
 // 4.20.28 release notes


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20773

Link to docs preview:
https://115966--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-30_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/656
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:40795 / RHBA-2026:40780

