### PR TITLE
OADP-6736: OOM Velero Server

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
@@ -12,7 +12,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :must-gather-v1-4: registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.4
 
 
-
 [role="_abstract"]
 Resolve Velero or Restic pod crashes caused by insufficient memory or CPU by configuring resource requests in the `DataProtectionApplication` custom resource (CR). This helps you allocate adequate CPU and memory resources to prevent pod restarts and ensure stable backup and restore operations.
 
@@ -32,6 +31,8 @@ requests:
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#oadp-velero-cpu-memory-requirements_about-installing-oadp[Velero CPU and memory requirements based on collected data]
 
 include::modules/oadp-pod-crash-set-resource-request-velero.adoc[leveloffset=+1]
+
+include::modules/velero-oomkilled-large-kopia-repos.adoc[leveloffset=+1]
 
 include::modules/oadp-pod-crash-set-resource-request-restic.adoc[leveloffset=+1]
 

--- a/modules/velero-oomkilled-large-kopia-repos.adoc
+++ b/modules/velero-oomkilled-large-kopia-repos.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="velero-oomkilled-large-kopia-repos_{context}"]
+= Velero server terminates with OOMKilled when accessing large Kopia repositories
+
+[role="_abstract"]
+If the Velero server accesses large Kopia repositories, the Velero pod might crash and report an `OOMKilled` event.
+
+During operations that access large Kopia repositories, such as backup deletion or checking repository existence, the Velero pod crashes and reports an `OOMKilled` event.
+
+This issue is typically caused by high memory usage when the Velero server loads many Kopia index blobs and related repository metadata. When the Backup Repository controller accesses a large-scale repository, the required memory can exceed the default limits.
+
+To resolve this issue, identify the peak memory usage and increase the memory limits in the `DataProtectionApplication` (DPA) custom resource (CR) so that the Velero server has enough memory to load the repository metadata.
+
+.Procedure
+
+. Check the Velero logs around the time of the `OOMKilled` event for repository-open or index-loading activity.
+
+. Note the approximate maximum memory usage observed for the Velero pod by using a command such as `oc top pods`.
+
+. Edit the `DataProtectionApplication` CR:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc edit dpa __<dpa_name>__ -n openshift-adp
+----
++
+where:
++
+`<dpa_name>`:: Specifies the name of your `DataProtectionApplication` CR.
+
+. Increase the Velero container memory request or limit in the `spec.configuration.velero.podConfig` block to exceed the observed peak. For example:
++
+[source,yaml,subs="+quotes"]
+----
+spec:
+  configuration:
+    velero:
+      podConfig:
+        resourceAllocations:
+          limits:
+            memory: __<memory_limit>__
+          requests:
+            memory: 512Mi
+----
++
+where:
++
+`<memory_limit>`:: Specifies a value that exceeds the maximum memory usage you observed in the logs, for example, `2Gi`.
+
+. Save your changes.
++
+The Velero pod redeploys automatically with the new limits.
+
+. Monitor the environment and repeat the process if necessary until `OOMKilled` events no longer occur.
+
+. Record the final stable memory values for your environment to use for future sizing guidance.


### PR DESCRIPTION
## JIRA

* [OADP-6736](https://redhat.atlassian.net/browse/OADP-6736)

---

## Version(s):

* OCP - main, 
* OCP - 4.22, 
* OCP 5.0

---

## Link to docs preview:

* [Velero server terminates with OOMKilled when accessing large Kopia repositories](https://115989--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.html#velero-oomkilled-large-kopia-repos_pods-crash-or-restart-due-to-lack-of-memory-or-cpu)

---

## QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

---


