### PR TITLE
[OSDOCS#18693]: CQA Remediation for Cert Manager Operator OSDOCS-17173 - PR2

### DIFF
--- a/modules/cert-manager-acme-challenges-types.adoc
+++ b/modules/cert-manager-acme-challenges-types.adoc
@@ -12,16 +12,12 @@ To validate domain ownership with ACME issuers, you can use the challenge types 
 The {cert-manager-operator} supports the following challenge types for ACME issuers:
 
 HTTP-01:: With the HTTP-01 challenge type, you provide a computed key at an HTTP URL endpoint in your domain. If the ACME CA server can get the key from the URL, it can validate you as the owner of the domain.
-+
-For more information, see link:https://cert-manager.io/docs/configuration/acme/http01/[HTTP01] in the upstream cert-manager documentation.
 
 [NOTE]
 ====
 HTTP-01 requires that the Let's Encrypt servers can access the route of the cluster. If an internal or private cluster is behind a proxy, the HTTP-01 validations for certificate issuance fail.
 
-The HTTP-01 challenge is restricted to port 80. For more information, see link:https://letsencrypt.org/docs/challenge-types/#http-01-challenge[HTTP-01 challenge] (Let's Encrypt).
+The HTTP-01 challenge is restricted to port 80.
 ====
 
 DNS-01:: With the DNS-01 challenge type, you provide a computed key at a DNS TXT record. If the ACME CA server can get the key by DNS lookup, it can validate you as the owner of the domain.
-+
-For more information, see link:https://cert-manager.io/docs/configuration/acme/dns01/[DNS01] in the upstream cert-manager documentation.

--- a/modules/cert-manager-acme-dns01-ambient-gcp.adoc
+++ b/modules/cert-manager-acme-dns01-ambient-gcp.adoc
@@ -94,6 +94,7 @@ spec:
 where:
 +
 `<issuer_name>`:: Specifies a name for the issuer.
+`<issuer_namespace>`:: Specifies a namespace for the issuer.
 `<secret_private_key>`:: Specifies the name of the secret to store the ACME account private key in.
 `<server>`:: Specifies the URL to access the ACME server's `directory` endpoint. This example uses the _Let's Encrypt_ staging environment.
 `<gcp_project_id>`:: Specifies the name of the {gcp-short} project that contains the Cloud DNS zone.

--- a/modules/cert-manager-acme-dns01-explicit-azure.adoc
+++ b/modules/cert-manager-acme-dns01-explicit-azure.adoc
@@ -11,7 +11,7 @@ You can use {cert-manager-operator} to set up an ACME issuer to solve DNS-01 cha
 
 .Prerequisites
 
-* You have set up a service principal with desired role for Azure DNS. For more information, see link:https://cert-manager.io/docs/configuration/acme/dns01/azuredns/[Azure DNS] in the upstream cert-manager documentation.
+* You have set up a service principal with desired role for Azure DNS.
 +
 [NOTE]
 ====

--- a/modules/cert-manager-acme-dns01-explicit-gcp.adoc
+++ b/modules/cert-manager-acme-dns01-explicit-gcp.adoc
@@ -11,7 +11,7 @@ You can use the {cert-manager-operator} to set up an ACME issuer to solve DNS-01
 
 .Prerequisites
 
-* You have set up a {gcp-full} service account with a desired role for {gcp-full} DNS. For more information, see link:https://cert-manager.io/docs/configuration/acme/dns01/google/[{gcp-full} DNS] in the upstream cert-manager documentation.
+* You have set up a {gcp-full} service account with a desired role for {gcp-full} DNS.
 +
 [NOTE]
 ====

--- a/modules/cert-manager-configuring-routes.adoc
+++ b/modules/cert-manager-configuring-routes.adoc
@@ -39,7 +39,9 @@ spec:
 EOF
 ----
 +
-Replace `<namespace>` with the namespace where the `Issuer` is located. It must be the same as the namespace of your route.
+where:
++
+`<namespace>`:: Specifies the namespace where the `Issuer` is located. It must be the same as the route namespace.
 
 . Create a `Certificate` object for the route by running the following command. The `secretName` specifies the TLS secret that is going to be issued and managed by cert-manager and will also be referenced in your route in the following steps.
 +
@@ -63,7 +65,6 @@ spec:
   secretName: <secret_name>
 EOF
 ----
-+
 where:
 +
 `<namespace>`:: Specifies the `namespace` where the `Certificate` resource is located. It should be the same as the namespace of your route.
@@ -83,7 +84,7 @@ $ oc create role secret-reader \
 ----
 +
 where:
-+
+
 `<secret_name>`:: Specifies the name of the secret that you want to grant access to. It should be consistent with your `secretName` specified in the `Certificate` resource.
 `<namespace>`:: Specifies the namespace where both your secret and route are located.
 
@@ -96,8 +97,9 @@ $ oc create rolebinding secret-reader-binding \
   --serviceaccount=openshift-ingress:router \
   --namespace=<namespace>
 ----
-+
-Replace `<namespace>` with the namespace where both your secret and route are located.
+where:
+
+`<namespace>`:: Specifies the namespace where both your secret and route are located.
 
 . Create a route for your service resource, that uses edge TLS termination and a custom hostname, by running the following command. The hostname is used when creating a `Certificate` resource in the next step.
 +
@@ -128,7 +130,7 @@ $ oc patch route <route_name> \
 +
 where:
 +
-`<route_name>`:: Specifies the route name.
+`<route_name>`:: Specifies the name of your route.
 `<namespace>`:: Specifies the namespace where both your secret and route are located.
 `<secret_name>`:: Specifies the name of the secret that contains the certificate.
 
@@ -142,7 +144,9 @@ $ oc get certificate -n <namespace>
 $ oc get secret -n <namespace>
 ----
 +
-Replace `<namespace>` with the namespace name where both your secret and route reside.
+where:
++
+`<namespace>`:: Specifies the namespace where both your secret and route are located.
 
 . Verify that the router is using the referenced external certificate by running the following command. The command should return with the status code `200 OK`.
 +
@@ -151,7 +155,9 @@ Replace `<namespace>` with the namespace name where both your secret and route r
 $ curl -IsS https://<hostname>
 ----
 +
-Replace `<hostname>` with the hostname of your route.
+where:
++
+`<hostname>`:: Specifies the hostname of your route.
 
 . Verify the `subject`, `subjectAltName`, and `issuer` fields of your server certificate are all as expected from the curl verbose outputs by running the following command:
 +
@@ -159,5 +165,8 @@ Replace `<hostname>` with the hostname of your route.
 ----
 $ curl -v https://<hostname>
 ----
+where:
 +
-Replace `<hostname>` with the hostname of your route. The certificate from the secret secures the route. The `cert-manager` component manages the lifecycle of the certificate.
+`<hostname>`:: Specifies the hostname of your route.
+
+The certificate from the referenced secret secures the route. The `cert-manager` component issues the certificate and automatically manages the certificate lifecycle.

--- a/modules/cert-manager-enable-operand-log-level.adoc
+++ b/modules/cert-manager-enable-operand-log-level.adoc
@@ -34,7 +34,15 @@ spec:
   logLevel: <log_level>
 ----
 +
-The valid log level values for the `CertManager` resource are `Normal`, `Debug`, `Trace`, and `TraceAll`. To audit logs and perform common operations when there are no issues, set `logLevel` to `Normal` . To troubleshoot a minor issue by viewing verbose logs, set `logLevel` to `Debug` . To troubleshoot a major issue by viewing more verbose logs, you can set `logLevel` to `Trace`. To troubleshoot serious issues, set `logLevel` to `TraceAll`. The default `logLevel` is `Normal`.
+The `CertManager` resource supports the following `logLevel` values:
++
+`Normal`:: Audits logs and records common operations. The default setting. Use this level when there are no issues.
++
+`Debug`:: Provides verbose logs. Use this level to troubleshoot minor issues.
++
+`Trace`:: Provides highly verbose logs. Use this level to troubleshoot major issues.
++
+`TraceAll`:: Provides maximum log detail. Use this level to troubleshoot serious issues.
 +
 [NOTE]
 ====

--- a/modules/cert-manager-install-cli.adoc
+++ b/modules/cert-manager-install-cli.adoc
@@ -7,7 +7,7 @@
 = Installing the {cert-manager-operator} by using the CLI
 
 [role="_abstract"]
-You can install the {cert-manager-operator} by using the command-line interface(CLI).
+You can install the {cert-manager-operator} by using the command-line interface (CLI).
 
 .Prerequisites
 

--- a/modules/cert-manager-istio-csr-setting-log-level.adoc
+++ b/modules/cert-manager-istio-csr-setting-log-level.adoc
@@ -41,7 +41,7 @@ spec:
 +
 where:
 +
-`logFormat`:: Specifies the log output format. You can set this field to either `text` or `json`.
-`logLevel`:: Specifies the log level. Supported values are in the range `1` through `5`, as defined by Kubernetes logging guidelines. The default value is `1`.
+`istioCSRConfig.logFormat`:: Specifies the log output format. You can set this field to either `text` or `json`.
+`istioCSRConfig.logLevel`:: Specifies the log level. Supported values are in the range `1` through `5`, as defined by Kubernetes logging guidelines. The default value is `1`.
 
 . Save and close the editor to apply your changes. After the changes are applied, the cert-manager Operator updates the log configuration for the istio-csr operand.

--- a/security/cert_manager_operator/cert-manager-operator-install.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-install.adoc
@@ -7,24 +7,22 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The {cert-manager-operator} is not installed in {product-title} by default. You can install the {cert-manager-operator} by using the web console.
+The {cert-manager-operator} is not installed in {product-title} by default. You can install the {cert-manager-operator} by using the web console and command-line interface (CLI).
 
-[NOTE]
-====
 The {cert-manager-operator} sets the `features.operators.openshift.io/token-auth-aws`, `features.operators.openshift.io/token-auth-azure`, and `features.operators.openshift.io/token-auth-gcp` annotations in the `ClusterServiceVersion` custom resource of the Operator. The {product-title} web console requires the credential details when these annotations are set. Currently, the Operator does not use the values collected by the OpenShift web console and you can provide any value when asked for the input. For example, when installing on the managed {product-title} cluster, the `identity-provider-arn` is asked and any value can be provided to proceed.
-====
+
 
 [IMPORTANT]
 ====
 The {cert-manager-operator} version 1.15 or later supports the `AllNamespaces`, `SingleNamespace`, and `OwnNamespace` installation modes. Earlier versions, such as 1.14, support only the `SingleNamespace` and `OwnNamespace` installation modes.
 ====
 
-== Installing the {cert-manager-operator}
+
 // Installing the {cert-manager-operator} using the web console
-include::modules/cert-manager-install-console.adoc[leveloffset=+2]
+include::modules/cert-manager-install-console.adoc[leveloffset=+1]
 
 //Installing using CLI
-include::modules/cert-manager-install-cli.adoc[leveloffset=+2]
+include::modules/cert-manager-install-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/security/cert_manager_operator/cert-manager-operator-integrating-istio.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-integrating-istio.adoc
@@ -11,11 +11,8 @@ The {cert-manager-operator} provides enhanced support for securing workloads and
 
 With this Istio-CSR integration, Istio can now obtain certificates from the {cert-manager-operator}, simplifying security and certificate management.
 
-[id="cert-manager-operator-istio-csr-installing_{context}"]
-== Installing the Istio-CSR agent through {cert-manager-operator}
-
 // Creating issuer
-include::modules/cert-manager-istio-creating-issuer.adoc[leveloffset=+2]
+include::modules/cert-manager-istio-creating-issuer.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -23,16 +20,16 @@ include::modules/cert-manager-istio-creating-issuer.adoc[leveloffset=+2]
 * xref:../../security/cert_manager_operator/index.adoc#cert-manager-issuer-types_cert-manager-operator-about[{cert-manager-operator} issuer providers]
 
 // Installing using Istio-CSR
-include::modules/cert-manager-istio-csr-installing.adoc[leveloffset=+2]
+include::modules/cert-manager-istio-csr-installing.adoc[leveloffset=+1]
 
 // Setting a log level for istio-csr
-include::modules/cert-manager-istio-csr-setting-log-level.adoc[leveloffset=+2]
+include::modules/cert-manager-istio-csr-setting-log-level.adoc[leveloffset=+1]
 
 // Configuring the namespace selector for CA bundle distribution
-include::modules/cert-manager-istio-csr-config-namespace-sel.adoc[leveloffset=+2]
+include::modules/cert-manager-istio-csr-config-namespace-sel.adoc[leveloffset=+1]
 
 // Configuring the CA certificate of the istio server
-include::modules/cert-manager-istio-csr-config-ca-cert.adoc[leveloffset=+2]
+include::modules/cert-manager-istio-csr-config-ca-cert.adoc[leveloffset=+1]
 
 // Uninstalling cert-manager Operator with Istio-CSR
 include::modules/cert-manager-istio-csr-uninstalling.adoc[leveloffset=+1]

--- a/security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
@@ -9,8 +9,6 @@ toc::[]
 [role="_abstract"]
 The {cert-manager-operator} supports using Automated Certificate Management Environment (ACME) CA servers, such as _Let's Encrypt_, to issue certificates. Explicit credentials are configured by specifying the secret details in the `Issuer` API object. Ambient credentials are extracted from the environment, metadata services, or local files which are not explicitly configured in the `Issuer` API object.
 
-[NOTE]
-====
 The `Issuer` object is namespace scoped. It can only issue certificates from the same namespace. You can also use the `ClusterIssuer` object to issue certificates across all namespaces in the cluster.
 
 .Example YAML file that defines the `ClusterIssuer` object
@@ -24,7 +22,6 @@ spec:
   acme:
     ...
 ----
-====
 
 [NOTE]
 ====
@@ -62,6 +59,10 @@ include::modules/cert-manager-acme-dns01-explicit-azure.adoc[leveloffset=+1]
 [id="additional-resources_cert-manager-operator-issuer-acme"]
 == Additional resources
 
+* link:https://cert-manager.io/docs/configuration/acme/dns01/azuredns/[Azure DNS]
+
+* link:https://cert-manager.io/docs/configuration/acme/dns01/google/[{gcp-full} DNS]
+
 * xref:../../security/cert_manager_operator/cert-manager-authenticate.adoc#cert-manager-configure-cloud-credentials-aws-sts_cert-manager-authenticate[Configuring cloud credentials for the {cert-manager-operator} for the AWS Security Token Service cluster]
 
 * xref:../../security/cert_manager_operator/cert-manager-authenticate.adoc#cert-manager-configure-cloud-credentials-aws-non-sts_cert-manager-authenticate[Configuring cloud credentials for the {cert-manager-operator} on AWS]
@@ -69,3 +70,9 @@ include::modules/cert-manager-acme-dns01-explicit-azure.adoc[leveloffset=+1]
 * xref:../../security/cert_manager_operator/cert-manager-authenticate.adoc#cert-manager-configure-cloud-credentials-gcp-sts_cert-manager-authenticate[Configuring cloud credentials for the {cert-manager-operator} with {gcp-short} Workload Identity]
 
 * xref:../../security/cert_manager_operator/cert-manager-authenticate.adoc#cert-manager-configure-cloud-credentials-gcp-non-sts_cert-manager-authenticate[Configuring cloud credentials for the {cert-manager-operator} on {gcp-short}]
+
+* link:https://cert-manager.io/docs/configuration/acme/http01/[HTTP01]
+
+* link:https://letsencrypt.org/docs/challenge-types/#http-01-challenge[HTTP-01 challenge]
+
+* link:https://cert-manager.io/docs/configuration/acme/dns01/[DNS01]


### PR DESCRIPTION

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18693

Link to docs preview:
https://116256--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-issuer-acme

QE review:
N/A

Additional information:
This PR is for CQA Remediation of the original JIRA: https://redhat.atlassian.net/browse/OSDOCS-17173
Associated CQA PR: https://github.com/openshift/openshift-docs/pull/104809
