### PR TITLE
OSDOCS-17039: OCI distributed CQA abstracts

### DIFF
--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} {product-version}, you can use the Agent-based Installer to install a cluster on {oci-distributed}, so that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments.
+[role="_abstract"]
+You can use the Agent-based Installer to install a cluster on {oci-distributed}, so that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments.
 
 Installing a cluster on {oci-distributed-no-rt} is supported for virtual machines (VMs) and bare-metal machines.
 

--- a/installing/installing_oci/installing-oci-assisted-installer.adoc
+++ b/installing/installing_oci/installing-oci-assisted-installer.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use the {ai-full} to install a cluster on {oci-distributed}. This method is recommended for most users, and requires an internet connection.
 
 If you want to set up the cluster manually or using other automation tools, or if you are working in a disconnected environment, you can use the Red Hat Agent-based Installer for the installation. For details, see xref:../../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-distributed-no-rt} by using the Agent-based Installer].

--- a/modules/abi-oci-resources-services.adoc
+++ b/modules/abi-oci-resources-services.adoc
@@ -6,7 +6,10 @@
 [id="abi-oci-resources-services_{context}"]
 = Creating {oci} infrastructure resources and services
 
-You must create an {oci-distributed-no-rt} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci-first-no-rt} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+[role="_abstract"]
+You must create an {oci-distributed-no-rt} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies.
+
+Having prior knowledge of {oci-first-no-rt} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
 
 The Agent-based Installer method for installing an {product-title} cluster on {oci-distributed-no-rt} requires that you manually create {oci} resources and services.
 

--- a/modules/complete-assisted-installer-oci-custom-manifests.adoc
+++ b/modules/complete-assisted-installer-oci-custom-manifests.adoc
@@ -6,7 +6,10 @@
 [id="adding-custom-manifests-oci_{context}"]
 = Adding custom manifests
 
-Add the mandatory custom manifests provided by Oracle. For details, see link:https://github.com/dfoster-oracle/oci-openshift/blob/v1.0.0-release-preview/custom_manifests/README.md[Custom Manifests (Oracle documentation).]
+[role="_abstract"]
+Add the mandatory custom manifests provided by Oracle.
+
+For details, see link:https://github.com/dfoster-oracle/oci-openshift/blob/v1.0.0-release-preview/custom_manifests/README.md[Custom Manifests (Oracle documentation).]
 
 .Prerequisites
 

--- a/modules/complete-assisted-installer-oci-node-roles.adoc
+++ b/modules/complete-assisted-installer-oci-node-roles.adoc
@@ -6,6 +6,7 @@
 [id="assigning-node-roles-oci_{context}"]
 = Assigning node roles
 
+[role="_abstract"]
 Following host discovery, the role of all nodes appears as *Auto-assign* by default. Change each of the node roles to either *Control Plane node* or *Worker*.
 
 .Prerequisites

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -18,21 +18,30 @@ ifdef::c3[]
 [id="creating-config-files-cluster-install-c3_{context}"]
 = Creating configuration files for installing a cluster on {oci-edge-no-rt}
 
-You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+[role="_abstract"]
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service.
+
+Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 endif::c3[]
 
 ifdef::pca[]
 [id="creating-config-files-cluster-install-pca_{context}"]
 = Creating configuration files for installing a cluster on {oci-pca-short}
 
-You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+[role="_abstract"]
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service.
+
+Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 endif::pca[]
 
 ifndef::pca,c3[]
 [id="creating-config-files-cluster-install-oci_{context}"]
 = Creating configuration files for installing a cluster on {oci-distributed-no-rt}
 
-You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+[role="_abstract"]
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service.
+
+Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 
 endif::pca,c3[]
 

--- a/modules/creating-oci-resources-services.adoc
+++ b/modules/creating-oci-resources-services.adoc
@@ -6,6 +6,7 @@
 [id="creating-oci-resources-services_{context}"]
 = Preparing the {oci-distributed-no-rt} environment
 
+[role="_abstract"]
 Before installing {product-title} using Assisted Installer, create the necessary resources and download the configuration file in the {oci-distributed-no-rt} environment.
 
 .Prerequisites

--- a/modules/installing-oci-about-agent-based-installer.adoc
+++ b/modules/installing-oci-about-agent-based-installer.adoc
@@ -6,6 +6,7 @@
 [id="installing-oci-about-agent-based-installer_{context}"]
 = The Agent-based Installer and {oci-distributed-no-rt} overview
 
+[role="_abstract"]
 You can install an {product-title} cluster on {oci-distributed} by using the Agent-based Installer. Red{nbsp}Hat and Oracle test, validate, and support running {oci-distributed-no-rt} workloads in an {product-title} cluster.
 
 The Agent-based Installer provides the ease of use of the Assisted Installation service, but with the capability to install a cluster in either a connected or disconnected environment.

--- a/modules/installing-oci-about-assisted-installer.adoc
+++ b/modules/installing-oci-about-assisted-installer.adoc
@@ -6,6 +6,7 @@
 [id="installing-oci-about-assisted-installer_{context}"]
 = About the {ai-full} and {oci-distributed-no-rt} integration
 
+[role="_abstract"]
 You can run cluster workloads on {oci-distributed} infrastructure that supports dedicated, hybrid, public, and multiple cloud environments. Both Red{nbsp}Hat and Oracle test, validate, and support running an {product-title} cluster on {oci-distributed-no-rt}.
 
 This section explains how to use the {ai-full} to install an {product-title} cluster on the {oci-first-no-rt} platform. The installation deploys cloud-native components such as {oci-ccm-full} and {oci-csi-full}, and integrates your cluster with {oci} API resources such as instance node, load balancer, and storage.

--- a/modules/installing-oci-adding-hosts-day-two.adoc
+++ b/modules/installing-oci-adding-hosts-day-two.adoc
@@ -6,6 +6,7 @@
 [id="installing-oci-adding-hosts-day-two_{context}"]
 = Adding hosts to the cluster following the installation
 
+[role="_abstract"]
 After creating a cluster with the {ai-full}, you can use the {hybrid-console} to add new host nodes to the cluster and approve their certificate signing requests (CSRs).
 
 For details, see link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/adding-nodes.htm[Adding Nodes to a Cluster (Oracle documentation)].

--- a/modules/installing-oci-distributed-infra-support.adoc
+++ b/modules/installing-oci-distributed-infra-support.adoc
@@ -7,6 +7,9 @@
 [id="installing-oci-distributed-infra-support_{context}"]
 = Supported {oci-distributed-no-rt} infrastructures
 
+[role="_abstract"]
+There are several different {oci-distributed} infrastructure offerings you can choose for your installation.
+
 The following table describes the support status of each {oci-distributed} infrastructure offering:
 
 .{oci-distributed-no-rt} infrastructure support statuses

--- a/modules/installing-troubleshooting-assisted-installer-oci.adoc
+++ b/modules/installing-troubleshooting-assisted-installer-oci.adoc
@@ -6,7 +6,10 @@
 [id="installing-troubleshooting-assisted-installer-oci_{context}"]
 = Troubleshooting the installation of a cluster on {oci-distributed-no-rt}
 
-If you experience issues with using the {ai-full} to install an {product-title} cluster on {oci-distributed}, read the following sections to troubleshoot common problems.
+[role="_abstract"]
+If you experience issues with using the {ai-full} to install an {product-title} cluster on {oci-distributed}, you can troubleshoot the installation.
+
+Read the following sections to troubleshoot common problems.
 
 [id="installing-troubleshooting-load-balancer_{context}"]
 == The Ingress Load Balancer in {oci-distributed-no-rt} is not at a healthy status

--- a/modules/provision-oci-infrastructure-ocp-cluster.adoc
+++ b/modules/provision-oci-infrastructure-ocp-cluster.adoc
@@ -6,7 +6,10 @@
 [id="provision-oci-infrastructure-ocp-cluster_{context}"]
 = Provisioning {oci} infrastructure for your cluster
 
-When using the {ai-full} to create details for your {product-title} cluster, you specify these details in a Terraform stack. A stack is an {oci-first-no-rt} feature that automates the provisioning of all necessary {oci} infrastructure resources that are required for installing an {product-title} cluster on {oci-distributed-no-rt}.
+[role="_abstract"]
+When using the {ai-full} to create details for your {product-title} cluster, you specify these details in a Terraform stack.
+
+A stack is an {oci-first-no-rt} feature that automates the provisioning of all necessary {oci} infrastructure resources that are required for installing an {product-title} cluster on {oci-distributed-no-rt}.
 
 .Prerequisites
 

--- a/modules/running-cluster-oci-agent-based.adoc
+++ b/modules/running-cluster-oci-agent-based.adoc
@@ -6,7 +6,10 @@
 [id="running-cluster-oci-agent-based_{context}"]
 = Running a cluster on {oci-distributed-no-rt}
 
-To run a cluster on {oci-distributed}, you must upload the generated agent ISO image to the default Object Storage bucket on {oci-distributed-no-rt}. Additionally, you must create a compute instance from the supplied base image, so that {product-title} and {oci-distributed-no-rt} can communicate with each other for the purposes of running the cluster on {oci-distributed-no-rt}.
+[role="_abstract"]
+To run a cluster on {oci-distributed}, you must upload the generated agent ISO image to the default Object Storage bucket on {oci-distributed-no-rt}.
+
+Additionally, you must create a compute instance from the supplied base image, so that {product-title} and {oci-distributed-no-rt} can communicate with each other for the purposes of running the cluster on {oci-distributed-no-rt}.
 
 [NOTE]
 ====

--- a/modules/using-assisted-installer-oci-agent-iso.adoc
+++ b/modules/using-assisted-installer-oci-agent-iso.adoc
@@ -6,15 +6,16 @@
 [id="using-assisted-installer-oci-generating-iso_{context}"]
 = Generating the Discovery ISO image
 
-Generate and download the Discovery ISO image.
+[role="_abstract"]
+After setting cluster details, generate and download the Discovery ISO image.
 
 .Procedure
 
 . On the *Host Discovery* page, click *Add hosts* and complete the following steps:
 
-.. For the *Provisioning type* field, select *Minimal image file*. 
+.. For the *Provisioning type* field, select *Minimal image file*.
 
-.. For the *SSH public key* field, add the SSH public key from your local system, by copying the output of the following command: 
+.. For the *SSH public key* field, add the SSH public key from your local system, by copying the output of the following command:
 +
 [source,terminal]
 ----

--- a/modules/using-assisted-installer-oci-create-cluster.adoc
+++ b/modules/using-assisted-installer-oci-create-cluster.adoc
@@ -6,7 +6,8 @@
 [id="using-assisted-installer-oci-create-cluster_{context}"]
 = Creating the cluster
 
-Set the cluster details.
+[role="_abstract"]
+To begin creating the cluster, set the cluster details.
 
 .Procedure
 

--- a/modules/verifying-cluster-install-ai-oci.adoc
+++ b/modules/verifying-cluster-install-ai-oci.adoc
@@ -6,6 +6,7 @@
 [id="verifying-cluster-install-ai-oci_{context}"]
 = Verifying a successful cluster installation on {oci-distributed-no-rt}
 
+[role="_abstract"]
 Verify that your cluster was installed and is running effectively on {oci-distributed}.
 
 .Procedure


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI distributed content. Just abstracts in this PR

QE review: Not required

Previews:
- [Installing a cluster on Oracle Distributed Cloud by using the Assisted Installer](https://116012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-assisted-installer)
- [Installing a cluster on Oracle Distributed Cloud by using the Agent-based Installer](https://116012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer)
