### PR TITLE
TELCODOCS-2635: fix AsciiDocDITA violations in cluster-compare modules

### DIFF
--- a/modules/cluster-compare-configure-inline-diff.adoc
+++ b/modules/cluster-compare-configure-inline-diff.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-configure-inline-diff_{context}"]
 = Configuring inline validation for template fields
 
+[role="_abstract"]
 You can enable inline regular expressions to validate template fields, especially in scenarios where Golang templating syntax is difficult to maintain or overly complex. Using inline regular expressions simplifies templates, improves readability, and allows for more advanced validation logic.
 
 The `cluster-compare` plugin provides two functions for inline validation:
@@ -36,11 +37,14 @@ parts:
     - path: example.yaml
       config:
         perField:
-        - pathToKey: spec.bigTextBlock <1>
-          inlineDiffFunc: regex <2>
+        - pathToKey: spec.bigTextBlock
+          inlineDiffFunc: regex
 ----
-<1> Specifies the field for inline validation.
-<2> Enables inline validation using regular expressions.
++
+where:
+
+`pathToKey: spec.bigTextBlock`:: Specifies the field for inline validation.
+`inlineDiffFunc: regex`:: Enables inline validation using regular expressions.
 
 . Use a regular expression to validate the field in the associated template:
 +
@@ -77,15 +81,18 @@ parts:
     - path: example.yaml
       config:
         perField:
-        - pathToKey: data.username <1>
-          inlineDiffFunc: regex <2>
-        - pathToKey: spec.bigTextBlock <3>
-          inlineDiffFunc: capturegroups <4>
+        - pathToKey: data.username
+          inlineDiffFunc: regex
+        - pathToKey: spec.bigTextBlock
+          inlineDiffFunc: capturegroups
 ----
-<1> Specifies the field for inline validation.
-<2> Enables inline validation using capture groups.
-<3> Specifies the multi-line field for capture-group validation.
-<4> Enables inline validation using capture groups.
++
+where:
+
+`pathToKey: data.username`:: Specifies the field for inline validation.
+`inlineDiffFunc: regex`:: Enables inline validation using capture groups.
+`pathToKey: spec.bigTextBlock`:: Specifies the multi-line field for capture-group validation.
+`inlineDiffFunc: capturegroups`:: Enables inline validation using capture groups.
 
 . Use a regular expression to validate the field in the associated template:
 +
@@ -96,15 +103,17 @@ kind: ConfigMap
 metadata:
   namespace: dashboard
 data:
-  username: "(?<username>[a-z0-9]+)" <1>
+  username: "(?<username>[a-z0-9]+)"
   bigTextBlock: |-
     This static content outside of a capture group should match exactly.
-    Here is a username capture group: (?<username>[a-z0-9]+). 
+    Here is a username capture group: (?<username>[a-z0-9]+).
     It should match this capture group: (?<username>[a-z0-9]+).
 ----
-<1> If the username value in the `data.username` field and the value captured in `bigTextBlock` do not match, the `cluster-compare` plugin warns you about the inconsistent matching. 
 +
-.Example output with warning about the inconsistent matching:
+If the username value captured in the `data.username` field does not match the value captured in `bigTextBlock`, the `cluster-compare` plugin warns you about the inconsistent matching.
+
+The following is example output with a warning about the inconsistent matching:
+
 [source,terminal]
 ----
 WARNING: Capturegroup (?<username>…) matched multiple values: « mismatchuser | exampleuser »

--- a/modules/cluster-compare-exclude-metadata.adoc
+++ b/modules/cluster-compare-exclude-metadata.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-exclude-metadata_{context}"]
 = Configuring the metadata.yaml file to exclude template fields
 
+[role="_abstract"]
 You can configure the `metadata.yaml` file to exclude fields from a comparison. Exclude fields that are irrelevant to a comparison, for example annotations or labels that are inconsequential to a cluster configuration. 
 
 You can configure exclusions in the `metadata.yaml` file in the following ways:
@@ -39,10 +40,13 @@ parts:
         allOf:
           - path: namespace.yaml
             config:
-              ignore-unspecified-fields: true <1>
+              ignore-unspecified-fields: true
 #...
 ----
-<1> Specify `true` to exclude from the comparison all fields in a CR that are not explicitly configured in the corresponding `namespace.yaml` template.
++
+where:
+
+`ignore-unspecified-fields: true`:: Specify `true` to exclude from the comparison all fields in a CR that are not explicitly configured in the corresponding `namespace.yaml` template.
 
 [id="cluster-compare-ignore-default-fields_{context}"]
 == Excluding specific fields by setting default exclusion fields
@@ -62,13 +66,16 @@ parts:
 #...
 
 fieldsToOmit:
-   defaultOmitRef: default <1>
+   defaultOmitRef: default
    items:
       default:
-         - pathToKey: a.custom.default."k8s.io" <2>
+         - pathToKey: a.custom.default."k8s.io"
 ----
-<1> Sets the default exclusion for all templates, unless overridden by the `config.fieldsToOmitRefs` field for a specific template.
-<2> The value is excluded for all templates.
++
+where:
+
+`defaultOmitRef: default`:: Sets the default exclusion for all templates, unless overridden by the `config.fieldsToOmitRefs` field for a specific template.
+`pathToKey: a.custom.default."k8s.io"`:: The value is excluded for all templates.
 
 [id="cluster-compare-ignore-specified-fields_{context}"]
 == Excluding specific fields
@@ -90,17 +97,20 @@ parts:
         - path: deployment.yaml
           config:
             fieldsToOmitRefs:
-              - deployments <1>
+              - deployments
 
 #...
 
 fieldsToOmit:
    items:
       deployments:
-         - pathToKey: spec.selector.matchLabels.k8s-app <2>
+         - pathToKey: spec.selector.matchLabels.k8s-app
 ----
-<1> References the `fieldsToOmit.items.deployments` item for the `deployment.yaml` template.
-<2> Excludes the `spec.selector.matchLabels.k8s-app` field from the comparison. 
++
+where:
+
+`deployments`:: References the `fieldsToOmit.items.deployments` item for the `deployment.yaml` template.
+`pathToKey: spec.selector.matchLabels.k8s-app`:: Excludes the `spec.selector.matchLabels.k8s-app` field from the comparison.
 +
 [NOTE]
 ====
@@ -136,7 +146,10 @@ fieldsToOmit:
       - pathToKey: spec.ownerReferences
       - pathToKey: metadata.ownerReferences
     default:
-      - include: common <1>
+      - include: common
       - pathToKey: status
 ----
-<1> The `common` group is included in the default group.
++
+where:
+
+`include: common`:: The `common` group is included in the default group.

--- a/modules/cluster-compare-manual-match.adoc
+++ b/modules/cluster-compare-manual-match.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-manual-match_{context}"]
 = Configuring manual matching between CRs and templates
 
+[role="_abstract"]
 In some cases, the `cluster-compare` plugin's default matching might not work as expected. You can manually define how a custom resource (CR) maps to a template by using a user configuration file.
 
 By default, the plugin maps a CR to a template based on the `apiversion`, `kind`, `name`, and `namespace` fields. However, multiple templates might match a single CR. For example, this can occur in the following scenarios:
@@ -24,21 +25,27 @@ When a CR matches multiple templates, the plugin uses a tie-breaking mechanism t
 .Example `user-config.yaml` file
 [source,yaml]
 ----
-correlationSettings: <1>
-   manualCorrelation: <2>
-      correlationPairs: <3>
-        ptp.openshift.io/v1_PtpConfig_openshift-ptp_grandmaster: optional/ptp-config/PtpOperatorConfig.yaml <4>
+correlationSettings:
+   manualCorrelation:
+      correlationPairs:
+        ptp.openshift.io/v1_PtpConfig_openshift-ptp_grandmaster: optional/ptp-config/PtpOperatorConfig.yaml
         ptp.openshift.io/v1_PtpOperatorConfig_openshift-ptp_default: optional/ptp-config/PtpOperatorConfig.yaml
 ----
-<1> The `correlationSettings` section contains the manual correlation settings.
-<2> The `manualCorrelation` section specifies that manual correlation is enabled.
-<3> The `correlationPairs` section lists the CR and template pairs to manually match.
-<4> Specifies the CR and template pair to match. The CR specification uses the following format: `<apiversion>_<kind>_<namespace>_<name>`. For cluster-scoped CRs that do not have a namespace, use the following format: `<apiversion>_<kind>_<name>`. The path to the template must be relative to the `metadata.yaml` file.
++
+where:
+
+`correlationSettings`:: The `correlationSettings` section contains the manual correlation settings.
+`manualCorrelation`:: The `manualCorrelation` section specifies that manual correlation is enabled.
+`correlationPairs`:: The `correlationPairs` section lists the CR and template pairs to manually match.
+`ptp.openshift.io/v1_PtpConfig_openshift-ptp_grandmaster: optional/ptp-config/PtpOperatorConfig.yaml`:: Specifies the CR and template pair to match. The CR specification uses the following format: `<apiversion>_<kind>_<namespace>_<name>`. For cluster-scoped CRs that do not have a namespace, use the following format: `<apiversion>_<kind>_<name>`. The path to the template must be relative to the `metadata.yaml` file.
 
 . Reference the user configuration file in a `cluster-compare` command by running the following command:
 +
 [source,terminal]
 ----
-$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -c <path_to_user_config>/user-config.yaml <1>
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -c <path_to_user_config>/user-config.yaml
 ----
-<1> Specify the `user-config.yaml` file by using the `-c` option.
++
+where:
+
+`-c <path_to_user_config>/user-config.yaml`:: Specify the `user-config.yaml` file by using the `-c` option.

--- a/modules/cluster-compare-metadata-structure.adoc
+++ b/modules/cluster-compare-metadata-structure.adoc
@@ -7,7 +7,8 @@
 [id="cluster-compare-metadata-structure_{context}"]
 = Structure of the metadata.yaml file
 
-The `metadata.yaml` file provides a central configuration point to define and configure the templates in a reference configuration. 
+[role="_abstract"]
+The `metadata.yaml` file provides a central configuration point to define and configure the templates in a reference configuration.
 The file features a hierarchy of `parts` and `components`. `parts` are groups of `components` and `components` are groups of templates.
 Under each component, you can configure template dependencies, validation rules, and add descriptive metadata.
 
@@ -15,16 +16,18 @@ Under each component, you can configure template dependencies, validation rules,
 [source,yaml]
 ----
 apiVersion: v2
-parts: <1>
-  - name: Part1 <2>
+parts:
+  - name: <part_name>
     components:
-      - name: Component1 <3>
-        <component1_configuration> <4>
-  - name: Part2
-      - name: Component2
-        <component2_configuration>
+      - name: <component_name>
+        <component_configuration>
+  - name: <part_name>
+      - name: <component_name>
+        <component_configuration>
 ----
-<1> Every `part` typically describes a workload or a set of workloads.
-<2> Specify a `part` name.
-<3> Specify a `component` name.
-<4> Specify the configuration for a template. For example, define template relationships or configure what fields to use in a comparison.
+
+where:
+
+`<part_name>`:: Specify a `part` name. Every `part` typically describes a workload or a set of workloads.
+`<component_name>`:: Specify a `component` name.
+`<component_configuration>`:: Specify the configuration for a template. For example, define template relationships or configure what fields to use in a comparison.

--- a/modules/cluster-compare-output-description.adoc
+++ b/modules/cluster-compare-output-description.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-output-description_{context}"]
 = Configuring descriptions for the output
 
+[role="_abstract"]
 Each part, component, or template can include descriptions to provide additional context, instructions, or documentation links. These descriptions are helpful to convey why a specific template or structure is required.
 
 .Procedure

--- a/modules/cluster-compare-overview.adoc
+++ b/modules/cluster-compare-overview.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-overview_{context}"]
 = Overview of the cluster-compare plugin
 
+[role="_abstract"]
 Clusters deployed at scale typically use a validated set of baseline custom resources (CRs) to configure clusters to meet use-case requirements and ensure consistency when deploying across different environments. 
 
 In live clusters, some variation from the validated set of CRs is expected. For example, configurations might differ because of variable substitution, optional components, or hardware-specific fields. This variation makes it difficult to accurately assess if a cluster is compliant with the baseline configuration.

--- a/modules/cluster-compare-patching.adoc
+++ b/modules/cluster-compare-patching.adoc
@@ -6,13 +6,14 @@
 [id="cluster-compare-patching_{context}"]
 = Patching a reference configuration
 
+[role="_abstract"]
 In certain scenarios, you might need to patch the reference configuration to handle expected deviations in a cluster configuration. The plugin applies the patch during the comparison process, modifying the specified resource fields as defined in the patch file.
 
 For example, you might need to temporarily patch a template because a cluster uses a deprecated field that is out-of-date with the latest reference configuration. Patched files are reported in the comparison output summary.
 
 You can create a patch file in two ways:
 
-* Use the `cluster-compare` plugin to generate a patch YAML file. 
+* Use the `cluster-compare` plugin to generate a patch YAML file.
 
 * Create your own patch file.
 
@@ -29,7 +30,7 @@ You can use the `cluster-compare` plugin to generate a patch for specific templa
 $ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -o 'generate-patches' --override-reason "A valid reason for the override" --generate-override-for "<template1_path>" --generate-override-for "<template2_path>" > <path_to_patches_file>
 ----
 +
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
+* `-r` specifies the path to the metadata.yaml file of the reference configuration.
 * `-o` specifies the output format. To generate a patch output, you must use the `generate-patches` value.
 * `--override-reason` describes the reason for the patch.
 * `--generate-override-for` specifies a path to the template that requires a patch.
@@ -49,14 +50,17 @@ You must use a file path for the target template that is relative to the `metada
 - apiVersion: storage.k8s.io/v1
   kind: StorageClass
   name: crc-csi-hostpath-provisioner
-  patch: '{"provisioner":"kubevirt.io.hostpath-provisioner"}' <1>
+  patch: '{"provisioner":"kubevirt.io.hostpath-provisioner"}'
   reason: A valid reason for the override
-  templatePath: optional/local-storage-operator/StorageClass.yaml <2>
-  type: mergepatch <3>
+  templatePath: optional/local-storage-operator/StorageClass.yaml
+  type: mergepatch
 ----
-<1> The plugin patches the fields in the template to match the CR.
-<2> The path to the template.
-<3> The `mergepath` option merges the JSON into the target template. Unspecified fields remain unchanged.
++
+where:
+
+`patch`:: The plugin patches the fields in the template to match the CR.
+`templatePath`:: The path to the template.
+`type: mergepatch`:: The `mergepath` option merges the JSON into the target template. Unspecified fields remain unchanged.
 
 . Apply the patch to the reference configuration by running the following command:
 +
@@ -65,10 +69,11 @@ You must use a file path for the target template that is relative to the `metada
 $ oc cluster-compare -r <referenceConfigurationDirectory> -p <path_to_patches_file>
 ----
 +
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
+* `-r` specifies the path to the metadata.yaml file of the reference configuration.
 * `-p` specifies the path to the patch file.
-+
-.Example output
+
+The following is example output:
+
 [source,terminal]
 ----
 ...
@@ -91,11 +96,11 @@ Cluster CRs with patches applied: 1
 
 == Creating a patch file manually
 
-You can write a patch file to handle expected deviations in a cluster configuration. 
+You can write a patch file to handle expected deviations in a cluster configuration.
 
 [NOTE]
 ====
-Patches have three possible values for the `type` field: 
+Patches have three possible values for the `type` field:
 
 * `mergepatch` - Merges the JSON into the target template. Unspecified fields remain unchanged.
 * `rfc6902` - Merges the JSON in the target template using `add`, `remove`, `replace`, `move`, and `copy` operations. Each operation targets a specific path.
@@ -111,7 +116,7 @@ The following example shows the same patch using all three different formats.
 .Example `patch-config`
 [source,yaml]
 ----
-- apiVersion: v1 <1>
+- apiVersion: v1
   kind: Namespace
   name: openshift-storage
   reason: known deviation
@@ -125,19 +130,19 @@ The following example shows the same patch using all three different formats.
   type: rfc6902
   reason: known deviation
   patch: '[
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"}, 
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"}, 
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"}, 
-    {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"}, 
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"},
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"},
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"},
+    {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"},
     {"op": "remove", "path": "/metadata/annotations/workload.openshift.io~1allowed"},
-    {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"}, 
-    {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""}, 
-    {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"}, 
-    {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"}, 
+    {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"},
+    {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""},
+    {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"},
+    {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"},
     {"op": "add", "path": "/spec", "value": {"finalizers": ["kubernetes"]}}
     ]'
 - apiVersion: v1
@@ -167,7 +172,8 @@ The following example shows the same patch using all three different formats.
         ]'
     }
 ----
-<1> The patches uses the `kind`, `apiVersion`, `name`, and `namespace` fields to match the patch with the correct cluster CR.
++
+The patches use the `kind`, `apiVersion`, `name`, and `namespace` fields to match the patch with the correct cluster CR.
 
 . Apply the patch to the reference configuration by running the following command:
 +
@@ -176,10 +182,11 @@ The following example shows the same patch using all three different formats.
 $ oc cluster-compare -r <referenceConfigurationDirectory> -p <path_to_patches_file>
 ----
 +
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
+* `-r` specifies the path to the metadata.yaml file of the reference configuration.
 * `p` specifies the path to the patch file.
-+
-.Example output
+
+The following is example output:
+
 [source,terminal]
 ----
 ...

--- a/modules/cluster-compare-reference-args.adoc
+++ b/modules/cluster-compare-reference-args.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-reference-args_{context}"]
 = Reference cluster-compare plugin options
 
+[role="_abstract"]
 The following content describes the options for the `cluster-compare` plugin. 
 
 .Cluster-compare plugin options

--- a/modules/cluster-compare-template-groupings.adoc
+++ b/modules/cluster-compare-template-groupings.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-template-groupings_{context}"]
 = Configuring template relationships
 
+[role="_abstract"]
 By defining relationships between templates in your reference configuration, you can support use-cases with complex dependencies. For example, you can configure a component to require specific templates, require one template from a group, or allow any template from a group, and so on. 
 
 .Procedure
@@ -21,35 +22,38 @@ parts:
   - name: Part1
     components:
       - name: Component1
-        allOf: <1>
+        allOf:
           - path: RequiredTemplate1.yaml
           - path: RequiredTemplate2.yaml
       - name: Component2
-        allOrNoneOf: <2>
+        allOrNoneOf:
           - path: OptionalBlockTemplate1.yaml
           - path: OptionalBlockTemplate2.yaml
       - name: Component3
-        anyOf: <3>
+        anyOf:
           - path: OptionalTemplate1.yaml
           - path: OptionalTemplate2.yaml
       - name: Component4
-        noneOf: <4>
+        noneOf:
           - path: BannedTemplate1.yaml
           - path: BannedTemplate2.yaml
       - name: Component5
-        oneOf: <5>
+        oneOf:
           - path: RequiredExclusiveTemplate1.yaml
           - path: RequiredExclusiveTemplate2.yaml
       - name: Component6
-        anyOneOf: <6>
+        anyOneOf:
           - path: OptionalExclusiveTemplate1.yaml
           - path: OptionalExclusiveTemplate2.yaml
 #...
 
 ----
-<1> Specifies required templates.
-<2> Specifies a group of templates that are either all required or all optional. If one corresponding custom resource (CR) is present in the cluster, then all corresponding CRs must be present in the cluster.
-<3> Specifies optional templates.
-<4> Specifies templates to exclude. If a corresponding CR is present in the cluster, the plugin returns a validation error.
-<5> Specifies templates where only one can be present. If none, or more than one of the corresponding CRs are present in the cluster, the plugin returns a validation error .
-<6> Specifies templates where only one can be present in the cluster. If more than one of the corresponding CRs are present in the cluster, the plugin returns a validation error.
++
+where:
+
+`allOf`:: Specifies required templates.
+`allOrNoneOf`:: Specifies a group of templates that are either all required or all optional. If one corresponding custom resource (CR) is present in the cluster, then all corresponding CRs must be present in the cluster.
+`anyOf`:: Specifies optional templates.
+`noneOf`:: Specifies templates to exclude. If a corresponding CR is present in the cluster, the plugin returns a validation error.
+`oneOf`:: Specifies templates where only one can be present. If none, or more than one of the corresponding CRs are present in the cluster, the plugin returns a validation error.
+`anyOneOf`:: Specifies templates where only one can be present in the cluster. If more than one of the corresponding CRs are present in the cluster, the plugin returns a validation error.

--- a/modules/cluster-compare-templating-reference.adoc
+++ b/modules/cluster-compare-templating-reference.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-templating-reference_{context}"]
 = Reference template functions
 
+[role="_abstract"]
 The `cluster-compare` plugin supports all `sprig` library functions, except for the `env` and `expandenv` functions. For the full list of `sprig` library functions, see "Sprig Function Documentation".
 
 The following table describes the additional template functions for the `cluster-compare` plugin:

--- a/modules/cluster-compare-templating.adoc
+++ b/modules/cluster-compare-templating.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-templating_{context}"]
 = Configuring expected variation in a template
 
+[role="_abstract"]
 You can handle variable content within a template by using Golang templating syntax. Using this syntax, you can configure validation logic that handles optional, required, and conditional content within the template.  
 
 [NOTE]
@@ -25,14 +26,14 @@ You can handle variable content within a template by using Golang templating syn
 apiVersion: v2
 kind: Service
 metadata:
-  name: frontend <1>
-  namespace: {{ .metadata.namespace }}  <2>
+  name: frontend
+  namespace: {{ .metadata.namespace }}
   labels:
     app: guestbook
     tier: frontend
 spec:
   {{- if and .spec.type (eq (.spec.type) "NodePort" "LoadBalancer") }}
-  type: {{.spec.type }} <3>
+  type: {{.spec.type }}
   {{- else }}
   type: should be NodePort or LoadBalancer
   {{- end }}
@@ -40,11 +41,14 @@ spec:
   - port: 80
   selector:
     app: guestbook
-    {{- if .spec.selector.tier }} <4>
+    {{- if .spec.selector.tier }}
     tier: frontend
     {{- end }}
 ----
-<1> Configures a required field that must match the specified value.
-<2> Configures a required field that can have any value.
-<3> Configures validation for the `.spec.type` field.
-<4> Configures an optional field.
++
+where:
+
+`name: frontend`:: Configures a required field that must match the specified value.
+`namespace: \{{ .metadata.namespace }}`:: Configures a required field that can have any value.
+`type: \{{.spec.type }}`:: Configures validation for the `.spec.type` field.
+`\{{- if .spec.selector.tier }}`:: Configures an optional field.

--- a/modules/installing-cluster-compare.adoc
+++ b/modules/installing-cluster-compare.adoc
@@ -7,6 +7,7 @@
 [id="installing-cluster-compare_{context}"]
 = Installing the cluster-compare plugin
 
+[role="_abstract"]
 Install the `cluster-compare` plugin to compare a reference configuration with a cluster configuration from a live cluster or `must-gather` data.
 
 .Prerequisites
@@ -58,7 +59,8 @@ $ podman cp cca:/usr/share/openshift/<arch>/kube-compare.<rhel_version> <directo
 $ oc cluster-compare -h
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 Compare a known valid reference configuration and a set of specific cluster configuration CRs.

--- a/modules/understanding-a-reference-config.adoc
+++ b/modules/understanding-a-reference-config.adoc
@@ -7,30 +7,34 @@
 [id="understanding-a-reference-config_{context}"]
 = Understanding a reference configuration
 
+[role="_abstract"]
 The `cluster-compare` plugin uses a reference configuration to validate a configuration from a live cluster.
 The reference configuration consists of a YAML file called `metadata.yaml`, which references a set of templates that represent the baseline configuration.
 
 .Example directory structure for a reference configuration
 [source,text]
 ----
-├── metadata.yaml <1>
-├── optional <2>
+├── metadata.yaml
+├── optional
 │   ├── optionalTemplate1.yaml
-│   └── optionalTemplate2.yaml 
+│   └── optionalTemplate2.yaml
 ├── required
 │   ├── requiredTemplate3.yaml
 │   └── requiredTemplate4.yaml
-└── baselineClusterResources <3>
+└── baselineClusterResources
     ├── clusterResource1.yaml
     ├── clusterResource2.yaml
     ├── clusterResource3.yaml
     └── clusterResource4.yaml
 ----
-<1> The reference configuration consists of the `metadata.yaml` file and a set of templates.
-<2> This example uses an optional and required directory structure for templates that are referenced by the `metadata.yaml` file.
-<3> The configuration CRs to use as a baseline configuration for clusters.
 
-During a comparison, the plugin matches each template to a configuration resource from the cluster. 
+where:
+
+`metadata.yaml`:: The reference configuration consists of the `metadata.yaml` file and a set of templates.
+`optional`:: This example uses an optional and required directory structure for templates that are referenced by the `metadata.yaml` file.
+`baselineClusterResources`:: The configuration CRs to use as a baseline configuration for clusters.
+
+During a comparison, the plugin matches each template to a configuration resource from the cluster.
 The plugin evaluates optional or required fields in the template using features such as Golang templating syntax and inline regular expression validation. The `metadata.yaml` file applies additional validation rules to decide whether a template is optional or required and assesses template dependency relationships.
 
 Using these features, the plugin identifies relevant configuration differences between the cluster and the reference configuration. For example, the plugin can highlight mismatched field values, missing resources, extra resources, field type mismatches, or version discrepancies.

--- a/modules/using-cluster-compare-live-cluster.adoc
+++ b/modules/using-cluster-compare-live-cluster.adoc
@@ -8,7 +8,8 @@
 [id="using-cluster-compare-live-cluster_{context}"]
 = Using the cluster-compare plugin with a live cluster
 
-You can use the `cluster-compare` plugin to compare a reference configuration with configuration custom resources (CRs) from a live cluster. 
+[role="_abstract"]
+You can use the `cluster-compare` plugin to compare a reference configuration with configuration custom resources (CRs) from a live cluster.
 
 Validate live cluster configurations to ensure compliance with reference configurations during design, development, or testing scenarios.
 
@@ -25,7 +26,7 @@ Use the `cluster-compare` plugin with live clusters in non-production environmen
 
 * You downloaded the `cluster-compare` plugin and include it in your `PATH` environment variable.
 
-* You have access to a reference configuration. 
+* You have access to a reference configuration.
 
 .Procedure
 
@@ -37,8 +38,9 @@ $ oc cluster-compare -r <path_to_reference_config>/metadata.yaml
 ----
 +
 ** `-r` specifies a path to the `metadata.yaml` file of the reference configuration. You can specify a local directory or a URI.
-+
-.Example output
+
+The following is example output:
+
 [source,terminal]
 ----
 
@@ -46,8 +48,8 @@ $ oc cluster-compare -r <path_to_reference_config>/metadata.yaml
 
 **********************************
 
-Cluster CR: operator.openshift.io/v1_Console_cluster <1>
-Reference File: optional/console-disable/ConsoleOperatorDisable.yaml <2>
+Cluster CR: operator.openshift.io/v1_Console_cluster
+Reference File: optional/console-disable/ConsoleOperatorDisable.yaml
 Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_cluster /tmp/LIVE-2358803347/operator-openshift-io-v1_console_cluster
 /tmp/MERGED-622469311/operator-openshift-io-v1_console_cluster	2024-11-20 15:43:42.888633602 +0000
 +++ /tmp/LIVE-2358803347/operator-openshift-io-v1_console_cluster	2024-11-20 15:43:42.888633602 +0000
@@ -55,7 +57,7 @@ Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_c
    name: cluster
  spec:
    logLevel: Normal
--  managementState: Removed <3>
+-  managementState: Removed
 +  managementState: Managed
    operatorLogLevel: Normal
 
@@ -63,27 +65,30 @@ Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_c
 
 …
 
-Summary <4>
-CRs with diffs: 5/49 <5> 
-CRs in reference missing from the cluster: 1 <6> 
+Summary
+CRs with diffs: 5/49
+CRs in reference missing from the cluster: 1
 required-cluster-tuning:
   cluster-tuning:
-    Missing CRs: <7> 
+    Missing CRs:
     - required/cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml
-No CRs are unmatched to reference CRs <8> 
-Metadata Hash: 512a9bf2e57fd5a5c44bbdea7abb3ffd7739d4a1f14ef9021f6793d5cdf868f0 <9>
-No patched CRs <10>
+No CRs are unmatched to reference CRs
+Metadata Hash: 512a9bf2e57fd5a5c44bbdea7abb3ffd7739d4a1f14ef9021f6793d5cdf868f0
+No patched CRs
 ----
-<1> The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
-<2> The template matching with the CR for comparison.
-<3> The output in Linux diff format shows the difference between the template and the cluster CR.
-<4> After the plugin reports the line diffs for each CR, the summary of differences are reported.
-<5> The number of CRs in the comparison with differences from the corresponding templates.
-<6> The number of CRs represented in the reference configuration, but missing from the live cluster.
-<7> The list of CRs represented in the reference configuration, but missing from the live cluster.
-<8> The CRs that did not match to a corresponding template in the reference configuration.
-<9> The metadata hash identifies the reference configuration.
-<10> The list of patched CRs.
+
+where:
+
+`Cluster CR`:: The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
+`Reference File`:: The template matching with the CR for comparison.
+`Diff Output`:: The output in Linux diff format shows the difference between the template and the cluster CR.
+`Summary`:: After the plugin reports the line diffs for each CR, the summary of differences are reported.
+`CRs with diffs`:: The number of CRs in the comparison with differences from the corresponding templates.
+`CRs in reference missing from the cluster`:: The number of CRs represented in the reference configuration, but missing from the live cluster.
+`Missing CRs`:: The list of CRs represented in the reference configuration, but missing from the live cluster.
+`No CRs are unmatched to reference CRs`:: The CRs that did not match to a corresponding template in the reference configuration.
+`Metadata Hash`:: The metadata hash identifies the reference configuration.
+`No patched CRs`:: The list of patched CRs.
 
 [NOTE]
 ====

--- a/modules/using-cluster-compare-must-gather.adoc
+++ b/modules/using-cluster-compare-must-gather.adoc
@@ -7,9 +7,10 @@
 [id="using-cluster-compare-must-gather_{context}"]
 = Using the cluster-compare plugin with must-gather data
 
-You can use the `cluster-compare` plugin to compare a reference configuration with configuration custom resources (CRs) from `must-gather` data. 
+[role="_abstract"]
+You can use the `cluster-compare` plugin to compare a reference configuration with configuration custom resources (CRs) from `must-gather` data.
 
-Validate cluster configurations by using `must-gather` data to troubleshoot configuration issues in production environments. 
+Validate cluster configurations by using `must-gather` data to troubleshoot configuration issues in production environments.
 
 [NOTE]
 ====
@@ -22,7 +23,7 @@ For production environments, use the `cluster-compare` plugin with `must-gather`
 
 * You have downloaded the `cluster-compare` plugin and included it in your `PATH` environment variable.
 
-* You have access to a reference configuration. 
+* You have access to a reference configuration.
 
 .Procedure
 
@@ -34,18 +35,19 @@ $ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -f "must-gather
 ----
 +
 ** `-r` specifies a path to the `metadata.yaml` file of the reference configuration. You can specify a local directory or a URI.
-** `-f` specifies the path to the `must-gather` data directory. You can specify a local directory or a URI. This example restricts the comparison to the relevant cluster configuration directories. 
+** `-f` specifies the path to the `must-gather` data directory. You can specify a local directory or a URI. This example restricts the comparison to the relevant cluster configuration directories.
 ** `-R` searches the target directories recursively.
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 ...
 
 **********************************
 
-Cluster CR: operator.openshift.io/v1_Console_cluster <1>
-Reference File: optional/console-disable/ConsoleOperatorDisable.yaml <2>
+Cluster CR: operator.openshift.io/v1_Console_cluster
+Reference File: optional/console-disable/ConsoleOperatorDisable.yaml
 Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_cluster /tmp/LIVE-2358803347/operator-openshift-io-v1_console_cluster
 /tmp/MERGED-622469311/operator-openshift-io-v1_console_cluster	2024-11-20 15:43:42.888633602 +0000
 +++ /tmp/LIVE-2358803347/operator-openshift-io-v1_console_cluster	2024-11-20 15:43:42.888633602 +0000
@@ -53,7 +55,7 @@ Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_c
    name: cluster
  spec:
    logLevel: Normal
--  managementState: Removed <3>
+-  managementState: Removed
 +  managementState: Managed
    operatorLogLevel: Normal
 
@@ -61,27 +63,30 @@ Diff Output: diff -u -N /tmp/MERGED-622469311/operator-openshift-io-v1_console_c
 
 …
 
-Summary <4>
-CRs with diffs: 5/49 <5>
-CRs in reference missing from the cluster: 1 <6>
+Summary
+CRs with diffs: 5/49
+CRs in reference missing from the cluster: 1
 required-cluster-tuning:
   cluster-tuning:
-    Missing CRs: <7>
+    Missing CRs:
     - required/cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml
-No CRs are unmatched to reference CRs <8>
-Metadata Hash: 512a9bf2e57fd5a5c44bbdea7abb3ffd7739d4a1f14ef9021f6793d5cdf868f0 <9>
-No patched CRs <10>
+No CRs are unmatched to reference CRs
+Metadata Hash: 512a9bf2e57fd5a5c44bbdea7abb3ffd7739d4a1f14ef9021f6793d5cdf868f0
+No patched CRs
 ----
-<1> The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
-<2> The template matching with the CR for comparison.
-<3> The output in Linux diff format shows the difference between the template and the cluster CR.
-<4> After the plugin reports the line diffs for each CR, the summary of differences are reported.
-<5> The number of CRs in the comparison with differences from the corresponding templates.
-<6> The number of CRs represented in the reference configuration, but missing from the live cluster.
-<7> The list of CRs represented in the reference configuration, but missing from the live cluster.
-<8> The CRs that did not match to a corresponding template in the reference configuration.
-<9> The metadata hash identifies the reference configuration.
-<10> The list of patched CRs.
++
+where:
+
+`Cluster CR`:: The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
+`Reference File`:: The template matching with the CR for comparison.
+`Diff Output`:: The output in Linux diff format shows the difference between the template and the cluster CR.
+`Summary`:: After the plugin reports the line diffs for each CR, the summary of differences are reported.
+`CRs with diffs`:: The number of CRs in the comparison with differences from the corresponding templates.
+`CRs in reference missing from the cluster`:: The number of CRs represented in the reference configuration, but missing from the live cluster.
+`Missing CRs`:: The list of CRs represented in the reference configuration, but missing from the live cluster.
+`No CRs are unmatched to reference CRs`:: The CRs that did not match to a corresponding template in the reference configuration.
+`Metadata Hash`:: The metadata hash identifies the reference configuration.
+`No patched CRs`:: The list of patched CRs.
 
 [NOTE]
 ====

--- a/modules/using-cluster-compare-telco-ref.adoc
+++ b/modules/using-cluster-compare-telco-ref.adoc
@@ -7,6 +7,7 @@
 [id="using-cluster-compare-telco_ref_{context}"]
 = Example: Comparing a cluster with the telco core reference configuration
 
+[role="_abstract"]
 You can use the `cluster-compare` plugin to compare a reference configuration with a configuration from a live cluster or `must-gather` data.
 
 This example compares a configuration from a live cluster with the telco core reference configuration. The telco core reference configuration is derived from the telco core reference design specifications (RDS). The telco core RDS is designed for clusters to support large scale telco applications including control plane and some centralized data plane functions.
@@ -49,22 +50,25 @@ You can view the reference configuration in the `reference-crs-kube-compare/` di
 [source,text]
 ----
 out/telco-core-rds/configuration/reference-crs-kube-compare/
-├── metadata.yaml <1>
-├── optional <2>
+├── metadata.yaml
+├── optional
 │   ├── logging
 │   ├── networking
 │   ├── other
 │   └── tuning
-└── required <3>
+└── required
     ├── networking
     ├── other
     ├── performance
     ├── scheduling
     └── storage
 ----
-<1> Configuration file for the reference configuration.
-<2> Directory for optional templates.
-<3> Directory for required templates.
++
+where:
+
+`metadata.yaml`:: Configuration file for the reference configuration.
+`optional`:: Directory for optional templates.
+`required`:: Directory for required templates.
 
 . Compare the configuration for your cluster to the telco core reference configuration by running the following command:
 +
@@ -73,7 +77,8 @@ out/telco-core-rds/configuration/reference-crs-kube-compare/
 $ oc cluster-compare -r out/telco-core-rds/configuration/reference-crs-kube-compare/metadata.yaml
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 W1212 14:13:06.281590   36629 compare.go:425] Reference Contains Templates With Types (kind) Not Supported By Cluster: BFDProfile, BGPAdvertisement, BGPPeer, ClusterLogForwarder, Community, IPAddressPool, MetalLB, MultiNetworkPolicy, NMState, NUMAResourcesOperator, NUMAResourcesScheduler, NodeNetworkConfigurationPolicy, SriovNetwork, SriovNetworkNodePolicy, SriovOperatorConfig, StorageCluster
@@ -82,8 +87,8 @@ W1212 14:13:06.281590   36629 compare.go:425] Reference Contains Templates With 
 
 **********************************
 
-Cluster CR: config.openshift.io/v1_OperatorHub_cluster <1>
-Reference File: required/other/operator-hub.yaml <2>
+Cluster CR: config.openshift.io/v1_OperatorHub_cluster
+Reference File: required/other/operator-hub.yaml
 Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster
 --- /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
 +++ /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
@@ -91,7 +96,7 @@ Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhu
  apiVersion: config.openshift.io/v1
  kind: OperatorHub
  metadata:
-+  annotations: <3>
++  annotations:
 +    include.release.openshift.io/hypershift: "true"
    name: cluster
 -spec:
@@ -99,12 +104,12 @@ Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhu
 
 **********************************
 
-Summary <4>
-CRs with diffs: 3/4 <5>
-CRs in reference missing from the cluster: 22 <6>
+Summary
+CRs with diffs: 3/4
+CRs in reference missing from the cluster: 22
 other:
   other:
-    Missing CRs: <7>
+    Missing CRs:
     - optional/other/control-plane-load-kernel-modules.yaml
     - optional/other/worker-load-kernel-modules.yaml
 required-networking:
@@ -144,20 +149,23 @@ required-storage:
     - required/storage/odf-external/odfNS.yaml
     - required/storage/odf-external/odfOperGroup.yaml
     - required/storage/odf-external/odfSubscription.yaml
-No CRs are unmatched to reference CRs <8>
-Metadata Hash: fe41066bac56517be02053d436c815661c9fa35eec5922af25a1be359818f297 <9>
-No patched CRs <10>
+No CRs are unmatched to reference CRs
+Metadata Hash: fe41066bac56517be02053d436c815661c9fa35eec5922af25a1be359818f297
+No patched CRs
 ----
-<1> The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
-<2> The template matching with the CR for comparison.
-<3> The output in Linux diff format shows the difference between the template and the cluster CR.
-<4> After the plugin reports the line diffs for each CR, the summary of differences are reported.
-<5> The number of CRs in the comparison with differences from the corresponding templates.
-<6> The number of CRs represented in the reference configuration, but missing from the live cluster.
-<7> The list of CRs represented in the reference configuration, but missing from the live cluster.
-<8> The CRs that did not match to a corresponding template in the reference configuration.
-<9> The metadata hash identifies the reference configuration.
-<10> The list of patched CRs.
++
+where:
+
+`Cluster CR`:: The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
+`Reference File`:: The template matching with the CR for comparison.
+`Diff Output`:: The output in Linux diff format shows the difference between the template and the cluster CR.
+`Summary`:: After the plugin reports the line diffs for each CR, the summary of differences are reported.
+`CRs with diffs`:: The number of CRs in the comparison with differences from the corresponding templates.
+`CRs in reference missing from the cluster`:: The number of CRs represented in the reference configuration, but missing from the live cluster.
+`Missing CRs`:: The list of CRs represented in the reference configuration, but missing from the live cluster.
+`No CRs are unmatched to reference CRs`:: The CRs that did not match to a corresponding template in the reference configuration.
+`Metadata Hash`:: The metadata hash identifies the reference configuration.
+`No patched CRs`:: The list of patched CRs.
 
 [NOTE]
 ====


### PR DESCRIPTION
## Summary

- Add `[role="_abstract"]` annotations for DITA short descriptions across 16 cluster-compare modules
- Replace callout lists with `where:` description lists for DITA compatibility
- Replace `.Example output` block titles with plain text paragraphs

Part of [TELCODOCS-2635](https://redhat.atlassian.net/browse/TELCODOCS-2635) final Vale pass for AsciiDocDITA rule compliance.

## Files changed

- `cluster-compare-configure-inline-diff.adoc`
- `cluster-compare-exclude-metadata.adoc`
- `cluster-compare-manual-match.adoc`
- `cluster-compare-metadata-structure.adoc`
- `cluster-compare-output-description.adoc`
- `cluster-compare-overview.adoc`
- `cluster-compare-patching.adoc`
- `cluster-compare-reference-args.adoc`
- `cluster-compare-template-groupings.adoc`
- `cluster-compare-templating-reference.adoc`
- `cluster-compare-templating.adoc`
- `installing-cluster-compare.adoc`
- `understanding-a-reference-config.adoc`
- `using-cluster-compare-live-cluster.adoc`
- `using-cluster-compare-must-gather.adoc`
- `using-cluster-compare-telco-ref.adoc`