### PR TITLE
ROX-35914: Release note changes for 4.9.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ commercial_package
 .vale
 .agent_workspace
 .claude
+CLAUDE.md

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -74,6 +74,7 @@ endif::[]
 :ga-date-497: 2 June 2026
 :ga-date-498: 18 June 2026
 :ga-date-499: 7 July 2026
+:ga-date-4910: 30 July 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -25,6 +25,7 @@ toc::[]
 |`4.9.7` | {ga-date-497}
 |`4.9.8` | {ga-date-498}
 |`4.9.9` | {ga-date-499}
+|`4.9.10` | {ga-date-4910}
 
 |====
 
@@ -791,5 +792,33 @@ This release addresses the following security vulnerabilities:
 * containerd: Privilege escalation via User directive parsing (link:https://access.redhat.com/security/cve/CVE-2026-46680[CVE-2026-46680])
 * github.com/containerd/containerd: Command execution vulnerability (link:https://access.redhat.com/security/cve/CVE-2026-53488[CVE-2026-53488])
 * Flaw in {product-title-short} potentially could allow excessive resource consumption leading to denial of service (link:https://access.redhat.com/security/cve/CVE-2026-9165[CVE-2026-9165])
+
+[id="about-this-release-4910_{context}"]
+== About release 4.9.10
+
+*Release date*: {ga-date-4910}
+
+This release addresses the following security vulnerabilities:
+
+* containerd:
+//ROX-35499
+** containerd: Host-root command execution via unvalidated image config labels in CRI plugin (link:https://access.redhat.com/security/cve/CVE-2026-53488[CVE-2026-53488])
+//ROX-35551, ROX-35566
+** containerd: Security bypass via Container Device Interface (CDI) annotation smuggling during checkpoint restoration (link:https://access.redhat.com/security/cve/CVE-2026-53492[CVE-2026-53492])
+* Go and golang.org:
+//ROX-35994
+** go-git: Unescaped single quotation marks in repository paths during SSH transport command construction allow shell command breakout and execution (link:https://access.redhat.com/security/cve/CVE-2026-45570[CVE-2026-45570])
+//ROX-36000
+** oras-go: Information disclosure and arbitrary file access via crafted tarball hard links (link:https://access.redhat.com/security/cve/CVE-2026-50163[CVE-2026-50163])
+//ROX-35469
+* Brace-expansion: Denial of service due to exponential-time complexity (link:https://access.redhat.com/security/cve/CVE-2026-13149[CVE-2026-13149])
+//ROX-35797
+* DOMPurify: Cross-site scripting vulnerability allows code execution (link:https://access.redhat.com/security/cve/CVE-2026-49978[CVE-2026-49978])
+//ROX-35694
+* js-yaml: Denial of service via crafted YAML documents (link:https://access.redhat.com/security/cve/CVE-2026-59869[CVE-2026-59869])
+//ROX-35996 
+* `github.com/jackc/pgx`: SQL injection via specific SQL query conditions (link:https://access.redhat.com/security/cve/CVE-2026-41889[CVE-2026-41889])
+//ROX-35998
+* `github.com/sigstore/fulcio`: Server-side request forgery (SSRF) and Kubernetes ServiceAccount token leakage (link:https://access.redhat.com/security/cve/CVE-2026-49478[CVE-2026-49478])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.9.10


Issue: [ROX-35914](https://redhat.atlassian.net/browse/ROX-35914)

Links to docs preview (top and 4.9.10 section):

- https://116469--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/49-release-notes
- https://116469--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/49-release-notes#about-this-release-4910_release-notes-49

QE review: **RHACS has no formal QE process, approved by SME**
- [x] QE has approved this change.


Additional information:

