### PR TITLE
OBSDOCS-3625: Add LokiStack alert troubleshooting procedures

### DIFF
--- a/logging_alerts/default-logging-alerts.adoc
+++ b/logging_alerts/default-logging-alerts.adoc
@@ -17,6 +17,8 @@ include::modules/logging-vector-collector-alerts.adoc[leveloffset=+1]
 
 include::modules/loki-alerts.adoc[leveloffset=+1]
 
+include::modules/troubleshooting-lokistack-alerts.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 == Additional resources
 

--- a/modules/troubleshooting-lokistack-alerts.adoc
+++ b/modules/troubleshooting-lokistack-alerts.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * logging_alerts/default-logging-alerts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-lokistack-alerts_{context}"]
+= Troubleshooting LokiStack alerts
+
+[role="_abstract"]
+When a LokiStack alert fires, you can use diagnostic commands to investigate the root cause and apply remediation steps.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. View the LokiStack status to identify issues:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging get lokistack logging-loki -o yaml
+----
++
+Review the `status.conditions` section for any warnings or errors.
+
+. Check the detailed status of the LokiStack resource:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging describe lokistack logging-loki
+----
++
+Look for conditions with `status: "False"` or recent events indicating problems.
+
+. List all LokiStack pods and their status:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging get pods -l app.kubernetes.io/instance=logging-loki
+----
++
+Verify that all component pods (distributor, ingester, querier, query-front end, index-gateway, compactor, gateway) are in `Running` state.
+
+. Examine the logs of the affected component:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging logs <pod-name>
+----
++
+Replace `<pod-name>` with the name of the pod from the alert labels or the pod that is experiencing issues.
+
+. For storage-related alerts, verify backend storage connectivity:
++
+.. Check if the storage secret exists and contains valid credentials:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging get secret logging-loki-<storage-type> -o yaml
+----
++
+Replace `<storage-type>` with your storage backend (for example, `aws`, `azure`, `gcp`, or `s3`).
+
+.. Review recent events for storage access errors:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging get events --sort-by=.lastTimestamp | grep -i storage
+----
+
+. For rate limit alerts (`LokiTenantRateLimit`), check which limits are being exceeded:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc -n openshift-logging logs -l app.kubernetes.io/component=distributor | grep "discarded"
+----
++
+This shows which tenant limits are causing samples to be discarded.
+
+. For detailed troubleshooting and remediation steps for each specific alert, see the link:https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md[LokiStack Standard Operating Procedures] runbook.
++
+--
+
+The runbook provides:
+
+* Root cause analysis for each alert
+* Specific diagnostic commands and metrics to check
+* Step-by-step remediation procedures
+* Common causes and prevention strategies
+
+Common remediation actions include:
++
+* **Storage connectivity issues**: Verify storage credentials, network policies, and firewall rules
+* **Rate limit errors**: Adjust tenant limits in the `LokiStack` custom resource
+* **High load**: Increase the number of queriers or ingesters
+* **Component failures**: Check pod logs and restart failing components
+--
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuring/configuring-the-log-store.adoc#configuring-the-log-store[Configuring the log store]
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]
+* link:https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md[LokiStack Standard Operating Procedures]


### PR DESCRIPTION
## Summary

Adds troubleshooting guidance and response procedures for LokiStack alerts to address the missing remediation documentation identified in JTBD Job #30.

## Preview

https://116470--ocpdocs-pr.netlify.app/openshift-logging/latest/logging_alerts/default-logging-alerts.html#troubleshooting-lokistack-alerts_default-logging-alerts

## Changes

- **New troubleshooting module**: Created `modules/troubleshooting-lokistack-alerts.adoc` with:
  - Common diagnostic commands for investigating LokiStack alerts
  - OpenShift-specific `oc` commands for checking LokiStack status, pods, and logs
  - Storage connectivity verification steps
  - Rate limit troubleshooting guidance
  - Reference to upstream Loki Operator runbook for detailed alert-specific remediation

- **Updated alerts assembly**: Added the troubleshooting module to `logging_alerts/default-logging-alerts.adoc`

## Upstream runbook reference

The module links to the official Grafana Loki Operator runbook at:
https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md

This runbook is the authoritative source for LokiStack alert remediation (embedded in the operator code as `RunbookDefaultURL`). It provides:
- Root cause analysis for all 14 LokiStack alerts
- Specific diagnostic commands and metrics
- Step-by-step remediation procedures
- Common causes and prevention strategies

## Vale warnings

Vale flagged the GitHub links with warnings (7 warnings total):
- `Do not include a link to https://github.com unless it is explicitly approved`

The links point to official upstream Loki Operator documentation. If GitHub links are not approved, we can either:
1. Remove the links and integrate the runbook content directly
2. Host the runbook content in Red Hat documentation
3. Request approval for linking to official upstream docs

## Testing

- ✅ Vale: 0 errors, 7 warnings (GitHub links)
- ✅ Local prow validation: All assemblies and portal builds passed
- ✅ DITA compliance: Procedure module structure validated

## JIRA

Addresses: https://redhat.atlassian.net/browse/OBSDOCS-3625

Version: 6.6

This closes the gap for "Default LokiStack alerts and responses" by providing response procedures for when alerts fire.

Signed-off-by: John Wilkins <jowilkin@redhat.com>