### PR TITLE
OSDOCS-20634: Document short-name alias precedence change in OCP 4.19

### DIFF
--- a/modules/images-configuration-shortname-when-not-to-use.adoc
+++ b/modules/images-configuration-shortname-when-not-to-use.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 To avoid deployment failures and security risks when using public registries in {product-title}, use fully-qualified image names instead of short names. Short names work with Red{nbsp}Hat internal or private registries, but public registries that require authentication might not deploy images with short names.
 
+[NOTE]
+====
+Starting with {product-title} 4.19, predefined short-name aliases in `/etc/containers/registries.conf.d/001-rhel-shortnames.conf` take precedence over the `containerRuntimeSearchRegistries` list. If a short name matches an alias in this file, the image is pulled from the alias target registry, not from the registries you configured. This can result in images being pulled from an unexpected registry.
+====
+
 You cannot list multiple public registries under the `containerRuntimeSearchRegistries` parameter if each public registry requires different credentials and a cluster does not list the public registry in the global pull secret.
 
 For a public registry that requires authentication, you can use an image short name only if the registry has its credentials stored in the global pull secret.

--- a/modules/images_configuration_shortname_con.adoc
+++ b/modules/images_configuration_shortname_con.adoc
@@ -14,3 +14,12 @@ For example, you could use `rhel7/etcd` instead of `registry.access.redhat.com/r
 You might use short names in situations where using the full path is not practical. For example, if your cluster references multiple internal registries whose DNS changes often, you would need to update the fully qualified domain names in your pull specs with each change. In this case, using an image short name might be beneficial.
 
 When pulling or pushing images, the container runtime searches the registries listed under the `registrySources` parameter in the `image.config.openshift.io/cluster` CR. If you created a list of registries under the `containerRuntimeSearchRegistries` parameter, when pulling an image with a short name, the container runtime searches those registries.
+
+[IMPORTANT]
+====
+Starting with {product-title} 4.19, {op-system} nodes include the `/etc/containers/registries.conf.d/001-rhel-shortnames.conf` file, which defines a set of predefined short-name aliases that map image short names to fully qualified image references. If a short name matches an alias in this file, the alias takes precedence over the unqualified search registries list, including any registries configured via the `containerRuntimeSearchRegistries` parameter.
+
+For example, if you reference an image using the short name `percona/percona-postgresql-operator` and an alias for that name exists in `001-rhel-shortnames.conf`, the container runtime resolves the image to the alias target rather than searching the registries in `containerRuntimeSearchRegistries`.
+
+To avoid unexpected image resolution, use fully qualified image names in pod specifications.
+====


### PR DESCRIPTION
[OSDOCS-20634](https://redhat.atlassian.net/browse/OSDOCS-20634)

Version(s): 4.19+

This PR documents the behavioral change introduced in OCP 4.19 where `/etc/containers/registries.conf.d/001-rhel-shortnames.conf` is now present on RHCOS nodes due to the switch from the RHAOS-specific `containers-common` package to the standard RHEL 9.6 version. Predefined short-name aliases in this file take precedence over `containerRuntimeSearchRegistries`.

**Changes:**
- `modules/images_configuration_shortname_con.adoc`: Added an IMPORTANT admonition explaining the alias precedence behavior.
- `modules/images-configuration-shortname-when-not-to-use.adoc`: Added a NOTE about alias precedence affecting registry resolution.

QE review:
- [ ] QE has approved this change.

Preview:
- [About adding registries that allow image short names](https://PREVIEW--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-shortname-con_image-configuration)