### PR TITLE
OBSDOCS-3154: Add namespace and managementState to TempoStack forwarding example

### DIFF
--- a/modules/otel-forwarding-traces.adoc
+++ b/modules/otel-forwarding-traces.adoc
@@ -27,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: otel-collector-deployment
+  namespace: otel-collector-example
 ----
 
 . Create a cluster role for the service account.
@@ -86,8 +87,10 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: otel
+  namespace: otel-collector-example
 spec:
   mode: deployment
+  managementState: managed
   serviceAccount: otel-collector-deployment
   config:
     receivers:


### PR DESCRIPTION
## Summary
- Fixes [OBSDOCS-3154](https://redhat.atlassian.net/browse/OBSDOCS-3154) in the Forwarding traces to a TempoStack instance example.
- Adds `namespace: otel-collector-example` to the `ServiceAccount` and `OpenTelemetryCollector` examples so they match the existing `ClusterRoleBinding`.
- Adds `spec.managementState: managed` to the `OpenTelemetryCollector` CR to resolve the console YAML schema error (`Missing property "managementState"`).

## Test plan
- [x] Confirm the updated YAML in `modules/otel-forwarding-traces.adoc` pastes into the OpenShift console without schema errors
- [x] Confirm namespace values are consistent across ServiceAccount, ClusterRoleBinding, and OpenTelemetryCollector
- [x] Preview the Forwarding telemetry assembly if applicable