### PR TITLE
OSDOCS-17040: minimum resource module links

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -238,7 +238,7 @@ For {product-title} version 4.22, {op-system} is based on {op-system-base} versi
 * IBM Power architecture requires Power 9 ISA
 * s390x architecture requires z14 ISA
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.2_release_notes/index#architectures[Architectures] ({op-system-base} documentation).
+For more information, see "Architectures".
 ====
 
 ifdef::azure[]
@@ -261,8 +261,17 @@ Do not use memory ballooning in {product-title} clusters. Memory ballooning can 
 
 These minimum CPU and memory requirements do not account for resources required by user workloads.
 
-For more information, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7074533[Memory Ballooning and OpenShift].
+For more information, see "Memory Ballooning and OpenShift".
 ====
+endif::vsphere[]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.2_release_notes/index#architectures[Architectures ({op-system-base} documentation)]
+
+ifdef::vsphere[]
+* link:https://access.redhat.com/articles/7074533[Memory Ballooning and OpenShift (Red{nbsp}Hat Knowledgebase article)]
 endif::vsphere[]
 
 ifeval::["{context}" == "installing-azure-customizations"]


### PR DESCRIPTION
[OSDOCS-17040](https://redhat.atlassian.net/browse/OSDOCS-17040)

Version(s): 4.20+

Moving a few install links to AR section as part of CQA

QE review: Not required

Previews:

- [Minimum resource requirements for cluster installation](https://115998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/upi-aws-installation-reqs#installation-minimum-resource-requirements_upi-aws-installation-reqs) (non-vsphere example)
- [Minimum resource requirements for cluster installation](https://115998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#installation-minimum-resource-requirements_upi-vsphere-installation-reqs) (vsphere)
