### PR TITLE
OSDOCS-17034: two node CQA pt 2

### DIFF
--- a/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
+++ b/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
@@ -14,9 +14,9 @@ After installation, you can add additional arbiter nodes to a cluster with two c
 
 You can install a cluster with two control plane nodes and one local arbiter node by using one of the following methods:
 
-* Installing on bare metal: xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node]
+* Installing on bare metal: See "Configuring a local arbiter node".
 
-* Installing with the Agent-based Installer: xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_installing-with-agent-based-installer[Configuring a local arbiter node]
+* Installing with the Agent-based Installer: See "About a local arbiter node".
 
 [NOTE]
 ====
@@ -26,5 +26,7 @@ For a cluster with an arbiter, the same networking requirements as a regular clu
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_preparing-to-install-with-agent-based-installer[About a local arbiter node]
 * xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installation-network-connectivity-user-infra_installing-platform-agnostic[Network connectivity requirements]
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_preparing-to-install-with-agent-based-installer[About a local arbiter node]


### PR DESCRIPTION
[OSDOCS-17034](https://redhat.atlassian.net/browse/OSDOCS-17034)

Version(s): 4.20 and 4.21 only

This PR addresses remaining 4.20 and 4.21 DITA errors in two node install content that was not captured in other PRs based off of the main branch

QE review: Not required

Previews: https://116003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/about-two-node-arbiter-installation.html