### PR TITLE
TELCODOCS-2635: Fix AsciiDocDITA rule violations in ZTP/TALM modules

### DIFF
--- a/modules/ztp-comparing-pgt-and-rhacm-pg-patching-strategies.adoc
+++ b/modules/ztp-comparing-pgt-and-rhacm-pg-patching-strategies.adoc
@@ -6,6 +6,7 @@
 [id="ztp-comparing-pgt-and-rhacm-pg-patching-strategies_{context}"]
 = Comparing {rh-rhacm} PolicyGenerator and PolicyGenTemplate resource patching
 
+[role="_abstract"]
 `PolicyGenerator` custom resources (CRs) and `PolicyGenTemplate` CRs can be used in {ztp} to generate {rh-rhacm} policies for managed clusters.
 
 There are advantages to using `PolicyGenerator` CRs over `PolicyGenTemplate` CRs when it comes to patching {product-title} resources with {ztp}.

--- a/modules/ztp-coordinating-reboots-for-config-changes.adoc
+++ b/modules/ztp-coordinating-reboots-for-config-changes.adoc
@@ -6,6 +6,7 @@
 [id="ztp-coordinating-reboots-for-config-changes_{context}"]
 = Coordinating reboots for configuration changes
 
+[role="_abstract"]
 You can use {cgu-operator-full} (TALM) to coordinate reboots across a fleet of spoke clusters when configuration changes require a reboot, such as deferred tuning changes. {cgu-operator} reboots all nodes in the targeted `MachineConfigPool` on the selected clusters when the reboot policy is applied.
 
 Instead of rebooting nodes after each individual change, you can apply all configuration updates through policies and then trigger a single, coordinated reboot. 
@@ -41,19 +42,24 @@ metadata:
   namespace: default
 spec:
   clusterLabelSelectors:
-  - matchLabels: <1>
+  - matchLabels:
 # ...
   enable: true
-  managedPolicies: <2>
+  managedPolicies:
   - example-reboot
   remediationStrategy:
-    timeout: 300 <3>
+    timeout: 300
     maxConcurrency: 10
 # ...
 ----
-<1> Configure the labels that match the clusters you want to reboot.
-<2> Add all required configuration policies before the reboot policy. {cgu-operator} applies the configuration changes as specified in the policies, in the order they are listed.
-<3> Specify the timeout in seconds for the entire upgrade across all selected clusters. Set this field by considering the worst-case scenario.
++
+where:
++
+--
+`matchLabels`:: Configure the labels that match the clusters you want to reboot.
+`managedPolicies`:: Add all required configuration policies before the reboot policy. {cgu-operator} applies the configuration changes as specified in the policies, in the order they are listed.
+`timeout`:: Specify the timeout in seconds for the entire upgrade across all selected clusters. Set this field by considering the worst-case scenario.
+--
 
 . After you apply the CGU custom resource, {cgu-operator} rolls out the configuration policies in order. Once all policies are compliant, it applies the reboot policy and triggers a reboot of all nodes in the specified `MachineConfigPool`.
 

--- a/modules/ztp-customizing-a-managed-site-using-pgt.adoc
+++ b/modules/ztp-customizing-a-managed-site-using-pgt.adoc
@@ -6,6 +6,7 @@
 [id="ztp-customizing-a-managed-site-using-pgt_{context}"]
 = Customizing a managed cluster with {policy-gen-cr} CRs
 
+[role="_abstract"]
 Use the following procedure to customize the policies that get applied to the managed cluster that you provision using the {ztp-first} pipeline.
 
 .Prerequisites

--- a/modules/ztp-definition-of-done-for-ztp-installations.adoc
+++ b/modules/ztp-definition-of-done-for-ztp-installations.adoc
@@ -6,6 +6,7 @@
 [id="ztp-definition-of-done-for-ztp-installations_{context}"]
 = Indication of done for {ztp} installations
 
+[role="_abstract"]
 {ztp-first} simplifies the process of checking the {ztp} installation status for a cluster. The {ztp} status moves through three phases: cluster installation, cluster configuration, and {ztp} done.
 
 Cluster installation phase::

--- a/modules/ztp-monitoring-policy-deployment-progress.adoc
+++ b/modules/ztp-monitoring-policy-deployment-progress.adoc
@@ -6,6 +6,7 @@
 [id="ztp-monitoring-policy-deployment-progress_{context}"]
 = Monitoring managed cluster policy deployment progress
 
+[role="_abstract"]
 The ArgoCD pipeline uses `{policy-gen-cr}` CRs in Git to generate the {rh-rhacm} policies and then sync them to the hub cluster. You can monitor the progress of the managed cluster policy synchronization after the assisted service installs {product-title} on the managed cluster.
 
 .Prerequisites
@@ -72,6 +73,9 @@ ztp-site.example1-perf-policy                            inform               No
 ... Click *Governance* -> *Find policies*.
 ... Click on a cluster policy to check its status.
 
+[NOTE]
+====
 When all of the cluster policies become compliant, {ztp} installation and configuration for the cluster is complete. The `ztp-done` label is added to the cluster.
 
 In the reference configuration, the final policy that becomes compliant is the one defined in the `*-du-validator-policy` policy. This policy, when compliant on a cluster, ensures that all cluster configuration, Operator installation, and Operator configuration is complete.
+====

--- a/modules/ztp-pgt-config-best-practices.adoc
+++ b/modules/ztp-pgt-config-best-practices.adoc
@@ -6,6 +6,7 @@
 [id="ztp-pgt-config-best-practices_{context}"]
 = Recommendations when customizing {policy-gen-cr} CRs
 
+[role="_abstract"]
 Consider the following best practices when customizing site configuration `{policy-gen-cr}` custom resources (CRs):
 
 * Use as few policies as are necessary. Using fewer policies requires less resources. Each additional policy creates increased CPU load for the hub cluster and the deployed managed cluster. CRs are combined into policies based on the `policyName` field in the `{policy-gen-cr}` CR. CRs in the same `{policy-gen-cr}` which have the same value for `policyName` are managed under a single policy.

--- a/modules/ztp-policygentemplates-for-ran.adoc
+++ b/modules/ztp-policygentemplates-for-ran.adoc
@@ -6,6 +6,7 @@
 [id="ztp-policygentemplates-for-ran_{context}"]
 = {policy-gen-cr} CRs for RAN deployments
 
+[role="_abstract"]
 Use `{policy-gen-cr}` custom resources (CRs) to customize the configuration applied to the cluster by using the {ztp-first} pipeline. The `{policy-gen-cr}` CR allows you to generate one or more policies to manage the set of configuration CRs on your fleet of clusters. The `{policy-gen-cr}` CR identifies the set of managed CRs, bundles them into policies, builds the policy wrapping around those CRs, and associates the policies with clusters by using label binding rules.
 
 The reference configuration, obtained from the {ztp} container, is designed to provide a set of critical features and node tuning settings that ensure the cluster can support the stringent performance and resource utilization constraints typical of RAN (Radio Access Network) Distributed Unit (DU) applications. Changes or omissions from the baseline configuration can affect feature availability, performance, and resource utilization. Use the reference `{policy-gen-cr}` CRs as the basis to create a hierarchy of configuration files tailored to your specific site requirements.

--- a/modules/ztp-removing-content-from-managed-clusters.adoc
+++ b/modules/ztp-removing-content-from-managed-clusters.adoc
@@ -6,6 +6,7 @@
 [id="ztp-removing-content-from-managed-clusters_{context}"]
 = Changing applied managed cluster CRs using policies
 
+[role="_abstract"]
 You can remove content from a custom resource (CR) that is deployed in a managed cluster through a policy.
 
 By default, all `Policy` CRs created from a `{policy-gen-cr}` CR have the `complianceType` field set to `musthave`.

--- a/modules/ztp-restarting-policies-reconciliation.adoc
+++ b/modules/ztp-restarting-policies-reconciliation.adoc
@@ -6,6 +6,7 @@
 [id="ztp-restarting-policies-reconciliation_{context}"]
 = Restarting policy reconciliation
 
+[role="_abstract"]
 You can restart policy reconciliation when unexpected compliance issues occur, for example, when the `ClusterGroupUpgrade` custom resource (CR) has timed out.
 
 .Procedure
@@ -36,6 +37,9 @@ $ oc get clustergroupupgrades -n ztp-install $CLUSTER -o jsonpath='{.status.cond
 $ oc delete clustergroupupgrades -n ztp-install $CLUSTER
 ----
 
-Note that when the `ClusterGroupUpgrade` CR completes with status `UpgradeCompleted` and the managed cluster has the label `ztp-done` applied, you can make additional configuration changes by using `{policy-gen-cr}`. Deleting the existing `ClusterGroupUpgrade` CR will not make the {cgu-operator} generate a new CR.
+[NOTE]
+====
+When the `ClusterGroupUpgrade` CR completes with status `UpgradeCompleted` and the managed cluster has the label `ztp-done` applied, you can make additional configuration changes by using `{policy-gen-cr}`. Deleting the existing `ClusterGroupUpgrade` CR will not make the {cgu-operator} generate a new CR.
 
 At this point, {ztp} has completed its interaction with the cluster and any further interactions should be treated as an update and a new `ClusterGroupUpgrade` CR created for remediation of the policies.
+====

--- a/modules/ztp-specifying-nics-in-pgt-crs-with-hub-cluster-templates.adoc
+++ b/modules/ztp-specifying-nics-in-pgt-crs-with-hub-cluster-templates.adoc
@@ -6,6 +6,7 @@
 [id="ztp-specifying-nics-in-pgt-crs-with-hub-cluster-templates_{context}"]
 = Specifying group and site configurations in group PolicyGenerator or PolicyGentemplate CRs
 
+[role="_abstract"]
 You can manage the configuration of fleets of clusters with `ConfigMap` CRs by using hub templates to populate the group and site values in the generated policies that get applied to the managed clusters.
 Using hub templates in site `PolicyGenerator` or `PolicyGentemplate` CRs means that you do not need to create a policy CR for each site.
 
@@ -51,7 +52,7 @@ metadata:
   name: group-hardware-types-configmap
   namespace: ztp-group
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true <1>
+    argocd.argoproj.io/sync-options: Replace=true
 data:
   # SriovNetworkNodePolicy.yaml
   hardware-type-1-sriov-node-policy-pfNames-1: "[\"ens5f0\"]"
@@ -63,7 +64,10 @@ data:
   hardware-type-1-hugepages-size: "1G"
   hardware-type-1-hugepages-count: "32"
 ----
-<1> The `argocd.argoproj.io/sync-options` annotation is required only if the `ConfigMap` is larger than 1 MiB in size.
++
+where:
++
+`argocd.argoproj.io/sync-options`:: The `argocd.argoproj.io/sync-options` annotation is required only if the `ConfigMap` is larger than 1 MiB in size.
 
 .. Create  a `ConfigMap` CR named `group-zones-configmap` to hold the regional configuration. For example:
 +

--- a/modules/ztp-syncing-new-configmap-changes-to-existing-pgt-crs.adoc
+++ b/modules/ztp-syncing-new-configmap-changes-to-existing-pgt-crs.adoc
@@ -6,6 +6,9 @@
 [id="ztp-syncing-new-configmap-changes-to-existing-pgt-crs_{context}"]
 = Syncing new ConfigMap changes to existing PolicyGenerator or PolicyGentemplate CRs
 
+[role="_abstract"]
+You can sync updated `ConfigMap` CR changes to existing `PolicyGenerator` or `PolicyGentemplate` CRs deployed on the hub cluster.
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/ztp-the-policygentemplate.adoc
+++ b/modules/ztp-the-policygentemplate.adoc
@@ -6,6 +6,7 @@
 [id="ztp-the-policygentemplate_{context}"]
 = About the {policy-gen-cr} CRD
 
+[role="_abstract"]
 The `{policy-gen-cr}` custom resource definition (CRD) tells the `PolicyGen` policy generator what custom resources (CRs) to include in the cluster configuration, how to combine the CRs into the generated policies, and what items in those CRs need to be updated with overlay content.
 
 The following example shows a `{policy-gen-cr}` CR (`{policy-prefix}common-du-ranGen.yaml`) extracted from the `ztp-site-generate` reference container. The `{policy-prefix}common-du-ranGen.yaml` file defines two {rh-rhacm-first} policies. The policies manage a collection of configuration CRs, one for each unique value of `policyName` in the CR. `{policy-prefix}common-du-ranGen.yaml` creates a single placement binding and a placement rule to bind the policies to clusters based on the labels listed in the `{binding-field}` section.

--- a/modules/ztp-validating-the-generation-of-configuration-policy-crs.adoc
+++ b/modules/ztp-validating-the-generation-of-configuration-policy-crs.adoc
@@ -6,6 +6,7 @@
 [id="ztp-validating-the-generation-of-configuration-policy-crs_{context}"]
 = Validating the generation of configuration policy CRs
 
+[role="_abstract"]
 `Policy` custom resources (CRs) are generated in the same namespace as the `{policy-gen-cr}` from which they are created. The same troubleshooting flow applies to all policy CRs generated from a `{policy-gen-cr}` regardless of whether they are `ztp-common`, `ztp-group`, or `ztp-site` based, as shown using the following commands:
 
 [source,terminal]
@@ -67,7 +68,6 @@ $ oc get policy -n $CLUSTER
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                                         REMEDIATION ACTION   COMPLIANCE STATE   AGE

--- a/snippets/pg-ztp-the-policygenerator.adoc
+++ b/snippets/pg-ztp-the-policygenerator.adoc
@@ -6,7 +6,7 @@ kind: PolicyGenerator
 metadata:
     name: common-latest
 placementBindingDefaults:
-    name: common-latest-placement-binding <1>
+    name: common-latest-placement-binding
 policyDefaults:
     namespace: ztp-common
     placement:
@@ -36,7 +36,7 @@ policies:
         ran.openshift.io/ztp-deploy-wave: "1"
       manifests:
         - path: source-crs/ReduceMonitoringFootprint.yaml
-        - path: source-crs/DefaultCatsrc.yaml <2>
+        - path: source-crs/DefaultCatsrc.yaml
           patches:
             - metadata:
                 name: redhat-operators-disconnected
@@ -53,7 +53,7 @@ policies:
     - name: common-latest-subscriptions-policy
       policyAnnotations:
         ran.openshift.io/ztp-deploy-wave: "2"
-      manifests: <3>
+      manifests:
         - path: source-crs/SriovSubscriptionNS.yaml
         - path: source-crs/SriovSubscriptionOperGroup.yaml
         - path: source-crs/SriovSubscription.yaml
@@ -71,6 +71,10 @@ policies:
         - path: source-crs/StorageSubscription.yaml
         - path: source-crs/StorageOperatorStatus.yaml
 ----
-<1> Applies the policies to all clusters with this label.
-<2> The `DefaultCatsrc.yaml` file contains the catalog source for the disconnected registry and related registry configuration details.
-<3> Files listed under `policies.manifests` create the Operator policies for installed clusters.
+
+where:
+--
+`name: common-latest-placement-binding`:: Applies the policies to all clusters with this label.
+`DefaultCatsrc.yaml`:: The `DefaultCatsrc.yaml` file contains the catalog source for the disconnected registry and related registry configuration details.
+`manifests`:: Files listed under `policies.manifests` create the Operator policies for installed clusters.
+--

--- a/snippets/pgt-ztp-the-policygentemplate.adoc
+++ b/snippets/pgt-ztp-the-policygentemplate.adoc
@@ -8,9 +8,9 @@ metadata:
   namespace: "ztp-common"
 spec:
   bindingRules:
-    common: "true" <1>
+    common: "true"
     du-profile: "latest"
-  sourceFiles: <2>
+  sourceFiles:
     - fileName: SriovSubscriptionNS.yaml
       policyName: "subscriptions-policy"
     - fileName: SriovSubscriptionOperGroup.yaml
@@ -43,8 +43,8 @@ spec:
       policyName: "subscriptions-policy"
     - fileName: StorageOperatorStatus.yaml
       policyName: "subscriptions-policy"
-    - fileName: DefaultCatsrc.yaml <3>
-      policyName: "config-policy" <4>
+    - fileName: DefaultCatsrc.yaml
+      policyName: "config-policy"
       metadata:
         name: redhat-operators-disconnected
       spec:
@@ -58,7 +58,12 @@ spec:
           - registry.example.com:5000
           source: registry.redhat.io
 ----
-<1> `common: "true"` applies the policies to all clusters with this label.
-<2> Files listed under `sourceFiles` create the Operator policies for installed clusters.
-<3> `DefaultCatsrc.yaml` configures the catalog source for the disconnected registry.
-<4> `policyName: "config-policy"` configures Operator subscriptions. The `OperatorHub` CR disables the default and this CR replaces `redhat-operators` with a `CatalogSource` CR that points to the disconnected registry.
+
+where:
+
+--
+`common: "true"`:: Applies the policies to all clusters with this label.
+`sourceFiles`:: Files listed under `sourceFiles` create the Operator policies for installed clusters.
+`DefaultCatsrc.yaml`:: Configures the catalog source for the disconnected registry.
+`policyName: "config-policy"`:: Configures Operator subscriptions. The `OperatorHub` CR disables the default and this CR replaces `redhat-operators` with a `CatalogSource` CR that points to the disconnected registry.
+--


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` for DITA short descriptions in 13 ZTP/TALM modules
- Replace callout lists with description lists in 2 modules (callouts not supported in DITA)
- Wrap loose post-procedure content in NOTE admonitions in 2 modules (DITA task step mapping)
- Fix block title separation from source block in 1 module

## Context
Final pass mop-up for [TELCODOCS-2635](https://redhat.atlassian.net/browse/TELCODOCS-2635) Phase 0 CQA 2.0 pre-migration review. These fixes resolve AsciiDocDITA Vale rule violations that would cause issues when porting content to DITA XML.

## Test plan
- [ ] Vale AsciiDocDITA rules pass on changed files
- [ ] Content renders correctly in preview
- [ ] No regressions in adjacent content