### PR TITLE
OSDOCS-20777: Add 4.12.94 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-94-about.adoc
+++ b/modules/zstream-4-12-94-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-94-about_{context}"]
+= RHSA-2026:40030 - {product-title} {product-version}.94 bug fix and security update
+
+[role="_abstract"]
+Issued: 23 July 2026
+
+{product-title} release {product-version}.94, which includes security updates, is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:40030[RHSA-2026:40030] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:40028[RHBA-2026:40028] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.94 --pullspecs
+----

--- a/modules/zstream-4-12-94-fixed-issues.adoc
+++ b/modules/zstream-4-12-94-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-94-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-96903[OCPBUGS-96903])

--- a/modules/zstream-4-12-94-updating.adoc
+++ b/modules/zstream-4-12-94-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-94-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5440,3 +5440,12 @@ include::modules/zstream-4-12-93-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.93 updating
 include::modules/zstream-4-12-93-updating.adoc[leveloffset=+3]
+
+// 4.12.94 about
+include::modules/zstream-4-12-94-about.adoc[leveloffset=+2]
+
+// 4.12.94 fixes
+include::modules/zstream-4-12-94-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.94 updating
+include::modules/zstream-4-12-94-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20777

Link to docs preview:
https://115970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-94-about_release-notes

QE review:

N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/648
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12
- Errata: RHSA-2026:40030 / RHBA-2026:40028