### PR TITLE
OSDOCS-17039: OCI Distributed Agent CQA

### DIFF
--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -27,21 +27,7 @@ include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
 * link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} Nodes (Oracle documentation)]
 
-[id="abi-oci-process-checklist_{context}"]
-== Installation process workflow
-
-The following workflow describes a high-level outline for the process of installing an {product-title} cluster on {oci-distributed-no-rt} using the Agent-based Installer:
-
-. Create {oci-first-no-rt} resources and services (Oracle).
-. Disconnected environments: Prepare a web server that is accessible by {oci} instances (Red{nbsp}Hat).
-. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
-. Generate the agent ISO image (Red{nbsp}Hat).
-. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
-. Configure your firewall for {product-title} (Red{nbsp}Hat).
-. Upload the agent ISO image to a storage bucket (Oracle).
-. Create a custom image from the uploaded agent ISO image (Oracle).
-. Create compute instances on {oci-distributed-no-rt} (Oracle).
-. Verify that your cluster runs on {oci-distributed-no-rt} (Oracle).
+include::modules/installing-oci-agent-workflow.adoc[leveloffset=+1]
 
 // Creating OCI infrastructure resources and services
 include::modules/abi-oci-resources-services.adoc[leveloffset=+1]

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -89,45 +89,48 @@ $ mkdir ~/<directory_name>
 . Configure the `install-config.yaml` configuration file to meet the needs of your organization and save the file in the directory you created.
 +
 .`install-config.yaml` file that sets an external platform
-+
 [source,yaml]
 ----
 # install-config.yaml
 apiVersion: v1
-baseDomain: <base_domain> <1>
+baseDomain: <base_domain>
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   network type: OVNKubernetes
   machineNetwork:
-  - cidr: <ip_address_from_cidr> <2>
+  - cidr: <ip_address_from_cidr>
   serviceNetwork:
   - 172.30.0.0/16
 compute:
-  - architecture: amd64 <3>
+  - architecture: amd64
   hyperthreading: Enabled
   name: worker
   replicas: 0
 controlPlane:
-  architecture: amd64 <3>
+  architecture: amd64
   hyperthreading: Enabled
   name: master
   replicas: 3
 platform:
    external:
-    platformName: oci <4>
+    platformName: oci
     cloudControllerManager: External
-sshKey: <public_ssh_key> <5>
-pullSecret: '<pull_secret>' <6>
+sshKey: <public_ssh_key>
+pullSecret: '<pull_secret>'
 # ...
 ----
-<1> The base domain of your cloud provider.
-<2> The IP address from the virtual cloud network (VCN) that the CIDR allocates to resources and components that operate on your network.
-<3> Depending on your infrastructure, you can select either `arm64` or `amd64`.
-<4> Set `OCI` as the external platform, so that {product-title} can integrate with {oci}.
-<5> Specify your SSH public key.
-<6> The pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the {hybrid-console}.
++
+where:
+
+`baseDomain`:: Specifies the base domain of your cloud provider.
+`machineNetwork.cidr`:: Specifies the IP address from the virtual cloud network (VCN) that the CIDR allocates to resources and components that operate on your network.
+`compute.architecture`:: Specifies the `compute.architecture` parameter. Depending on your infrastructure, you can select either `arm64` or `amd64`.
+`controlPlane.architecture`:: Specifies the `controlPlane.architecture` parameter. Depending on your infrastructure, you can select either `arm64` or `amd64`.
+`platformName`:: Specifies `OCI` as the external platform, so that {product-title} can integrate with {oci}.
+`sshKey`:: Specifies you SSH public key.
+`pullSecret`:: Specifies the pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the {hybrid-console}.
 
 . Create a directory on your local system named `openshift`. This must be a subdirectory of the installation directory.
 +
@@ -179,16 +182,19 @@ endif::pca[]
 ----
 apiVersion: v1beta1
 metadata:
-  name: <cluster_name> // <1>
-  namespace: <cluster_namespace> <2>
-rendezvousIP: <ip_address_from_CIDR> <3>
-bootArtifactsBaseURL: <server_URL> <4>
+  name: <cluster_name>
+  namespace: <cluster_namespace>
+rendezvousIP: <ip_address_from_CIDR>
+bootArtifactsBaseURL: <server_URL>
 # ...
 ----
-<1> The cluster name that you specified in your DNS record.
-<2> The namespace of your cluster on {product-title}.
-<3> If you use IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN's Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for the `rendezvousIP` parameter.
-<4> The URL of the server where you want to upload the rootfs image. This parameter is required only for disconnected environments.
++
+where:
+
+`name`:: Specifies the cluster name that you specified in your DNS record.
+`namespace`:: Specifies the namespace of your cluster on {product-title}.
+`rendezvousIP`:: Specifies the `rendezvousIP` parameter. If you use IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN's Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for the `rendezvousIP` parameter.
+`bootArtifactsBaseURL`:: Specifies the URL of the server where you want to upload the rootfs image. This parameter is required only for disconnected environments.
 
 . Generate a minimal ISO image, which excludes the rootfs image, by entering the following command in your installation directory:
 +

--- a/modules/installing-oci-agent-workflow.adoc
+++ b/modules/installing-oci-agent-workflow.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="abi-oci-process-checklist_{context}"]
+= Installation process workflow
+
+[role="_abstract"]
+To better understand the process, see a high-level outline of installing an {product-title} cluster on {oci-distributed-no-rt} using the Agent-based Installer.
+
+The following workflow describes the general installation process:
+
+. Create {oci-first-no-rt} resources and services (Oracle).
+. Disconnected environments: Prepare a web server that is accessible by {oci} instances (Red{nbsp}Hat).
+. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
+. Generate the agent ISO image (Red{nbsp}Hat).
+. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
+. Configure your firewall for {product-title} (Red{nbsp}Hat).
+. Upload the agent ISO image to a storage bucket (Oracle).
+. Create a custom image from the uploaded agent ISO image (Oracle).
+. Create compute instances on {oci-distributed-no-rt} (Oracle).
+. Verify that your cluster runs on {oci-distributed-no-rt} (Oracle).

--- a/modules/verifying-cluster-install-oci-agent-based.adoc
+++ b/modules/verifying-cluster-install-oci-agent-based.adoc
@@ -16,6 +16,7 @@ ifdef::c3[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci-edge-no-rt}
 
+[role="_abstract"]
 Verify that your cluster was installed and is running effectively on {oci-edge-no-rt}.
 
 .Prerequisites
@@ -29,6 +30,7 @@ ifdef::pca[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci-pca-short}
 
+[role="_abstract"]
 Verify that your cluster was installed and is running effectively on {oci-pca-short}.
 
 .Prerequisites
@@ -42,6 +44,7 @@ ifndef::pca,c3[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci-distributed-no-rt}
 
+[role="_abstract"]
 Verify that your cluster was installed and is running effectively on {oci-distributed}.
 
 .Prerequisites
@@ -53,9 +56,9 @@ endif::pca,c3[]
 
 .Procedure
 
-After you deploy the compute instance on a self-managed node in your {product-title} cluster, you can monitor the cluster’s status by choosing one of the following options:
+* After you deploy the compute instance on a self-managed node in your {product-title} cluster, monitor the cluster's status by choosing one of the following options:
 
-* From the {product-title} CLI, enter the following command:
+** From the {product-title} CLI, enter the following command:
 +
 [source,terminal]
 ----
@@ -63,8 +66,8 @@ $ ./openshift-install agent wait-for install-complete --log-level debug
 ----
 +
 Check the status of the `rendezvous` host node that runs the bootstrap node.  After the host reboots, the host forms part of the cluster.
-+
-* Use the `kubeconfig` API to check the status of various {product-title} components. For the  `KUBECONFIG` environment variable, set the relative path of the cluster's `kubeconfig` configuration file:
+
+** Use the `kubeconfig` API to check the status of various {product-title} components. For the  `KUBECONFIG` environment variable, set the relative path of the cluster's `kubeconfig` configuration file:
 +
 [source,terminal]
 ----
@@ -79,7 +82,6 @@ $ oc get nodes -A
 ----
 +
 .Output example
-+
 [source,terminal]
 ----
 NAME                                   STATUS ROLES                 AGE VERSION
@@ -96,7 +98,6 @@ $ oc get co
 ----
 +
 .Truncated output example
-+
 [source,terminal]
 ----
 NAME           VERSION     AVAILABLE  PROGRESSING    DEGRADED   SINCE   MESSAGE


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI distributed content. This PR resolves remaining errors in Agent based Installer content.

QE review: Not required

Preview: https://116209--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html