### PR TITLE
OSDOCS-17039: OCI edge CQA abstracts

### DIFF
--- a/installing/installing_oci_edge/installing-c3-agent-based-installer.adoc
+++ b/installing/installing_oci_edge/installing-c3-agent-based-installer.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use the Agent-based Installer to install a cluster on {oci-edge}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
 
 The following procedures describe a cluster installation on {oci-c3} as an example.

--- a/installing/installing_oci_edge/installing-c3-assisted-installer.adoc
+++ b/installing/installing_oci_edge/installing-c3-assisted-installer.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can use the {ai-full} to install a cluster on {oci-edge}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
+
 With {oci-edge}, you can run applications and middleware by using {oci-first} services on high performance cloud infrastructure in your data center.
 
 The following procedures describe a cluster installation on {oci-c3} as an example.

--- a/modules/abi-c3-resources-services.adoc
+++ b/modules/abi-c3-resources-services.adoc
@@ -6,7 +6,10 @@
 [id="abi-c3-resources-services_{context}"]
 = Creating {oci} infrastructure resources and services
 
-You must create an {oci-edge-no-rt} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci-first-no-rt} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+[role="_abstract"]
+You must create an {oci-edge-no-rt} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies.
+
+Having prior knowledge of {oci-first-no-rt} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
 
 [IMPORTANT]
 ====

--- a/modules/c3-assisted-installer-completing-installation-manifests.adoc
+++ b/modules/c3-assisted-installer-completing-installation-manifests.adoc
@@ -6,6 +6,7 @@
 [id="c3-ai-completing-installation-manifests_{context}"]
 = Adding custom manifests
 
+[role="_abstract"]
 Create, modify, and upload the four mandatory custom manifests provided by Oracle.
 
 * In the `C3/custom_manifests_C3/manifests` folder, the following manifests are mandatory:
@@ -16,7 +17,7 @@ Create, modify, and upload the four mandatory custom manifests provided by Oracl
 * In the `C3/custom_manifests_C3/openshift` folder, the following manifests are mandatory:
 
 ** `machineconfig-ccm.yml`
-** `machineconfig-csi.yml` 
+** `machineconfig-csi.yml`
 
 .Prerequisites
 
@@ -32,7 +33,7 @@ Create, modify, and upload the four mandatory custom manifests provided by Oracl
 
 .. In the *File name* field, enter `oci-ccm.yml`.
 
-.. In the *Content* section, click *Browse*. 
+.. In the *Content* section, click *Browse*.
 
 .. Select the *oci-ccm.yml* file from the `C3/custom_ manifest_C3/manifests` folder.
 
@@ -46,7 +47,7 @@ Create, modify, and upload the four mandatory custom manifests provided by Oracl
 
 .. In the *File name* field, enter `machineconfig-ccm.yml`.
 
-.. In the *Content* section, click *Browse*. 
+.. In the *Content* section, click *Browse*.
 
 .. Select the *machineconfig-ccm.yml* file from the `C3/custom_ manifest_C3/openshift` folder.
 

--- a/modules/c3-assisted-installer-completing-installation-networking.adoc
+++ b/modules/c3-assisted-installer-completing-installation-networking.adoc
@@ -6,14 +6,15 @@
 [id="c3-ai-completing-installation-networking_{context}"]
 = Configuring networking
 
+[role="_abstract"]
 On the *Networking* page, add the NTP sources for any hosts that display the `Some validations failed` status.
 
 .Procedure
 
 . In the *Host inventory* table, click the *Some validations failed* link for each host displaying this status.
 
-. Click *Add NTP sources*, and then add the IP address `169.254.169.254` for one of the nodes. 
+. Click *Add NTP sources*, and then add the IP address `169.254.169.254` for one of the nodes.
 
-. Wait for 2 - 3 minutes until all the *Some validations failed* indicators disappear. 
+. Wait for 2 - 3 minutes until all the *Some validations failed* indicators disappear.
 
 . Select *Next*.

--- a/modules/c3-assisted-installer-completing-installation-nodes.adoc
+++ b/modules/c3-assisted-installer-completing-installation-nodes.adoc
@@ -6,20 +6,21 @@
 [id="c3-ai-completing-installation-nodes_{context}"]
 = Assigning node roles
 
-If the Terraform scripts completed successfully, twelve hosts are now listed for the cluster. Three control plane hosts and three compute hosts have the status "Disconnected". Three control plane hosts and three compute hosts have the status "Insufficient". 
+[role="_abstract"]
+If the Terraform scripts completed successfully, twelve hosts are now listed for the cluster. Three control plane hosts and three compute hosts have the status "Disconnected". Three control plane hosts and three compute hosts have the status "Insufficient".
 
-Delete the disconnected hosts and assign roles to the remaining hosts. 
+Delete the disconnected hosts and assign roles to the remaining hosts.
 
 .Procedure
 
-. From the link:https://console.redhat.com/openshift/assisted-installer/clusters[{ai-full} web console], select the cluster and navigate to the *Host discovery* page. 
+. From the link:https://console.redhat.com/openshift/assisted-installer/clusters[{ai-full} web console], select the cluster and navigate to the *Host discovery* page.
 
 . Delete the six hosts with a "Disconnected" status, by clicking the option button for each host and selecting *Remove host*. The status of the remaining hosts changes from "Insufficient" to "Ready". This process can take up to three minutes.
 
-. From the *Role* column, assign the *Control plane* role to the three nodes with a boot size of 1.10 TB. Assign the *Worker* role to the three nodes with boot size of 100 GB. 
+. From the *Role* column, assign the *Control plane* role to the three nodes with a boot size of 1.10 TB. Assign the *Worker* role to the three nodes with boot size of 100 GB.
 
-. Rename any hosts with a name shorter than 63 characters, by clicking the option button for the host and selecting *Change hostname*. Otherwise the cluster installation will fail. 
+. Rename any hosts with a name shorter than 63 characters, by clicking the option button for the host and selecting *Change hostname*. Otherwise the cluster installation will fail.
 
-. Click *Next*. 
+. Click *Next*.
 
 . On the *Storage* page, click *Next*.

--- a/modules/c3-assisted-installer-opening-cluster.adoc
+++ b/modules/c3-assisted-installer-opening-cluster.adoc
@@ -6,4 +6,9 @@
 [id="c3-ai-opening-cluster_{context}"]
 = Opening {product-title} from the {oci-edge-no-rt} web console
 
-For instructions to access the {product-title} console from {oci-edge-no-rt}, see steps 15 - 17 in the "Install the Cluster using the RH Assisted Installer UI" section of the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].
+[role="_abstract"]
+After cluster installation has been completed, access the {product-title} console from {oci-edge-no-rt}.
+
+.Procedure
+
+* See steps 15 - 17 in the "Install the Cluster using the RH Assisted Installer UI" section of the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].

--- a/modules/c3-assisted-installer-overview.adoc
+++ b/modules/c3-assisted-installer-overview.adoc
@@ -6,6 +6,7 @@
 [id="c3-ai-overview_{context}"]
 = Overview
 
+[role="_abstract"]
 You can install {product-title} on {oci-edge-no-rt} by using the {ai-full}.
 
 For an alternative installation method, see "Installing a cluster on {oci-edge} by using the Agent-based Installer".

--- a/modules/c3-assisted-installer-preparing-bastion-server.adoc
+++ b/modules/c3-assisted-installer-preparing-bastion-server.adoc
@@ -6,6 +6,7 @@
 [id="c3-ai-preparing-bastian-server_{context}"]
 = Preparing the {oci} bastion server
 
+[role="_abstract"]
 By implementing a bastion host, you can securely and efficiently manage access to your {oci-first-no-rt} resources, ensuring that your private instances remain protected and accessible only through a secure, controlled entry point.
 
 .Prerequisites

--- a/modules/c3-assisted-installer-preparing-image-converting.adoc
+++ b/modules/c3-assisted-installer-preparing-image-converting.adoc
@@ -6,6 +6,7 @@
 [id="c3-assisted-installer-preparing-image-converting_{context}"]
 = Converting and uploading the image to {oci-edge-no-rt}
 
+[role="_abstract"]
 Convert the ISO image to an {oci-first-no-rt} image and upload it to your {oci-edge-no-rt} system from your OCI Home Region Object
 Store.
 

--- a/modules/c3-assisted-installer-preparing-image-generating.adoc
+++ b/modules/c3-assisted-installer-preparing-image-generating.adoc
@@ -6,6 +6,7 @@
 [id="c3-assisted-installer-preparing-image-generating_{context}"]
 = Generating the image in the {ai-full}
 
+[role="_abstract"]
 Create a cluster and download the discovery ISO image.
 
 .Procedure

--- a/modules/c3-assisted-installer-running-script-via-home.adoc
+++ b/modules/c3-assisted-installer-running-script-via-home.adoc
@@ -6,7 +6,10 @@
 [id="c3-ai-running-script-via-home_{context}"]
 = Running the Terraform script via the Home region
 
-Copy the Terraform scripts `createInfraResources.tf` and `terraform.tfvars` onto the bastion server. Then run the `createInfraResources.tf` script to create the Dynamic Group Identity resources on your {oci-first-no-rt} Home Region. These resources include dynamic groups, policies, and tags.
+[role="_abstract"]
+Copy the Terraform scripts `createInfraResources.tf` and `terraform.tfvars` onto the bastion server. Then run the `createInfraResources.tf` script to create the Dynamic Group Identity resources on your {oci-first-no-rt} Home Region.
+
+These resources include dynamic groups, policies, and tags.
 
 .Prerequisites
 

--- a/modules/c3-assisted-installer-running-script-via-region.adoc
+++ b/modules/c3-assisted-installer-running-script-via-region.adoc
@@ -6,6 +6,7 @@
 [id="c3-ai-running-script-via-region_{context}"]
 = Running the Terraform script via the C3 region
 
+[role="_abstract"]
 Run the `terraform.tfvars` Terraform script to create all infrastructure resources on {oci-edge}. These resources include the {product-title} VCN, public and private subnets, load balancers, internet GW, NAT GW, and DNS server.
 
 This procedure deploys a cluster consisting of three control plane (master) and three compute (worker) nodes. After deployment, you must rename and reboot the nodes. This process temporarily duplicates nodes, requiring manual cleanup in the next procedure.

--- a/modules/installing-oci-edge-infra-support.adoc
+++ b/modules/installing-oci-edge-infra-support.adoc
@@ -7,6 +7,9 @@
 [id="installing-oci-edge-infra-support_{context}"]
 = Supported {oci-edge-no-rt} infrastructures
 
+[role="_abstract"]
+There are several different {oci-edge} infrastructure offerings you can choose for your installation.
+
 The following table describes the support status of each {oci-edge} infrastructure offering:
 
 .{oci-edge-no-rt} infrastructure support statuses

--- a/modules/running-cluster-oci-c3-agent-based.adoc
+++ b/modules/running-cluster-oci-c3-agent-based.adoc
@@ -6,6 +6,7 @@
 [id="running-cluster-oci-c3-agent-based_{context}"]
 = Running a cluster on {oci-edge-no-rt}
 
+[role="_abstract"]
 To run a cluster on {oci-edge}, you must first convert your generated Agent ISO image into an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-edge-no-rt} system.
 
 [NOTE]


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI edge content. Just abstracts in this PR

QE review: Not required

Previews:
https://116225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-agent-based-installer.html
https://116225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-assisted-installer.html
