### PR TITLE
OSDOCS-19342: adds MCP isolated deployment to docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -59,6 +59,8 @@ Distros: rhcl
 Topics:
 - Name: Install MCP gateway
   File: mcp-gateway-install
+- Name: Deploy isolated MCP gateway instances
+  File: mcp-gateway-isolated-deployment
 ---
 Name: Deploy Red Hat Connectivity Link
 Dir: deployment
@@ -126,6 +128,8 @@ Distros: rhcl
 Topics:
 - Name: Troubleshoot MCP gateway
   File: mcp-gateway-troubleshooting
+- Name: Troubleshoot isolated MCP gateway deployments
+  File: mcp-gateway-ts-isolated-deployment
 ---
 Name: Get support
 Dir: support

--- a/mcp_gateway_install/mcp-gateway-install.adoc
+++ b/mcp_gateway_install/mcp-gateway-install.adoc
@@ -2,7 +2,7 @@
 include::_attributes/attributes.adoc[]
 [id="mcp-gateway-install"]
 = Install and configure {mcpg}
-:context: mcp-gateway-get-install
+:context: mcp-gateway-install
 
 toc::[]
 
@@ -34,3 +34,10 @@ include::modules/con-mcp-gateway-dns-management.adoc[leveloffset=+1]
 include::modules/proc-mcp-gateway-custom-route.adoc[leveloffset=+1]
 
 include::modules/proc-mcp-gateway-config-verify.adoc[leveloffset=+1]
+
+[id="additional-resources_mcp-gateway-install"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Register on-premise MCP servers]
+* xref:../mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc#mcp-gateway-register-ext-mcp-servers[Register external MCP servers]

--- a/mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
+++ b/mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="mcp-gateway-isolated-deployment"]
+= Deploy isolated {mcpg} instances
+:context: mcp-gateway-isolated-deployment
+
+toc::[]
+
+[role="_abstract"]
+You can deploy multiple {mcpg} instances within a single cluster to isolate traffic between teams. Each instance uses a single `MCPGatewayExtension` custom resource (CR) to manage associated MCP servers.
+
+:FeatureName: {mcpg}
+
+include::snippets/technology-preview.adoc[]
+
+include::modules/con-mcp-gateway-isolated-deployment.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-deploy-isolated-instances.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-expose-isolated-instances.adoc[leveloffset=+1]
+
+[id="additional-resources_mcp-gateway-isolated-deployment"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../troubleshoot/mcp-gateway-ts-isolated-deployment.adoc#mcp-gateway-ts-isolated-deployment[Troubleshoot isolated {mcpg} deployments]
+* xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Register on-premise MCP servers]
+* xref:../mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc#mcp-gateway-register-ext-mcp-servers[Register external MCP servers]

--- a/modules/con-mcp-gateway-install-olm-ext-cr.adoc
+++ b/modules/con-mcp-gateway-install-olm-ext-cr.adoc
@@ -7,11 +7,13 @@
 = Understand the MCPGatewayExtension custom resource
 
 [role="_abstract"]
-You can deploy more than one {mcpg} instance within a single cluster by using more than one `Gateway` custom resource (CR). You muse use an `MCPGatewayExtension` CR for each `Gateway` CR. Each deployment of the {mcpg} manages its associated MCP servers by using the `MCPGatewayExtension` controller in the following ways:
+You can deploy more than one {mcpg} instance within a single cluster by using more than one `Gateway` custom resource (CR).
+
+You must use an `MCPGatewayExtension` CR for each `Gateway` CR. Each deployment of the {mcpg} manages its associated MCP servers by using the `MCPGatewayExtension` controller in the following ways:
 
 * Defines which `Gateway` object the {mcpg} instance is responsible for.
 * Determines where configuration `Secret` objects are created.
-* Enables isolation by allowing multiple {mcpg} instances in different namespaces to target different `Gateway` objects.
+* Enables isolation by allowing more than one {mcpg} instance in different namespaces to target different `Gateway` objects.
 
 [IMPORTANT]
 ====
@@ -30,4 +32,4 @@ The `MCPGatewayExtension` controller automatically creates an `HTTPRoute` CR nam
 
 Custom route creation::
 
-If you require custom route, you can disable automatic `HTTPRoute` CR creation by setting the `spec.httpRouteManagement:` parameter to `Disabled` in your `MCPGatewayExtension` CR. After you create the `MCPGatewayExtension` CR, you can create a custom `HTTPRoute` CR.
+If you require a custom `HTTPRoute` CR, you can disable automatic `HTTPRoute` CR creation by setting the `spec.httpRouteManagement:` parameter to `Disabled` in your `MCPGatewayExtension` CR. After you create the `MCPGatewayExtension` CR, you can create a custom `HTTPRoute` CR.

--- a/modules/con-mcp-gateway-isolated-deployment.adoc
+++ b/modules/con-mcp-gateway-isolated-deployment.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-mcp-gateway-isolated-deployment_{context}"]
+= How isolated {mcpg} deployment works
+
+[role="_abstract"]
+By using isolated {mcpg} deployments, different teams can manage their own Model Context Protocol (MCP) servers independently. Each isolated {mcpg} deployment uses a single `MCPGatewayExtension` custom resource (CR).
+
+You can deploy more than one {mcpg} instance within a single cluster by using more than one `Gateway` CR. You must use one `MCPGatewayExtension` CR for each `Gateway` CR.
+
+Each deployment of the {mcpg} manages its associated MCP servers by using the `MCPGatewayExtension` CR in the following ways:
+
+* Defines which `Gateway` object the {mcpg} instance is responsible for.
+* Determines where configuration `Secret` objects are created.
+* Enables isolation by allowing multiple {mcpg} instances in different namespaces to target different `Gateway` objects.
+
+For example, Team A and Team B share a single, cluster-wide {mcpg} controller. Each team namespace has a different `Gateway` object, uses different Secrets, and has different `MCPServerRegistration` CRs.
+
+Team A namespace::
+* `MCPGatewayExtension` CR targeting `Gateway` A
+* MCP broker and router
+* Config Secret
+* `MCPServerRegistration` CRs
+
+Team B namespace::
+* `MCPGatewayExtension` CR targeting `Gateway` B
+* MCP broker and router
+* Config Secret
+* `MCPServerRegistration` CRs
+
+[id="con-mcp-gateway-isolated-deployment-considerations_{context}"]
+== Important considerations
+
+One `MCPGatewayExtension` CR per namespace:: Each namespace can have only one `MCPGatewayExtension` CR. The controller writes configuration to a well-known `Secret` object name. More than one extension in the same namespace causes them to overwrite each other.
+
+One `MCPGatewayExtension` CR per `Gateway` object and listener:: Only one `MCPGatewayExtension` CR can target a specified listener for a given `Gateway` object. When more than one extension targets the same `Gateway` object, the controller marks newer ones as `Ready: False`, with a message starting with `conflict: `. The oldest extension by creation timestamp takes precedence.
+
+Cross-namespace `Gateway` object references require a `ReferenceGrant` CR:: The `ReferenceGrant` CR must exist in the target `Gateway` object namespace.

--- a/modules/proc-config-mcp-gateway-gateway.adoc
+++ b/modules/proc-config-mcp-gateway-gateway.adoc
@@ -71,6 +71,15 @@ spec:
 You must use the `spec.listeners[].name` value in the corresponding `MCPGatewayExtension` CR `spec.targetRef.sectionName:` field.
 ====
 
+. Apply the `Gateway` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_gateway.yaml>_
+----
++
+Replace `_<mcp_gateway.yaml>_` with the name of your `Gateway` YAML.
+
 . Optional. Verify the {prodname} `DNSPolicy` CR attachment by checking its status with the following command:
 +
 [source,terminal,subs="+quotes"]

--- a/modules/proc-mcp-gateway-deploy-isolated-instances.adoc
+++ b/modules/proc-mcp-gateway-deploy-isolated-instances.adoc
@@ -1,0 +1,172 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-deploy-isolated-instances_{context}"]
+= Deploy isolated {mcpg} instances
+
+[role="_abstract"]
+You can deploy more than one isolated {mcpg} instance, each with its own `Gateway` object, `MCPGatewayExtension` custom resource (CR), and `ReferenceGrant` CR. To get started, create an isolated instance for a team. Repeat this procedure for each team that you need to isolate.
+
+.Prerequisites
+
+* You installed {ocp}.
+* You installed {oc-first}.
+* You installed the {mcpg} in a cluster-central namespace.
+* You configured at least one listener on the `Gateway` object applied in your central namespace.
+* You set up multi-tenancy on your {ocp} cluster.
+
+.Procedure
+
+. Get the hostname for Team A by running the following command:
++
+[source,terminal]
+----
+$ echo "team-a.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')"
+----
+
+. Create a team `Gateway` object for Team A by using the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: _<team_a_mcp_gateway>_
+  namespace: _<gateway_system>_
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+    - name: mcp
+      hostname: _<team_a_hostname>_
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - group: ''
+            kind: Secret
+            name: default-ingress-cert
+        mode: Terminate
+----
++
+* Replace the `metadata.name` value with the name you want to use.
+* If you want your central platform team to manage network infrastructure, TLS certificates, and public IP address allocations, use the same value for `metadata.namespace` as the cluster-wide `Gateway` object.
+* If you want Team A to own everything from the network entry point to their MCP server pods, apply the `Gateway` object directly inside `_<team_a>_` in the `metadata.namespace` parameter.
+* Replace the value of `spec.listeners.hostname` with the hostname for Team A.
+
+. Apply the `Gateway` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<team_a_mcp_gateway.yaml>_
+----
++
+Replace `_<team_a_mcp_gateway.yaml>_` with the filename you used.
+
+. Verify the Team A `Gateway` object by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get gateway _<team_a_mcp_gateway>_ -n _<gateway_system>_
+----
++
+* Replace with the Team A `Gateway` object name.
+* Replace with the namespace where the Team A `Gateway` object is applied.
+
+. Create an `MCPGatewayExtension` CR for Team A to associate the namespace with the team `Gateway` object by using the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPGatewayExtension
+metadata:
+  name: _<team_a_mcp_gateway_ext>_
+  namespace: _<team_a>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<team_a_mcp_gateway>_
+    namespace: _<gateway_system>_
+    sectionName: mcp
+----
++
+* Replace the `metadata.name` value with the name you want to use.
+* Replace the `metadata.namespace` value with the team namespace.
+* Replace the `spec.targetRef.name` value with the name of the team `Gateway` object.
+* Replace the `spec.targetRef.namespace` value with the name of the `Gateway` object namespace.
++
+[IMPORTANT]
+====
+You can create several `Gateway` objects in the same namespace, but you must only reference one `Gateway` object one time in your `MCPGatewayExtension` CRs.
+====
+
+. Apply the `MCPGatewayExtension` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<team_a_mcp_gateway_ext.yaml>_
+----
++
+Replace `_<team_a_mcp_gateway_ext.yaml>_` with the filename you used.
+
+. If you are using the central `Gateway` object namespace, create a `ReferenceGrant` CR in the `Gateway` object namespace by using the following example:
++
+[source,yaml]
+----
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: _<team_a_ref_grant>_
+  namespace: _<gateway_system>_
+spec:
+  from:
+    - group: mcp.kuadrant.io
+      kind: MCPGatewayExtension
+      namespace: _<team_a>_
+  to:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: _<team_a_mcp_gateway>_
+----
++
+* Replace the `metadata.name` value with the name you want to use.
+* Replace the `metadata.namespace` value with the namespace where your `Gateway` object is applied.
+* Replace the `spec.from.namespace` value with the team namespace.
+* Replace the `spec.to.name` value with the team `Gateway` object name.
+
+. Apply the `ReferenceGrant` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<team_a_ref_grant.yaml>_
+----
++
+Replace `_<team_a_ref_grant.yaml>_` with the filename you used.
+
+. Verify the team `MCPGatewayExtension` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc wait --for=condition=Ready mcpgatewayextension/_<team_a_mcp_gateway_ext>_ -n _<team_a>_ --timeout=60s
+----
++
+* Replace `_<team_a_mcp_gateway_ext>_` with the name of the extension.
+* Replace `_<team_a>_` with the team namespace.
+
+. Verify that a pod prefixed `mcp-gateway-` in the team namespace is running by using the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get pods -n _<team_a>_
+----
++
+* Replace `_<team_a>_` with the team namespace.
+
+.Next steps
+
+* Repeat the steps for additional teams by creating the namespace, `Gateway` object, `MCPGatewayExtension` CR, and `ReferenceGrant` CR with the relevant team values. For example, "Team B", and so on.

--- a/modules/proc-mcp-gateway-expose-isolated-instances.adoc
+++ b/modules/proc-mcp-gateway-expose-isolated-instances.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-expose-isolated-instances_{context}"]
+= Expose isolated {mcpg} instances externally
+
+[role="_abstract"]
+After you deploy isolated {mcpg} instances, you can expose each `Gateway` object externally by creating {ocp} routes with TLS termination. Repeat these steps for each team.
+
+.Prerequisites
+
+* You installed {ocp}.
+* You installed {oc-first}.
+* You deployed an isolated {mcpg} instance for a team.
+
+.Procedure
+
+. Create an {ocp} route for the Team A `Gateway` object by using the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: _<team_a_route>_
+  namespace: _<gateway_system>_
+spec:
+  host: _<team_a_host>_
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  port:
+    targetPort: mcp
+  to:
+    kind: Service
+    name: <team_a_mcp_gateway>-openshift-default
+    weight: 100
+  wildcardPolicy: None
+----
++
+* Replace the `metadata.name` value with the route name that you want to use.
+* Replace the `metadata.namespace` value with the namespace where the `Gateway` object is applied.
+* Replace the value of `spec.host` with the hostname for the team you are making the route for.
+* Replace the value of `spec.to.name` with the `Gateway` object name and `gatewayClassName` value.
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<team_a_route.yaml>_
+----
++
+Replace `_<team_a_route.yaml>_` with the name that you used for your `Route` CR.
+
+. Verify that the router has successfully admitted the route and mapped it to active endpoints by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc describe route _<team_a_route>_ -n _<gateway_system>_
+----
++
+* Replace `_<team_a_route>_` with the name of the route.
+* Replace `_<gateway_system>_` with the namespace where the `Gateway` object is applied.
+
+.Next steps
+
+Register MCP servers with each `Gateway` object. When registering MCP servers, ensure that each `HTTPRoute` CR `parentRef` targets the correct `Gateway` object, for example:
+
+** Team A instance: `team_a_gateway` in the `gateway_system` namespace.

--- a/modules/proc-mcp-gateway-install-olm-ext-cr.adoc
+++ b/modules/proc-mcp-gateway-install-olm-ext-cr.adoc
@@ -44,6 +44,7 @@ spec:
     sectionName: mcp
   httpRouteManagement: Enabled
 ----
++
 * Replace the `metadata.name:` parameter value with the name you want to use.
 * Replace the `metadata.namespace:` parameter value with the namespace you want to use.
 * The `spec.targetRef.sectionName:` parameter value must be the same as name of the listener on the gateway. In this example, `mcp` is used.

--- a/modules/proc-mcp-gateway-ts-isolated-empty-config-secret.adoc
+++ b/modules/proc-mcp-gateway-ts-isolated-empty-config-secret.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-ts-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-ts-isolated-empty-config-secret_{context}"]
+= Troubleshooting an empty configuration secret
+
+[role="_abstract"]
+If the configuration `Secret` object exists but contains no MCP server entries, the `MCPServerRegistration` custom resources (CRs) might not be in a `Ready` state.
+
+.Prerequisites
+
+* You installed {oc-first}.
+* You deployed isolated {mcpg} instances.
+
+.Procedure
+
+. Check the contents of the configuration `Secret` object by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get secret mcp-gateway-config -n _<namespace>_ -o jsonpath='{.data.config\.yaml}' | base64 -d
+----
++
+Replace `_<namespace>_` with the namespace where the `MCPGatewayExtension` CR is applied.
+
+. Verify that `MCPServerRegistration` CRs exist and are in `Ready` state by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get mcpserverregistration -n _<namespace>_
+----
++
+If no `MCPServerRegistration` CRs exist or none are in `Ready` state, register MCP servers for this gateway instance.

--- a/modules/proc-mcp-gateway-ts-isolated-invalid-ext.adoc
+++ b/modules/proc-mcp-gateway-ts-isolated-invalid-ext.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-ts-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-ts-isolated-invalid-ext_{context}"]
+= Troubleshooting an MCPGatewayExtension InvalidMCPGatewayExtension status
+
+[role="_abstract"]
+If an `MCPGatewayExtension` custom resource (CR) shows an `InvalidMCPGatewayExtension` status, the target `Gateway` object does not exist or there is a conflict with another extension.
+
+.Prerequisites
+
+* You installed {oc-first}.
+* You deployed isolated {mcpg} instances.
+
+.Procedure
+
+. Verify that the target `Gateway` object exists by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get gateway _<gateway_name>_ -n _<gateway_namespace>_
+----
++
+* Replace `_<gateway_name>_` with the name of the `Gateway` object.
+* Replace `_<gateway_namespace>_` with the namespace where the `Gateway` object is applied.
+
+. Check for conflicting `MCPGatewayExtension` CRs that target the same `Gateway` object by running the following command:
++
+[source,terminal]
+----
+$ oc get mcpgatewayextension -A
+----
++
+Only one `MCPGatewayExtension` CR can target a given `Gateway` object. If multiple extensions target the same `Gateway` object, the controller marks newer ones as conflicted. The oldest extension by creation timestamp takes precedence.
+
+. If a conflict exists, update the newer `MCPGatewayExtension` CR to target a different `Gateway` object, or delete the conflicting extension.

--- a/modules/proc-mcp-gateway-ts-isolated-refgrant-required.adoc
+++ b/modules/proc-mcp-gateway-ts-isolated-refgrant-required.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-ts-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-ts-isolated-refgrant-required_{context}"]
+= Troubleshoot an MCPGatewayExtension ReferenceGrantRequired status
+
+[role="_abstract"]
+If an `MCPGatewayExtension` custom resource (CR) targets a `Gateway` object in a different namespace and no `ReferenceGrant` CR exists, the extension shows a `ReferenceGrantRequired` condition.
+
+.Prerequisites
+
+* You installed {oc-first}.
+* You deployed isolated {mcpg} instances.
+
+.Procedure
+
+. Check the status of the `MCPGatewayExtension` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get mcpgatewayextension -n _<namespace>_ -o yaml
+----
++
+Replace `_<namespace>_` with the namespace where the `MCPGatewayExtension` CR is applied.
+
+. Look for the following condition in the output:
++
+[source,yaml]
+----
+conditions:
+  - type: Ready
+    status: "False"
+    reason: ReferenceGrantRequired
+    message: "invalid: ReferenceGrant required in %s to allow cross-namespace reference from %s"
+----
+
+. Create a `ReferenceGrant` CR in the `Gateway` object namespace:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: _<team_a_refgrant>_
+  namespace: _<gateway_namespace>_
+spec:
+  from:
+    - group: mcp.kuadrant.io
+      kind: MCPGatewayExtension
+      namespace: _<team_namespace>_
+  to:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: _<team_a_gateway>_
+----
++
+* Replace the `metadata.name` value with the name of your team.
+* Replace the `metadata.namespace` value with the namespace where the `Gateway` object is applied.
+* Replace the `spec.from.namespace` value with the namespace where the `MCPGatewayExtension` CR is applied.
+* Replace the `spec.to.name` value with the name of the team `Gateway` object.
+
+. Verify the `MCPGatewayExtension` CR is ready by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc wait --for=condition=Ready mcpgatewayextension/_<extension_name>_ -n _<namespace>_ --timeout=60s
+----

--- a/modules/proc-mcp-gateway-ts-isolated-registration-not-ready.adoc
+++ b/modules/proc-mcp-gateway-ts-isolated-registration-not-ready.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * mcp_gateway_install/mcp-gateway-ts-isolated-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-ts-isolated-registration-not-ready_{context}"]
+= Troubleshooting an MCPServerRegistration NotReady status
+
+[role="_abstract"]
+If an `MCPServerRegistration` custom resource (CR) shows a `NotReady` status, the registration cannot find a valid `MCPGatewayExtension` CR for the `Gateway` object that its `HTTPRoute` CR is attached to. `MCPServerRegistration` CRs are processed only when a valid `MCPGatewayExtension` CR exists for the `Gateway` object that their `HTTPRoute` CR is attached to.
+
+.Prerequisites
+
+* You installed {oc-first}.
+* You deployed isolated {mcpg} instances.
+
+.Procedure
+
+. Check the status of the `MCPServerRegistration` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get mcpserverregistration -n _<namespace>_ -o yaml
+----
++
+Replace `_<namespace>_` with the namespace where the `MCPServerRegistration` CR is applied.
+
+. Verify the following conditions:
+
+.. The `HTTPRoute` CR exists and references the correct `Gateway` object, and its status is accepted.
+.. An `MCPGatewayExtension` CR exists that targets the same `Gateway` object.
+.. The `MCPGatewayExtension` CR is in `Ready` state by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get mcpgatewayextension -n _<namespace>_
+----

--- a/troubleshoot/mcp-gateway-ts-isolated-deployment.adoc
+++ b/troubleshoot/mcp-gateway-ts-isolated-deployment.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="mcp-gateway-ts-isolated-deployment"]
+= Troubleshoot isolated {mcpg} deployments
+:context: mcp-gateway-ts-isolated-deployment
+
+toc::[]
+
+[role="_abstract"]
+You can troubleshoot common issues with isolated {mcpg} deployments, including `MCPGatewayExtension` status errors, `MCPServerRegistration` issues, and empty configuration secrets.
+
+:FeatureName: {mcpg}
+
+include::snippets/technology-preview.adoc[]
+
+include::modules/proc-mcp-gateway-ts-isolated-refgrant-required.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-ts-isolated-invalid-ext.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-ts-isolated-registration-not-ready.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-ts-isolated-empty-config-secret.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-19342](https://redhat.atlassian.net/browse/OSDOCS-19342)

Link to docs preview:
https://116421--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html
https://116421--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-isolated-deployment.html
https://116421--ocpdocs-pr.netlify.app/rhcl/latest/troubleshoot/mcp-gateway-ts-isolated-deployment.html

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Follow-on PR removes Tech Preview snippet from `main` and `1.5`, https://github.com/openshift/openshift-docs/pull/119122.
