### PR TITLE
OSDOCS-17034: two node CQA pt 3

### DIFF
--- a/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can perform postinstallation troubleshooting and recovery tasks on a Two-node OpenShift cluster with fencing if you encounter issues with the cluster.
+
 :FeatureName: Two-node OpenShift cluster with fencing
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
@@ -15,7 +18,7 @@ Use the following sections help you with recovering from issues in a two-node Op
 include::modules/installation-manual-recovering-when-auto-recovery-is-unavail.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd-restoring_backing-up-etcd[Restoring etcd from a backup]
 
@@ -25,9 +28,9 @@ include::modules/installation-manual-recovering-when-auto-recovery-is-unavail.ad
 include::modules/installation-replacing-control-plane-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd-restoring_backing-up-etcd[Restoring etcd from a backup].
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd-restoring_backing-up-etcd[Restoring etcd from a backup]
 
 // Verifying etcd health in a two-node OpenShift cluster with fencing
 include::modules/installation-verifying-etcd-health.adoc[leveloffset=+1]

--- a/installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
@@ -6,10 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can deploy a two-node OpenShift cluster with fencing by using either the installer-provisioned infrastructure or the user-provisioned infrastructure installation method.
+
+The following examples provide sample `install-config.yaml` configurations for both methods.
+
 :FeatureName: Two-node OpenShift cluster with fencing
 include::snippets/technology-preview.adoc[leveloffset=+1]
-
-You can deploy a two-node OpenShift cluster with fencing by using either the installer-provisioned infrastructure or the user-provisioned infrastructure installation method. The following examples provide sample `install-config.yaml` configurations for both methods.
 
 // Sample install-config.yaml for a two-node installer-provisioned infrastructure cluster with fencing
 include::modules/installation-sample-install-config-two-node-fencing-ipi.adoc[leveloffset=+1]

--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -6,12 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Two-node OpenShift cluster with fencing
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
+[role="_abstract"]
 A two-node OpenShift cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
 
 A two-node cluster does not include compute nodes. The two control plane machines run user workloads in addition to managing the cluster.
+
+:FeatureName: Two-node OpenShift cluster with fencing
+include::snippets/technology-preview.adoc[leveloffset=+1]
 
 Fencing is managed by Pacemaker, which can isolate an unresponsive node by using the Baseboard Management Console (BMC) of the node. After the unresponsive node is fenced, the remaining node can safely continue operating the cluster without the risk of resource corruption.
 
@@ -36,7 +37,7 @@ The two-node OpenShift cluster with fencing requires the following hosts:
 
 |===
 
-The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see xref:../../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#creating-machines-bare-metal_installing-bare-metal-network-customizations[Installing {op-system} and starting the {product-title} bootstrap process]
+The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see "Installing {op-system} and starting the {product-title} bootstrap process".
 
 [NOTE]
 ====
@@ -62,6 +63,8 @@ include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[level
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+
+* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#creating-machines-bare-metal_installing-bare-metal-network-customizations[Installing {op-system} and starting the {product-title} bootstrap process]
 
 * xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest file for a customized br-ex bridge]
 

--- a/modules/installation-manual-recovering-when-auto-recovery-is-unavail.adoc
+++ b/modules/installation-manual-recovering-when-auto-recovery-is-unavail.adoc
@@ -2,7 +2,10 @@
 [id="installation-manual-recovering-when-auto-recovery-is-unavail_{context}"]
 = Manually recovering from a disruption event when automated recovery is unavailable
 
-You might need to perform manual recovery steps if a disruption event prevents fencing from functioning correctly. In this case, you can run commands directly on the control plane nodes to recover the cluster. There are four main recovery scenarios, which should be attempted in the following order:
+[role="_abstract"]
+You might need to perform manual recovery steps if a disruption event prevents fencing from functioning correctly. In this case, you can run commands directly on the control plane nodes to recover the cluster.
+
+There are four main recovery scenarios, which should be attempted in the following order:
 
 . Update fencing secrets:  Refresh the Baseboard Management Console (BMC) credentials if they are incorrect or outdated.
 . Recover from a single-node failure: Restore functionality when only one control plane node is down.
@@ -135,7 +138,7 @@ $ sudo journalctl -u pacemaker
 $ sudo journalctl -u kubelet
 ----
 
-.. Handle out-of-sync etcd. 
+.. Handle out-of-sync etcd.
 +
 If one node has a more up-to-date etcd, Pacemaker attempts to fence the lagging node and start it as a learner. If this process stalls, verify the Redfish fencing endpoint and credentials by running the following command:
 +

--- a/modules/installation-sample-install-config-two-node-fencing-ipi.adoc
+++ b/modules/installation-sample-install-config-two-node-fencing-ipi.adoc
@@ -2,7 +2,8 @@
 [id="sample-install-config-two-node-fencing-ipi_{context}"]
 = Sample install-config.yaml for a two-node installer-provisioned infrastructure cluster with fencing
 
-You can use the following `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the installer-provisioned infrastructure method:
+[role="_abstract"]
+You can use a sample `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the installer-provisioned infrastructure method.
 
 [NOTE]
 ====
@@ -59,12 +60,12 @@ platform:
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
-* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.  
-* `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.  
-* `fencing.credentials.hostname`: Provide the Baseboard Management Console (BMC) credentials for each control plane node. These credentials are required for node fencing and prevent split-brain scenarios. 
+* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.
+* `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.
+* `fencing.credentials.hostname`: Provide the Baseboard Management Console (BMC) credentials for each control plane node. These credentials are required for node fencing and prevent split-brain scenarios.
 * `fencing.credentials.certificateVerification`: Set this field to `Disabled` if your Redfish URL uses self-signed certificates, which is common for internally-hosted endpoints. Set this field to `Enabled` for URLs with valid CA-signed certificates.
-* `metadata.name`: The cluster name is used as a prefix for hostnames and DNS records.  
-* `featureSet`: Set this field to `TechPreviewNoUpgrade` to enable two-node OpenShift cluster deployments.  
-* `platform.baremetal.apiVIPs` and `platform.baremetal.ingressVIPs` : Virtual IPs for the API and Ingress endpoints. Ensure they are reachable by all nodes and external clients.  
-* `pullSecret`: Contains credentials required to pull container images for the cluster components.  
+* `metadata.name`: The cluster name is used as a prefix for hostnames and DNS records.
+* `featureSet`: Set this field to `TechPreviewNoUpgrade` to enable two-node OpenShift cluster deployments.
+* `platform.baremetal.apiVIPs` and `platform.baremetal.ingressVIPs` : Virtual IPs for the API and Ingress endpoints. Ensure they are reachable by all nodes and external clients.
+* `pullSecret`: Contains credentials required to pull container images for the cluster components.
 * `sshKey`: The SSH public key for accessing cluster nodes after installation.

--- a/modules/installation-sample-install-config-two-node-fencing-upi.adoc
+++ b/modules/installation-sample-install-config-two-node-fencing-upi.adoc
@@ -2,7 +2,8 @@
 [id="sample-install-config-two-node-fencing-upi_{context}"]
 = Sample install-config.yaml for a two-node user-provisioned infrastructure cluster with fencing
 
-You can use the following `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the user-provisioned infrastructure method:
+[role="_abstract"]
+You can use a sample `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the user-provisioned infrastructure method.
 
 [NOTE]
 ====
@@ -38,11 +39,11 @@ platform:
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
-* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.  
-* `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.  
-* `fencing.credentials.hostname`: Provide BMC credentials for each control plane node.  
-* `metadata.name`: Cluster name is used as a prefix for hostnames and DNS records.  
-* `featureSet`: Enables two-node OpenShift cluster deployments.  
+* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.
+* `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.
+* `fencing.credentials.hostname`: Provide BMC credentials for each control plane node.
+* `metadata.name`: Cluster name is used as a prefix for hostnames and DNS records.
+* `featureSet`: Enables two-node OpenShift cluster deployments.
 * `platform.none` Set the platform to `none` for user-provisioned infrastructure deployments. Bare-metal hosts are pre-provisioned outside of the installation program.
-* `pullSecret`: Contains credentials required to pull container images for the cluster components.  
+* `pullSecret`: Contains credentials required to pull container images for the cluster components.
 * `sshKey`: The SSH public key for accessing cluster nodes after installation.

--- a/modules/installation-two-node-ingress-lb-configuration.adoc
+++ b/modules/installation-two-node-ingress-lb-configuration.adoc
@@ -2,27 +2,28 @@
 [id="two-node-ingress-lb-configuration_{context}"]
 = Configuring an Ingress load balancer for a two-node cluster with fencing
 
+[role="_abstract"]
 You must configure an external Ingress load balancer (LB) before you install a two-node OpenShift cluster with fencing. The Ingress LB forwards external application traffic to the Ingress Controller pods that run on the control plane nodes. Both nodes can actively receive traffic.
 
 .Prerequisites
 
-* You have two control plane nodes with fencing enabled.  
-* You have network connectivity from the load balancer to both control plane nodes.  
-* You created DNS records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>`.  
-* You have an external load balancer that supports health checks on endpoints.  
+* You have two control plane nodes with fencing enabled.
+* You have network connectivity from the load balancer to both control plane nodes.
+* You created DNS records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>`.
+* You have an external load balancer that supports health checks on endpoints.
 
 .Procedure
 
 . Configure the load balancer to forward traffic for the following ports:
 +
-* `6443`: Kubernetes API server  
+* `6443`: Kubernetes API server
 * `80` and `443`: Application ingress
 +
 You must forward traffic to both control plane nodes.
 
 . Configure health checks on the load balancer. You must monitor the backend endpoints so that the load balancer only sends traffic to nodes that respond.
 
-. Configure the load balancer to forward traffic to both control plane nodes. The following example shows how to configure two control plane nodes:  
+. Configure the load balancer to forward traffic to both control plane nodes. The following example shows how to configure two control plane nodes:
 +
 [source,terminal]
 ----
@@ -67,5 +68,5 @@ $ curl -k https://api.<cluster_name>.<base_domain>:6443/version
 ----
 $ curl https://<app>.<cluster_name>.<base_domain>
 ----
-
++
 You can shut down a control plane node and verify that the load balancer stops sending traffic to that node while the other node continues to serve requests.


### PR DESCRIPTION
[OSDOCS-17034](https://redhat.atlassian.net/browse/OSDOCS-17034)

Version(s): 4.20 and 4.21 only

This PR addresses remaining 4.20 and 4.21 DITA errors in two node install content that was not captured in other PRs based off of the main branch

QE review: Not required

Previews:

- https://116010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.html
- https://116010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.html
- https://116010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-tnf.html

