### PR TITLE
TELCODOCS-2635: Final Vale pass - Day 2/Security

### DIFF
--- a/post_installation_configuration/day_2_core_cnf_clusters/security/security-sec-context-constraints.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/security/security-sec-context-constraints.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Similar to the way that RBAC resources control user access, administrators can use security context constraints (SCCs) to control permissions for pods. These permissions determine the actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run.
 
 Security context constraints allow an administrator to control the following security constraints:


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` DITA short description annotation to `security-sec-context-constraints.adoc`
- Part of final AsciiDocDITA Vale mop-up pass across telco assemblies

## Files changed
- `post_installation_configuration/day_2_core_cnf_clusters/security/security-sec-context-constraints.adoc`

## Notes
- ConceptLink hits in this batch are all external links or internal xrefs — both acceptable for DITA porting
- No CalloutList, BlockTitle, or other AsciiDocDITA violations found in this section
- TaskInclude errors skipped (systemic openshift-docs pattern)

## Test plan
- [x] Vale AsciiDocDITA.ShortDescription error resolved
- [ ] Review rendered output for correctness