### PR TITLE
[WIP] OSDOCS-20793: adds backend ref doc RHDH plugin API

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -108,8 +108,10 @@ Topics:
   Dir: rhdh_plugin
   Distros: rhcl
   Topics:
-   - Name: Managing APIs through Red Hat Developer Hub
+   - Name: Manage APIs through Red Hat Developer Hub
      File: rhdh-plugin-installation
+   - Name: Backstage backend API reference
+     File: backstage-backend-api-ref
 ---
 Name: Observability
 Dir: observe

--- a/develop/rhdh_plugin/backstage-backend-api-ref.adoc
+++ b/develop/rhdh_plugin/backstage-backend-api-ref.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="backstage-backend-api-ref"]
+= {rhdh} backend API reference
+:context: backstage-backend-api-ref
+
+toc::[]
+
+[role="_abstract"]
+When you need to understand the API surface that the {prodname} {rhdh} plugin uses, you can reference the REST API endpoints that the plugin backend exposes. All endpoints require authentication and enforce role-based access control (RBAC) permissions.
+
+include::modules/ref-backstage-backend-rest-api.adoc[leveloffset=+1]

--- a/modules/ref-backstage-backend-rest-api.adoc
+++ b/modules/ref-backstage-backend-rest-api.adoc
@@ -1,0 +1,201 @@
+// Module included in the following assemblies:
+//
+// * develop/api-management-rest-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-backstage-backend-rest-api_{context}"]
+= {rhdh} backend API reference
+
+[role="_abstract"]
+The {prodname} {rhdh} plugin backend exposes REST API endpoints at `/api/kuadrant/`. All endpoints require authentication and enforce role-based access control (RBAC) permissions. Use the following endpoint references to understand the API surface available for API management operations.
+
+[id="ref-backend-api-product-endpoints_{context}"]
+== API product endpoints
+
+Use the following endpoints to manage `APIProduct` resources. Non-administrator users see only `APIProduct` resources that they own.
+
+.API product endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/apiproducts`
+|Lists all API products. Non-administrators see only products that they own.
+|`kuadrant.apiproduct.list`
+
+|`GET`
+|`/api/kuadrant/apiproducts/_<namespace>_/_<name>_`
+|Returns a specific API product.
+|`kuadrant.apiproduct.read.own` or `kuadrant.apiproduct.read.all`
+
+|`POST`
+|`/api/kuadrant/apiproducts`
+|Creates a new API product.
+|`kuadrant.apiproduct.create`
+
+|`PATCH`
+|`/api/kuadrant/apiproducts/_<namespace>_/_<name>_`
+|Updates an existing API product.
+|`kuadrant.apiproduct.update.own` or `kuadrant.apiproduct.update.all`
+
+|`DELETE`
+|`/api/kuadrant/apiproducts/_<namespace>_/_<name>_`
+|Deletes an API product. This operation also deletes associated API keys.
+|`kuadrant.apiproduct.delete.own` or `kuadrant.apiproduct.delete.all`
+|===
+
+[id="ref-backend-http-route-endpoints_{context}"]
+== HTTPRoute endpoints
+
+Use the following endpoint to list `HTTPRoute` custom resources (CRs).
+
+.HTTPRoute endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/httproutes`
+|Lists all `HTTPRoute` resources.
+|`kuadrant.apiproduct.list`
+|===
+
+[id="ref-backend-plan-policy-endpoints_{context}"]
+== Plan policy endpoints
+
+Use the following endpoints to retrieve `PlanPolicy` custom resources (CRs).
+
+.Plan policy endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/planpolicies`
+|Lists all plan policies.
+|`kuadrant.planpolicy.list`
+
+|`GET`
+|`/api/kuadrant/planpolicies/_<namespace>_/_<name>_`
+|Returns a specific plan policy.
+|`kuadrant.planpolicy.read`
+|===
+
+[id="ref-backend-auth-policy-endpoints_{context}"]
+== AuthPolicy endpoints
+
+Use the following endpoint to list `AuthPolicy` custom resources (CRs).
+
+.AuthPolicy endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/authpolicies`
+|Lists all `AuthPolicy` resources.
+|`kuadrant.authpolicy.list`
+|===
+
+[id="ref-backend-rate-limit-policy-endpoints_{context}"]
+== RateLimitPolicy endpoints
+
+Use the following endpoint to list `RateLimitPolicy` custom resources (CRs).
+
+.RateLimitPolicy endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/ratelimitpolicies`
+|Lists all `RateLimitPolicy` resources.
+|`kuadrant.ratelimitpolicy.list`
+|===
+
+[id="ref-backend-api-key-endpoints_{context}"]
+== API key endpoints
+
+Use the following endpoints to manage API key requests and approvals.
+
+.API key endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/requests`
+|Lists API keys. Non-administrators see only keys that they own.
+|`kuadrant.apikey.read.own` or `kuadrant.apikey.read.all`
+
+|`GET`
+|`/api/kuadrant/requests/my`
+|Lists API keys for the current user.
+|`kuadrant.apikey.read.own`
+
+|`POST`
+|`/api/kuadrant/requests`
+|Creates an API key request.
+|`kuadrant.apikey.create`
+
+|`PATCH`
+|`/api/kuadrant/requests/_<namespace>_/_<name>_`
+|Edits a pending API key request.
+|`kuadrant.apikey.update.own` or `kuadrant.apikey.update.all`
+
+|`DELETE`
+|`/api/kuadrant/requests/_<namespace>_/_<name>_`
+|Deletes or cancels an API key request.
+|`kuadrant.apikey.delete.own` or `kuadrant.apikey.delete.all`
+
+|`POST`
+|`/api/kuadrant/requests/_<namespace>_/_<name>_/approve`
+|Approves an API key request.
+|`kuadrant.apikey.approve`
+
+|`POST`
+|`/api/kuadrant/requests/_<namespace>_/_<name>_/reject`
+|Rejects an API key request.
+|`kuadrant.apikey.approve`
+
+|`POST`
+|`/api/kuadrant/requests/bulk-approve`
+|Approves multiple API key requests.
+|`kuadrant.apikey.approve`
+
+|`POST`
+|`/api/kuadrant/requests/bulk-reject`
+|Rejects multiple API key requests.
+|`kuadrant.apikey.approve`
+|===
+
+[id="ref-rhcl-api-key-secret-endpoints_{context}"]
+== API key secret endpoints
+
+Use the following endpoint to retrieve API key secrets. The secret value is available for one-time retrieval only.
+
+.API key secret endpoints
+[cols="1,3,3,2",options="header"]
+|===
+|Method |Endpoint |Description |Permission
+
+|`GET`
+|`/api/kuadrant/apikeys/_<namespace>_/_<name>_/secret`
+|Returns the API key secret. This is a one-time read operation.
+|`kuadrant.apikey.read.own` or `kuadrant.apikey.read.all`
+|===
+
+[id="ref-backend-api-query-parameters_{context}"]
+== Query parameters
+
+You can use the following query parameters to filter API key request results.
+
+For `GET /api/kuadrant/requests`:
+
+`status`:: Filters results by status. Accepted values are `Pending`, `Approved`, and `Rejected`.
+`namespace`:: Filters results by Kubernetes namespace.
+
+For `GET /api/kuadrant/requests/my`:
+
+`namespace`:: Filters results by Kubernetes namespace.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-20793](https://redhat.atlassian.net/browse/OSDOCS-20793)

Link to docs preview:
https://116178--ocpdocs-pr.netlify.app/rhcl/latest/develop/backstage-backend-api-ref.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Supports https://github.com/openshift/openshift-docs/pull/115220

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
