### PR TITLE
networking: document masquerade subnet size requirement for UDN

### DIFF
--- a/modules/nw-ovn-k-day-2-masq-subnet.adoc
+++ b/modules/nw-ovn-k-day-2-masq-subnet.adoc
@@ -8,6 +8,13 @@
 
 You can change the masquerade subnet used by OVN-Kubernetes as a post-installation operation to avoid conflicts with any existing subnets that are already in use in your environment.
 
+[IMPORTANT]
+====
+If you are using or plan to use UserDefinedNetworks (UDN), the masquerade subnet must be `/18` or larger for IPv4. Each UDN consumes two masquerade IPs, and the allocator supports up to 4,096 networks. A subnet smaller than `/18` exhausts available IPs after a finite number of total UDN create operations — even across delete cycles — causing an _"out of range"_ failure.
+
+Clusters installed before {product-title} 4.17 retain the default `169.254.169.0/29` (8 IPs), which cannot support any UDN. Use `169.254.0.0/17` as described in this procedure before creating any UDNs.
+====
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).

--- a/modules/nw-udn-limitations.adoc
+++ b/modules/nw-udn-limitations.adoc
@@ -33,6 +33,10 @@ Consider the following limitations before implementing a UDN.
 
 * *Unclear error message for IP address exhaustion*: When the subnet of a user-defined network runs out of available IP addresses, new pods fail to start. When this occurs, the following error is returned: `Warning: Failed to create pod sandbox`. This error message does not clearly specify that IP depletion is the cause. To confirm the issue, you can check the *Events* page in the pod's namespace on the {product-title} web console, where an explicit message about subnet exhaustion is reported.
 
+* *Masquerade subnet size requirement*: When UserDefinedNetworks are in use, the `internalMasqueradeSubnet` must be `/18` or larger for IPv4 (at minimum 16,384 IPs). Each UDN consumes two masquerade IPs derived from a forward-scanning allocator capped at 4,096 networks. A subnet smaller than `/18` will exhaust the available IP range after a finite number of total UDN create operations — even if UDNs are deleted in between — causing `ovnkube-controller` to fail with an _"out of range"_ error and leaving nodes in `CrashLoopBackOff`.
++
+Clusters installed before {product-title} 4.17 retain the old default of `169.254.169.0/29` (only 8 IPs, insufficient for any UDN). Use the day-2 masquerade subnet change procedure to set the subnet to `169.254.0.0/17` before creating any UDNs. See _Configuring the OVN-Kubernetes masquerade subnet as a post-installation operation_.
+
 * *Layer2 egress IP limitations* (`UserDefinedNetwork` CRs only):
 
 ** Egress IP does not work without a default gateway.


### PR DESCRIPTION
## Summary

- Adds a limitation bullet to `nw-udn-limitations.adoc`: `internalMasqueradeSubnet` must be `/18` or larger for IPv4 when UDNs are in use
- Adds an IMPORTANT admonition to `nw-ovn-k-day-2-masq-subnet.adoc` warning UDN users about the minimum subnet size and directing pre-4.17 upgraded clusters to perform the day-2 change before creating UDNs

## Context

OCPBUGS-55362: clusters with small masquerade subnets hit an _"out of range"_ crash after a finite number of UDN create/delete cycles. The OVN-Kubernetes network ID allocator uses a forward-scanning round-robin capped at MaxNetworks=4096. The masquerade IP formula (`10 + networkID×2`) means the subnet must contain at least 8203 IPs — a `/18` minimum.

Clusters installed before 4.17 retain the default `169.254.169.0/29` (8 IPs), which cannot support any UDN. The existing day-2 procedure already covers how to change this; this PR adds the critical warning that UDN users **must** perform it on pre-4.17 upgraded clusters.

## Test plan

- [ ] Render `nw-udn-limitations.adoc` — confirm limitation appears in UDN limitations section
- [ ] Render `nw-ovn-k-day-2-masq-subnet.adoc` — confirm IMPORTANT box appears before Prerequisites

