### PR TITLE
[enterprise-4.15] OSDOCS 20866 Typo in pod disruption budget doc URL

### DIFF
--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -5,7 +5,7 @@
 // * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="nodes-pods-pod-distruption-about_{context}"]
+[id="nodes-pods-pod-disruption-about_{context}"]
 = Understanding how to use pod disruption budgets to specify the number of pods that must be up
 
 A _pod disruption budget_ allows the specification of safety constraints on pods during operations, such as draining a node for maintenance.

--- a/operators/understanding/olm/olm-operatorconditions.adoc
+++ b/operators/understanding/olm/olm-operatorconditions.adoc
@@ -19,6 +19,6 @@ include::modules/olm-supported-operatorconditions.adoc[leveloffset=+1]
 * xref:../../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-operatorconditions_osdk-generating-csvs[Enabling Operator conditions]
 // The following xrefs point to topics that are not currently included in the OSD/ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa[]
-* xref:../../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring[Using pod disruption budgets to specify the number of pods that must be up]
+* xref:../../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-disruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
 * xref:../../../applications/deployments/route-based-deployment-strategies.adoc#deployments-graceful-termination_route-based-deployment-strategies[Graceful termination]
 endif::openshift-dedicated,openshift-rosa[]

--- a/updating/understanding_updates/understanding-openshift-update-duration.adoc
+++ b/updating/understanding_updates/understanding-openshift-update-duration.adoc
@@ -34,7 +34,7 @@ include::modules/update-duration-mco.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview]
-* xref:../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring[Pod disruption budget]
+* xref:../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-pod-disruption-about_nodes-pods-configuring[Understanding how to use pod disruption budgets to specify the number of pods that must be up]
 
 //Example update duration of cluster Operators
 include::modules/update-duration-example.adoc[leveloffset=+2]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/116297