### PR TITLE
TELCODOCS-2935: Remove KCS 7090422 link from firewall docs

### DIFF
--- a/installing/install_config/configuring-firewall.adoc
+++ b/installing/install_config/configuring-firewall.adoc
@@ -34,7 +34,6 @@ include::modules/commatrix-restricting-ingress-traffic.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Minimizing node disruption with MachineConfig changes]
-* link:https://access.redhat.com/articles/7090422[Custom nftables firewall rules in OpenShift]
 
 include::modules/commatrix-generate-butane.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2935

Link to docs preview:
https://116414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#commatrix-restricting-ingress-traffic_configuring-firewall

QE review:
Small fix. No QE review needed.

Additional information:
Removes the Additional resources link to KCS 7090422 ("Custom nftables firewall rules in OpenShift") from the configuring firewall assembly. The link created a circular reference between the KCS and the documentation; the OCP docs are the source of truth. This was the only reference to KCS 7090422 in the repository.