### PR TITLE
OBSDOCS-1772: Document RFC5424 syslog format change

### DIFF
--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -137,6 +137,8 @@ include::modules/cluster-logging-collector-log-forward-logs-from-application-pod
 
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+2]
 
+include::modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc[leveloffset=+2]
+
 include::modules/cluster-logging-collector-log-forward-cloudwatch.adoc[leveloffset=+1]
 
 [id="forwarding-logs-to-amazon-cloudwatch-from-sts-enabled-clusters_{context}"]

--- a/modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cluster-logging-collector-log-forward-syslog-rfc5424-defaults_{context}"]
+= Default field mappings for RFC5424
+
+[role="_abstract"]
+When using the RFC5424 protocol, the collector automatically populates the `APP-NAME`, `PROCID`, and `MSGID` fields with default values based on the log source type. You can override these defaults by specifying `appName`, `procId`, or `msgId` in the syslog output configuration.
+
+The following table shows the default field mappings:
+
+.Default RFC5424 field values by log source
+[cols="2,3,3,3",options="header"]
+|===
+|Log source |APP-NAME |PROCID |MSGID
+
+|Infrastructure (journal logs)
+|`SYSLOG_IDENTIFIER`
+|`_PID`
+|`.log_source`
+
+|Infrastructure (container logs)
+|`namespace_pod_container`
+|`pod_id`
+|`.log_source`
+
+|Application (container logs)
+|`namespace_pod_container`
+|`pod_id`
+|`.log_source`
+
+|Audit logs
+|`.log_source`
+|`.auditID` (if available)
+|`.log_source`
+|===
+
+[NOTE]
+====
+Field values can use template syntax for dynamic per-event values. The maximum length for `APP-NAME` and `PROCID` is 48 characters, and for `MSGID` is 32 characters. The collector truncates values that exceed these limits.
+====

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -115,5 +115,5 @@ This configuration is compatible with both RFC3164 and RFC5424.
 
 [source, text]
 ----
-2025-03-03T11:48:01+00:00  example-worker-x  syslogsyslogserverd846bb9b: namespace_name=cakephp-project container_name=mysql pod_name=mysql-1-wr96h,message: {...} 
+2025-03-03T11:48:01+00:00  example-worker-x  syslogsyslogserverd846bb9b: namespace_name=cakephp-project container_name=mysql pod_name=mysql-1-wr96h,message: {...}
 ----

--- a/modules/logging-release-notes-6-2-0.adoc
+++ b/modules/logging-release-notes-6-2-0.adoc
@@ -16,6 +16,11 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:2398[{logg
 
 * With this update, HTTP outputs include a `proxy` field that you can use to send log data through an HTTP proxy. (link:https://issues.redhat.com/browse/LOG-6069[LOG-6069])
 
+[IMPORTANT]
+====
+*Breaking change for syslog RFC5424 format:* Logging 6 introduces a new default field mapping for RFC5424 syslog outputs. If you have existing automation for parsing logs received at a syslog server, you must update your parsers to accommodate the new format. The `APP-NAME`, `PROCID`, and `MSGID` fields now use different default values based on log source type. For details about the new field mappings, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/logging/log-collection-and-forwarding#cluster-logging-collector-log-forward-syslog_configuring-log-forwarding[Forwarding logs by using the syslog protocol].
+====
+
 === Log Storage
 
 * With this update, time-based stream sharding in Loki is now enabled by the {loki-op}. This solves the issue of ingesting log entries older than the sliding time-window used by Loki. (link:https://issues.redhat.com/browse/LOG-6757[LOG-6757])


### PR DESCRIPTION
## Summary

Documents the breaking change in RFC5424 syslog format introduced in Logging 6.2.0.

In Logging 6, the RFC5424 syslog output uses new default field mappings for `APP-NAME`, `PROCID`, and `MSGID` that differ from previous versions. This is a breaking change for users with automation that parses syslog output.

## Changes

- **Release notes**: Added IMPORTANT admonition to Logging 6.2.0 release notes warning about the breaking change in RFC5424 field mappings
- **Syslog forwarding docs**: Added new section documenting default field mappings by log source type (infrastructure journal/container, application, audit)
- Included notes about field length limits and truncation behavior

## Testing

- ✅ Vale validation: 0 errors, 0 warnings
- ✅ Local build validation: All AsciiDoc assemblies validated successfully
- ✅ Portal build: All books built successfully

## JIRA

Fixes: https://redhat.atlassian.net/browse/OBSDOCS-1772

Signed-off-by: John Wilkins <jowilkin@redhat.com>