### PR TITLE
OSDOCS-20734: CQA fixes for ROSA HCP Tutorials 7-9

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -7,30 +7,12 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-include::snippets/snip-mobb-support-statement.adoc[leveloffset=+1]
-
-[TIP]
-====
-Load Balancers created by the AWS Load Balancer Operator cannot be used for {OCP-short} Routes, and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an {OCP-short} Route. For more information about {OCP-short} Routes, see _Additional resources_.
-====
-
 [role="_abstract"]
-The AWS Load Balancer Controller manages AWS Elastic Load Balancers for a {product-title} cluster. The controller provisions AWS Application Load Balancers (ALB) when you create Kubernetes Ingress resources and AWS Network Load Balancers (NLB) when implementing Kubernetes Service resources with a type of LoadBalancer. For more information, see _Additional resources_.
+Install and configure the AWS Load Balancer Operator to provision advanced AWS Application Load Balancers (ALBs) and Network Load Balancers (NLBs) for your {product-title} cluster.
 
-Compared with the default AWS in-tree load balancer provider, this controller is developed with advanced annotations for both ALBs and NLBs. Some advanced use cases are:
+include::snippets/snip-mobb-support-statement.adoc[]
 
-* Using native Kubernetes Ingress objects with ALBs
-* Integrate ALBs with the AWS Web Application Firewall (WAF) service
-+
-[NOTE]
-====
-WAFv1, WAF classic, is no longer supported. Use WAFv2.
-====
-+
-* Specify custom NLB source IP ranges
-* Specify custom NLB internal IP addresses
-
-The AWS Load Balancer Operator is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. For more information, see _Additional resources_.
+include::modules/cloud-experts-aws-load-balancer-operator-about.adoc[leveloffset=+1]
 
 include::modules/cloud-experts-aws-load-balancer-operator-environment.adoc[leveloffset=+1]
 
@@ -45,8 +27,8 @@ include::modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc[leveloffs
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../networking/ingress_load_balancing/routes/nw-configuring-routes.adoc#nw-configuring-routes[{OCP-short} Routes]
 * link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller]
 * link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers]
 * link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers]
+* xref:../networking/ingress_load_balancing/routes/nw-configuring-routes.adoc#nw-configuring-routes[{OCP-short} Routes]
 * link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator]

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -8,7 +8,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on {product-title}.
+The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then securely retrieve them through your {product-title} workloads without hardcoding sensitive data in application configurations.
 
 include::modules/cloud-experts-aws-secret-manager-preparing-environment.adoc[leveloffset=+1]
 

--- a/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-entra-id-idp"]
-= Tutorial: Configure Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
+= Tutorial: Configure Microsoft Entra ID as an identity provider
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-entra-id-idp
@@ -8,7 +8,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can configure Microsoft Entra ID (formerly Azure Active Directory) as the cluster identity provider in {product-title}.
+Configure Microsoft Entra ID (formerly Azure Active Directory) as the cluster identity provider to enable user authentication and group-based access control for your {product-title} cluster by using OpenID Connect (OIDC).
 
 This tutorial guides you to complete the following tasks:
 

--- a/modules/cloud-experts-aws-load-balancer-operator-about.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cloud-experts-aws-load-balancer-operator-about_{context}"]
+= AWS Load Balancer Operator overview
+
+[role="_abstract"]
+The AWS Load Balancer Operator installs and manages the AWS Load Balancer Controller, which provisions Application Load Balancers (ALBs) and Network Load Balancers (NLBs) with advanced annotations beyond the default in-tree provider.
+
+[TIP]
+====
+Load Balancers created by the AWS Load Balancer Operator cannot be used for {OCP-short} Routes, and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an {OCP-short} Route.
+====
+
+Compared with the default AWS in-tree load balancer provider, the AWS Load Balancer Controller is developed with advanced annotations for both ALBs and NLBs. Some advanced use cases are:
+
+* Using native Kubernetes Ingress objects with ALBs.
+* Integrating ALBs with the AWS Web Application Firewall (WAF) service. WAFv1, WAF classic, is no longer supported; use WAFv2.
+* Specifying custom NLB source IP ranges.
+* Specifying custom NLB internal IP addresses.
+
+The AWS Load Balancer Operator is used to install, manage, and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. For more information, see _Additional resources_.

--- a/modules/cloud-experts-aws-load-balancer-operator-aws-vpc-subnets.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-aws-vpc-subnets.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-aws-vpc-subnets_{context}"]
-= AWS VPC and subnets
+= Tag your AWS VPC and subnets
 
 [role="_abstract"]
-Before installing the AWS Load Balancer Operator, you must tag your Virtual Private Cloud (VPC) and its subnets.
+Tag your Virtual Private Cloud (VPC) and subnets so the AWS Load Balancer Operator can identify your network resources and assign load balancers to the correct public or private subnets.
 
 [NOTE]
 ====

--- a/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-cleanup_{context}"]
-= Clean up
+= Clean up AWS resources
 
 [role="_abstract"]
-Clean up your AWS resources after completing this lab tutorial.
+Remove the sample application, AWS Load Balancer Operator, and associated Identity and Access Management (IAM) roles and policies created during this tutorial.
 
 .Procedure
-. Delete the hello world application namespace (and all the resources in the namespace):
+. Delete the `hello-world` application namespace and all the resources in the namespace:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-load-balancer-operator-environment.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-environment.adoc
@@ -7,7 +7,7 @@
 = Set up your environment
 
 [role="_abstract"]
-You can use environment variables to ensure consistency across the commands within this lab.
+Set environment variables for your cluster name, region, and OpenID Connect (OIDC) endpoint to ensure consistency across AWS Load Balancer Operator commands.
 
 .Prerequisites
 
@@ -20,7 +20,7 @@ endif::openshift-rosa-hcp[]
 +
 [NOTE]
 ====
-AWS ALBs require a multi-AZ cluster, as well as three public subnets split across three AZs in the same (Virtual Private Cloud) VPC as the cluster. This makes ALBs unsuitable for many PrivateLink clusters. AWS NLBs do not have this restriction.
+AWS Application Load Balancers (ALBs) require a multi-AZ cluster and three public subnets split across three AZs in the same Virtual Private Cloud (VPC) as the cluster. This makes ALBs unsuitable for many PrivateLink clusters. AWS Network Load Balancers (NLBs) do not have this restriction.
 ====
 +
 * You have created a Bring Your Own (BYO) VPC cluster.

--- a/modules/cloud-experts-aws-load-balancer-operator-install.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-install.adoc
@@ -7,10 +7,10 @@
 = Install the AWS Load Balancer Operator
 
 [role="_abstract"]
-You can use the {oc-first} tool to install the AWS Load Balancer Operator.
+Install the AWS Load Balancer Operator to provision and manage AWS Application Load Balancers (ALBs) and Network Load Balancers (NLBs) for your {product-title} cluster.
 
 .Procedure
-. Create an AWS IAM policy for the AWS Load Balancer Controller:
+. Create an AWS Identity and Access Management (IAM) policy for the AWS Load Balancer Controller:
 +
 [NOTE]
 ====
@@ -72,7 +72,7 @@ $ aws iam attach-role-policy --role-name "${ROSA_CLUSTER_NAME}-alb-operator" \
      --policy-arn $POLICY_ARN
 ----
 +
-. Create a secret for the AWS Load Balancer Operator to assume our newly created AWS IAM role:
+. Create a secret for the AWS Load Balancer Operator to assume the newly created AWS IAM role:
 +
 [source,terminal]
 ----
@@ -122,7 +122,7 @@ EOF
 +
 [NOTE]
 ====
-If you get an error here wait a minute and try again, it means the Operator has not completed installing yet.
+If you get an error, the Operator has not completed installing yet. Wait briefly and retry the step.
 ====
 +
 [source,terminal]
@@ -138,15 +138,14 @@ spec:
 EOF
 ----
 +
-. Check the that the Operator and controller pods are both running:
+. Check that the Operator and controller pods are both running:
 +
 [source,terminal]
 ----
 $ oc -n aws-load-balancer-operator get pods
 ----
 +
-You should see the following, if not wait a moment and retry:
-+
+.Example output
 [source,terminal]
 ----
 NAME                                                             READY   STATUS    RESTARTS   AGE

--- a/modules/cloud-experts-aws-load-balancer-operator-validating.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-validating.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-validating_{context}"]
-= Validate the deployment
+= Validate the AWS Load Balancer Operator deployment
 
 [role="_abstract"]
-You can validate your load balancer Operators using the {oc-first} tool.
+Deploy a sample application with Application Load Balancer (ALB) and Network Load Balancer (NLB) resources to verify that the AWS Load Balancer Operator successfully provisions load balancers to your cluster.
 
 .Procedure
 . Create a new project:
@@ -17,7 +17,7 @@ You can validate your load balancer Operators using the {oc-first} tool.
 $ oc new-project hello-world
 ----
 +
-. Deploy a hello world application:
+. Deploy a `hello-world` application:
 +
 [source,terminal]
 ----
@@ -71,29 +71,28 @@ spec:
                   number: 80
 EOF
 ----
-+
-. Curl the AWS ALB Ingress endpoint to verify the hello world application is accessible:
+
+. Curl the AWS ALB Ingress endpoint to verify the `hello-world` application is accessible:
 +
 [NOTE]
 ====
-AWS ALB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, please wait and try again.
+AWS ALB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, wait and try again.
 ====
 +
-[source,termnial]
+[source,terminal]
 ----
 $ INGRESS=$(oc -n hello-world get ingress hello-openshift-alb \
     -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 $ curl "http://${INGRESS}"
 ----
 +
-**Example output**:
+.Example output
 [source,text]
-+
 ----
 Hello OpenShift!
 ----
 
-. Deploy an AWS Network Load Balancer (NLB) for your hello world application:
+. Deploy an AWS Network Load Balancer (NLB) for your `hello-world` application:
 +
 [source,terminal]
 ----
@@ -117,12 +116,12 @@ spec:
     deployment: hello-openshift
 EOF
 ----
-+
+
 . Test the AWS NLB endpoint:
 +
 [NOTE]
 ====
-NLB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, please wait and try again.
+NLB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, wait and try again.
 ====
 +
 [source,terminal]

--- a/modules/cloud-experts-aws-secret-manager-cleanup.adoc
+++ b/modules/cloud-experts-aws-secret-manager-cleanup.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-cleanup_{context}"]
-= Clean up
+= Clean up AWS resources
 
 [role="_abstract"]
 Clean up your AWS resources after completing this lab tutorial.
@@ -17,7 +17,7 @@ Clean up your AWS resources after completing this lab tutorial.
 $ oc delete project my-application
 ----
 
-. Delete the secrets store csi driver by running the following command:
+. Delete the secrets store Container Storage Interface (CSI) driver by running the following command:
 +
 [source,terminal]
 ----
@@ -41,7 +41,7 @@ $ oc -n csi-secrets-store delete -f \
 https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secrets-store-csi/aws-provider-installer.yaml
 ----
 
-. Delete AWS Roles and Policies by running the following command:
+. Delete AWS roles and policies by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-create-iam-polices.adoc
+++ b/modules/cloud-experts-aws-secret-manager-create-iam-polices.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-create-iam-polices_{context}"]
-= Create a Secret and IAM Access Policies
+= Create a secret and IAM access policies
 
 [role="_abstract"]
-Use the AWS CLI to create your AWS secret and IAM access policies.
+Create a secret in AWS Secrets Manager and configure the necessary AWS Identity and Access Management (IAM) policies and roles to allow your application workloads to retrieve the secret securely using the Security Token Service (STS).
 
 .Procedure
-. Create a secret in Secrets Manager by running the following command:
+. Create a secret in AWS Secrets Manager by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-creating-application.adoc
+++ b/modules/cloud-experts-aws-secret-manager-creating-application.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-creating-application_{context}"]
-= Create an application to use this secret
+= Create an application that uses an AWS Secrets Manager secret
 
 [role="_abstract"]
-You can create your application using the secret that you created.
+Deploy a sample application with the `SecretProviderClass` Container Storage Interface (CSI) volume to verify that your workload can retrieve secrets from AWS Secrets Manager.
 
 .Procedure
 . Create an {OCP-short} project by running the following command:
@@ -17,7 +17,7 @@ You can create your application using the secret that you created.
 $ oc new-project my-application
 ----
 
-. Annotate the default service account to use the STS Role by running the following command:
+. Annotate the default service account to use the Security Token Service (STS) role by running the following command:
 +
 [source,terminal]
 ----
@@ -75,7 +75,9 @@ spec:
 EOF
 ----
 
-. Verify the pod has the secret mounted by running the following command:
+.Verification
+
+* Verify the pod has the secret mounted by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-deply-aws-secrets.adoc
+++ b/modules/cloud-experts-aws-secret-manager-deply-aws-secrets.adoc
@@ -7,9 +7,10 @@
 = Deploy the AWS Secrets and Configuration Provider
 
 [role="_abstract"]
+Deploy the Secrets Store Container Storage Interface (CSI) Driver and the AWS Secrets and Configuration Provider by using Helm to enable your {product-title} workloads to mount AWS Secrets as volumes.
 
 .Procedure
-. Use Helm to register the secrets store CSI driver by running the following command:
+. Use Helm to register the Secrets Store CSI Driver by running the following command:
 +
 [source,terminal]
 ----
@@ -24,7 +25,7 @@ $ helm repo add secrets-store-csi-driver \
 $ helm repo update
 ----
 
-. Install the secrets store CSI driver by running the following command:
+. Install the Secrets Store CSI Driver by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-preparing-environment.adoc
+++ b/modules/cloud-experts-aws-secret-manager-preparing-environment.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-preparing-environment_{context}"]
-= Additional environment requirements
+= Prepare your environment for AWS Secrets Manager
 
 [role="_abstract"]
-Before creating your application, you need to gain access to your {product-title} cluster.
+Before creating your application, you need to gain access to your {product-title} cluster and configure it with permissions and variables required by the AWS Secrets and Configuration Provider.
 
 .Prerequisites
-* You have created a {product-title} cluster deployed with STS.
+* You have created a {product-title} cluster deployed with Security Token Service (STS).
 * You have installed Helm 3.
 * You have access to the AWS CLI (`aws`).
 * You have access to the {oc-first}.
@@ -49,7 +49,7 @@ ifdef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
 endif::openshift-rosa-hcp[]
 
-. Set the `SecurityContextConstraints` permission to allow the CSI driver to run by running the following command:
+. Set the `SecurityContextConstraints` permission to allow the Container Storage Interface (CSI) driver to run by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-entra-id-idp-additional-individual-groups.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-individual-groups.adoc
@@ -7,7 +7,7 @@
 = Grant additional permissions to individual groups
 
 [role="_abstract"]
-If you opted to enable group claims, the cluster OAuth provider automatically creates or updates the user's group memberships by using the group ID. The cluster OAuth provider does not automatically create `RoleBindings` and `ClusterRoleBindings` for the groups that are created; you are responsible for creating those bindings by using your own processes.
+When group claims are enabled, the cluster OAuth provider automatically creates or updates group memberships by using the group ID, but does not create `RoleBindings` or `ClusterRoleBindings`. You must create those bindings to grant group-based permissions.
 
 To grant an automatically generated group access to the `cluster-admin` role, you must create a `ClusterRoleBinding` to the group ID.
 
@@ -22,7 +22,7 @@ $ oc create clusterrolebinding cluster-admin-group --clusterrole=cluster-admin -
 --
 where:
 
-`<GROUP-ID>`:: Provide the Entra ID group ID that you want to have cluster admin permissions.
+`<GROUP_ID>`:: Specifies the Entra ID group ID that you want to have cluster admin permissions.
 --
 +
 Now, any user in the specified group automatically receives `cluster-admin` access.

--- a/modules/cloud-experts-entra-id-idp-additional-individual-user.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-individual-user.adoc
@@ -7,7 +7,7 @@
 = Grant additional permissions to individual users
 
 [role="_abstract"]
-{product-title} includes a significant number of preconfigured roles, including the `cluster-admin` role that grants full access and control over the cluster.
+Grant the `cluster-admin` role to individual Entra ID users so that they have full access and control over the cluster.
 
 .Procedure
 * Grant a user access to the `cluster-admin` role by running the following command:

--- a/modules/cloud-experts-entra-id-idp-additional-user-groups.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-user-groups.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="cloud-experts-entra-id-idp-additional-user-groups_{context}"]
-= Grant additional permissions to individual users and groups
+= Additional permissions for individual users and groups
 
 [role="_abstract"]
 When you first log in, you might notice that you have very limited permissions. By default, {product-title} only grants you the ability to create new projects, or namespaces, in the cluster. Other projects are restricted from view.

--- a/modules/cloud-experts-entra-id-idp-configure-app.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-app.adoc
@@ -4,9 +4,13 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="cloud-experts-entra-id-idp-configure-app_{context}"]
-= Configure the application registration in Entra ID to include optional and group claims
+= Optional and group claims for Entra ID application registration
 
 [role="_abstract"]
-To ensure that {product-title} has enough information to create the user's account, you must configure Entra ID to give two optional claims: `email` and `preferred_username`. For more information about optional claims in Entra ID, see link:https://learn.microsoft.com/en-us/azure/active-directory/develop/optional-claims[the Microsoft documentation].
+The `email` and `preferred_username` Entra ID optional claims provide {product-title} with the information it needs to create user accounts. Group claims enable group-based access control.
 
 In addition to individual user authentication, {product-title} provides group claim functionality. This functionality allows an OpenID Connect (OIDC) identity provider, such as Entra ID, to offer a user's group membership for use within {product-title}.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://learn.microsoft.com/en-us/azure/active-directory/develop/optional-claims[Configure and manage optional claims - Microsoft documentation]

--- a/modules/cloud-experts-entra-id-idp-configure-entra-idp.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-entra-idp.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-entra-idp_{context}"]
-= Configure the {product-title} cluster to use Entra ID as the identity provider
+= Configure Entra ID as the cluster identity provider
 
 [role="_abstract"]
-You must configure {product-title} to use Entra ID as its identity provider. Although {product-title} offers the ability to configure identity providers by using {cluster-manager}, use the {rosa-cli-first} to configure the cluster's OAuth provider to use Entra ID as its identity provider. Before configuring the identity provider, set the necessary variables for the identity provider configuration.
+Use the {rosa-cli-first} to configure the cluster's OAuth provider to use Entra ID as its identity provider, enabling users to log in with their Microsoft credentials and optional group-based access control.
 
 .Procedure
-. Create the variables by running the following command:
+. Create the variables necessary for the identity provider configuration by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-entra-id-idp-configure-group-claims.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-group-claims.adoc
@@ -4,21 +4,26 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-group-claims_{context}"]
-= Configure group claims (optional)
+= Configure group claims
 
 [role="_abstract"]
-Configure Entra ID to offer a groups claim.
+Configure group claims in Entra ID to allow {product-title} to manage user group memberships and enable group-based role bindings in the cluster.
+
+[NOTE]
+====
+Configuring group claims is an optional step.
+====
 
 .Procedure
 . From the *Token configuration* sub-blade, click *Add groups claim*.
 +
 image:azure-portal_optional-group-claims-page.png[Azure Portal - Add Groups Claim Page]
 
-. To configure group claims for your Entra ID application, select *Security groups* and then click the *Add*.
+. To configure group claims for your Entra ID application, select *Security groups* and then click *Add*.
 +
 [NOTE]
 ====
-In this example, the group claim includes all of the security groups that a user is a member of. In a real production environment, ensure that the groups that the group claim only includes groups that apply to {product-title}.
+In this example, the group claim includes all of the security groups that a user is a member of. In a real production environment, ensure that the group claim only includes groups that apply to {product-title}.
 ====
 +
 image:azure-portal_edit-group-claims-page.png[Azure Portal - Edit Groups Claim Page]

--- a/modules/cloud-experts-entra-id-idp-configure-optional-claims.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-optional-claims.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-optional-claims_{context}"]
-= Configure optional claims
+= Configure optional claims in Entra ID
 
 [role="_abstract"]
-You can configure the optional claims in Entra ID.
+Configure the `email` and `preferred_username` optional claims in Entra ID so that {product-title} can identify users during authentication.
 
 .Procedure
-. Click the *Token configuration* sub-blade and select the *Add optional claim* button.
+. Click the *Token configuration* sub-blade and click *Add optional claim*.
 +
 image:azure-portal_optional-claims-page.png[Azure Portal - Add Optional Claims Page]
 
@@ -26,6 +26,6 @@ image:azure-portal_add-optional-email-claims-page.png[Azure Portal - Add Optiona
 +
 image:azure-portal_add-optional-preferred_username-claims-page.png[Azure Portal - Add Optional Claims - preferred_username]
 
-. A dialog box appears at the top of the page. Follow the prompt to enable the necessary Microsoft Graph permissions.
+. Follow the prompt in the dialog box to enable the necessary Microsoft Graph permissions.
 +
 image:azure-portal_add-optional-claims-graph-permissions-prompt.png[Azure Portal - Add Optional Claims - Graph Permissions Prompt]

--- a/modules/cloud-experts-entra-id-idp-register-app.adoc
+++ b/modules/cloud-experts-entra-id-idp-register-app.adoc
@@ -7,7 +7,7 @@
 = Register a new application in Entra ID for authentication
 
 [role="_abstract"]
-To register your application in Entra ID, first create the OAuth callback URL, then register your application.
+Register an application in Entra ID using your cluster OAuth callback URL to generate the credentials for cluster authentication.
 
 .Prerequisites
 * You have created a set of security groups and assigned users by following link:https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/how-to-manage-groups[the Microsoft documentation].
@@ -15,18 +15,18 @@ To register your application in Entra ID, first create the OAuth callback URL, t
 .Procedure
 . Create the cluster's OAuth callback URL by changing the specified variables and running the following command:
 +
-[NOTE]
-====
-Remember to save this callback URL; it will be required later in the process.
-====
-+
 [source,terminal]
 ----
 $ domain=$(rosa describe cluster -c <cluster_name> | grep "DNS" | grep -oE '\S+.openshiftapps.com')
 echo "OAuth callback URL: https://oauth.${domain}/oauth2callback/AAD"
 ----
 +
-The "AAD" directory at the end of the OAuth callback URL must match the OAuth identity provider name that you will set up later in this process.
+The `AAD` directory at the end of the OAuth callback URL must match the OAuth identity provider name that you will set up later in this process.
++
+[NOTE]
+====
+Remember to save this callback URL; it will be required later in the process.
+====
 
 . Create the Entra ID application by logging in to the Azure portal, and select the link:https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade[App registrations blade]. Then, select *New registration* to create a new application.
 +


### PR DESCRIPTION
Version(s):
4.22+
5.0+

UPD: Removing 4.20+ since Tutorials are ROSA-only and we don't need to cherry-pick further than 4.22.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20734

Link to docs preview:

**ROSA HCP**
https://116081--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.html
https://116081--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html
https://116081--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-entra-id-idp.html

**ROSA Classic** (the same 3 assemblies/tutorials)
https://116081--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.html
https://116081--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html
https://116081--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-entra-id-idp.html

QE review:
N/A

Additional information:
The PR mostly addresses issues around the modular docs and short descriptions requirements.

Issues were identified by the following 5 CCS AI plugins (skills):

- docs-tools:docs-review-modular-docs
- cqa-tools:cqa-modularization
- dita-tools:dita-rewrite-shortdesc
- cqa-tools:cqa-titles-descriptions
- docs-tools:docs-review-style
