### PR TITLE
OSDOCS-16918: Fix Vale errors in web terminal session-config modules

### DIFF
--- a/modules/odc-access-web-terminal.adoc
+++ b/modules/odc-access-web-terminal.adoc
@@ -34,7 +34,7 @@ cluster and are logged into the web console.
 * One `DevWorkspace` CR defines the web terminal of one user. This CR contains details about the user's web terminal status and container image components.
 * The `DevWorkspace` CR is created only if it does not already exist.
 ifndef::openshift-rosa,openshift-dedicated[]
-* The `openshift-terminal` project is the default project used for cluster administrators. They do not have the option to choose another project.  The {web-terminal-op} installs the DevWorkspace Operator as a dependency.
+* The `openshift-terminal` project is the default project used for cluster administrators. They do not have the option to choose another project. The {web-terminal-op} installs the DevWorkspace Operator as a dependency.
 endif::openshift-rosa,openshift-dedicated[]
 ====
 

--- a/modules/odc-configure-web-terminal-image-session.adoc
+++ b/modules/odc-configure-web-terminal-image-session.adoc
@@ -7,6 +7,7 @@
 [id="odc-configure-web-terminal-image-session_{context}"]
 = Configuring the web terminal image for a session
 
+[role="_abstract"]
 You can change the default image for the web terminal for your current session.
 
 .Prerequisites

--- a/modules/odc-configure-web-terminal-timeout-session.adoc
+++ b/modules/odc-configure-web-terminal-timeout-session.adoc
@@ -7,6 +7,7 @@
 [id="odc-configure-web-terminal-timeout-session_{context}"]
 = Configuring the web terminal timeout for a session
 
+[role="_abstract"]
 You can change the default timeout period for the web terminal for your current session.
 
 .Prerequisites

--- a/web_console/web_terminal/configuring-web-terminal.adoc
+++ b/web_console/web_terminal/configuring-web-terminal.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure timeout and image settings for the web terminal, either for your current session or for all user sessions if you are a cluster administrator.
 
 include::modules/odc-configure-web-terminal-timeout-session.adoc[leveloffset=+1]


### PR DESCRIPTION
Assigns [role="_abstract"] to the existing opening paragraph in configuring-web-terminal.adoc, odc-configure-web-terminal-image-session.adoc, and odc-configure-web-terminal-timeout-session.adoc, clearing the AsciiDocDITA.ShortDescription error in each. Also fixes a double-space typo in odc-access-web-terminal.adoc, clearing a RedHat.Spacing error.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): CQA
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-16918
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: This PR does not require QE/SME ack. No content removed, no new concepts added, no structural changes. The fixes are minor and low-risk. 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
