### PR TITLE
OSDOCS-16959-config-gitlab-id-provider CQA

### DIFF
--- a/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `gitlab` identity provider using link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider.
+[role="_abstract"]
+Configure the `gitlab` identity provider so users can log in to {product-title} with GitLab account credentials through OAuth.
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
@@ -14,6 +15,13 @@ include::modules/identity-provider-overview.adoc[leveloffset=+1]
 endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 
 include::modules/identity-provider-gitlab-about.adoc[leveloffset=+1]
+
+// Included here so that it is associated with above module
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.gitlab.com/ce/integration/oauth_provider.html[OAuth integration]
+* link:https://docs.gitlab.com/ce/integration/openid_connect_provider.html[OpenID Connect]
 
 include::modules/identity-provider-secret.adoc[leveloffset=+1]
 
@@ -25,6 +33,11 @@ include::modules/identity-provider-gitlab-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://gitlab.com/[GitLab.com]

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -12,7 +12,7 @@
 // * authentication/identity_providers/configuring-google-identity-provider.adoc
 // * authentication/identity_providers/configuring-oidc-identity-provider.adoc
 
-// GitHub and Google IDPs do not support username/password login commands
+// GitHub, and Google IDPs do not support username/password login commands
 ifeval::["{context}" == "configuring-github-identity-provider"]
 :no-username-password-login:
 endif::[]

--- a/modules/identity-provider-gitlab-CR.adoc
+++ b/modules/identity-provider-gitlab-CR.adoc
@@ -4,12 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="identity-provider-gitlab-CR_{context}"]
-= Sample GitLab CR
+= Sample GitLab custom resource
 
-The following custom resource (CR) shows the parameters and acceptable values for a
-GitLab identity provider.
-
-.GitLab CR
+[role="_abstract"]
+Review the sample GitLab `OAuth` custom resource (CR) to understand provider parameters and acceptable values before you configure the identity provider in your cluster.
 
 [source,yaml]
 ----
@@ -19,28 +17,23 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: gitlabidp <1>
-    mappingMethod: claim <2>
+  - name: gitlabidp
+    mappingMethod: claim
     type: GitLab
     gitlab:
-      clientID: {...} <3>
-      clientSecret: <4>
+      clientID: {...}
+      clientSecret:
         name: gitlab-secret
-      url: https://gitlab.com <5>
-      ca: <6>
+      url: https://gitlab.com
+      ca:
         name: ca-config-map
 ----
-<1> This provider name is prefixed to the GitLab numeric user ID to form an
-identity name. It is also used to build the callback URL.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> The client ID of a
-link:https://docs.gitlab.com/ce/api/oauth2.html[registered GitLab OAuth application].
-The application must be configured with a callback URL of
-`\https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`.
-<4> Reference to an {product-title} `Secret` object containing the client secret
-issued by GitLab.
-<5> The host URL of a GitLab provider. This could either be `\https://gitlab.com/`
-or any other self hosted instance of GitLab.
-<6> Optional: Reference to an {product-title} `ConfigMap` object containing the
-PEM-encoded certificate authority bundle to use in validating server
-certificates for the configured URL.
+
+where:
+
+`spec.identityProviders.name`:: Specifies that the provider name is prefixed to the GitLab numeric user ID to form an identity name. It is also used to build the callback URL.
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between identities from this provider and `User` objects.
+`spec.identityProviders.gitlab.clientID`:: Specifies the client ID of a registered GitLab OAuth application. The application must be configured with a callback URL of `\https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`.
+`spec.identityProviders.gitlab.clientSecret`:: Specifies a reference to an {product-title} `Secret` object containing the client secret issued by GitLab.
+`spec.identityProviders.gitlab.url`:: Specifies the host URL of a GitLab provider. This could either be `\https://gitlab.com/` or any other self-hosted instance of GitLab.
+`spec.identityProviders.gitlab.ca`:: Specifies a reference to an {product-title} `ConfigMap` object containing the PEM-encoded certificate authority bundle to use in validating server certificates for the configured URL. This value is optional.

--- a/modules/identity-provider-gitlab-about.adoc
+++ b/modules/identity-provider-gitlab-about.adoc
@@ -6,6 +6,7 @@
 [id="identity-provider-gitlab-about_{context}"]
 = About GitLab authentication
 
-Configuring GitLab authentication allows users to log in to {product-title} with their GitLab credentials.
+[role="_abstract"]
+Review GitLab authentication options for {product-title}. Use this integration when you want users to log in with GitLab account credentials through OAuth or OpenID Connect.
 
-If you use GitLab version 7.7.0 to 11.0, you connect using the link:https://docs.gitlab.com/ce/integration/oauth_provider.html[OAuth integration]. If you use GitLab version 11.1 or later, you can use link:https://docs.gitlab.com/ce/integration/openid_connect_provider.html[OpenID Connect] (OIDC) to connect instead of OAuth.
+If you use GitLab version 7.7.0 to 11.0, you connect using OAuth integration. If you use GitLab version 11.1 or later, you can use OpenID Connect (OIDC) to connect instead of OAuth. 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16959

Link to docs preview:
https://116076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-gitlab-identity-provider.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
