### PR TITLE
OSDOCS-20776: Add 4.13.69 z-stream release notes

### DIFF
--- a/modules/zstream-4-13-69-about.adoc
+++ b/modules/zstream-4-13-69-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-69-about_{context}"]
+= RHSA-2026:40022 - {product-title} 4.13.69 bug fix and security update
+
+Issued: 23 July 2026
+
+[role="_abstract"]
+{product-title} release 4.13.69, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40022[RHSA-2026:40022] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40020[RHBA-2026:40020] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.69 --pullspecs
+----

--- a/modules/zstream-4-13-69-bug-fixes.adoc
+++ b/modules/zstream-4-13-69-bug-fixes.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-69-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-96902[OCPBUGS-96902])

--- a/modules/zstream-4-13-69-updating.adoc
+++ b/modules/zstream-4-13-69-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-69-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4693,3 +4693,10 @@ include::modules/zstream-4-13-68-about.adoc[leveloffset=+2]
 include::modules/zstream-4-13-68-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-68-updating.adoc[leveloffset=+2]
+
+//4.13.69
+include::modules/zstream-4-13-69-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-69-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-69-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20776

Link to docs preview:
https://115969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-69-about_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/647
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13
- Errata: RHSA-2026:40022 / RHBA-2026:40020