### PR TITLE
OSDOCS-20775: Add 4.18.49 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-49.adoc
+++ b/modules/zstream-4-18-49.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-49_{context}"]
+= RHSA-2026:40828 - {product-title} {product-version}.49 bug fix and security update
+
+Issued: 22 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.49 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40828[RHSA-2026:40828] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40826[RHBA-2026:40826] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.49 --pullspecs
+----
+
+[id="zstream-4-18-49-enhancements_{context}"]
+== Enhancements
+
+* Before this update, deleting a BareMetalHost (BMH) that referenced a pre-provisioning network data Secret through the `spec.preprovisioningNetworkDataName` parameter could report a `RegistrationError` if the Secret was removed before the BMH finished deleting. As a consequence, the BMH deletion would take minutes to complete before an eventual force-delete by the controller. With this release, the Bare Metal Operator (BMO) manages the lifecycle of that Secret in the same way as the BMC credential Secrets. The BMO now protects the Secret using a finalizer while the host is active, which prevents the Secret deletion until the finalizer is removed by the controller. As a result, the BMH is removed successfully before the Secret is allowed to be deleted. (link:https://redhat.atlassian.net/browse/OCPBUGS-87967[OCPBUGS-87967])
+
+[id="zstream-4-18-49-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the tuned daemon lost its connection to the API server during primary node restarts. As a consequence, during resiliency testing when primary nodes were restarted one by one, the `PerformanceProfile` might have entered a degraded state with a `rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout` error message. With this release, the Operator now properly handles connection timeouts and automatically recovers. As a result, the `PerformanceProfile` does not enter a degraded state during master node restarts. (link:https://issues.redhat.com/browse/OCPBUGS-90575[OCPBUGS-90575])
+
+* Before this update, when you provisioned machines on an OpenStack cloud provider that does not support the optional Standard Attributes Tag extension, the Machine API Provider for OpenStack (MAPO) attempted to apply port tags during network port creation. As a consequence, network port creation failed and machine provisioning did not complete. With this release, MAPO checks whether the OpenStack Neutron `standard-attr-tag` extension is available before applying port tags. If the extension is not supported, MAPO skips tag assignment during provisioning. If you explicitly configure port tags on an unsupported OpenStack deployment, MAPO returns an error that prompts you to remove the port tags configuration. As a result, machine provisioning completes successfully on OpenStack deployments that do not support the tag extension. (link:https://issues.redhat.com/browse/OCPBUGS-93867[OCPBUGS-93867])
+
+* Before this update, shared key access was enabled on the cluster storage account, preventing it from being migrated to identity-based access to {azure-first} Storage. As a consequence, shared key access caused security concerns and prevented migration. With this release, shared key access is automatically disabled when using a managed identity, which facilitates a seamless transition to identity-based access. As a result, disabling shared key access improves security. (link:https://issues.redhat.com/browse/OCPBUGS-95616[OCPBUGS-95616])
+
+* Before this update, by default, the Vertical Pod Autoscaler (VPA) Operator required a primary node for running the VPA controllers, even on hosted control plane (HCP) clusters where these nodes did not exist in the guest cluster. As a consequence, installation of the VPA on HCP clusters failed. With this release, the VPA controllers can run on any nodes in HCP clusters. As a result, you can install the VPA successfully on HCP clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-98714[OCPBUGS-98714])
+
+[id="zstream-4-18-49-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3065,6 +3065,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
 // 4.18.48 RNs and updating
+// 4.18.49 RNs and updating
+include::modules/zstream-4-18-49.adoc[leveloffset=+2]
+
 include::modules/zstream-4-18-48.adoc[leveloffset=+2]
 
 // 4.18.47 RNs and updating


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20775

Link to docs preview:
https://115968--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-49_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/657
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:40828 / RHBA-2026:40826
