### PR TITLE
OSDOCS-20774: Add 4.19.39 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-39.adoc
+++ b/modules/zstream-4-19-39.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-39_{context}"]
+= RHSA-2026:40765 - {product-title} {product-version}.39 bug fix and security update
+
+Issued: 22 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.39 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40765[RHSA-2026:40765] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.39 --pullspecs
+----
+
+[id="zstream-4-19-39-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, by default, the Vertical Pod Autoscaler (VPA) Operator required a primary node for running the VPA controllers, even on hosted control plane (HCP) clusters where these nodes did not exist in the guest cluster. As a consequence, installation of the VPA on HCP clusters failed. With this release, the VPA controllers can run on any nodes in HCP clusters. As a result, you can install the VPA successfully on HCP clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-98699[OCPBUGS-98699])
+
+[id="zstream-4-19-39-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2978,6 +2978,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
 // 4.19.38 RNs and updating
+// 4.19.39 RNs and updating
+include::modules/zstream-4-19-39.adoc[leveloffset=+2]
+
 include::modules/zstream-4-19-38.adoc[leveloffset=+2]
 
 // 4.19.37 z-stream RNs full document


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20774

Link to docs preview:
https://115967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-39_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/653
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:40765 / RHBA-2026:40761
