### PR TITLE
OSDOCS-20789: Remove obsolete ROSA attribute and related content

### DIFF
--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -4,10 +4,6 @@
 // * post_installation_configuration/node-tasks.adoc
 // * nodes/nodes/nodes-node-tuning-operator.adoc
 
-ifeval::["{context}" == "rosa-tuning-config"]
-:rosa-hcp-tuning:
-endif::[]
-
 :_mod-docs-content-type: REFERENCE
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
@@ -29,7 +25,6 @@ The Operator Management state is set by adjusting the default Tuned CR. By defau
 
 The `profile:` section lists TuneD profiles and their names.
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 profile:
@@ -53,30 +48,11 @@ profile:
 
     # tuned_profile_n profile settings
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,json]
-----
-{
-  "profile": [
-    {
-      "name": "tuned_profile_1",
-      "data": "# TuneD profile specification\n[main]\nsummary=Description of tuned_profile_1 profile\n\n[sysctl]\nnet.ipv4.ip_forward=1\n# ... other sysctl's or other TuneD daemon plugins supported by the containerized TuneD\n"
-    },
-    {
-      "name": "tuned_profile_n",
-      "data": "# TuneD profile specification\n[main]\nsummary=Description of tuned_profile_n profile\n\n# tuned_profile_n profile settings\n"
-    }
-  ]
-}
-----
-endif::[]
 
 *Recommended profiles*
 
 The `profile:` selection logic is defined by the `recommend:` section of the CR. The `recommend:` section is a list of items to recommend the profiles based on a selection criteria.
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 recommend:
@@ -84,23 +60,9 @@ recommend:
 # ...
 <recommend-item-n>
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,json]
-----
-"recommend": [
-    {
-      "recommend-item-1": details_of_recommendation,
-      # ...
-      "recommend-item-n": details_of_recommendation,
-    }
-  ]
-----
-endif::[]
 
 The individual items of the list:
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - machineConfigLabels:
@@ -126,42 +88,9 @@ where:
 `debug`:: Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
 `reapply_sysctl`:: Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
 
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,json]
-----
-{
-  "profile": [
-    {
-    # ...
-    }
-  ],
-  "recommend": [
-    {
-      "profile": <tuned_profile_name>,
-      "priority":{ <priority>,
-      },
-      "match": [
-        {
-          "label": <label_information>
-        },
-      ]
-    },
-  ]
-}
-----
-where:
-
-`<tuned_profile_name>`:: A TuneD profile to apply on a match. For example `tuned_profile_1`.
-`<priority>`:: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-`match`:: If omitted, profile match is assumed unless a profile with a higher priority matches first.
-`<label_information>`:: The label for the profile matched items.
-
-endif::[]
 
 The `<match>` parameter is an optional list recursively defined as follows:
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - label: <label_name>
@@ -176,24 +105,8 @@ where:
 `<label_type>`:: Optional object type (`node` or `pod`). If omitted, `node` is assumed.
 `<match>`:: An optional `<match>` list.
 
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,yaml]
-----
-"match": [
-        {
-          "label": <label_name>
-        },
-]
-----
-where:
-
-`<label_name>`:: Node or pod label name.
-
-endif::[]
 
 If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR operator.
-ifndef::rosa-hcp-tuning[]
 
 If `machineConfigLabels` is defined, machine config pool based matching is turned on for the given `recommend:` list item. `<mcLabels>` specifies the labels for a machine config. The machine config is created automatically to apply host settings, such as kernel boot parameters, for the profile `<tuned_profile_name>`. This involves finding all machine config pools with machine config selector matching `<mcLabels>` and setting the profile `<tuned_profile_name>` on all nodes that are assigned the found machine config pools. To target nodes that have both master and worker roles, you must use the master role.
 
@@ -203,10 +116,8 @@ The list items `match` and `machineConfigLabels` are connected by the logical OR
 ====
 When using machine config pool based matching, it is advised to group nodes with the same hardware configuration into the same machine config pool. Not following this practice might result in TuneD operands calculating conflicting kernel parameters for two or more nodes sharing the same machine config pool.
 ====
-endif::rosa-hcp-tuning[]
 .Example: Node or pod label based matching
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - match:
@@ -225,48 +136,6 @@ ifndef::rosa-hcp-tuning[]
 - priority: 30
   profile: openshift-node
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,JSON]
-----
-[
-  {
-    "match": [
-      {
-        "label": "tuned.openshift.io/elasticsearch",
-        "match": [
-          {
-            "label": "node-role.kubernetes.io/master"
-          },
-          {
-            "label": "node-role.kubernetes.io/infra"
-          }
-        ],
-        "type": "pod"
-      }
-    ],
-    "priority": 10,
-    "profile": "openshift-control-plane-es"
-  },
-  {
-    "match": [
-      {
-        "label": "node-role.kubernetes.io/master"
-      },
-      {
-        "label": "node-role.kubernetes.io/infra"
-      }
-    ],
-    "priority": 20,
-    "profile": "openshift-control-plane"
-  },
-  {
-    "priority": 30,
-    "profile": "openshift-node"
-  }
-]
-----
-endif::[]
 
 The CR above is translated for the containerized TuneD daemon into its `recommend.conf` file based on the profile priorities. The profile with the highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized TuneD daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
@@ -276,7 +145,6 @@ Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks 
 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]
 
-ifndef::rosa-hcp-tuning[]
 .Example: Machine config pool based matching
 [source,yaml]
 ----
@@ -301,39 +169,8 @@ spec:
     priority: 20
     profile: openshift-node-custom
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-.Example: Machine pool based matching
-[source,JSON]
-----
-{
-  "apiVersion": "tuned.openshift.io/v1",
-  "kind": "Tuned",
-  "metadata": {
-    "name": "openshift-node-custom",
-    "namespace": "openshift-cluster-node-tuning-operator"
-  },
-  "spec": {
-    "profile": [
-      {
-        "data": "[main]\nsummary=Custom OpenShift node profile with an additional kernel parameter\ninclude=openshift-node\n[bootloader]\ncmdline_openshift_node_custom=+skew_tick=1\n",
-        "name": "openshift-node-custom"
-      }
-    ],
-    "recommend": [
-      {
-        "priority": 20,
-        "profile": "openshift-node-custom"
-      }
-    ]
-  }
-}
-----
-endif::[]
 
-ifndef::rosa-hcp-tuning[]
 To minimize node reboots, label the target nodes with a label the machine config pool's node selector will match, then create the Tuned CR above and finally create the custom machine config pool itself.
-endif::rosa-hcp-tuning[]
 // $ oc label node <node> node-role.kubernetes.io/worker-custom=
 // $ oc create -f <tuned-cr-above>
 // $ oc create -f- <<EOF
@@ -354,20 +191,13 @@ endif::rosa-hcp-tuning[]
 
 *Cloud provider-specific TuneD profiles*
 
-With this functionality, all Cloud provider-specific nodes can conveniently be assigned a TuneD profile specifically tailored to a given Cloud provider on a {product-title} cluster. This can be accomplished without adding additional node labels or grouping nodes into
-ifndef::rosa-hcp-tuning[]
-machine config pools.
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-machine pools.
-endif::rosa-hcp-tuning[]
+With this functionality, all Cloud provider-specific nodes can conveniently be assigned a TuneD profile specifically tailored to a given Cloud provider on a {product-title} cluster. This can be accomplished without adding additional node labels or grouping nodes into machine config pools.
 
 This functionality takes advantage of `spec.providerID` node object values in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes the file `/var/lib/ocp-tuned/provider` with the value `<cloud-provider>` in NTO operand containers. The content of this file is then used by TuneD to load `provider-<cloud-provider>` profile if such profile exists.
 
 The `openshift` profile that both `openshift-control-plane` and `openshift-node` profiles inherit settings from is now updated to use this functionality through the use of conditional profile loading. Neither NTO nor TuneD currently include any Cloud provider-specific profiles. However, it is possible to create a custom profile `provider-<cloud-provider>` that will be applied to all Cloud provider-specific cluster nodes.
 
 .Example GCE Cloud provider profile
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -383,28 +213,6 @@ spec:
       # Your tuning for GCE Cloud provider goes here.
     name: provider-gce
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,JSON]
-----
-{
-  "apiVersion": "tuned.openshift.io/v1",
-  "kind": "Tuned",
-  "metadata": {
-    "name": "provider-gce",
-    "namespace": "openshift-cluster-node-tuning-operator"
-  },
-  "spec": {
-    "profile": [
-      {
-        "data": "[main]\nsummary=GCE Cloud provider-specific profile\n# Your tuning for GCE Cloud provider goes here.\n",
-        "name": "provider-gce"
-      }
-    ]
-  }
-}
-----
-endif::[]
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-20789](https://redhat.atlassian.net/browse/OSDOCS-20789)

Link to docs preview:


QE review:
N/A

Additional information:
Cleanup of content that wasn't published anywhere since 4.16