### PR TITLE
Switching openshift templates to use local files instead of docs.okd.io

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -16,13 +16,13 @@
 
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css"/>
-  <link href="/_stylesheets/search.css" rel="stylesheet" media="screen"/>
-  <link href="/_stylesheets/autumn.css" rel="stylesheet"  media="screen"/>
+  <link href="<%= css_path %>search.css" rel="stylesheet" media="screen"/>
+  <link href="<%= css_path %>autumn.css" rel="stylesheet"  media="screen"/>
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png"/>
   <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="text/css"/>
   <link href="https://assets.openshift.net/content/osh-nav-footer.css" rel="stylesheet" type="text/css" media="screen"/>
-  <link href="/_stylesheets/docs.css" rel="stylesheet"  media="screen"/>
-  <link href="/_stylesheets/print.css" rel="stylesheet" type="text/css" media="print"/>
+  <link href="<%= css_path %>docs.css" rel="stylesheet"  media="screen"/>
+  <link href="<%= css_path %>print.css" rel="stylesheet" type="text/css" media="print"/>
   <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
   <!-- or, set /favicon.ico for IE10 win -->
   <meta content="OpenShift" name="application-name">
@@ -567,13 +567,13 @@
   <script src="https://assets.openshift.net/content/modernizr.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/nav-tertiary.js" type="text/javascript"></script>
-  <script src="/_javascripts/bootstrap-offcanvas.js" type="text/javascript"></script>
-  <script src="/_javascripts/reformat-html.js" type="text/javascript"></script>
-  <script src="/_javascripts/hc-search.js" type="text/javascript"></script>
-  <script src="/_javascripts/page-loader.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>bootstrap-offcanvas.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>reformat-html.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>hc-search.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>page-loader.js" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
-  <script src="/_javascripts/clipboard.js" type="text/javascript"></script>
-  <script src="/_javascripts/collapsible.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>clipboard.js" type="text/javascript"></script>
+  <script src="<%= javascripts_path %>collapsible.js" type="text/javascript"></script>
   <script>
   var dk = '<%= distro_key %>';
   var version = '<%= version %>';

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -16,13 +16,13 @@
 
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css"/>
-  <link href="https://docs.okd.io/latest/_stylesheets/search.css" rel="stylesheet" media="screen"/>
-  <link href="https://docs.okd.io/latest/_stylesheets/autumn.css" rel="stylesheet"  media="screen"/>
+  <link href="/_stylesheets/search.css" rel="stylesheet" media="screen"/>
+  <link href="/_stylesheets/autumn.css" rel="stylesheet"  media="screen"/>
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png"/>
   <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="text/css"/>
   <link href="https://assets.openshift.net/content/osh-nav-footer.css" rel="stylesheet" type="text/css" media="screen"/>
-  <link href="https://docs.okd.io/latest/_stylesheets/docs.css" rel="stylesheet"  media="screen"/>
-  <link href="https://docs.okd.io/latest/_stylesheets/print.css" rel="stylesheet" type="text/css" media="print"/>
+  <link href="/_stylesheets/docs.css" rel="stylesheet"  media="screen"/>
+  <link href="/_stylesheets/print.css" rel="stylesheet" type="text/css" media="print"/>
   <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
   <!-- or, set /favicon.ico for IE10 win -->
   <meta content="OpenShift" name="application-name">
@@ -567,13 +567,13 @@
   <script src="https://assets.openshift.net/content/modernizr.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/nav-tertiary.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/bootstrap-offcanvas.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/reformat-html.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/hc-search.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/page-loader.js" type="text/javascript"></script>
+  <script src="/_javascripts/bootstrap-offcanvas.js" type="text/javascript"></script>
+  <script src="/_javascripts/reformat-html.js" type="text/javascript"></script>
+  <script src="/_javascripts/hc-search.js" type="text/javascript"></script>
+  <script src="/_javascripts/page-loader.js" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/clipboard.js" type="text/javascript"></script>
-  <script src="https://docs.okd.io/latest/_javascripts/collapsible.js" type="text/javascript"></script>
+  <script src="/_javascripts/clipboard.js" type="text/javascript"></script>
+  <script src="/_javascripts/collapsible.js" type="text/javascript"></script>
   <script>
   var dk = '<%= distro_key %>';
   var version = '<%= version %>';


### PR DESCRIPTION
Updating the openshift template to use local files instead of files hosted on docs.okd.io.

Preview:
https://116337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/