### PR TITLE
[OSDOCS#18989] CQA pre-migration for Updating index assembly

### DIFF
--- a/modules/updating-clusters-overview-canary-rollout-reference.adoc
+++ b/modules/updating-clusters-overview-canary-rollout-reference.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-perform-canary-rollout-update_{context}"]
+= Performing a canary rollout update
+
+[role="_abstract"]
+Control the rollout of an update to your worker nodes to keep mission-critical applications available during the update.
+
+xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]: By controlling the rollout of an update to the worker nodes, you can ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, and then update the remaining nodes. This is referred to as a _canary_ update. Alternatively, you might also want to fit worker node updates, which often requires a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time. You can perform the following procedures:
+
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp_update-using-custom-machine-config-pools[Creating machine configuration pools to perform a canary rollout update]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine configuration pools]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-update_update-using-custom-machine-config-pools[Performing the cluster update]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-unpause_update-using-custom-machine-config-pools[Unpausing the machine configuration pools]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp-remove_update-using-custom-machine-config-pools[Moving a node to the original machine configuration pool]

--- a/modules/updating-clusters-overview-cli-reference.adoc
+++ b/modules/updating-clusters-overview-cli-reference.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-update-cluster-using-cli_{context}"]
+= Updating a cluster using the CLI
+
+[role="_abstract"]
+Update an {product-title} cluster within or between minor versions by using the OpenShift CLI (`oc`).
+
+xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]: You can update an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`). The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
+
+* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#machine-health-checks-pausing_updating-cluster-cli[Pausing a MachineHealthCheck resource]
+* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-single-node-openshift_updating-cluster-cli[About updating {product-title} on a single-node cluster]
+* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI]
+* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-changing-update-server-cli_updating-cluster-cli[Changing the update server by using the CLI]

--- a/modules/updating-clusters-overview-disconnected-reference.adoc
+++ b/modules/updating-clusters-overview-disconnected-reference.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-update-restricted-network-cluster_{context}"]
+= Updating a cluster in a disconnected environment
+
+[role="_abstract"]
+Mirror release images to a disconnected environment so that you can update a cluster that does not have direct internet access.
+
+xref:../disconnected/updating/index.adoc#about-disconnected-updates[About cluster updates in a disconnected environment]: If your mirror host cannot access both the internet and the cluster, you can mirror the images to a file system that is disconnected from that environment. You can then bring that host or removable media across that gap. If the local container registry and the cluster are connected to the mirror host of a registry, you can directly push the release images to the local registry.
+
+* xref:../disconnected/updating/mirroring-image-repository.adoc#updating-disconnected-mirror-host_mirroring-ocp-image-repository[Preparing your mirror host]
+* xref:../disconnected/updating/mirroring-image-repository.adoc#installation-adding-registry-pull-secret_mirroring-ocp-image-repository_mirroring-ocp-image-repository[Configuring credentials that allow images to be mirrored]
+* xref:../disconnected/updating/mirroring-image-repository.adoc#mirroring-ocp-image-repository_mirroring-ocp-image-repository[Mirroring {product-title} images]
+* xref:../disconnected/updating/disconnected-update.adoc#update-disconnected_updating-disconnected-cluster[Updating the disconnected cluster]
+* xref:../disconnected/updating/disconnected-update.adoc#images-configuration-registry-mirror_updating-disconnected-cluster[Configuring image registry repository mirroring]
+* xref:../disconnected/updating/disconnected-update.adoc#generating-icsp-object-scoped-to-a-registry_updating-disconnected-cluster[Widening the scope of the mirror image catalog to reduce the frequency of cluster node reboots]
+* xref:../disconnected/updating/disconnected-update-osus.adoc#update-service-install_updating-disconnected-cluster-osus[Installing the OpenShift Update Service Operator]
+* xref:../disconnected/updating/disconnected-update-osus.adoc#update-service-create-service_updating-disconnected-cluster-osus[Creating an OpenShift Update Service application]
+* xref:../disconnected/updating/uninstalling-osus.adoc#update-service-delete-service_updating-disconnected-cluster-osus[Deleting an OpenShift Update Service application]
+* xref:../disconnected/updating/uninstalling-osus.adoc#update-service-uninstall_updating-disconnected-cluster-osus[Uninstalling the OpenShift Update Service Operator]

--- a/modules/updating-clusters-overview-hosted-control-planes-reference.adoc
+++ b/modules/updating-clusters-overview-hosted-control-planes-reference.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-hosted-control-planes_{context}"]
+= Updating {hcp}
+
+[role="_abstract"]
+Updates for {hcp} are decoupled between the control plane and the nodes.
+
+xref:../hosted_control_planes/hcp-updating.adoc#hcp-updating_hcp-updating[Updating {hcp}]: On {hcp} for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates. For more information, see the following information:
+
+* xref:../hosted_control_planes/hcp-updating.adoc#hcp-updates-hosted-cluster_hcp-updating[Updates for the hosted cluster]
+* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]

--- a/modules/updating-clusters-overview-update-channels-reference.adoc
+++ b/modules/updating-clusters-overview-update-channels-reference.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-update-channels-and-releases_{context}"]
+= Understanding update channels and releases
+
+[role="_abstract"]
+Choose an update channel to control which {product-title} releases are offered for your cluster.
+
+With update channels, you can choose an update strategy. Update channels are specific to a minor version of {product-title}. Update channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version.
+
+{product-title} {product-version} offers the following update channel:
+
+* `stable-4`

--- a/modules/updating-clusters-overview-vsphere-hardware-reference.adoc
+++ b/modules/updating-clusters-overview-vsphere-hardware-reference.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-vsphere-updating-hardware_{context}"]
+= Updating hardware on nodes running in vSphere
+
+[role="_abstract"]
+Ensure that your nodes running in vSphere are running on a supported virtual hardware version.
+
+xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
+
+* xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
+* xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]
+
+[IMPORTANT]
+====
+Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
+====

--- a/modules/updating-clusters-overview-web-console-reference.adoc
+++ b/modules/updating-clusters-overview-web-console-reference.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="updating-clusters-overview-update-cluster-using-web-console_{context}"]
+= Updating a cluster using the web console
+
+[role="_abstract"]
+Update an {product-title} cluster within or between minor versions by using the web console.
+
+xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]: You can update an {product-title} cluster by using the web console. The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
+
+* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-using-custom-machine-config-pools-canary_updating-cluster-web-console[Performing a canary rollout update]
+* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#machine-health-checks-pausing-web-console_updating-cluster-web-console[Pausing a MachineHealthCheck resource]
+* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-single-node-openshift_updating-cluster-web-console[About updating {product-title} on a single-node cluster]
+* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-upgrading-web_updating-cluster-web-console[Updating a cluster by using the web console]
+* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-changing-update-server-web_updating-cluster-web-console[Changing the update server by using the web console]

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -1,82 +1,24 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="updating-clusters-overview"]
-include::_attributes/common-attributes.adoc[]
 = Updating clusters overview
+include::_attributes/common-attributes.adoc[]
 :context: updating-clusters-overview
 
 toc::[]
 
+[role="_abstract"]
 You can update an {product-title} 4 cluster with a single operation by using the web console or the OpenShift CLI (`oc`).
 
-[id="updating-clusters-overview-update-channels-and-releases"]
-== Understanding update channels and releases
-With update channels, you can choose an update strategy. Update channels are specific to a minor version of {product-title}. Update channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version.
+include::modules/updating-clusters-overview-update-channels-reference.adoc[leveloffset=+1]
 
-{product-title} {product-version} offers the following update channel:
+include::modules/updating-clusters-overview-web-console-reference.adoc[leveloffset=+1]
 
-* `stable-4`
+include::modules/updating-clusters-overview-cli-reference.adoc[leveloffset=+1]
 
-[id="updating-clusters-overview-update-cluster-using-web-console"]
-== Updating a cluster using the web console
-xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]: You can update an {product-title} cluster by using the web console. The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
+include::modules/updating-clusters-overview-canary-rollout-reference.adoc[leveloffset=+1]
 
-* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-using-custom-machine-config-pools-canary_updating-cluster-web-console[Performing a canary rollout update]
-* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#machine-health-checks-pausing-web-console_updating-cluster-web-console[Pausing a MachineHealthCheck resource]
-* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-single-node-openshift_updating-cluster-web-console[About updating {product-title} on a single-node cluster]
-* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-upgrading-web_updating-cluster-web-console[Updating a cluster by using the web console]
-* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-changing-update-server-web_updating-cluster-web-console[Changing the update server by using the web console]
+include::modules/updating-clusters-overview-disconnected-reference.adoc[leveloffset=+1]
 
-[id="updating-clusters-overview-update-cluster-using-cli"]
-== Updating a cluster using the CLI
-xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]: You can update an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`). The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
+include::modules/updating-clusters-overview-vsphere-hardware-reference.adoc[leveloffset=+1]
 
-* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#machine-health-checks-pausing_updating-cluster-cli[Pausing a MachineHealthCheck resource]
-* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-single-node-openshift_updating-cluster-cli[About updating {product-title} on a single-node cluster]
-* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI]
-* xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-changing-update-server-cli_updating-cluster-cli[Changing the update server by using the CLI]
-
-[id="updating-clusters-overview-perform-canary-rollout-update"]
-== Performing a canary rollout update
-xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]: By controlling the rollout of an update to the worker nodes, you can ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, and then update the remaining nodes. This is referred to as a _canary_ update. Alternatively, you might also want to fit worker node updates, which often requires a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time. You can perform the following procedures:
-
-* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp_update-using-custom-machine-config-pools[Creating machine configuration pools to perform a canary rollout update]
-* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine configuration pools]
-* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-update_update-using-custom-machine-config-pools[Performing the cluster update]
-* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-unpause_update-using-custom-machine-config-pools[Unpausing the machine configuration pools]
-* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp-remove_update-using-custom-machine-config-pools[Moving a node to the original machine configuration pool]
-
-[id="updating-clusters-overview-update-restricted-network-cluster"]
-== Updating a cluster in a disconnected environment
-xref:../disconnected/updating/index.adoc#about-disconnected-updates[About cluster updates in a disconnected environment]: If your mirror host cannot access both the internet and the cluster, you can mirror the images to a file system that is disconnected from that environment. You can then bring that host or removable media across that gap. If the local container registry and the cluster are connected to the mirror host of a registry, you can directly push the release images to the local registry.
-
-* xref:../disconnected/updating/mirroring-image-repository.adoc#updating-disconnected-mirror-host_mirroring-ocp-image-repository[Preparing your mirror host]
-* xref:../disconnected/updating/mirroring-image-repository.adoc#installation-adding-registry-pull-secret_mirroring-ocp-image-repository_mirroring-ocp-image-repository[Configuring credentials that allow images to be mirrored]
-* xref:../disconnected/updating/mirroring-image-repository.adoc#mirroring-ocp-image-repository_mirroring-ocp-image-repository[Mirroring {product-title} images]
-* xref:../disconnected/updating/disconnected-update.adoc#update-disconnected_updating-disconnected-cluster[Updating the disconnected cluster]
-* xref:../disconnected/updating/disconnected-update.adoc#images-configuration-registry-mirror_updating-disconnected-cluster[Configuring image registry repository mirroring]
-* xref:../disconnected/updating/disconnected-update.adoc#generating-icsp-object-scoped-to-a-registry_updating-disconnected-cluster[Widening the scope of the mirror image catalog to reduce the frequency of cluster node reboots]
-* xref:../disconnected/updating/disconnected-update-osus.adoc#update-service-install_updating-disconnected-cluster-osus[Installing the OpenShift Update Service Operator]
-* xref:../disconnected/updating/disconnected-update-osus.adoc#update-service-create-service_updating-disconnected-cluster-osus[Creating an OpenShift Update Service application]
-* xref:../disconnected/updating/uninstalling-osus.adoc#update-service-delete-service_updating-disconnected-cluster-osus[Deleting an OpenShift Update Service application]
-* xref:../disconnected/updating/uninstalling-osus.adoc#update-service-uninstall_updating-disconnected-cluster-osus[Uninstalling the OpenShift Update Service Operator]
-
-[id="updating-clusters-overview-vsphere-updating-hardware"]
-== Updating hardware on nodes running in vSphere
-
-xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
-
-* xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
-* xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]
-
-[IMPORTANT]
-====
-Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
-====
-
-[id="updating-clusters-overview-hosted-control-planes"]
-== Updating {hcp}
-
-xref:../hosted_control_planes/hcp-updating.adoc#hcp-updating_hcp-updating[Updating {hcp}]: On {hcp} for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates. For more information, see the following information:
-
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-updates-hosted-cluster_hcp-updating[Updates for the hosted cluster]
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
+include::modules/updating-clusters-overview-hosted-control-planes-reference.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989)

Link to docs preview:
- https://116483--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 3 of 5 PRs splitting [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989) by assembly. Xrefs allowed per the index.adoc navigation-file exception; nav modules are single-use.