### PR TITLE
TELCODOCS-2635: Final Vale pass - Low Latency/CNF

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -41,7 +41,8 @@ If the results exceed the latency threshold, the test fails.
 During testing shorter time periods, as shown, can be used to run the tests. However, for final verification and valid results, the test should run for at least 12 hours (43200 seconds).
 ====
 +
-.Example failure output
+In this example failure output, the measured latency is outside the maximum allowed value.
++
 [source,terminal,subs="attributes+"]
 ----
 running /usr/bin/cnftests -ginkgo.v -ginkgo.focus=oslat
@@ -61,7 +62,7 @@ Will run 1 of 3 specs
     should succeed [It]
     /remote-source/app/vendor/github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/4_latency/latency.go:153
 
-    The current latency 304 is bigger than the expected one 1 : <1>
+    The current latency 304 is bigger than the expected one 1 :
 
 [...]
 
@@ -75,4 +76,3 @@ FAIL! -- 0 Passed | 1 Failed | 0 Pending | 2 Skipped
 --- FAIL: TestTest (161.42s)
 FAIL
 ----
-<1> In this example, the measured latency is outside the maximum allowed value.


### PR DESCRIPTION
## Summary
- Remove unsupported callout from oslat test failure output example in `cnf-performing-end-to-end-tests-running-oslat.adoc`
- Inline the callout explanation as plain text

## Notes
- BlockTitle `.Example output` hits are standard openshift-docs patterns — left as-is
- TaskContents error on `cnf-cpu-infra-container.adoc` is a module type mismatch (typed PROCEDURE but no steps) — out of scope for this pass
- Part of final AsciiDocDITA Vale mop-up pass across telco assemblies

## Test plan
- [x] Vale AsciiDocDITA.CalloutList error resolved
- [ ] Review rendered output for correctness