### PR TITLE
OSDOCS-16959-configure-htpasswd CQA

### DIFF
--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -6,16 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `htpasswd` identity provider to allow users to log in to {product-title} with credentials from an htpasswd file.
+[role="_abstract"]
+Configure the `htpasswd` identity provider so users can log in to {product-title} with credentials from an `htpasswd` file.
 
-To define an htpasswd identity provider, perform the following tasks:
+To define an htpasswd identity provider, complete these tasks:
 
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#creating-htpasswd-file[Create an `htpasswd` file] to store the user and password information.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-secret_{context}[Create
-a secret] to represent the `htpasswd` file.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-htpasswd-CR_{context}[Define an htpasswd identity provider resource] that references the secret.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#add-identity-provider_{context}[Apply the resource] to
-the default OAuth configuration to add the identity provider.
+. Create an `htpasswd` file to store the user and password information.
+. Create a secret to represent the `htpasswd` file.
+. Define an htpasswd identity provider resource that references the secret.
+. Apply the resource to the default OAuth configuration to add the identity provider.
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
@@ -24,13 +23,7 @@ endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 
 include::modules/identity-provider-htpasswd-about.adoc[leveloffset=+1]
 
-[id="creating-htpasswd-file"]
-== Creating the htpasswd file
-
-See one of the following sections for instructions about how to create the htpasswd file:
-
-* xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-linux_configuring-htpasswd-identity-provider[Creating an htpasswd file using Linux]
-* xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-windows_configuring-htpasswd-identity-provider[Creating an htpasswd file using Windows]
+include::modules/identity-provider-creating-htpasswd-file.adoc[leveloffset=+1]
 
 include::modules/identity-provider-creating-htpasswd-file-linux.adoc[leveloffset=+2]
 
@@ -44,10 +37,15 @@ include::modules/identity-provider-htpasswd-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
 include::modules/identity-provider-htpasswd-update-users.adoc[leveloffset=+1]
 
 include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[htpasswd utility (Apache HTTP Server documentation)]

--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -6,16 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `htpasswd` identity provider to allow users to log in to {product-title} with credentials from an htpasswd file.
+[role="_abstract"]
+Configure the `htpasswd` identity provider so users can log in to {product-title} with credentials from an `htpasswd` file.
 
-To define an htpasswd identity provider, perform the following tasks:
+To define an `htpasswd` identity provider, complete these tasks:
 
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#creating-htpasswd-file[Create an `htpasswd` file] to store the user and password information.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-secret_{context}[Create
-a secret] to represent the `htpasswd` file.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-htpasswd-CR_{context}[Define an htpasswd identity provider resource] that references the secret.
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#add-identity-provider_{context}[Apply the resource] to
-the default OAuth configuration to add the identity provider.
+. Create an `htpasswd` file to store the user and password information.
+. Create a secret to represent the `htpasswd` file.
+. Define an `htpasswd` identity provider resource that references the secret.
+. Apply the resource to the default OAuth configuration to add the identity provider.
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
@@ -24,13 +23,7 @@ endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 
 include::modules/identity-provider-htpasswd-about.adoc[leveloffset=+1]
 
-[id="creating-htpasswd-file"]
-== Creating the htpasswd file
-
-See one of the following sections for instructions about how to create the htpasswd file:
-
-* xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-linux_configuring-htpasswd-identity-provider[Creating an htpasswd file using Linux]
-* xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-windows_configuring-htpasswd-identity-provider[Creating an htpasswd file using Windows]
+include::modules/identity-provider-creating-htpasswd-file.adoc[leveloffset=+1]
 
 include::modules/identity-provider-creating-htpasswd-file-linux.adoc[leveloffset=+2]
 
@@ -44,10 +37,16 @@ include::modules/identity-provider-htpasswd-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
 include::modules/identity-provider-htpasswd-update-users.adoc[leveloffset=+1]
 
 include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[htpasswd utility (Apache HTTP Server documentation)]

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -34,8 +34,8 @@ Apply the identity provider custom resource (CR) to your cluster so users can au
 
 .Prerequisites
 
-* You installed an {product-title} cluster.
-* You defined the CR for your identity provider.
+* You created an {product-title} cluster.
+* You created the custom resource (CR) for your identity providers.
 * You are logged in as an administrator.
 
 .Procedure
@@ -53,7 +53,7 @@ If a CR does not exist, `oc apply` creates a new CR and might trigger the follow
 ====
 
 ifndef::no-username-password-login[]
-. Log in to the cluster as a user from your identity provider by running the following command, entering the password when prompted:
+. Log in to the cluster as a user from your identity provider, entering the password when prompted.
 +
 [source,terminal]
 ----
@@ -81,6 +81,8 @@ $ oc login --token=<token>
 ifdef::oidc[]
 After the OIDC identity provider is configured in {product-title}, you can also log in by running the following command, which prompts for your username and password:
 
+. After the OIDC identity provider is configured in {product-title}, log in by running the following command. The command prompts you for your username and password:
++
 [source,terminal]
 ----
 $ oc login -u <identity_provider_username> --server=<api_server_url_and_port>
@@ -88,6 +90,7 @@ $ oc login -u <identity_provider_username> --server=<api_server_url_and_port>
 
 If your OpenID Connect identity provider supports the resource owner password credentials (ROPC) grant flow, you might need to take steps to enable the ROPC grant flow for your identity provider.
 endif::oidc[]
+
 
 ifndef::oidc[]
 This identity provider does not support logging in with a username and password.
@@ -113,3 +116,4 @@ endif::[]
 ifeval::["{context}" == "configuring-github-identity-provider"]
 :!no-username-password-login:
 endif::[]
+

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -34,8 +34,8 @@ Apply the OAuth custom resource (CR) to add an identity provider to your cluster
 
 .Prerequisites
 
-* You installed an {product-title} cluster.
-* You defined the CR for your identity provider.
+* You created an {product-title} cluster.
+* You created the custom resource (CR) for your identity providers.
 * You are logged in as an administrator.
 
 .Procedure
@@ -53,7 +53,7 @@ If a CR does not exist, `oc apply` creates a new CR and might trigger the follow
 ====
 
 ifndef::no-username-password-login[]
-. Log in to the cluster as a user from your identity provider, entering the password when prompted. Run the following command:
+. Log in to the cluster as a user from your identity provider, entering the password when prompted.
 +
 [source,terminal]
 ----
@@ -82,7 +82,7 @@ ifdef::oidc[]
 If your OpenID Connect identity provider supports the resource owner password credentials (ROPC) grant flow, you can log in with a username and password. You might need to take steps to enable the ROPC grant flow for your identity provider.
 ====
 
-. After the OIDC identity provider is configured in {product-title}, you can log in by running the following command, which prompts for your username and password:
+. After the OIDC identity provider is configured in {product-title}, log in by running the following command. The command prompts you for your username and password:
 +
 [source,terminal]
 ----
@@ -91,6 +91,7 @@ $ oc login -u <identity_provider_username> --server=<api_server_url_and_port>
 +
 If your OpenID Connect identity provider supports the resource owner password credentials (ROPC) grant flow, you might need to take steps to enable the ROPC grant flow for your identity provider.
 endif::oidc[]
+
 
 ifndef::oidc[]
 This identity provider does not support logging in with a username and password.
@@ -116,3 +117,4 @@ endif::[]
 ifeval::["{context}" == "configuring-github-identity-provider"]
 :!no-username-password-login:
 endif::[]
+

--- a/modules/identity-provider-configuring-using-web-console.adoc
+++ b/modules/identity-provider-configuring-using-web-console.adoc
@@ -7,21 +7,20 @@
 [id="identity-provider-configuring-using-the-web-console_{context}"]
 = Configuring identity providers using the web console
 
-Configure your identity provider (IDP) through the web console instead of the CLI.
+[role="_abstract"]
+Configure identity providers in the {product-title} web console. Use this procedure when you want to add providers through the UI rather than with a custom resource and the CLI.
 
 .Prerequisites
 
-* You must be logged in to the web console as a cluster administrator.
+* You are logged in to the web console as a cluster administrator.
 
 .Procedure
 
 . Navigate to *Administration* -> *Cluster Settings*.
 . Under the *Configuration* tab, click *OAuth*.
-. Under the *Identity Providers* section, select your identity provider from the
-*Add* drop-down menu.
-
+. Under the *Identity Providers* section, select your identity provider from the *Add* drop-down list.
++
 [NOTE]
 ====
-You can specify multiple IDPs through the web console without overwriting
-existing IDPs.
+You can specify multiple identity providers through the web console without overwriting existing identity providers.
 ====

--- a/modules/identity-provider-configuring-using-web-console.adoc
+++ b/modules/identity-provider-configuring-using-web-console.adoc
@@ -10,20 +10,17 @@
 [role="_abstract"]
 You can configure identity providers on your {product-title} cluster through the web console by updating the *OAuth* settings in the *Cluster Settings*.
 
-
-[NOTE]
-====
-You can specify multiple identity providers through the web console without overwriting existing identity providers.
-====
-
 .Prerequisites
 
-* You must be logged in to the web console as a cluster administrator.
+* You are logged in to the web console as a cluster administrator.
 
 .Procedure
 
 . Navigate to *Administration* -> *Cluster Settings*.
 . Under the *Configuration* tab, click *OAuth*.
-. Under the *Identity Providers* section, select your identity provider from the
-*Add* drop-down menu.
-
+. Under the *Identity Providers* section, select your identity provider from the *Add* drop-down list.
++
+[NOTE]
+====
+You can specify multiple identity providers through the web console without overwriting existing identity providers.
+====

--- a/modules/identity-provider-creating-htpasswd-file-linux.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-linux.adoc
@@ -6,18 +6,16 @@
 [id="identity-provider-creating-htpasswd-file-linux_{context}"]
 = Creating an htpasswd file using Linux
 
-To use the htpasswd identity provider, you must generate a flat file that
-contains the user names and passwords for your cluster by using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+[role="_abstract"]
+Create a flat `htpasswd` file on {op-system-base-full} with the `htpasswd` utility to store usernames and hashed passwords for your cluster. The file enables the htpasswd identity provider to authenticate users in {product-title} from locally stored credentials.
 
 .Prerequisites
 
-* Have access to the `htpasswd` utility. On Red Hat Enterprise Linux
-this is available by installing the `httpd-tools` package.
+* You have access to the `htpasswd` utility. On {op-system-base-full}, this is available by installing the `httpd-tools` package.
 
 .Procedure
 
-. Create or update your flat file with a user name and hashed password:
+. Create or update your `htpasswd` file with a username and hashed password by running the following command:
 +
 [source,terminal]
 ----
@@ -39,7 +37,7 @@ $ htpasswd -c -B -b users.htpasswd <username> <password>
 Adding password for user user1
 ----
 
-. Continue to add or update credentials to the file:
+. Continue to add or update credentials to the file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/identity-provider-creating-htpasswd-file-linux.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-linux.adoc
@@ -6,18 +6,16 @@
 [id="identity-provider-creating-htpasswd-file-linux_{context}"]
 = Creating an htpasswd file using Linux
 
-To use the htpasswd identity provider, you must generate a flat file that
-contains the user names and passwords for your cluster by using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+[role="_abstract"]
+Create a flat `htpasswd` file on {op-system-base-full} with the `htpasswd` utility to store usernames and hashed passwords for your cluster. The file enables the `htpasswd` identity provider to authenticate users in {product-title} from locally stored credentials.
 
 .Prerequisites
 
-* Have access to the `htpasswd` utility. On Red Hat Enterprise Linux
-this is available by installing the `httpd-tools` package.
+* You have access to the `htpasswd` utility. On {op-system-base-full}, this is available by installing the `httpd-tools` package.
 
 .Procedure
 
-. Create or update your flat file with a user name and hashed password:
+. Create or update your `htpasswd` file with a username and hashed password by running the following command:
 +
 [source,terminal]
 ----
@@ -39,7 +37,7 @@ $ htpasswd -c -B -b users.htpasswd <username> <password>
 Adding password for user user1
 ----
 
-. Continue to add or update credentials to the file:
+. Continue to add or update credentials to the file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/identity-provider-creating-htpasswd-file-windows.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-windows.adoc
@@ -6,22 +6,20 @@
 [id="identity-provider-creating-htpasswd-file-windows_{context}"]
 = Creating an htpasswd file using Windows
 
-To use the htpasswd identity provider, you must generate a flat file that
-contains the user names and passwords for your cluster by using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+[role="_abstract"]
+Create a flat `htpasswd` file on Windows with the `htpasswd.exe` utility to store usernames and hashed passwords for your cluster. The file enables the htpasswd identity provider to authenticate users in {product-title} from locally stored credentials.
 
 .Prerequisites
 
-* Have access to `htpasswd.exe`. This file is included in the `\bin`
-directory of many Apache httpd distributions.
+* You have access to the `htpasswd.exe` utility. On Windows, this utility is included in the `\bin` subdirectory of many Apache httpd distributions.
 
 .Procedure
 
-. Create or update your flat file with a user name and hashed password:
+. Create or update your `htpasswd` file with a username and hashed password by running the following command:
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b <\path\to\users.htpasswd> <username> <password>
+$ htpasswd.exe -c -B -b <\path\to\users.htpasswd> <username> <password>
 ----
 +
 The command generates a hashed version of the password.
@@ -30,7 +28,7 @@ For example:
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b users.htpasswd <username> <password>
+$ htpasswd.exe -c -B -b users.htpasswd <username> <password>
 ----
 +
 .Example output
@@ -39,9 +37,9 @@ For example:
 Adding password for user user1
 ----
 
-. Continue to add or update credentials to the file:
+. Continue to add or update credentials to the file by running the following command:
 +
 [source,terminal]
 ----
-> htpasswd.exe -b <\path\to\users.htpasswd> <username> <password>
+$ htpasswd.exe -b <\path\to\users.htpasswd> <username> <password>
 ----

--- a/modules/identity-provider-creating-htpasswd-file-windows.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-windows.adoc
@@ -6,22 +6,20 @@
 [id="identity-provider-creating-htpasswd-file-windows_{context}"]
 = Creating an htpasswd file using Windows
 
-To use the htpasswd identity provider, you must generate a flat file that
-contains the user names and passwords for your cluster by using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+[role="_abstract"]
+Create a flat `htpasswd` file on Windows with the `htpasswd.exe` utility to store usernames and hashed passwords for your cluster. The file enables the `htpasswd` identity provider to authenticate users in {product-title} from locally stored credentials.
 
 .Prerequisites
 
-* Have access to `htpasswd.exe`. This file is included in the `\bin`
-directory of many Apache httpd distributions.
+* You have access to the `htpasswd.exe` utility. On Windows, this utility is included in the `\bin` subdirectory of many Apache httpd distributions.
 
 .Procedure
 
-. Create or update your flat file with a user name and hashed password:
+. Create or update your `htpasswd` file with a username and hashed password by running the following command:
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b <\path\to\users.htpasswd> <username> <password>
+$ htpasswd.exe -c -B -b <\path\to\users.htpasswd> <username> <password>
 ----
 +
 The command generates a hashed version of the password.
@@ -30,7 +28,7 @@ For example:
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b users.htpasswd <username> <password>
+$ htpasswd.exe -c -B -b users.htpasswd <username> <password>
 ----
 +
 .Example output
@@ -39,9 +37,9 @@ For example:
 Adding password for user user1
 ----
 
-. Continue to add or update credentials to the file:
+. Continue to add or update credentials to the file by running the following command:
 +
 [source,terminal]
 ----
-> htpasswd.exe -b <\path\to\users.htpasswd> <username> <password>
+$ htpasswd.exe -b <\path\to\users.htpasswd> <username> <password>
 ----

--- a/modules/identity-provider-creating-htpasswd-file.adoc
+++ b/modules/identity-provider-creating-htpasswd-file.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="identity-provider-creating-htpasswd-file_{context}"]
+= Creating the htpasswd file
+
+[role="_abstract"]
+To configure the `htpasswd` identity provider, create an `htpasswd` file so usernames and hashed passwords are available for the cluster secret. The following procedures describe how to create the file on Linux and Windows Operating Systems.
+
+* Creating an `htpasswd` file using Linux
+* Creating an `htpasswd` file using Windows
+

--- a/modules/identity-provider-htpasswd-CR.adoc
+++ b/modules/identity-provider-htpasswd-CR.adoc
@@ -6,8 +6,8 @@
 [id="identity-provider-htpasswd-CR_{context}"]
 = Sample htpasswd CR
 
-The following custom resource (CR) shows the parameters and acceptable values for an
-htpasswd identity provider.
+[role="_abstract"]
+Review the custom resource fields and acceptable values for configuring an htpasswd identity provider in {product-title}.
 
 .htpasswd CR
 
@@ -19,15 +19,17 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: my_htpasswd_provider <1>
-    mappingMethod: claim <2>
+  - name: my_htpasswd_provider
+    mappingMethod: claim
     type: HTPasswd
     htpasswd:
       fileData:
-        name: htpass-secret <3>
+        name: htpass-secret
 ----
-<1> This provider name is prefixed to provider user names to form an identity
-name.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> An existing secret containing a file generated using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+
+where:
+
+`spec.identityProviders.name`:: Specifies the provider name, which is prefixed to provider usernames to form an identity name.
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between identities from this provider and `User` objects.
+`spec.identityProviders.htpasswd.fileData.name`:: Specifies an existing secret containing a file generated using `htpasswd`. For more information, see "htpasswd".
+

--- a/modules/identity-provider-htpasswd-CR.adoc
+++ b/modules/identity-provider-htpasswd-CR.adoc
@@ -6,8 +6,8 @@
 [id="identity-provider-htpasswd-CR_{context}"]
 = Sample htpasswd CR
 
-The following custom resource (CR) shows the parameters and acceptable values for an
-htpasswd identity provider.
+[role="_abstract"]
+Review the custom resource fields and acceptable values for configuring an `htpasswd` identity provider in {product-title}.
 
 .htpasswd CR
 
@@ -19,15 +19,17 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: my_htpasswd_provider <1>
-    mappingMethod: claim <2>
+  - name: my_htpasswd_provider
+    mappingMethod: claim
     type: HTPasswd
     htpasswd:
       fileData:
-        name: htpass-secret <3>
+        name: htpass-secret
 ----
-<1> This provider name is prefixed to provider user names to form an identity
-name.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> An existing secret containing a file generated using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+
+where:
+
+`spec.identityProviders.name`:: Specifies the provider name, which is prefixed to provider usernames to form an identity name.
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between identities from this provider and `User` objects.
+`spec.identityProviders.htpasswd.fileData.name`:: Specifies an existing secret containing a file generated using `htpasswd`. For more information, see "htpasswd".
+

--- a/modules/identity-provider-htpasswd-about.adoc
+++ b/modules/identity-provider-htpasswd-about.adoc
@@ -6,7 +6,8 @@
 [id="identity-provider-htpasswd-about_{context}"]
 = About htpasswd authentication
 
-Using htpasswd authentication in {product-title} allows you to identify users based on an htpasswd file. An htpasswd file is a flat file that contains the user name and hashed password for each user. You can use the `htpasswd` utility to create this file.
+[role="_abstract"]
+Configure htpasswd authentication to use a flat password file for login to {product-title}. The file stores hashed credentials for each user and enables local authentication without an external identity provider.
 
 [WARNING]
 ====

--- a/modules/identity-provider-htpasswd-about.adoc
+++ b/modules/identity-provider-htpasswd-about.adoc
@@ -6,9 +6,10 @@
 [id="identity-provider-htpasswd-about_{context}"]
 = About htpasswd authentication
 
-Using htpasswd authentication in {product-title} allows you to identify users based on an htpasswd file. An htpasswd file is a flat file that contains the user name and hashed password for each user. You can use the `htpasswd` utility to create this file.
+[role="_abstract"]
+Configure `htpasswd` authentication to use a flat password file for login to {product-title}. The file stores hashed credentials for each user and enables local authentication without an external identity provider.
 
 [WARNING]
 ====
-Do not use htpasswd authentication in {product-title} for production environments. Use htpasswd authentication only for development environments.
+Do not use `htpasswd` authentication in {product-title} for production environments. Use `htpasswd` authentication only for development environments.
 ====

--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -6,22 +6,23 @@
 [id="identity-provider-creating-htpasswd-secret_{context}"]
 = Creating the htpasswd secret
 
-To use the htpasswd identity provider, you must define a secret that
-contains the htpasswd user file.
+[role="_abstract"]
+Create an {product-title} secret from your `htpasswd` file so the htpasswd identity provider can read user credentials for cluster login.
 
 .Prerequisites
 
-* Create an htpasswd file.
+* You created an `htpasswd` file.
 
 .Procedure
 
-* Create a `Secret` object that contains the htpasswd users file:
+* Create a `Secret` object that contains the `htpasswd` users file by running the following command:
 +
 [source,terminal]
 ----
-$ oc create secret generic htpass-secret --from-file=htpasswd=<path_to_users.htpasswd> -n openshift-config <1>
+$ oc create secret generic htpass-secret --from-file=htpasswd=<path_to_users.htpasswd> -n openshift-config
 ----
-<1> The secret key containing the users file for the `--from-file` argument must be named `htpasswd`, as shown in the above command.
++
+The `--from-file` key must be named `htpasswd`.
 +
 [TIP]
 ====

--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -6,22 +6,23 @@
 [id="identity-provider-creating-htpasswd-secret_{context}"]
 = Creating the htpasswd secret
 
-To use the htpasswd identity provider, you must define a secret that
-contains the htpasswd user file.
+[role="_abstract"]
+Create an {product-title} secret from your `htpasswd` file so the `htpasswd` identity provider can read user credentials for cluster login.
 
 .Prerequisites
 
-* Create an htpasswd file.
+* You created an `htpasswd` file.
 
 .Procedure
 
-* Create a `Secret` object that contains the htpasswd users file:
+* Create a `Secret` object that contains the `htpasswd` users file by running the following command:
 +
 [source,terminal]
 ----
-$ oc create secret generic htpass-secret --from-file=htpasswd=<path_to_users.htpasswd> -n openshift-config <1>
+$ oc create secret generic htpass-secret --from-file=htpasswd=<path_to_users.htpasswd> -n openshift-config
 ----
-<1> The secret key containing the users file for the `--from-file` argument must be named `htpasswd`, as shown in the above command.
++
+The `--from-file` key must be named `htpasswd`.
 +
 [TIP]
 ====

--- a/modules/identity-provider-htpasswd-update-users.adoc
+++ b/modules/identity-provider-htpasswd-update-users.adoc
@@ -6,27 +6,28 @@
 [id="identity-provider-htpasswd-update-users_{context}"]
 = Updating users for an htpasswd identity provider
 
-You can add or remove users from an existing htpasswd identity provider.
+[role="_abstract"]
+Update users in the htpasswd identity provider so login credentials in {product-title} stay in sync when you add or remove accounts.
 
 .Prerequisites
 
-* You have created a `Secret` object that contains the htpasswd user file. This procedure assumes that it is named `htpass-secret`.
-* You have configured an htpasswd identity provider. This procedure assumes that it is named `my_htpasswd_provider`.
-* You have access to the `htpasswd` utility. On Red Hat Enterprise Linux this is available by installing the `httpd-tools` package.
+* You have created a `Secret` object named `htpass-secret` that contains the `htpasswd` user file.
+* You have configured an htpasswd identity provider named `my_htpasswd_provider`.
+* You have access to the `htpasswd` utility. On {op-system-base-full}, this is available by installing the `httpd-tools` package.
 * You have cluster administrator privileges.
 
 .Procedure
 
-. Retrieve the htpasswd file from the `htpass-secret` `Secret` object and save the file to your file system:
+. Retrieve the `htpasswd` file from the `htpass-secret` `Secret` object and save it to your local machine by running the following command:
 +
 [source,terminal]
 ----
 $ oc get secret htpass-secret -ojsonpath={.data.htpasswd} -n openshift-config | base64 --decode > users.htpasswd
 ----
 
-. Add or remove users from the `users.htpasswd` file.
+. Add or remove users from the `users.htpasswd` file by running the following commands:
 
-** To add a new user:
+.. To add a new user:
 +
 [source,terminal]
 ----
@@ -39,7 +40,7 @@ $ htpasswd -bB users.htpasswd <username> <password>
 Adding password for user <username>
 ----
 
-** To remove an existing user:
+.. To remove an existing user:
 +
 [source,terminal]
 ----
@@ -52,7 +53,7 @@ $ htpasswd -D users.htpasswd <username>
 Deleting password for user <username>
 ----
 
-. Replace the `htpass-secret` `Secret` object with the updated users in the `users.htpasswd` file:
+. Replace the `htpass-secret` `Secret` object with the updated users in the `users.htpasswd` file by running the following command:
 +
 [source,terminal]
 ----
@@ -61,7 +62,7 @@ $ oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd --d
 +
 [TIP]
 ====
-You can alternatively apply the following YAML to replace the secret:
+You can also apply the following YAML to replace the secret:
 
 [source,yaml]
 ----
@@ -76,7 +77,7 @@ data:
 ----
 ====
 
-. If you removed one or more users, you must additionally remove existing resources for each user.
+. If you removed one or more users, you must remove the existing resources for each user by running the following commands:
 
 .. Delete the `User` object:
 +

--- a/modules/identity-provider-htpasswd-update-users.adoc
+++ b/modules/identity-provider-htpasswd-update-users.adoc
@@ -6,27 +6,28 @@
 [id="identity-provider-htpasswd-update-users_{context}"]
 = Updating users for an htpasswd identity provider
 
-You can add or remove users from an existing htpasswd identity provider.
+[role="_abstract"]
+Update users in the `htpasswd` identity provider so login credentials in {product-title} stay in sync when you add or remove accounts.
 
 .Prerequisites
 
-* You have created a `Secret` object that contains the htpasswd user file. This procedure assumes that it is named `htpass-secret`.
-* You have configured an htpasswd identity provider. This procedure assumes that it is named `my_htpasswd_provider`.
-* You have access to the `htpasswd` utility. On Red Hat Enterprise Linux this is available by installing the `httpd-tools` package.
+* You have created a `Secret` object named `htpass-secret` that contains the `htpasswd` user file.
+* You have configured an `htpasswd` identity provider named `my_htpasswd_provider`.
+* You have access to the `htpasswd` utility. On {op-system-base-full}, this is available by installing the `httpd-tools` package.
 * You have cluster administrator privileges.
 
 .Procedure
 
-. Retrieve the htpasswd file from the `htpass-secret` `Secret` object and save the file to your file system:
+. Retrieve the `htpasswd` file from the `htpass-secret` `Secret` object and save it to your local machine by running the following command:
 +
 [source,terminal]
 ----
 $ oc get secret htpass-secret -ojsonpath={.data.htpasswd} -n openshift-config | base64 --decode > users.htpasswd
 ----
 
-. Add or remove users from the `users.htpasswd` file.
+. Add or remove users from the `users.htpasswd` file by running the following commands:
 
-** To add a new user:
+.. To add a new user:
 +
 [source,terminal]
 ----
@@ -39,7 +40,7 @@ $ htpasswd -bB users.htpasswd <username> <password>
 Adding password for user <username>
 ----
 
-** To remove an existing user:
+.. To remove an existing user:
 +
 [source,terminal]
 ----
@@ -52,7 +53,7 @@ $ htpasswd -D users.htpasswd <username>
 Deleting password for user <username>
 ----
 
-. Replace the `htpass-secret` `Secret` object with the updated users in the `users.htpasswd` file:
+. Replace the `htpass-secret` `Secret` object with the updated users in the `users.htpasswd` file by running the following command:
 +
 [source,terminal]
 ----
@@ -61,7 +62,7 @@ $ oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd --d
 +
 [TIP]
 ====
-You can alternatively apply the following YAML to replace the secret:
+You can also apply the following YAML to replace the secret:
 
 [source,yaml]
 ----
@@ -76,7 +77,7 @@ data:
 ----
 ====
 
-. If you removed one or more users, you must additionally remove existing resources for each user.
+. If you removed one or more users, you must remove the existing resources for each user by running the following commands:
 
 .. Delete the `User` object:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16959

Link to docs preview:
https://116017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-htpasswd-identity-provider.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
