### PR TITLE
OSDOCS-17172-fix-proxy-cert-customization

### DIFF
--- a/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
+++ b/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
@@ -80,5 +80,5 @@ include::modules/nw-verify-proxy-configuration.adoc[leveloffset=+1]
 
 * xref:../../networking/configuring_network_settings/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
 * xref:../../security/certificates/updating-ca-bundle.adoc#ca-bundle-understanding_updating-ca-bundle[Understanding the CA Bundle certificate]
-* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificates]
+* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-cert-customization_proxy-certificates[Proxy certificates]
 * link:https://access.redhat.com/solutions/7065528[How is the cluster-wide proxy setting applied to {product-title} nodes?]

--- a/security/certificates/replacing-default-ingress-certificate.adoc
+++ b/security/certificates/replacing-default-ingress-certificate.adoc
@@ -18,4 +18,4 @@ include::modules/customize-certificates-replace-default-router.adoc[leveloffset=
 == Additional resources
 
 * xref:../../security/certificates/updating-ca-bundle.adoc#ca-bundle-understanding_updating-ca-bundle[Replacing the CA Bundle certificate]
-* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificate customization]
+* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-cert-customization_proxy-certificates[Proxy certificate customization]

--- a/security/certificates/updating-ca-bundle.adoc
+++ b/security/certificates/updating-ca-bundle.adoc
@@ -19,4 +19,4 @@ include::modules/ca-bundle-replacing.adoc[leveloffset=+1]
 
 * xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress_replacing-default-ingress[Replacing the default ingress certificate]
 * xref:../../networking/configuring_network_settings/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[Enabling the cluster-wide proxy]
-* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificate customization]
+* xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-cert-customization_proxy-certificates[Proxy certificate customization]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://116244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/enable-cluster-wide-proxy.html
https://116244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate.html
https://116244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/updating-ca-bundle.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This update is related to PR https://github.com/openshift/openshift-docs/pull/115883. When this PR was merged, it broke the repo because of some bad xrefs. Those xrefs are fixed in this PR

Rebased onto current main after the #115883 revert (#116226). The branch is now up to   date; this PR only fixes the xref anchor IDs and does not re-include the reverted CQA  changes.


