### PR TITLE
No Jira: Minor fixes in HCP networking section

### DIFF
--- a/hosted_control_planes/hcp-networking.adoc
+++ b/hosted_control_planes/hcp-networking.adoc
@@ -15,7 +15,7 @@ include::modules/hcp-isolation-overview.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
  * xref:../hosted_control_planes/hcp-networking.adoc#hcp-isolation_hcp-networking[Control plane isolation]
- * xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-node-labeling_hcp-distribute-workloads[Node labeling for {hcp}]
+ * xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
 
 //control plane isolation
 include::modules/hcp-isolation.adoc[leveloffset=+2]

--- a/modules/hcp-custom-ovn-subnets.adoc
+++ b/modules/hcp-custom-ovn-subnets.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 In hosted clusters, you can configure internal OVN subnets to avoid routing conflicts, customize network architecture, or enable virtual private cloud (VPC) peering.
 
-Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16. To avoid a conflict on a `kubevirt` hosted cluster, the HyperShift Operator sets the OVN join subnet to `100.66.0.0/16` instead of `100.64.0.0/16` or `100.65.0.0/16`. The default CIDR for the OVN gateway router is `100.64.0.0/16`. The default CIDR for the user-defined network (UDN) join subnet is `100.65.0.0/16`.
+Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16. To avoid a conflict on a `kubevirt` hosted cluster, the HyperShift Operator sets the OVN join subnet to `100.66.0.0/16` instead of `100.64.0.0/16` or `100.65.0.0/16`. The default classless inter-domain routing (CIDR) for the OVN gateway router is `100.64.0.0/16`. The default CIDR for the user-defined network (UDN) join subnet is `100.65.0.0/16`.
 Customize network architecture:: Configure internal OVN subnets to align with your corporate network policies.
 Enable VPC peering:: Deploy hosted clusters in environments where default subnets conflict with peered networks.
 
@@ -68,11 +68,6 @@ For full details about creating a hosted cluster, see "Creating a hosted cluster
 
 * To configure internal OVN subnets in an existing hosted cluster, enter the following command:
 +
-[IMPORTANT]
-====
-When you make this change to an existing hosted cluster, the `ovnkube-node` DaemonSet is rolled out and the OVN components on compute nodes are restarted. During this process, you might experience brief network disruptions.
-====
-+
 [source,terminal]
 ----
 $ oc patch hostedcluster <hosted_cluster_name> \
@@ -96,10 +91,12 @@ $ oc patch hostedcluster <hosted_cluster_name> \
 +
 where:
 +
---
-`metadata`:: Specifies the name of the hosted cluster and the name of the hosted control plane namespace.
 `spec.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig.ipv4`:: Specifies the subnets to use. Both subnet fields in this section must be in a valid IPv4 CIDR notation, such as `192.168.1.0/24`. The prefix range is `/0` to `/30`, inclusive. The first octet cannot be 0, and the string length must be 9-18 characters. The subnet fields cannot use the same value. The subnet must be large enough to accommodate one IP address per node in the cluster. When you plan subnet size, consider future cluster growth. If you omit these fields, the default value for the `internalJoinSubnet` field is `100.64.0.0/16`, and the default value for the `internalTransitSwitchSubnet` field is `100.88.0.0/16`.
---
++
+[IMPORTANT]
+====
+When you make this change to an existing hosted cluster, the `ovnkube-node` DaemonSet is rolled out and the OVN components on compute nodes are restarted. During this process, you might experience brief network disruptions.
+====
 
 .Verification
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: n/a
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Networking isolation for hosted clusters (updated link): https://116228--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-isolation-overview_hcp-networking
- Configuring internal OVN IPv4 subnets for hosted clusters: https://116228--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-custom-ovn-subnets_hcp-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
