### PR TITLE
[OSDOCS-20889]: Fix invalid pausedUntil value in HostedControlPlane restore reconciliation step.

### DIFF
--- a/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
+++ b/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
@@ -280,7 +280,7 @@ $ oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd -w
 [source,terminal]
 ----
 $ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} \
-  -p '{"spec":{"pausedUntil":"null"}}' --type=merge
+  -p '{"spec":{"pausedUntil":"false"}}' --type=merge
 ----
 
 . Manually roll out the hosted cluster by entering the following command:


### PR DESCRIPTION

Version(s):
4.22+ (Main)

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20889

Link to docs preview:
https://github.com/AlfredoPizarro/openshift-docs/blob/AlfredoPizarro-hcp-restore-patch1/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc

QE review:

 Small doc syntax fix.

Additional information:
Updating the pausedUntil command example for HostedControlPlane.

Attempting to patch spec.pausedUntil using "null" produces an API validation error:
spec.pausedUntil: Invalid value: "null": PausedUntil must be a date in RFC3339 format or 'True', 'true', 'False' or 'false'

Replaced "null" with "false" so the patch command executes successfully.
