### PR TITLE
TELCODOCS-2935: Remove KCS 7090422 link from firewall docs [4.22]

### DIFF
--- a/installing/install_config/configuring-firewall.adoc
+++ b/installing/install_config/configuring-firewall.adoc
@@ -34,7 +34,6 @@ include::modules/commatrix-restricting-ingress-traffic.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Minimizing node disruption with MachineConfig changes]
-* link:https://access.redhat.com/articles/7090422[Custom nftables firewall rules in OpenShift]
 
 include::modules/commatrix-generate-butane.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/openshift/openshift-docs/pull/116414 to `enterprise-4.22`
- Remove the Additional resources link to KCS 7090422 from `installing/install_config/configuring-firewall.adoc` so 4.22 docs are not circular with the KCS

## Test plan
- [ ] Confirm the KCS link is gone from the published 4.22 configuring-firewall Additional resources
- [ ] Confirm the MachineConfig node disruption xref remains
- [ ] `git grep 7090422` returns no matches on this branch

Jira: https://redhat.atlassian.net/browse/TELCODOCS-2935

Made with [Cursor](https://cursor.com)