### PR TITLE
OSDOCS-17172-xref: manual revert ID additions

### DIFF
--- a/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
+++ b/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
@@ -9,27 +9,27 @@ toc::[]
 [role="_abstract"]
 Review user-provided TLS certificates for the API server in {product-title} to understand their purpose, location, management, and expiration for external client access.
 
-[id="user-provided-certificates-for-api-server-purpose_{context}"]
+//[id="user-provided-certificates-for-api-server-purpose_{context}"]
 == Purpose
 
 The API server is accessible by clients external to the cluster at `api.<cluster_name>.<base_domain>`. You might want clients to access the API server at a different hostname or without the need to distribute the cluster-managed certificate authority (CA) certificates to the clients. The administrator must set a custom default certificate to be used by the API server when serving content.
 
-[id="user-provided-certificates-for-api-server-location_{context}"]
+//[id="user-provided-certificates-for-api-server-location_{context}"]
 == Location
 
 The user-provided certificates must be provided in a `kubernetes.io/tls` type `Secret` in the `openshift-config` namespace. Update the API server cluster configuration, the `apiserver/cluster` resource, to enable the use of the user-provided certificate.
 
-[id="user-provided-certificates-for-api-server-management_{context}"]
+//[id="user-provided-certificates-for-api-server-management_{context}"]
 == Management
 
 User-provided certificates are managed by the user.
 
-[id="user-provided-certificates-for-api-server-expiration_{context}"]
+//[id="user-provided-certificates-for-api-server-expiration_{context}"]
 == Expiration
 
 API server client certificate expiration is less than five minutes.
 
-[id="user-provided-certificates-for-api-server-customization_{context}"]
+//[id="user-provided-certificates-for-api-server-customization_{context}"]
 == Customization
 
 Update the secret containing the user-managed certificate as needed.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
