### PR TITLE
[OSDOCS#18989] CQA pre-migration for Installation overview index assembly

### DIFF
--- a/installing/overview/index.adoc
+++ b/installing/overview/index.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Learn about the installation methods, requirements, and process for deploying an {product-title} cluster.
+
 include::modules/installation-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -41,15 +44,7 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 
 * link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[Assisted Installer for OpenShift Container Platform]
 
-
-=== Installation scope
-
-The scope of the {product-title} installation program is intentionally narrow. It is designed for simplicity and ensured success. You can complete many more configuration tasks after installation completes.
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Available cluster customizations] for details about {product-title} configuration resources.
+include::modules/installation-overview-scope-reference.adoc[leveloffset=+2]
 
 include::modules/installation-openshift-local.adoc[leveloffset=+2]
 
@@ -58,8 +53,8 @@ include::modules/supported-platforms-for-openshift-clusters.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../installing/overview/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms] for more information about the types of installations that are available for each supported platform.
+* xref:../../installing/overview/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
 
-* See xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users] for information about choosing an installation method and preparing the required resources.
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 
-* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] can help you design your cluster network during both the deployment and expansion phases. It addresses common questions related to the cluster network and provides output in a convenient JSON format.
+* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator]

--- a/modules/install-openshift-common-terms.adoc
+++ b/modules/install-openshift-common-terms.adoc
@@ -6,6 +6,7 @@
 [id="install-openshift-common-terms_{context}"]
 = Glossary of common terms for {product-title} installing
 
+[role="_abstract"]
 The glossary defines common terms that relate to the installation content. Read the following list of terms to better understand the installation process.
 
 {ai-full}::
@@ -37,7 +38,7 @@ A file that the Ignition tool uses to configure {op-system-first} during operati
 Kubernetes manifests::
 Specifications of a Kubernetes API object in a JSON or YAML format. A configuration file can include deployments, config maps, secrets, daemonsets, and so on.
 
-Kubelet::
+kubelet::
 A primary node agent that runs on each node in the cluster to ensure that containers are running in a pod.
 
 Load balancers::

--- a/modules/installation-openshift-local.adoc
+++ b/modules/installation-openshift-local.adoc
@@ -7,10 +7,13 @@
 [id="installation-openshift-local_{context}"]
 = OpenShift Local overview
 
+[role="_abstract"]
 OpenShift Local supports rapid application development to get started building {product-title} clusters. OpenShift Local is designed to run on a local computer to simplify setup and testing, and to emulate the cloud development environment locally with all of the tools needed to develop container-based applications.
 
 Regardless of the programming language you use, OpenShift Local hosts your application and brings a minimal, preconfigured Red Hat {product-title} cluster to your local PC without the need for a server-based infrastructure.
 
 On a hosted environment, OpenShift Local can create microservices, convert them into images, and run them in Kubernetes-hosted containers directly on your laptop or desktop running Linux, macOS, or Windows 10 or later.
 
-For more information about OpenShift Local, see link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local Overview].
+[role="_additional-resources"]
+.Additional resources
+* link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local Overview]

--- a/modules/installation-overview-scope-reference.adoc
+++ b/modules/installation-overview-scope-reference.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * installing/overview/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-overview-scope-reference_{context}"]
+= Installation scope
+
+[role="_abstract"]
+The scope of the {product-title} installation program is intentionally narrow. It is designed for simplicity and ensured success. You can complete many more configuration tasks after installation completes.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Available cluster customizations]

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -7,11 +7,12 @@
 [id="installation-overview_{context}"]
 = About {product-title} installation
 
+[role="_abstract"]
 The {product-title} installation program offers four methods for deploying a cluster which are detailed in the following list:
 
-* *Interactive*: You can deploy a cluster with the web-based link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}]. This is an ideal approach for clusters with networks connected to the internet. The {ai-full} is the easiest way to install {product-title}, it provides smart defaults, and it performs pre-flight validations before installing the cluster. It also provides a RESTful API for automation and advanced configuration scenarios.
+* *Interactive*: You can deploy a cluster with the web-based {ai-full}. This is an ideal approach for clusters with networks connected to the internet. The {ai-full} is the easiest way to install {product-title}, it provides smart defaults, and it performs pre-flight validations before installing the cluster. It also provides a RESTful API for automation and advanced configuration scenarios.
 
-* *Local Agent-based*: You can deploy a cluster locally with the Agent-based Installer for disconnected environments or restricted networks. It provides many of the benefits of the {ai-full}, but you must download and configure the link:https://console.redhat.com/openshift/install/metal/agent-based[Agent-based Installer] first. Configuration is done with a command-line interface. This approach is ideal for disconnected environments.
+* *Local Agent-based*: You can deploy a cluster locally with the Agent-based Installer for disconnected environments or restricted networks. It provides many of the benefits of the {ai-full}, but you must download and configure the Agent-based Installer first. Configuration is done with a command-line interface. This approach is ideal for disconnected environments.
 ** Additionally, you can deploy a cluster without an external registry, using self-contained installation media that also provides a simplified user interface similar to the {ai-full} during on-premise installations.
 For more information, see "Installing a cluster without an external registry".
 
@@ -38,8 +39,13 @@ image::targets-and-dependencies.png[{product-title} installation targets and dep
 [id="about-rhcos"]
 == About {op-system-first}
 
-Post-installation, each cluster machine uses {op-system-first} as the operating system. {op-system} is the immutable container host version of {op-system-base-full} and features a {op-system-base} kernel with SELinux enabled by default. {op-system} includes the `kubelet`, which is the Kubernetes node agent, and the CRI-O container runtime, which is optimized for Kubernetes.
+Postinstallation, each cluster machine uses {op-system-first} as the operating system. {op-system} is the immutable container host version of {op-system-base-full} and features a {op-system-base} kernel with SELinux enabled by default. {op-system} includes the `kubelet`, which is the Kubernetes node agent, and the CRI-O container runtime, which is optimized for Kubernetes.
 
 Every control plane machine in an {product-title} {product-version} cluster must use {op-system}, which includes a critical first-boot provisioning tool called Ignition. This tool enables the cluster to configure the machines. Operating system updates are delivered as a bootable container image, using **OSTree** as a backend, that is deployed across the cluster by the Machine Config Operator. Actual operating system changes are made in-place on each machine as an atomic operation by using **rpm-ostree**. Together, these technologies enable {product-title} to manage the operating system like it manages any other application on the cluster, by in-place upgrades that keep the entire platform up to date. These in-place updates can reduce the burden on operations teams.
 
 If you use {op-system} as the operating system for all cluster machines, the cluster manages all aspects of its components and machines, including the operating system. Because of this, only the installation program and the Machine Config Operator can change machines. The installation program uses Ignition config files to set the exact state of each machine, and the Machine Config Operator completes more changes to the machines, such as the application of new certificates or keys, after installation.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}]
+* link:https://console.redhat.com/openshift/install/metal/agent-based[Agent-based Installer]

--- a/modules/installation-process.adoc
+++ b/modules/installation-process.adoc
@@ -7,23 +7,26 @@
 [id="installation-process_{context}"]
 = Installation process
 
+[role="_abstract"]
+The {product-title} installation program transforms a set of assets into a running cluster, using an installation process that varies depending on your installation method.
+
 Except for the {ai-full}, when you install an {product-title} cluster, you must download the installation program from
 ifndef::openshift-origin[]
-the appropriate link:https://console.redhat.com/openshift/create[*Cluster Type*] page on the {cluster-manager} {hybrid-console-second}. This console manages:
+the appropriate *Cluster Type* page on the {cluster-manager} {hybrid-console-second}. This console manages:
 
 * REST API for accounts.
 * Registry tokens, which are the pull secrets that you use to obtain the required components.
 * Cluster registration, which associates the cluster identity to your Red Hat account to facilitate the gathering of usage metrics.
 endif::[]
 ifdef::openshift-origin[]
-https://github.com/openshift/okd/releases.
+the OKD releases page.
 endif::[]
 
 In {product-title} {product-version}, the installation program is a Go binary file that performs a series of file transformations on a set of assets. The way you interact with the installation program differs depending on your installation type. Consider the following installation use cases:
 
-*  To deploy a cluster with the {ai-full}, you must configure the cluster settings by using the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}]. There is no installation program to download and configure. After you finish setting the cluster configuration, you download a discovery ISO and then boot cluster machines with that image. You can install clusters with the {ai-full} on Nutanix, vSphere, and bare metal with full integration, and other platforms without integration. If you install on bare metal, you must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines.
+*  To deploy a cluster with the {ai-full}, you must configure the cluster settings by using the {ai-full}. There is no installation program to download and configure. After you finish setting the cluster configuration, you download a discovery ISO and then boot cluster machines with that image. You can install clusters with the {ai-full} on Nutanix, vSphere, and bare metal with full integration, and other platforms without integration. If you install on bare metal, you must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines.
 
-* To deploy clusters with the Agent-based Installer, you can download the link:https://console.redhat.com/openshift/install/metal/agent-based[Agent-based Installer] first. You can then configure the cluster and generate a discovery image. You boot cluster machines with the discovery image, which installs an agent that communicates with the installation program and handles the provisioning for you instead of you interacting with the installation program or setting up a provisioner machine yourself. You must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines. This approach is ideal for disconnected environments.
+* To deploy clusters with the Agent-based Installer, you can download the Agent-based Installer first. You can then configure the cluster and generate a discovery image. You boot cluster machines with the discovery image, which installs an agent that communicates with the installation program and handles the provisioning for you instead of you interacting with the installation program or setting up a provisioner machine yourself. You must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines. This approach is ideal for disconnected environments.
 
 * For clusters with installer-provisioned infrastructure, you delegate the infrastructure bootstrapping and provisioning to the installation program instead of doing it yourself. The installation program creates all of the networking, machines, and operating systems that are required to support the cluster, except if you install on bare metal. If you install on bare metal, you must provide all of the cluster infrastructure and resources, including the bootstrap machine, networking, load balancing, storage, and individual cluster machines.
 
@@ -48,7 +51,7 @@ You cannot modify the parameters that you set during installation, but you can m
 
 == The installation process with the {ai-full}
 
-Installation with the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}] involves creating a cluster configuration interactively by using the web-based user interface or the RESTful API. The {ai-full} user interface prompts you for required values and provides reasonable default values for the remaining parameters, unless you change them in the user interface or with the API.  The {ai-full} generates a discovery image, which you download and use to boot the cluster machines. The image installs {op-system} and an agent, and the agent handles the provisioning for you. You can install {product-title} with the {ai-full} and full integration on Nutanix, vSphere, and bare metal. Additionally, you can install {product-title} with the {ai-full} on other platforms without integration.
+Installation with the {ai-full} involves creating a cluster configuration interactively by using the web-based user interface or the RESTful API. The {ai-full} user interface prompts you for required values and provides reasonable default values for the remaining parameters, unless you change them in the user interface or with the API. The {ai-full} generates a discovery image, which you download and use to boot the cluster machines. The image installs {op-system} and an agent, and the agent handles the provisioning for you. You can install {product-title} with the {ai-full} and full integration on Nutanix, vSphere, and bare metal. Additionally, you can install {product-title} with the {ai-full} on other platforms without integration.
 
 {product-title} manages all aspects of the cluster, including the operating system itself. Each machine boots with a configuration that references resources hosted in the cluster that it joins. This configuration allows the cluster to manage itself as updates are applied.
 
@@ -57,7 +60,7 @@ If possible, use the {ai-full} feature to avoid having to download and configure
 
 == The installation process with Agent-based infrastructure
 
-Agent-based installation is similar to using the {ai-full}, except that you must initially download and install the link:https://console.redhat.com/openshift/install/metal/agent-based[Agent-based Installer]. An Agent-based installation is useful when you want the convenience of the {ai-full}, but you need to install a cluster in a disconnected environment.
+Agent-based installation is similar to using the {ai-full}, except that you must initially download and install the Agent-based Installer. An Agent-based installation is useful when you want the convenience of the {ai-full}, but you need to install a cluster in a disconnected environment.
 
 If possible, use the Agent-based installation feature to avoid having to create a provisioner machine with a bootstrap VM, and then provision and maintain the cluster infrastructure.
 
@@ -128,3 +131,14 @@ Bootstrapping a cluster involves the following steps:
 . The control plane installs additional services in the form of a set of Operators.
 
 The result of this bootstrapping process is a running {product-title} cluster. The cluster then downloads and configures remaining components needed for the day-to-day operations, including the creation of compute machines in supported environments.
+
+[role="_additional-resources"]
+.Additional resources
+ifndef::openshift-origin[]
+* link:https://console.redhat.com/openshift/create[*Cluster Type*]
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+* https://github.com/openshift/okd/releases
+endif::openshift-origin[]
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}]
+* link:https://console.redhat.com/openshift/install/metal/agent-based[Agent-based Installer]

--- a/modules/ipi-verifying-nodes-after-installation.adoc
+++ b/modules/ipi-verifying-nodes-after-installation.adoc
@@ -6,6 +6,7 @@
 [id="ipi-verifying-nodes-after-installation_{context}"]
 = Verifying node state after installation
 
+[role="_abstract"]
 The {product-title} installation completes when the following installation health checks are successful:
 
 * The provisioner can access the {product-title} web console.

--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -7,6 +7,7 @@
 [id="supported-platforms-for-openshift-clusters_{context}"]
 = Supported platforms for {product-title} clusters
 
+[role="_abstract"]
 The following table describes which platforms are supported by the different methods available for installing {product-title} clusters:
 
 // Should `none` and `external` be mentioned in this table?


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989)

Link to docs preview:
- https://116482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 2 of 5 PRs splitting [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.