### PR TITLE
OSDOCS 20866 Typo in pod disruption budget doc URL

### DIFF
--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -5,7 +5,7 @@
 // * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="nodes-pods-pod-distruption-about_{context}"]
+[id="nodes-pods-pod-disruption-about_{context}"]
 = Understanding how to use pod disruption budgets to specify the number of pods that must be up
 
 [role="_abstract"]

--- a/operators/understanding/olm/olm-operatorconditions.adoc
+++ b/operators/understanding/olm/olm-operatorconditions.adoc
@@ -19,6 +19,6 @@ include::modules/olm-supported-operatorconditions.adoc[leveloffset=+1]
 * xref:../../../operators/admin/olm-managing-operatorconditions.adoc#olm-operatorconditions[Managing Operator conditions]
 // The following xrefs point to topics that are not currently included in the OSD/ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* xref:../../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring[Using pod disruption budgets to specify the number of pods that must be up]
+* xref:../../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-disruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
 * xref:../../../applications/deployments/route-based-deployment-strategies.adoc#deployments-graceful-termination_route-based-deployment-strategies[Graceful termination]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -32,7 +32,7 @@ include::modules/telco-core-zones.adoc[leveloffset=+2]
 
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Applying MachineConfigPool labels to nodes before the update]
 
-* xref:../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-distruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
+* xref:../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-disruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
 
 * xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
 

--- a/updating/understanding_updates/understanding-openshift-update-duration.adoc
+++ b/updating/understanding_updates/understanding-openshift-update-duration.adoc
@@ -24,7 +24,7 @@ include::modules/update-duration-mco.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../../machine_configuration/index.adoc#machine-config-overview[Machine Config Overview]
-* xref:../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring[Pod disruption budget]
+* xref:../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-disruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
 
 //Example update duration of cluster Operators
 include::modules/update-duration-example.adoc[leveloffset=+2]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-20866

[Understanding how to use pod disruption budgets to specify the number of pods that must be up](https://116297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-pod-disruption-about_nodes-pods-configuring) -- Updated ID string.
Operator conditions -> [Additional resources](https://116297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-operatorconditions.html#olm-operatorconditions-addtl-resources) -- Updated link and link text to _Understanding how to use pod disruption budgets to specify the number of pods that must be up_.
Scalability and performance -> Telco core reference design specifications -> [Zones](https://116297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html#telco-core-zones_telco-core) -- Updated link to _Understanding how to use pod disruption budgets to specify the number of pods that must be up_ in module Additional Resources.
Updating clusters -> Understanding OpenShift updates -> Understanding OpenShift update duration -> [Machine Config Operator node updates](https://116297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/understanding-openshift-update-duration#additional-resources_update-duration) -- Updated link and link text to _Understanding how to use pod disruption budgets to specify the number of pods that must be up_ in module Additional Resources.
