### PR TITLE
OSDOCS-17039: OCI Distributed Assisted CQA

### DIFF
--- a/installing/installing_oci/installing-oci-assisted-installer.adoc
+++ b/installing/installing_oci/installing-oci-assisted-installer.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 You can use the {ai-full} to install a cluster on {oci-distributed}. This method is recommended for most users, and requires an internet connection.
 
-If you want to set up the cluster manually or using other automation tools, or if you are working in a disconnected environment, you can use the Red Hat Agent-based Installer for the installation. For details, see xref:../../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-distributed-no-rt} by using the Agent-based Installer].
+If you want to set up the cluster manually or using other automation tools, or if you are working in a disconnected environment, you can use the Red Hat Agent-based Installer for the installation. For details, see "Installing a cluster on {oci-distributed-no-rt} by using the Agent-based Installer".
 
 // Supported Oracle Distributed Cloud Infrastructures
 include::modules/installing-oci-distributed-infra-support.adoc[leveloffset=+1]
@@ -20,6 +20,9 @@ include::modules/installing-oci-about-assisted-installer.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://catalog.redhat.com/cloud/detail/216977[Cloud instance types (Red{nbsp}Hat Ecosystem Catalog portal)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} Nodes (Oracle documentation)]
 * link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/[{ai-full} for {product-title}]
 * link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/installing-assisted.htm[Installing a Cluster with Red Hat's {ai-full} (Oracle documentation)]
 * xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#cluster-entitlements_installing-platform-agnostic[Internet access for {product-title}]
@@ -28,15 +31,7 @@ include::modules/installing-oci-about-assisted-installer.adoc[leveloffset=+1]
 include::modules/creating-oci-resources-services.adoc[leveloffset=+1]
 
 // Using the Assisted Installer to generate an OCI-compatible discovery ISO image
-[id="using-assisted-installer-oci-agent-iso_{context}"]
-== Using the {ai-full} to generate a discovery ISO image
-
-Create the cluster configuration and generate the discovery ISO image in the {ai-full} web console.
-
-.Prerequisites
-
-* You created a child compartment and an object storage bucket on {oci-distributed-no-rt}. For details, see _Preparing the {oci-distributed-no-rt} environment_.
-* You reviewed details about the {product-title} installation and update processes.
+include::modules/using-assisted-installer-oci-discovery-iso.adoc[leveloffset=+1]
 
 include::modules/using-assisted-installer-oci-create-cluster.adoc[leveloffset=+2]
 
@@ -52,11 +47,7 @@ include::modules/using-assisted-installer-oci-agent-iso.adoc[leveloffset=+2]
 include::modules/provision-oci-infrastructure-ocp-cluster.adoc[leveloffset=+1]
 
 // Completing the remaining Assisted Installer steps
-
-[id="completing-assisted-installer-oci_{context}"]
-== Completing the remaining {ai-full} steps
-
-After you provision {oci-distributed} resources and upload {product-title} custom manifest configuration files to {oci-distributed-no-rt}, you must complete the remaining cluster installation steps on the {ai-full} before you can create an {oci-distributed-no-rt} instance. These steps include assigning node roles and adding custom manifests.
+include::modules/complete-assisted-installer-remaining-steps.adoc[leveloffset=+1]
 
 include::modules/complete-assisted-installer-oci-node-roles.adoc[leveloffset=+2]
 
@@ -78,7 +69,12 @@ include::modules/installing-oci-adding-hosts-day-two.adoc[leveloffset=+1]
 include::modules/installing-troubleshooting-assisted-installer-oci.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-distributed-no-rt} by using the Agent-based Installer]
+
+* link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[{hybrid-console}]
 
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/openshift-troubleshooting.htm[Troubleshooting {product-title} on {oci} (Oracle documentation)]
 

--- a/modules/complete-assisted-installer-oci-custom-manifests.adoc
+++ b/modules/complete-assisted-installer-oci-custom-manifests.adoc
@@ -30,5 +30,5 @@ For details, see link:https://github.com/dfoster-oracle/oci-openshift/blob/v1.0.
 . Click *Next* to save the custom manifest.
 
 . From the *Review and create* page, click *Install cluster* to create your {product-title} cluster on {oci-distributed-no-rt}.
-
++
 After the cluster installation and initialization operations, the {ai-full} indicates the completion of the cluster installation operation. For more information, see "Completing the installation" section in the {ai-full} for {product-title} document.

--- a/modules/complete-assisted-installer-remaining-steps.adoc
+++ b/modules/complete-assisted-installer-remaining-steps.adoc
@@ -1,0 +1,11 @@
+
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="completing-assisted-installer-oci_{context}"]
+= Completing the remaining {ai-full} steps
+
+[role="_abstract"]
+After you provision {oci-distributed} resources and upload {product-title} custom manifest configuration files to {oci-distributed-no-rt}, you must complete the remaining cluster installation steps on the {ai-full} before you can create an {oci-distributed-no-rt} instance. These steps include assigning node roles and adding custom manifests.

--- a/modules/installing-oci-about-assisted-installer.adoc
+++ b/modules/installing-oci-about-assisted-installer.adoc
@@ -18,27 +18,27 @@ The installation process uses the {product-title} discovery ISO image provided b
 
 Before installing {product-title} on {oci-distributed-no-rt}, you must consider the following configuration choices.
 
-.Deployment platforms
+Deployment platforms::
 
 The integration between {product-title} and {oci-distributed-no-rt} is certified on both virtual machines (VMs) and bare-metal (BM) machines. Bare-metal installations using iSCSI boot drives require a secondary vNIC that is automatically created in the Terraform stack provided by Oracle.
++
+Before you create a virtual machine (VM) or bare-metal (BM) machine, you must identify the relevant {oci} shape. For details, see "Cloud instance types".
 
-Before you create a virtual machine (VM) or bare-metal (BM) machine, you must identify the relevant {oci} shape. For details, see the following resource:
-
-* link:https://catalog.redhat.com/cloud/detail/216977[Cloud instance types (Red{nbsp}Hat Ecosystem Catalog portal)].
-
-.VPU sizing recommendations
+VPU sizing recommendations::
 
 To ensure the best performance conditions for your cluster workloads that operate on {oci-distributed-no-rt}, ensure that volume performance units (VPUs) for your block volume are sized for your workloads. The following list provides guidance for selecting the VPUs needed for specific performance needs:
-
++
+--
 * Test or proof of concept environment: 100 GB, and 20 to 30 VPUs.
 * Basic environment: 500 GB, and 60 VPUs.
 * Heavy production environment: More than 500 GB, and 100 or more VPUs.
+--
++
+Consider reserving additional VPUs to provide sufficient capacity for updates and scaling activities. For more information about VPUs, see "Volume Performance Units".
 
-Consider reserving additional VPUs to provide sufficient capacity for updates and scaling activities. For more information about VPUs, see link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)].
+Instance sizing recommendations::
 
-.Instance sizing recommendations
-
-Find recommended values for compute instance CPU, memory, VPU, and volume size for {product-title} nodes. For details, see link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} Nodes (Oracle documentation)].
+Find recommended values for compute instance CPU, memory, VPU, and volume size for {product-title} nodes. For details, see "Instance Sizing Recommendations for {product-title} Nodes".
 
 [id="installing-oci-workflow_{context}"]
 == Workflow

--- a/modules/installing-oci-adding-hosts-day-two.adoc
+++ b/modules/installing-oci-adding-hosts-day-two.adoc
@@ -9,4 +9,6 @@
 [role="_abstract"]
 After creating a cluster with the {ai-full}, you can use the {hybrid-console} to add new host nodes to the cluster and approve their certificate signing requests (CSRs).
 
-For details, see link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/adding-nodes.htm[Adding Nodes to a Cluster (Oracle documentation)].
+.Procedure
+
+* See the instructions in link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/adding-nodes.htm[Adding Nodes to a Cluster (Oracle documentation)].

--- a/modules/installing-troubleshooting-assisted-installer-oci.adoc
+++ b/modules/installing-troubleshooting-assisted-installer-oci.adoc
@@ -2,9 +2,9 @@
 //
 // * installing/installing_oci/installing-oci-assisted-installer.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="installing-troubleshooting-assisted-installer-oci_{context}"]
-= Troubleshooting the installation of a cluster on {oci-distributed-no-rt}
+= Installation troubleshooting of a cluster on {oci-distributed-no-rt}
 
 [role="_abstract"]
 If you experience issues with using the {ai-full} to install an {product-title} cluster on {oci-distributed}, you can troubleshoot the installation.
@@ -33,4 +33,6 @@ Suggestion: Please update the parameter(s) in the Terraform config as per error 
 Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn
 ----
 
-Go to the https://console.redhat.com/openshift/assisted-installer/clusters/~new[*Install OpenShift with the Assisted Installer*] page on the Hybrid Cloud Console, and check the *Cluster name* field on the *Cluster Details* step. Remove any special characters, such as a hyphen (`-`), from the name, because these special characters are not compatible with the {oci} naming conventions. For example, change `oci-demo` to `ocidemo`.
+Go to the *Install OpenShift with the Assisted Installer* page on the Hybrid Cloud Console, and check the *Cluster name* field on the *Cluster Details* step. Remove any special characters, such as a hyphen (`-`), from the name, because these special characters are not compatible with the {oci} naming conventions. For example, change `oci-demo` to `ocidemo`.
+
+For more information, see "{hybrid-console}".

--- a/modules/using-assisted-installer-oci-create-cluster.adoc
+++ b/modules/using-assisted-installer-oci-create-cluster.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 To begin creating the cluster, set the cluster details.
 
+.Prerequisites
+
+* You created a child compartment and an object storage bucket on {oci-distributed-no-rt}. For details, see _Preparing the {oci-distributed-no-rt} environment_.
+* You reviewed details about the {product-title} installation and update processes.
+
 .Procedure
 
 . Log in to the link:https://console.redhat.com/[{ai-full} web console] with your credentials.

--- a/modules/using-assisted-installer-oci-discovery-iso.adoc
+++ b/modules/using-assisted-installer-oci-discovery-iso.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="using-assisted-installer-oci-agent-iso_{context}"]
+= Using the {ai-full} to generate a discovery ISO image
+
+[role="_abstract"]
+Create the cluster configuration and generate the discovery ISO image in the {ai-full} web console.


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI distributed content. This PR resolves remaining errors in Assisted Installer content.

QE review: Not required

Previews: https://116073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-assisted-installer.html