### PR TITLE
OSDOCS-16959-ldap-sync configure identity CQA

### DIFF
--- a/authentication/identity_providers/configuring-ldap-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-ldap-identity-provider.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `ldap` identity provider to validate user names and passwords against an LDAPv3 server, using simple bind authentication.
+[role="_abstract"]
+Configure an LDAP identity provider so users can log in to {product-title} with usernames and passwords validated against your LDAPv3 directory.
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
@@ -26,7 +27,7 @@ include::modules/identity-provider-ldap-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 

--- a/modules/identity-provider-about-ldap.adoc
+++ b/modules/identity-provider-about-ldap.adoc
@@ -6,25 +6,21 @@
 [id="identity-provider-about-ldap_{context}"]
 = About LDAP authentication
 
-During authentication, the LDAP directory is searched for an entry that matches
-the provided user name. If a single unique match is found, a simple bind is
-attempted using the distinguished name (DN) of the entry plus the provided
+[role="_abstract"]
+Review how usernames and passwords are validated against the LDAP directory so you can configure the LDAP identity provider correctly.
+
+During authentication, the LDAP directory is searched for an entry that matches the provided username. If a single unique match is found, a simple bind is attempted using the distinguished name (DN) of the entry plus the provided
 password.
 
-These are the steps taken:
+LDAP authentication uses the following process:
 
-. Generate a search filter by combining the attribute and filter in the
-configured `url` with the user-provided user name.
-. Search the directory using the generated filter. If the search does not return
-exactly one entry, deny access.
-. Attempt to bind to the LDAP server using the DN of the entry retrieved from
-the search, and the user-provided password.
-. If the bind is unsuccessful, deny access.
-. If the bind is successful, build an identity using the configured attributes
-as the identity, email address, display name, and preferred user name.
+. Generates a search filter by combining the attribute and filter in the configured `url` with the user-provided username.
+. Searches the directory using the generated filter. Denies access if the search does not return exactly one entry.
+. Attempts to bind to the LDAP server using the DN of the entry retrieved from the search, and the user-provided password.
+. Denies access if the bind is unsuccessful.
+. Builds an identity using the configured attributes as the identity, email address, display name, and preferred username if the bind is successful.
 
-The configured `url` is an RFC 2255 URL, which specifies the LDAP host and
-search parameters to use. The syntax of the URL is:
+The configured `url` is an RFC 2255 URL, which specifies the LDAP host and search parameters to use. The syntax of the URL is:
 
 ----
 ldap://host:port/basedn?attribute?scope?filter
@@ -38,23 +34,22 @@ For this URL:
 .^|`ldap`      | For regular LDAP, use the string `ldap`. For secure LDAP
 (LDAPS), use `ldaps` instead.
 .^|`host:port` | The name and port of the LDAP server. Defaults to
-`localhost:389` for ldap and `localhost:636` for LDAPS.
+`localhost:389` for LDAP and `localhost:636` for LDAPS.
 .^|`basedn`    | The DN of the branch of the directory where all searches should
 start from. At the very least, this must be the top of your directory tree, but
 it could also specify a subtree in the directory.
 .^|`attribute` | The attribute to search for. Although RFC 2255 allows a
-comma-separated list of attributes, only the first attribute will be used, no
+comma-separated list of attributes, only the first attribute is used, no
 matter how many are provided. If no attributes are provided, the default is to
-use `uid`. It is recommended to choose an attribute that will be unique across
-all entries in the subtree you will be using.
+use `uid`. It is recommended to choose an attribute that is unique across
+all entries in the subtree you are using.
 .^|`scope`     | The scope of the search. Can be either `one` or `sub`.
 If the scope is not provided, the default is to use a scope of `sub`.
 .^|`filter`    | A valid LDAP search filter. If not provided, defaults to
 `(objectClass=*)`
 |===
 
-When doing searches, the attribute, filter, and provided user name are combined
-to create a search filter that looks like:
+During a search, the attribute and filter from the configured `url` are combined with the user-provided username to create a search filter in the following format:
 
 ----
 (&(<filter>)(<attribute>=<username>))
@@ -66,8 +61,6 @@ For example, consider a URL of:
 ldap://ldap.example.com/o=Acme?cn?sub?(enabled=true)
 ----
 
-When a client attempts to connect using a user name of `bob`, the resulting
-search filter will be `(&(enabled=true)(cn=bob))`.
+When a client attempts to connect using username `bob`, the resulting search filter is `(&(enabled=true)(cn=bob))`.
 
-If the LDAP directory requires authentication to search, specify a `bindDN` and
-`bindPassword` to use to perform the entry search.
+If the LDAP directory requires authentication to search, specify a `bindDN` and `bindPassword` to use to perform the entry search.

--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -21,7 +21,7 @@ Create a `ConfigMap` object in the `openshift-config` namespace to store the cer
 ifdef::github[]
 [NOTE]
 ====
-This procedure is only required for GitHub Enterprise.
+This procedure is required only for GitHub Enterprise.
 ====
 endif::github[]
 

--- a/modules/identity-provider-ldap-CR.adoc
+++ b/modules/identity-provider-ldap-CR.adoc
@@ -4,12 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="identity-provider-ldap-CR_{context}"]
-= Sample LDAP CR
+= Sample LDAP custom resource
 
-The following custom resource (CR) shows the parameters and acceptable values for an
-LDAP identity provider.
-
-.LDAP CR
+[role="_abstract"]
+Review the sample LDAP custom resource (CR) and acceptable parameter values so you can configure attribute mappings, bind credentials, and connection settings for the LDAP identity provider.
 
 [source,yaml]
 ----
@@ -19,56 +17,44 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: ldapidp <1>
-    mappingMethod: claim <2>
+  - name: ldapidp
+    mappingMethod: claim
     type: LDAP
     ldap:
       attributes:
-        id: <3>
+        id:
         - dn
-        email: <4>
+        email:
         - mail
-        name: <5>
+        name:
         - cn
-        preferredUsername: <6>
+        preferredUsername:
         - uid
-      bindDN: "" <7>
-      bindPassword: <8>
+      bindDN: ""
+      bindPassword:
         name: ldap-secret
-      ca: <9>
+      ca:
         name: ca-config-map
-      insecure: false <10>
-      url: "ldaps://ldaps.example.com/ou=users,dc=acme,dc=com?uid" <11>
+      insecure: false
+      url: "ldaps://ldaps.example.com/ou=users,dc=acme,dc=com?uid"
 ----
-<1> This provider name is prefixed to the returned user ID to form an identity
-name.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> List of attributes to use as the identity. First non-empty attribute is
-used. At least one attribute is required. If none of the listed attribute
-have a value, authentication fails. Defined attributes are retrieved as raw,
-allowing for binary values to be used.
-<4> List of attributes to use as the email address. First non-empty
-attribute is used.
-<5> List of attributes to use as the display name. First non-empty
-attribute is used.
-<6> List of attributes to use as the preferred user name when provisioning a
-user for this identity. First non-empty attribute is used.
-<7> Optional DN to use to bind during the search phase. Must be set if
-`bindPassword` is defined.
-<8> Optional reference to an {product-title} `Secret` object containing the bind
+
+where:
+
+`spec.identityProviders.name`:: Specifies the provider name. The provider name is prefixed to the returned user ID to form an identity
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between the identities of this provider and `User` objects.
+`spec.identityProviders.ldap.attributes.id`:: Specifies the list of attributes to use as the identity. The first non-empty attribute is used. At least one attribute is required. If none of the listed attributes have a value, authentication fails. Defined attributes are retrieved as raw, allowing binary values to be used.
+`spec.identityProviders.ldap.attributes.email`:: Specifies the list of attributes to use as the email address. The first non-empty attribute is used.
+`spec.identityProviders.ldap.attributes.name`:: Specifies the list of attributes to use as the display name. The first non-empty attribute is used.
+`spec.identityProviders.ldap.attributes.preferredUsername`:: Specifies the list of attributes to use as the preferred username when provisioning a user for this identity. The first non-empty attribute is used.
+`spec.identityProviders.ldap.bindDN`:: Specifies the optional DN to use to bind during the search phase. Must be set if `bindPassword` is defined.
+`spec.identityProviders.ldap.bindPassword`:: Specifies an optional reference to an {product-title} `Secret` object containing the bind
 password. Must be set if `bindDN` is defined.
-<9> Optional: Reference to an {product-title} `ConfigMap` object containing the
-PEM-encoded certificate authority bundle to use in validating server
-certificates for the configured URL. Only used when `insecure` is `false`.
-<10> When `true`, no TLS connection is made to the server. When `false`,
-`ldaps://` URLs connect using TLS, and `ldap://` URLs are upgraded to TLS.
-This must be set to `false` when `ldaps://` URLs are in use, as these
-URLs always attempt to connect using TLS.
-<11> An RFC 2255 URL which specifies the LDAP host and search parameters to use.
+`spec.identityProviders.ldap.ca`:: Specifies an optional reference to an {product-title} `ConfigMap` object containing the Privacy-Enhanced Mail (PEM)-encoded certificate authority bundle to use in validating server certificates for the configured URL. Only used when `insecure` is `false`.
+`spec.identityProviders.ldap.insecure`:: Specifies whether a TLS connection is made to the server. When `true`, no TLS connection is made to the server. When `false`, `ldaps://` URLs connect using TLS, and `ldap://` URLs are upgraded to TLS. This must be set to `false` when `ldaps://` URLs are in use, as these URLs always attempt to connect using TLS.
+`spec.identityProviders.ldap.url`:: Specifies an RFC 2255 URL for the LDAP host and search parameters to use.
 
 [NOTE]
 ====
-To whitelist users for an LDAP integration, use the `lookup` mapping method.
-Before a login from LDAP would be allowed, a cluster administrator must create
-an `Identity` object and a `User` object for each LDAP user.
+To allowlist users for an LDAP integration, use the `lookup` mapping method. Before a login from LDAP is allowed, a cluster administrator must create an `Identity` object and a `User` object for each LDAP user.
 ====

--- a/modules/identity-provider-ldap-secret.adoc
+++ b/modules/identity-provider-ldap-secret.adoc
@@ -6,22 +6,24 @@
 [id="identity-provider-creating-ldap-secret_{context}"]
 = Creating the LDAP secret
 
-To use the identity provider, you must define an {product-title} `Secret` object that contains the `bindPassword` field.
+[role="_abstract"]
+Create a secret that contains the LDAP bind password in the `openshift-config` namespace so the identity provider can authenticate to the directory.
 
 .Procedure
 
-* Create a `Secret` object that contains the `bindPassword` field:
+* Create a `Secret` object that contains the `bindPassword` field by running the following command:
 +
 [source,terminal]
 ----
-$ oc create secret generic ldap-secret --from-literal=bindPassword=<secret> -n openshift-config <1>
+$ oc create secret generic ldap-secret --from-literal=bindPassword=<secret> -n openshift-config
 ----
-<1> The secret key containing the bindPassword for the `--from-literal` argument must be called `bindPassword`.
 +
-[TIP]
-====
-You can alternatively apply the following YAML to create the secret:
+where:
 
+`<secret>`:: Specifies the LDAP bind password value for the `--from-literal` argument. The key name must be `bindPassword`.
+
+* Alternatively, apply the following YAML to create the secret:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -33,4 +35,3 @@ type: Opaque
 data:
   bindPassword: <base64_encoded_bind_password>
 ----
-====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16959

Link to docs preview:
https://116416--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-ldap-identity-provider.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This work was for configuring the LDAP identity provider not the LDAP sync
