### PR TITLE
[OSDOCS#18989] CQA pre-migration for Disconnected updating index assembly

### DIFF
--- a/disconnected/index.adoc
+++ b/disconnected/index.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content.
 
 include::modules/installing-mirroring-disconnected-con.adoc[leveloffset=+1]

--- a/modules/installing-mirroring-disconnected-con.adoc
+++ b/modules/installing-mirroring-disconnected-con.adoc
@@ -6,7 +6,10 @@
 [id="installing-mirroring-disconnected-con_{context}"]
 = Mirror registries for installing clusters in disconnected environments
 
-You must mirror required container images into a disconnected environment before you can install and provision a cluster there. To mirror those container images, you must have a mirror registry. Consider the following options for creating and using a mirror registry:
+[role="_abstract"]
+You must mirror required container images into a disconnected environment before you can install and provision a cluster there. To mirror those container images, you must have a mirror registry.
+
+Consider the following options for creating and using a mirror registry:
 
 * If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you must create one.
 


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989)

Link to docs preview:
- https://116481--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 1 of 5 PRs splitting [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.