### PR TITLE
OSDOCS-17172-user-provided-certs-for-API-server-redo CQA

### DIFF
--- a/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
+++ b/security/certificate_types_descriptions/user-provided-certificates-for-api-server.adoc
@@ -6,24 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Review user-provided TLS certificates for the API server in {product-title} to understand their purpose, location, management, and expiration for external client access.
+
+[id="user-provided-certificates-for-api-server-purpose_{context}"]
 == Purpose
 
 The API server is accessible by clients external to the cluster at `api.<cluster_name>.<base_domain>`. You might want clients to access the API server at a different hostname or without the need to distribute the cluster-managed certificate authority (CA) certificates to the clients. The administrator must set a custom default certificate to be used by the API server when serving content.
 
+[id="user-provided-certificates-for-api-server-location_{context}"]
 == Location
 
 The user-provided certificates must be provided in a `kubernetes.io/tls` type `Secret` in the `openshift-config` namespace. Update the API server cluster configuration, the `apiserver/cluster` resource, to enable the use of the user-provided certificate.
 
+[id="user-provided-certificates-for-api-server-management_{context}"]
 == Management
 
 User-provided certificates are managed by the user.
 
+[id="user-provided-certificates-for-api-server-expiration_{context}"]
 == Expiration
 
 API server client certificate expiration is less than five minutes.
 
-User-provided certificates are managed by the user.
-
+[id="user-provided-certificates-for-api-server-customization_{context}"]
 == Customization
 
 Update the secret containing the user-managed certificate as needed.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://116332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/user-provided-certificates-for-api-server.html


QE review:
- [ ] QE has approved this change.


Additional information:
This PR is a redo of PR https://github.com/openshift/openshift-docs/pull/115883. When merged that PR broke things because of incorrect xrefs.

Those xrefs were fixed in PR https://github.com/openshift/openshift-docs/pull/116244
