### PR TITLE
OBSDOCS-3312: Restore restructured format for configuring-the-log-store.adoc

### DIFF
--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -7,34 +7,29 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure a `LokiStack` custom resource (CR) to store application, audit, and infrastructure-related logs.
 
 include::snippets/loki-statement-snip.adoc[leveloffset=+1]
 
-
-// Loki sizing
-include::modules/loki-sizing.adoc[leveloffset=+1]
-
-
-// Loki object storage
-include::modules/logging-loki-storage.adoc[leveloffset=+1]
-
-// create object storage
-include::modules/logging-loki-storage-aws.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-azure.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-azure-entra.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-gcp.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-s3-compatible.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-odf.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-swift.adoc[leveloffset=+2]
+[NOTE]
+====
+Before configuring LokiStack, review the xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[deployment sizing guidance] and xref:../installing/configuring-storage-for-lokistack.adoc#configuring-storage-for-lokistack[configure your object storage backend].
+====
 
 //Loki storage STS
-include::modules/about-loki-storage-sts.adoc[leveloffset=+2]
-include::modules/logging-identity-federation.adoc[leveloffset=+3]
-include::modules/logging-create-loki-cr-console.adoc[leveloffset=+3,tag=!pre-5.9]
-include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+3]
-include::modules/logging-loki-log-access.adoc[leveloffset=+2,tag=!NetObservMode]
-include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]
+[id="installing-log-storage-loki-sts"]
+include::modules/about-loki-storage-sts.adoc[leveloffset=+1]
+
+include::modules/logging-identity-federation.adoc[leveloffset=+2]
+
+include::modules/logging-create-loki-cr-console.adoc[leveloffset=+2,tag=!pre-5.9]
+
+include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+2]
+
+include::modules/logging-loki-log-access.adoc[leveloffset=+1,tag=!NetObservMode]
+
+include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]
 
 //Enhanced reliability and performance
 [id="performance_{context}"]
@@ -43,9 +38,13 @@ include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[levelof
 Use the following configurations to ensure reliability and efficiency of Loki in production.
 
 include::modules/loki-pod-placement.adoc[leveloffset=+2]
+
 include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+2]
+
 include::modules/logging-loki-retention.adoc[leveloffset=+2]
+
 include::modules/loki-memberlist-ip.adoc[leveloffset=+2]
+
 include::modules/loki-restart-hardening.adoc[leveloffset=+2]
 //include::modules/enabling-automatic-stream-sharding.adoc[leveloffset=+2]
 
@@ -56,7 +55,9 @@ include::modules/loki-restart-hardening.adoc[leveloffset=+2]
 You can configure high availability, scalability, and error handling for Loki.
 
 include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
+
 include::modules/loki-zone-fail-recovery.adoc[leveloffset=+2]
+
 include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
 
 [id="loki-network-policies-for-added-security_{context}"]
@@ -79,4 +80,5 @@ include::modules/integrating-loki-network-policy-with-external-systems.adoc[leve
 You can configure log-based alerts for Loki by creating an `AlertingRule` custom resource (CR).
 
 include::modules/loki-rbac-rules-permissions.adoc[leveloffset=+2]
+
 include::modules/enabling-loki-alerts.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
Fix inadvertent reversion of [OBSDOCS-3312](https://redhat.atlassian.net/browse/OBSDOCS-3312) restructuring that occurred in [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) (PR #113999).

## Problem
[OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) added filtering documentation on 2026-07-13, but also inadvertently reverted the [OBSDOCS-3312](https://redhat.atlassian.net/browse/OBSDOCS-3312)/OBSDOCS-3551 restructuring of `configuring/configuring-the-log-store.adoc`. The file was changed from the simplified 6.6 format back to the pre-restructuring format with embedded sizing/storage includes.

This created an inconsistency where:
- **standalone-logging-docs-6.6** has the correct restructured format ✅
- **standalone-logging-docs-main** had the old pre-restructuring format ❌

## Solution
Restore the simplified format to match 6.6 structure:
- Remove sizing/storage includes (they live in `installing/` assemblies)
- Add NOTE block pointing users to deployment sizing and storage configuration docs
- Fix STS section leveloffset from +3 to +2
- Add `[role="_abstract"]` to abstract paragraph

## Structure after this fix
- **Sizing content**: `installing/loki-deployment-sizing.adoc`
- **Storage configuration**: `installing/configuring-storage-for-lokistack.adoc`  
- **This file**: Simplified with NOTE pointing to above docs

## Testing
Compared resulting structure with upstream/standalone-logging-docs-6.6 to ensure consistency.

## Related
- Original restructuring: [OBSDOCS-3312](https://redhat.atlassian.net/browse/OBSDOCS-3312) (May 2026)
- Inadvertent reversion: [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) / PR #113999 (July 13, 2026)
- 6.6 cherry-pick of [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539): PR #116488 (maintained correct structure)

## Note
This PR should **NOT** be cherry-picked to 6.6 since 6.6 already has the correct structure.