### PR TITLE
TELCODOCS-2635: Add DITA short description annotations to Telco hub RDS modules

### DIFF
--- a/modules/telco-hub-cert-manager-operator.adoc
+++ b/modules/telco-hub-cert-manager-operator.adoc
@@ -6,6 +6,9 @@
 [id="telco-hub-cert-manager-operator_{context}"]
 = cert-manager Operator
 
+[role="_abstract"]
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for hub cluster components and workloads.
+
 New in this release::
 * cert-manager Operator is a new optional component in this release.
 

--- a/modules/telco-hub-crs-backup-recovery.adoc
+++ b/modules/telco-hub-crs-backup-recovery.adoc
@@ -6,6 +6,9 @@
 [id="backup-recovery-crs_{context}"]
 = Backup Recovery reference CRs
 
+[role="_abstract"]
+The following table lists the backup and recovery reference configuration custom resources (CRs) for the hub cluster.
+
 .Backup Recovery CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-hub-crs-security.adoc
+++ b/modules/telco-hub-crs-security.adoc
@@ -6,6 +6,9 @@
 [id="security-crs_{context}"]
 = Security reference CRs
 
+[role="_abstract"]
+The following table lists the security reference configuration custom resources (CRs) for the hub cluster.
+
 .Security CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/using-cluster-compare-telco-hub.adoc
+++ b/modules/using-cluster-compare-telco-hub.adoc
@@ -7,6 +7,7 @@
 [id="using-cluster-compare-telco_hub_{context}"]
 = Comparing a cluster with the {rds} reference configuration
 
+[role="_abstract"]
 After you deploy a {rds} cluster, you can use the `cluster-compare` plugin to assess the cluster's compliance with the {rds} reference design specifications (RDS). The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin. The plugin uses a {rds} reference configuration to validate the cluster with the {rds} custom resources (CRs).
 
 The plugin-specific reference configuration for {rds} is packaged in a container image with the {rds} CRs.


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` DITA short description annotations and paragraphs to 4 hub cluster RDS modules:
  - `telco-hub-cert-manager-operator.adoc`
  - `telco-hub-crs-backup-recovery.adoc`
  - `telco-hub-crs-security.adoc`
  - `using-cluster-compare-telco-hub.adoc`

## Notes
- Backport of #116107 to enterprise-4.21
- Part of final AsciiDocDITA Vale mop-up pass across telco assemblies