### PR TITLE
[OSDOCS#18989] CQA pre-migration for Postinstallation configuration overview index assembly

### DIFF
--- a/modules/post-install-configuration-tasks-reference.adoc
+++ b/modules/post-install-configuration-tasks-reference.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="post-install-tasks_{context}"]
+= Postinstallation configuration tasks
+
+[role="_abstract"]
+You can perform the postinstallation configuration tasks to configure your environment to meet your needs.
+
+The following lists details these configurations:
+
+* Configure operating system features: The Machine Config Operator (MCO) manages `MachineConfig` objects. By using the MCO, you can configure nodes and custom resources.
+
+* Configure cluster features. You can modify the following features of an {product-title} cluster:
+
+** Image registry
+** Networking configuration
+** Image build behavior
+** Identity provider
+** The etcd configuration
+** Machine set creation to handle the workloads
+** Cloud provider credential management
+
+* Configuring a private cluster: By default, the installation program provisions {product-title} by using a publicly accessible DNS and endpoints. To make your cluster accessible only from within an internal network, configure the following components to make them private:
+
+** DNS
+** Ingress Controller
+** API server
+
+* Perform node operations: By default, {product-title} uses {op-system-first} compute machines. You can perform the following node operations:
+
+** Add and remove compute machines.
+** Add and remove taints and tolerations.
+** Configure the maximum number of pods per node.
+** Enable Device Manager.
+
+* Configure users: Users can authenticate themselves to the API by using OAuth access tokens. You can configure OAuth to perform the following tasks:
+
+** Specify an identity provider.
+** Use role-based access control to define and grant permissions to users.
+** Install an Operator from the software catalog.
+
+* Configuring alert notifications: By default, firing alerts are displayed on the Alerting UI of the web console. You can also configure {product-title} to send alert notifications to external systems.

--- a/post_installation_configuration/index.adoc
+++ b/post_installation_configuration/index.adoc
@@ -20,45 +20,7 @@ After installing {product-title}, a cluster administrator can configure and cust
 * Users
 * Alerts and notifications
 
-[id="post-install-tasks"]
-== Postinstallation configuration tasks
-
-You can perform the postinstallation configuration tasks to configure your environment to meet your needs.
-
-The following lists details these configurations:
-
-* Configure operating system features: The Machine Config Operator (MCO) manages `MachineConfig` objects. By using the MCO, you can configure nodes and custom resources.
-
-* Configure cluster features. You can modify the following features of an {product-title} cluster:
-
-** Image registry
-** Networking configuration
-** Image build behavior
-** Identity provider
-** The etcd configuration
-** Machine set creation to handle the workloads
-** Cloud provider credential management
-
-* Configuring a private cluster: By default, the installation program provisions {product-title} by using a publicly accessible DNS and endpoints. To make your cluster accessible only from within an internal network, configure the following components to make them private:
-
-** DNS
-** Ingress Controller
-** API server
-
-* Perform node operations: By default, {product-title} uses {op-system-first} compute machines. You can perform the following node operations:
-
-** Add and remove compute machines.
-** Add and remove taints and tolerations.
-** Configure the maximum number of pods per node.
-** Enable Device Manager.
-
-* Configure users: Users can authenticate themselves to the API by using OAuth access tokens. You can configure OAuth to perform the following tasks:
-
-** Specify an identity provider.
-** Use role-based access control to define and grant permissions to users.
-** Install an Operator from the software catalog.
-
-* Configuring alert notifications: By default, firing alerts are displayed on the Alerting UI of the web console. You can also configure {product-title} to send alert notifications to external systems.
+include::modules/post-install-configuration-tasks-reference.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]


### PR DESCRIPTION
Version(s): 4.20+

Issue: [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989)

Link to docs preview:
- https://116485--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/index.html

QE review:
- [ ] ~~QE has approved this change.~~

Additional information: 5 of 5 PRs splitting [OSDOCS-18989](https://redhat.atlassian.net/browse/OSDOCS-18989) by assembly.