### PR TITLE
OSDOCS-16959-config-basic-auth CQA

### DIFF
--- a/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `basic-authentication` identity provider for users to log in to {product-title} with credentials validated against a remote identity provider. Basic authentication is a generic back-end integration mechanism.
+[role="_abstract"]
+Configure the `basic-authentication` identity provider. Users can log in to {product-title} with credentials validated against a remote authentication service, without maintaining a separate user store in the cluster.
 
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
 
@@ -22,7 +23,7 @@ include::modules/identity-provider-basic-authentication-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 

--- a/modules/example-apache-httpd-configuration.adoc
+++ b/modules/example-apache-httpd-configuration.adoc
@@ -6,11 +6,12 @@
 [id="example-apache-httpd-configuration_{context}"]
 = Example Apache HTTPD configuration for basic identity providers
 
-The basic identify provider (IDP) configuration in {product-title} 4 requires
-that the IDP server respond with JSON for success and failures. You can use CGI
-scripting in Apache HTTPD to accomplish this. This section provides examples.
+[role="_abstract"]
+You can use CGI scripting in Apache HTTPD to configure a remote authentication server that returns JSON responses for basic identity providers in {product-title}.
 
-.Example `/etc/httpd/conf.d/login.conf`
+The following is an example of an Apache `VirtualHost` configuration file.
+
+[source,conf]
 ----
 <VirtualHost *:443>
   # CGI Scripts in here
@@ -40,7 +41,9 @@ scripting in Apache HTTPD to accomplish this. This section provides examples.
 </VirtualHost>
 ----
 
-.Example `/var/www/cgi-bin/login.cgi`
+The following is an example of a `login.cgi` CGI script file.
+
+[source,bash]
 ----
 #!/bin/bash
 echo "Content-Type: application/json"
@@ -49,7 +52,9 @@ echo '{"sub":"userid", "name":"'$REMOTE_USER'"}'
 exit 0
 ----
 
-.Example `/var/www/cgi-bin/fail.cgi`
+The following is an example of a `fail.cgi` CGI script file.
+
+[source,bash]
 ----
 #!/bin/bash
 echo "Content-Type: application/json"
@@ -60,14 +65,9 @@ exit 0
 
 == File requirements
 
-These are the requirements for the files you create on an Apache HTTPD web
-server:
+These are the requirements for the files you create on an Apache HTTPD web server:
 
-* `login.cgi` and `fail.cgi` must be executable (`chmod +x`).
-* `login.cgi` and `fail.cgi` must have proper SELinux contexts if SELinux is
-enabled: `restorecon -RFv /var/www/cgi-bin`, or ensure that the context is
-`httpd_sys_script_exec_t` using `ls -laZ`.
-* `login.cgi` is only executed if your user successfully logs in per `Require
-and Auth` directives.
-* `fail.cgi` is executed if the user fails to log in, resulting in an `HTTP 401`
-response.
+* The `login.cgi` and `fail.cgi` CGI script files must be executable. Use the `chmod +x` command on both files.
+* If SELinux is enabled, the `login.cgi` and `fail.cgi` CGI script files must have proper SELinux security contexts. Run the `restorecon -RFv /var/www/cgi-bin` command, or ensure that the context is the `httpd_sys_script_exec_t` SELinux type by using the `ls -laZ` command.
+* The `login.cgi` CGI script file runs only when the user successfully logs in according to the `Require` and `Auth` Apache configuration directives.
+* The `fail.cgi` CGI script file runs when the user fails to log in and returns an `HTTP 401` HTTP status code.

--- a/modules/identity-provider-about-basic-authentication.adoc
+++ b/modules/identity-provider-about-basic-authentication.adoc
@@ -6,39 +6,30 @@
 [id="identity-provider-about-basic-authentication_{context}"]
 = About basic authentication
 
-Basic authentication is a generic back-end integration mechanism that allows
-users to log in to {product-title} with credentials validated against a remote
-identity provider.
+[role="_abstract"]
+Configure basic authentication to validate user credentials against a remote service over HTTP. Use this integration when you need a flexible back-end for username and password login in {product-title}.
 
-Because basic authentication is generic, you can use this identity
-provider for advanced authentication configurations.
+Basic authentication is a generic back-end integration mechanism that allows users to log in to {product-title} with credentials validated against a remote identity provider.
+
+Because basic authentication is generic, you can use this identity provider for advanced authentication configurations.
 
 [IMPORTANT]
 ====
-Basic authentication must use an HTTPS connection to the remote server to
-prevent potential snooping of the user ID and password and man-in-the-middle
-attacks.
+Basic authentication must use an HTTPS connection to the remote server to prevent potential snooping of the user ID and password and man-in-the-middle attacks.
 ====
 
-With basic authentication configured, users send their user name
-and password to {product-title}, which then validates those credentials against
-a remote server by making a server-to-server request, passing the credentials as
-a basic authentication header. This requires users to send their credentials to
-{product-title} during login.
+With basic authentication configured, users send their username and password to {product-title} during login. {product-title} validates those credentials against a remote server. {product-title} makes a server-to-server request, passing the credentials as a basic authentication header.
 
 [NOTE]
 ====
-This only works for user name/password login mechanisms, and {product-title} must
-be able to make network requests to the remote authentication server.
+This only works for username and password login mechanisms, and {product-title} must be able to make network requests to the remote authentication server.
 ====
 
-User names and passwords are validated against a remote URL that is protected
-by basic authentication and returns JSON.
+Usernames and passwords are validated against a remote URL that is protected by basic authentication and returns JSON.
 
 A `401` response indicates failed authentication.
 
-A non-`200` status, or the presence of a non-empty "error" key, indicates an
-error:
+A non-`200` status, or the presence of a non-empty "error" key, indicates an error:
 
 [source,terminal]
 ----
@@ -49,10 +40,12 @@ A `200` status with a `sub` (subject) key indicates success:
 
 [source,terminal]
 ----
-{"sub":"userid"} <1>
+{"sub":"userid"}
 ----
-<1> The subject must be unique to the authenticated user and must not be able to
-be modified.
+
+where:
+
+`userid`:: Specifies a value that is unique to the authenticated user and must not be modified.
 
 A successful response can optionally provide additional data, such as:
 
@@ -70,12 +63,10 @@ A successful response can optionally provide additional data, such as:
 {"sub":"userid", "email":"user@example.com", ...}
 ----
 +
-* A preferred user name using the `preferred_username` key. This is useful when
-the unique, unchangeable subject is a database key or UID, and a more
-human-readable name exists. This is used as a hint when provisioning the
-{product-title} user for the authenticated identity. For example:
+* A preferred username using the `preferred_username` key. This is useful when the unique, unchangeable subject is a database key or UID, and a more human-readable name exists. This is used as a hint when provisioning the {product-title} user for the authenticated identity. For example:
 +
 [source,terminal]
 ----
 {"sub":"014fbff9a07c", "preferred_username":"bob", ...}
 ----
+

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -30,7 +30,7 @@ endif::[]
 = Adding an identity provider to your cluster
 
 [role="_abstract"]
-Apply the OAuth custom resource (CR) to add an identity provider to your cluster so users can authenticate with external credentials instead of the default `kubeadmin` user.
+Apply the identity provider custom resource (CR) to your cluster so users can authenticate with the configured identity provider.
 
 .Prerequisites
 
@@ -53,7 +53,7 @@ If a CR does not exist, `oc apply` creates a new CR and might trigger the follow
 ====
 
 ifndef::no-username-password-login[]
-. Log in to the cluster as a user from your identity provider by running the following command, which prompts for your username and password:
+. Log in to the cluster with credentials from the configured identity provider by running the following command. Enter the password when prompted:
 +
 [source,terminal]
 ----
@@ -69,7 +69,7 @@ As long as the `kubeadmin` user has been removed, the `oc login` command provide
 +
 You can also access this page from the web console by navigating to *(?) Help* -> *Command Line Tools* -> *Copy Login Command*.
 
-. Log in to the cluster by running the following command, passing in the token to authenticate:
+. Log in to the cluster by running the following command and pass in the token to authenticate:
 +
 [source,terminal]
 ----
@@ -81,7 +81,7 @@ $ oc login --token=<token>
 ifdef::oidc[]
 If your OpenID Connect identity provider supports the resource owner password credentials (ROPC) grant flow, you can log in with a username and password. You might need to take steps to enable the ROPC grant flow for your identity provider.
 
-After the OIDC identity provider is configured in {product-title}, you can log in by running the following command, which prompts for your username and password:
+After the OIDC identity provider is configured in {product-title}, you can log in by using the following command, which prompts for your username and password:
 
 [source,terminal]
 ----

--- a/modules/identity-provider-basic-authentication-CR.adoc
+++ b/modules/identity-provider-basic-authentication-CR.adoc
@@ -4,12 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="identity-provider-basic-authentication-CR_{context}"]
-= Sample basic authentication CR
+= Sample basic authentication custom resource
 
-The following custom resource (CR) shows the parameters and acceptable values for a
-basic authentication identity provider.
-
-.Basic authentication CR
+[role="_abstract"]
+You can configure basic authentication for your cluster by applying an `OAuth` custom resource (CR) with a `BasicAuth` identity provider. Use this sample to review provider parameters and acceptable values before you connect to your remote authentication server.
 
 [source,yaml]
 ----
@@ -19,26 +17,27 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: basicidp <1>
-    mappingMethod: claim <2>
+  - name: basicidp
+    mappingMethod: claim
     type: BasicAuth
     basicAuth:
-      url: https://www.example.com/remote-idp <3>
-      ca: <4>
+      url: https://www.example.com/remote-idp
+      ca:
         name: ca-config-map
-      tlsClientCert: <5>
+      tlsClientCert:
         name: client-cert-secret
-      tlsClientKey: <6>
+      tlsClientKey:
         name: client-key-secret
 ----
-<1> This provider name is prefixed to the returned user ID to form an identity
+
+where:
+
+`spec.identityProviders.name`:: Specifies that the provider name is prefixed to the returned user ID to form an identity
 name.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> URL accepting credentials in Basic authentication headers.
-<4> Optional: Reference to an {product-title} `ConfigMap` object containing the
-PEM-encoded certificate authority bundle to use in validating server
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between the identities of this provider and `User` objects.
+`spec.identityProviders.basicAuth.url`:: Specifies the URL that accepts credentials in Basic authentication headers.
+`spec.identityProviders.basicAuth.ca`:: Optional: Specifies a reference to an {product-title} `ConfigMap` object containing the Privacy-Enhanced Mail (PEM)-encoded certificate authority bundle to use in validating server
 certificates for the configured URL.
-<5> Optional: Reference to an {product-title} `Secret` object containing the client
-certificate to present when making requests to the configured URL.
-<6> Reference to an {product-title} `Secret` object containing the key for the
-client certificate. Required if `tlsClientCert` is specified.
+`spec.identityProviders.basicAuth.tlsClientCert`:: Optional: Specifies a reference to an {product-title} `Secret` object containing the client certificate to present when making requests to the configured URL.
+`spec.identityProviders.basicAuth.tlsClientKey`:: Specifies a reference to an {product-title} `Secret` object containing the key for the client certificate. Required if `tlsClientCert` is specified.
+

--- a/modules/identity-provider-basic-authentication-troubleshooting.adoc
+++ b/modules/identity-provider-basic-authentication-troubleshooting.adoc
@@ -4,32 +4,36 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="identity-provider-basic-authentication-troubleshooting_{context}"]
-= Basic authentication troubleshooting
+= Troubleshooting basic authentication
 
-The most common issue relates to network connectivity to the backend server. For
-simple debugging, run `curl` commands on the master. To test for a successful
-login, replace the `<user>` and `<password>` in the following example command
-with valid credentials. To test an invalid login, replace them with false
-credentials.
+[role="_abstract"]
+Troubleshoot basic authentication by testing backend connectivity and verifying JSON login responses when users cannot authenticate in {product-title}.
 
+The most common issue relates to network connectivity to the backend server. To debug connectivity, run `curl` commands on a control plane node.
+
+.Procedure
+
+. To test successful and unsuccessful logins, replace the `<user>` and `<password>` in the following example command with valid or invalid credentials:
++
 [source,terminal]
 ----
 $ curl --cacert /path/to/ca.crt --cert /path/to/client.crt --key /path/to/client.key -u <user>:<password> -v https://www.example.com/remote-idp
 ----
 
-*Successful responses*
-
+. Review successful login responses.
++
 A `200` status with a `sub` (subject) key indicates success:
-
++
 [source,terminal]
 ----
 {"sub":"userid"}
 ----
-The subject must be unique to the authenticated user, and must not be able to
-be modified.
-
++
+The subject must be unique to the authenticated user and must not be modified.
++
 A successful response can optionally provide additional data, such as:
-
++
+--
 * A display name using the `name` key:
 +
 [source,terminal]
@@ -42,20 +46,17 @@ A successful response can optionally provide additional data, such as:
 ----
 {"sub":"userid", "email":"user@example.com", ...}
 ----
-* A preferred user name using the `preferred_username` key:
+* A preferred username using the `preferred_username` key:
 +
 [source,terminal]
 ----
 {"sub":"014fbff9a07c", "preferred_username":"bob", ...}
 ----
+--
 +
-The `preferred_username` key is useful when
-the unique, unchangeable subject is a database key or UID, and a more
-human-readable name exists. This is used as a hint when provisioning the
-{product-title} user for the authenticated identity.
+The `preferred_username` key is useful when the unique, unchangeable subject is a database key or UID, and a more human-readable name exists. This is used as a hint when provisioning the {product-title} user for the authenticated identity.
 
-*Failed responses*
-
-- A `401` response indicates failed authentication.
-- A non-`200` status or the presence of a non-empty "error" key indicates an
-error: `{"error":"Error message"}`
+. Review failed login responses.
++
+* A `401` response indicates failed authentication.
+* A non-`200` status or the presence of a non-empty "error" key indicates an error: `{"error":"Error message"}`

--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -13,11 +13,10 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="identity-provider-creating-configmap_{context}"]
-= Creating a config map
+= Creating a 'ConfigMap'
 
-Identity providers use {product-title} `ConfigMap` objects in the `openshift-config`
-namespace to contain the certificate authority bundle. These are primarily
-used to contain certificate bundles needed by the identity provider.
+[role="_abstract"]
+Create a `ConfigMap` object in the `openshift-config` namespace to store the certificate authority bundle that identity providers use to validate secure connections to the remote authentication service.
 
 ifdef::github[]
 [NOTE]
@@ -28,19 +27,15 @@ endif::github[]
 
 .Procedure
 
-* Define an {product-title} `ConfigMap` object containing the
-certificate authority by using the following command. The certificate
-authority must be stored in the `ca.crt` key of the `ConfigMap` object.
+. Define an {product-title} `ConfigMap` object containing the certificate authority by running the following command:
 +
 [source,terminal]
 ----
 $ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config
 ----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to create the config map:
 
+. Optional: Apply the following YAML to create the config map:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -52,7 +47,8 @@ data:
   ca.crt: |
     <CA_certificate_PEM>
 ----
-====
++
+The certificate authority must be stored in the `ca.crt` key of the `ConfigMap` object.
 
 // Undefining attributes
 ifeval::["{context}" == "configuring-google-identity-provider"]

--- a/modules/identity-provider-secret-tls.adoc
+++ b/modules/identity-provider-secret-tls.adoc
@@ -7,21 +7,20 @@
 [id="identity-provider-creating-secret-tls_{context}"]
 = Creating the secret
 
-Identity providers use {product-title} `Secret` objects in the `openshift-config` namespace to contain the client secret, client certificates, and keys.
+[role="_abstract"]
+You can create a TLS `Secret` object in the `openshift-config` namespace by using the `oc` CLI or by applying a YAML file to store client certificates and keys that identity providers require for secure communication.
 
 .Procedure
 
-* Create a `Secret` object that contains the key and certificate by using the following command:
+. Create a `Secret` object that contains the key and certificate by running the following command:
 +
 [source,terminal]
 ----
 $ oc create secret tls <secret_name> --key=key.pem --cert=cert.pem -n openshift-config
 ----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to create the secret:
 
+. Optional: Apply the following YAML to create the secret:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -34,4 +33,3 @@ data:
   tls.crt: <base64_encoded_cert>
   tls.key: <base64_encoded_key>
 ----
-====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16959

Link to docs preview:
https://116367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-basic-authentication-identity-provider.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
