### PR TITLE
[enterprise-4.20] OSDOCS-20786: Configuring NFD worker node selectors and tolerations.

### DIFF
--- a/hardware_enablement/psap-node-feature-discovery-operator.adoc
+++ b/hardware_enablement/psap-node-feature-discovery-operator.adoc
@@ -33,6 +33,8 @@ include::modules/creating-nfd-cr-web-console.adoc[leveloffset=+2]
 
 include::modules/psap-configuring-node-feature-discovery.adoc[leveloffset=+1]
 
+include::modules/configuring-nfd-worker-master-pod-scheduling.adoc[leveloffset=+1]
+
 include::modules/nfd-rules-about.adoc[leveloffset=+1]
 
 include::modules/nfd-rules-using.adoc[leveloffset=+1]

--- a/modules/configuring-nfd-worker-master-pod-scheduling.adoc
+++ b/modules/configuring-nfd-worker-master-pod-scheduling.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-nfd-worker-master-pod-scheduling_{context}"]
+= Configuring NFD worker and master pod scheduling
+
+You can control where Node Feature Discovery (NFD) worker pods run by configuring node selectors and tolerations in the `NodeFeatureDiscovery` custom resource.
+
+Use the following fields in `spec.operand`:
+
+* `workerNodeSelector` - Schedules NFD worker pods only on nodes that match the specified labels.
+* `workerTolerations` - Allows NFD worker pods to run on tainted nodes.
+* `masterTolerations` - Allows NFD master pods to tolerate node taints.
+
+.Prerequisites
+
+* You installed the Node Feature Discovery Operator.
+* You logged in as a user with `cluster-admin` privileges.
+* The target node is labeled appropriately.
+
+For example:
+
+[source,terminal]
+----
+$ oc label node <node_name> special-node=true
+----
+
+.Procedure
+
+. Edit the `NodeFeatureDiscovery` custom resource:
++
+[source,terminal]
+----
+$ oc edit NodeFeatureDiscovery nfd-instance -n openshift-nfd
+----
+
+. Configure the scheduling options:
++
+[source,yaml]
+----
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  enableTaints: false
+  instance: ""
+
+  operand:
+    imagePullPolicy: IfNotPresent
+    servicePort: 12000
+
+    workerNodeSelector:
+      special-node: "true"
+
+    workerTolerations:
+      - key: "node-role.kubernetes.io/ai"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+      - key: "node-role.kubernetes.io/ai"
+        operator: "Exists"
+        effect: "NoExecute"
+
+    masterTolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  prunerOnDelete: false
+  topologyUpdater: false
+----
+
+- The `workerNodeSelector` field controls where the NFD worker DaemonSet is scheduled.
+
+- The `workerTolerations` field allows the NFD worker pods to tolerate taints applied to the selected nodes.
+
+- Both `workerNodeSelector` and `workerTolerations` fields are configured under `spec.operand`.
+
+- If `workerNodeSelector` is specified without the required `workerTolerations`, the NFD worker pods will not be scheduled on tainted nodes, even if the nodes match the configured node selector.
+
+- The `masterTolerations` field allows NFD master pods to tolerate taints applied to control plane/master nodes. 
+
+- The tolerations must match the node taints for the NFD master pods to successfully schedule.
+
+
+.Verification
+
+. Verify that the NFD worker pods are scheduled on the expected nodes:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-nfd -o wide
+----
+
+. Verify the node labels:
++
+[source,terminal]
+----
+$ oc get nodes --show-labels
+----
+
+. Verify the node taints:
++
+[source,terminal]
+----
+$ oc get node <node_name> -o jsonpath='{.spec.taints}'
+----
+
+.Expected result
+
+The NFD worker pods are scheduled only on nodes that match the `workerNodeSelector` configuration and can run on nodes with taints that match the configured `workerTolerations`. NFD master pods can tolerate taints specified in `masterTolerations`.
+
+

--- a/modules/configuring-nfd-worker-master-pod-scheduling.adoc
+++ b/modules/configuring-nfd-worker-master-pod-scheduling.adoc
@@ -4,15 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-nfd-worker-master-pod-scheduling_{context}"]
-= Configuring NFD worker and master pod scheduling
+= Configure NFD worker and controller pod scheduling
 
+[role="_abstract"]
 You can control where Node Feature Discovery (NFD) worker pods run by configuring node selectors and tolerations in the `NodeFeatureDiscovery` custom resource.
 
 Use the following fields in `spec.operand`:
 
 * `workerNodeSelector` - Schedules NFD worker pods only on nodes that match the specified labels.
 * `workerTolerations` - Allows NFD worker pods to run on tainted nodes.
-* `masterTolerations` - Allows NFD master pods to tolerate node taints.
+* `masterTolerations` - Allows NFD controller pods to tolerate node taints.
 
 .Prerequisites
 
@@ -27,9 +28,10 @@ For example:
 $ oc label node <node_name> special-node=true
 ----
 
+Edit the `NodeFeatureDiscovery` custom resource:
+
 .Procedure
 
-. Edit the `NodeFeatureDiscovery` custom resource:
 +
 [source,terminal]
 ----
@@ -86,9 +88,9 @@ spec:
 
 - If `workerNodeSelector` is specified without the required `workerTolerations`, the NFD worker pods will not be scheduled on tainted nodes, even if the nodes match the configured node selector.
 
-- The `masterTolerations` field allows NFD master pods to tolerate taints applied to control plane/master nodes. 
+- The `masterTolerations` field allows NFD controller pods to tolerate taints applied to control plane/master nodes. 
 
-- The tolerations must match the node taints for the NFD master pods to successfully schedule.
+- The tolerations must match the node taints for the NFD controller pods to successfully schedule.
 
 
 .Verification
@@ -114,8 +116,6 @@ $ oc get nodes --show-labels
 $ oc get node <node_name> -o jsonpath='{.spec.taints}'
 ----
 
-.Expected result
-
-The NFD worker pods are scheduled only on nodes that match the `workerNodeSelector` configuration and can run on nodes with taints that match the configured `workerTolerations`. NFD master pods can tolerate taints specified in `masterTolerations`.
+The NFD worker pods are scheduled only on nodes that match the `workerNodeSelector` configuration and can run on nodes with taints that match the configured `workerTolerations`. NFD controller pods can tolerate taints specified in `masterTolerations`.
 
 


### PR DESCRIPTION
The current Node Feature Discovery (NFD) Operator [documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/specialized_hardware_and_driver_enablement/psap-node-feature-discovery-operator#psap-node-feature-discovery-operator-using-the-operator) does not describe the `workerNodeSelector` and `workerTolerations` fields available under `spec.operand` of the `NodeFeatureDiscovery` custom resource.

These fields allow cluster administrators to:

- Schedule NFD worker pods only on selected nodes by using `workerNodeSelector`.
- Schedule NFD worker pods on tainted nodes by configuring `workerTolerations`
- The `masterTolerations` field allows NFD master pods to tolerate taints applied to control plane/master nodes.

Beginning with Red Hat OpenShift Container Platform **4.20**, the `NodeFeatureDiscovery` custom resource supports configuring the placement of NFD worker and master pods through the `spec.operand` section.

Ref: 
https://github.com/openshift/cluster-nfd-operator/blob/98a074e63cd08de9748892a1d2361e33665efaf1/api/v1/nodefeaturediscovery_types.go#L112

```
masterTolerations	<[]Object>         <<<<<<----------------
    effect	<string>
    key	<string>

 workerNodeSelector	<map[string]string>   <<<<<<------------------
  workerPriorityClassName	<string>
  workerTolerations	<[]Object>
    effect	<string>
```

**Additional Information**

- Version(s): 4.20+
- Issue: https://redhat.atlassian.net/browse/OSDOCS-20786
- Link to docs preview: https://116224--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html

QE review:

[ ] QE has approved this change.

