### PR TITLE
OSDOCS-20634: Add release note for short-name alias precedence change

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1205,6 +1205,15 @@ As part of aligning with Image Mode for {op-system-base}, {op-system} is now bui
 
 Because {op-system} now uses the {op-system-base} base image, any new operating system features added to that base image will usually be inherited by all {product-title} releases that use this base image.
 
+[id="ocp-4-19-rhcos-shortname-alias-precedence_{context}"]
+=== Image short-name alias file included on {op-system} nodes
+
+With the move to {op-system-base} 9.6 packages, {op-system} nodes now include the `/etc/containers/registries.conf.d/001-rhel-shortnames.conf` file from the `containers-common` package. This file defines predefined short-name aliases that map image short names to fully qualified image references.
+
+If an image is referenced using a short name and a matching alias exists in this file, the alias takes precedence over the unqualified search registries list, including registries configured via the `containerRuntimeSearchRegistries` parameter in the `image.config.openshift.io/cluster` custom resource.
+
+To avoid unexpected image resolution when upgrading from {product-title} 4.18, use fully qualified image names in pod specifications.
+
 [id="vmw-7-vcf-4-eogs_{context}"]
 === {vmw-full} 7 and VMware Cloud Foundation 4 end of general support
 


### PR DESCRIPTION
[OSDOCS-20634](https://redhat.atlassian.net/browse/OSDOCS-20634)

Version(s): 4.19

Adds a notable technical change entry to the 4.19 release notes documenting that RHCOS nodes now include `001-rhel-shortnames.conf` from the `containers-common` package (due to the switch to RHEL 9.6), which changes short-name resolution precedence for clusters upgrading from 4.18.

**Changes:**
- `release_notes/ocp-4-19-release-notes.adoc`: Added new entry under "Notable technical changes" > RHCOS section.

QE review:
- [ ] QE has approved this change.