### PR TITLE
TELCODOCS-2635: Final Vale pass - Image-Based Upgrade/Install

### DIFF
--- a/modules/ztp-image-based-upgrade-prep-label-extramanifests.adoc
+++ b/modules/ztp-image-based-upgrade-prep-label-extramanifests.adoc
@@ -5,6 +5,7 @@
 [id="ztp-image-based-upgrade-prep-label-extramanifests_{context}"]
 = Labeling extra manifests for the image-based upgrade with {ztp}
 
+[role="_abstract"]
 Label your extra manifests so that the {lcao} can extract resources that are labeled with the `lca.openshift.io/target-ocp-version: <target_version>` label.
 
 .Prerequisites
@@ -36,7 +37,7 @@ spec:
       metadata:
         name: "sriov-nw-du-fh"
         labels:
-          lca.openshift.io/target-ocp-version: "4.15" <1>
+          lca.openshift.io/target-ocp-version: "4.15"
       spec:
         resourceName: du_fh
         vlan: 140
@@ -77,7 +78,7 @@ spec:
         numVfs: 8
         priority: 10
         resourceName: du_mh
-    - fileName: DefaultCatsrc.yaml <2>
+    - fileName: DefaultCatsrc.yaml
       policyName: "config-policy"
       metadata:
         name: default-cat-source
@@ -88,7 +89,11 @@ spec:
           displayName: default-cat-source
           image: quay.io/example-org/example-catalog:v1
 ----
-<1> Ensure that the `lca.openshift.io/target-ocp-version` label matches either the y-stream or the z-stream of the target {product-title} version that is specified in the `spec.seedImageRef.version` field of the `ImageBasedUpgrade` CR. The {lcao} only applies the CRs that match the specified version.
-<2> If you do not want to use custom catalog sources, remove this entry.
++
+where:
+
+`lca.openshift.io/target-ocp-version`:: Ensure that this label matches either the y-stream or the z-stream of the target {product-title} version that is specified in the `spec.seedImageRef.version` field of the `ImageBasedUpgrade` CR. The {lcao} only applies the CRs that match the specified version.
+
+`DefaultCatsrc.yaml`:: If you do not want to use custom catalog sources, remove this entry.
 
 . Push the changes to your Git repository.

--- a/modules/ztp-image-based-upgrade-prep-oadp.adoc
+++ b/modules/ztp-image-based-upgrade-prep-oadp.adoc
@@ -5,6 +5,7 @@
 [id="ztp-image-based-upgrade-prep-oadp_{context}"]
 = Creating {oadp-short} resources for the image-based upgrade with {ztp}
 
+[role="_abstract"]
 Prepare your {oadp-short} resources to restore your application after an upgrade.
 
 .Prerequisites
@@ -80,17 +81,21 @@ The same version of the applications must function on both the current and the t
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-configMapGenerator: # <1>
+configMapGenerator:
 - files:
   - source-crs/ibu/PlatformBackupRestoreWithIBGU.yaml
   #- source-crs/custom-crs/ApplicationClusterScopedBackupRestore.yaml
   #- source-crs/custom-crs/ApplicationApplicationBackupRestoreLso.yaml
   name: oadp-cm
-  namespace: openshift-adp # <2>
+  namespace: openshift-adp
 generatorOptions:
   disableNameSuffixHash: true
 ----
-<1> Creates the `oadp-cm` `ConfigMap` object on the hub cluster with `Backup` and `Restore` CRs.
-<2> The namespace must exist on all managed clusters and the hub for the OADP `ConfigMap` to be generated and copied to the clusters.
++
+where:
+
+`configMapGenerator`:: Creates the `oadp-cm` `ConfigMap` object on the hub cluster with `Backup` and `Restore` CRs.
+
+`namespace: openshift-adp`:: The namespace must exist on all managed clusters and the hub for the OADP `ConfigMap` to be generated and copied to the clusters.
 
 . Push the changes to your Git repository.

--- a/snippets/ibu-PlatformBackupRestoreWithIBGU.adoc
+++ b/snippets/ibu-PlatformBackupRestoreWithIBGU.adoc
@@ -5,7 +5,7 @@ kind: Backup
 metadata:
   name: acm-klusterlet
   annotations:
-    lca.openshift.io/apply-label: "apps/v1/deployments/open-cluster-management-agent/klusterlet,v1/secrets/open-cluster-management-agent/bootstrap-hub-kubeconfig,rbac.authorization.k8s.io/v1/clusterroles/klusterlet,v1/serviceaccounts/open-cluster-management-agent/klusterlet,scheduling.k8s.io/v1/priorityclasses/klusterlet-critical,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-work:ibu-role,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-admin-aggregate-clusterrole,rbac.authorization.k8s.io/v1/clusterrolebindings/klusterlet,operator.open-cluster-management.io/v1/klusterlets/klusterlet,apiextensions.k8s.io/v1/customresourcedefinitions/klusterlets.operator.open-cluster-management.io,v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials" <1>
+    lca.openshift.io/apply-label: "apps/v1/deployments/open-cluster-management-agent/klusterlet,v1/secrets/open-cluster-management-agent/bootstrap-hub-kubeconfig,rbac.authorization.k8s.io/v1/clusterroles/klusterlet,v1/serviceaccounts/open-cluster-management-agent/klusterlet,scheduling.k8s.io/v1/priorityclasses/klusterlet-critical,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-work:ibu-role,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-admin-aggregate-clusterrole,rbac.authorization.k8s.io/v1/clusterrolebindings/klusterlet,operator.open-cluster-management.io/v1/klusterlets/klusterlet,apiextensions.k8s.io/v1/customresourcedefinitions/klusterlets.operator.open-cluster-management.io,v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials"
   labels:
     velero.io/storage-location: default
   namespace: openshift-adp
@@ -36,4 +36,9 @@ spec:
   backupName:
     acm-klusterlet
 ----
-<1> If your `multiclusterHub` CR does not have `.spec.imagePullSecret` defined and the secret does not exist on the `open-cluster-management-agent` namespace in your hub cluster, remove `v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials`.
+
+[NOTE]
+====
+If your `multiclusterHub` CR does not have `.spec.imagePullSecret` defined and the secret does not exist on the `open-cluster-management-agent` namespace in your hub cluster, remove `v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials` from the `metadata.annotations.lca.openshift.io/apply-label` value in the `acm-klusterlet` `Backup` CR.
+====
+


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` DITA short description annotations to 2 modules
- Replace callout lists with `where:` description lists in 2 modules
- Fixes in `ztp-image-based-upgrade-prep-label-extramanifests.adoc` and `ztp-image-based-upgrade-prep-oadp.adoc`

## Notes
- BlockTitle/TaskTitle hits on `.Example` titles before snippet includes are contextual labels — left as-is
- TaskStep hit on `ztp-image-based-upgrade-installing-oadp.adoc` is a red herring (content after procedure steps)
- Part of final AsciiDocDITA Vale mop-up pass across telco assemblies

## Test plan
- [x] Vale AsciiDocDITA.ShortDescription errors resolved
- [x] Vale AsciiDocDITA.CalloutList errors resolved
- [ ] Review rendered output for correctness