### PR TITLE
[enterprise-4.20] OSDOCS-17043_corr_b#CQA updates for machine sets_420

### DIFF
--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -147,8 +147,6 @@ ifdef::upi[]
 .. Update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters by using the values from your offer.
 .. Specify a `plan` for the virtual machines (VMs).
 +
-.Example `06_workers.json` ARM template with an updated `storageProfile.imageReference` object and a specified `plan`
-+
 [source,json,subs="none"]
 ----
 ...
@@ -181,8 +179,7 @@ ifdef::mapi[]
 endif::mapi[]
 
 ifdef::ipi[]
-.Sample `install-config.yaml` file with the {azure-short} Marketplace compute nodes
-
++
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -34,7 +34,7 @@ endif::cpmso[]
 . In a text editor, open the YAML file for an existing machine set or create a new one.
 
 . Edit the following lines under the `providerSpec` field:
-
++
 [source,yaml]
 ----
 ifndef::cpmso[]
@@ -60,16 +60,15 @@ spec:
           placementGroupPartition: <placement_group_partition_number>
 # ...
 ----
-
++
 where:
-
++
 `spec.template.spec.providerSpec.value.instanceType`:: Specifies an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
 `spec.template.spec.providerSpec.value.networkInterfaceType`:: Specifies the `EFA` network interface type.
 `spec.template.spec.providerSpec.value.placement.availabilityZone`:: Specifies the zone, for example, `us-east-1a`.
 `spec.template.spec.providerSpec.value.placement.region`:: Specifies the region, for example, `us-east-1`.
 `spec.template.spec.providerSpec.value.placementGroupName`:: Specifies the name of the existing {aws-short} placement group to deploy machines in.
-`spec.template.spec.providerSpec.value.placementGroupPartition`:: Specifies the partition number of the existing AWS placement group to deploy machines in. This value is optional.
-
+`spec.template.spec.providerSpec.value.placementGroupPartition`:: Optional: Specifies the partition number of the existing AWS placement group to deploy machines in.
 
 .Verification
 

--- a/modules/machineset-azure-confidential-vms.adoc
+++ b/modules/machineset-azure-confidential-vms.adoc
@@ -37,7 +37,6 @@ For more information about related features and functionality, see the {azure-fu
 . Edit the following section under the `providerSpec` field:
 +
 --
-.Sample configuration
 [source,yaml]
 ----
 ifndef::cpmso[]

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -58,13 +58,30 @@ providerSpec:
 You can optionally set the `spotVMOptions.maxPrice` field to limit the cost of the Spot VM. For example you can set `maxPrice: '0.98765'`. If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to `-1` and charges up to the standard VM price.
 +
 {azure-full} caps Spot VM prices at the standard price. {azure-short} will not evict an instance due to pricing if the instance is set with the default `maxPrice`. However, an instance can still be evicted due to capacity restrictions.
-
++
 [NOTE]
 ====
 It is strongly recommended to use the default standard VM price as the `maxPrice` value and to not set the maximum price for Spot VMs.
 ====
 endif::azure[]
 ifdef::gcp[]
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    provisioningModel: "Spot"
+----
++
+If you specify `provisioningModel: "Spot"`, the machine is labeled as an `interruptible-instance` after the instance is launched.
++
+[NOTE]
+====
+This parameter is not compatible with setting the `providerSpec.value.preemptible` value to `true`.
+====
+endif::gcp[]
+ifdef::gcp-legacy-preempt[]
++
 [source,yaml]
 ----
 providerSpec:
@@ -73,8 +90,12 @@ providerSpec:
 ----
 +
 If `preemptible` is set to `true`, the machine is labeled as an `interruptible-instance` after the instance is launched.
-
-endif::gcp[]
++
+[NOTE]
+====
+This parameter is not compatible with setting the `providerSpec.value.provisioningModel` value to `"Spot"`.
+====
+endif::gcp-legacy-preempt[]
 
 ifeval::["{context}" == "creating-machineset-aws"]
 :!aws:

--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -24,8 +24,6 @@ For more information about the supported instance types, see the following NVIDI
 $ oc get nodes
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE     VERSION
@@ -37,14 +35,12 @@ ip-10-0-72-170.us-east-2.compute.internal   Ready    control-plane,master   3d17
 ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.33.4
 ----
 
-. View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the AWS region. The installer automatically load balances compute machines across availability zones.
+. View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the AWS region. The installation program automatically load balances compute machines across availability zones.
 +
 [source,terminal]
 ----
 $ oc get machinesets -n openshift-machine-api
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -59,8 +55,6 @@ preserve-dsoc12r4-ktjfc-worker-us-east-2b   2         2         2       2       
 ----
 $ oc get machines -n openshift-machine-api | grep worker
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -110,8 +104,6 @@ to match the new `.metadata.name`.
 $ oc -n openshift-machine-api get preserve-dsoc12r4-ktjfc-worker-us-east-2a -o json | diff preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a.json -
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 10c10
@@ -146,8 +138,6 @@ $ oc -n openshift-machine-api get preserve-dsoc12r4-ktjfc-worker-us-east-2a -o j
 $ oc create -f preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a.json
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 machineset.machine.openshift.io/preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a created
@@ -165,8 +155,6 @@ $ oc -n openshift-machine-api get machinesets | grep gpu
 The MachineSet replica count is set to `1` so a new `Machine` object is created automatically.
 
 +
-.Example output
-+
 [source,terminal]
 ----
 preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a   1         1         1       1           4m21s
@@ -178,8 +166,6 @@ preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a   1         1         1       1   
 ----
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
-+
-.Example output
 +
 [source,terminal]
 ----

--- a/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
+++ b/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
@@ -26,8 +26,6 @@ The NFD Operator identifies hardware device features in nodes. It solves the gen
 $ oc get pods -n openshift-nfd
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                                       READY    STATUS     RESTARTS   AGE

--- a/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
@@ -45,8 +45,6 @@ By default, {azure-full} subscriptions do not have a quota for the {azure-full} 
 $ oc get machineset -n openshift-machine-api
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                              DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -63,14 +61,12 @@ This will be the basis for the GPU-enabled compute machine set definition.
 $ oc get machineset -n openshift-machine-api myclustername-worker-centralus1 -o yaml > machineset-azure.yaml
 ----
 
-. View the content of the machineset:
+. View the content of the compute machine set:
 +
 [source,terminal]
 ----
 $ cat machineset-azure.yaml
 ----
-+
-.Example `machineset-azure.yaml` file
 +
 [source,yaml]
 ----
@@ -168,8 +164,6 @@ $ cp machineset-azure.yaml machineset-azure-gpu.yaml
 
 * Change `.spec.template.spec.providerSpec.value.vmSize` to `Standard_NC4as_T4_v3`.
 +
-.Example `machineset-azure-gpu.yaml` file
-+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -256,7 +250,6 @@ status:
 $ diff machineset-azure.yaml machineset-azure-gpu.yaml
 ----
 +
-.Example output
 [source,terminal]
 ----
 14c14
@@ -284,8 +277,6 @@ $ diff machineset-azure.yaml machineset-azure-gpu.yaml
 $ oc create -f machineset-azure-gpu.yaml
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 machineset.machine.openshift.io/myclustername-nc4ast4-gpu-worker-centralus1 created
@@ -297,8 +288,6 @@ machineset.machine.openshift.io/myclustername-nc4ast4-gpu-worker-centralus1 crea
 ----
 $ oc get machineset -n openshift-machine-api
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -315,8 +304,6 @@ clustername-n6n4r-worker-centralus3                1         1         1       1
 ----
 $ oc get machines -n openshift-machine-api
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -337,8 +324,6 @@ myclustername-worker-centralus3-p9b8c               Running   Standard_D4s_v3   
 $ oc get nodes
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES                  AGE     VERSION
@@ -357,8 +342,6 @@ myclustername-worker-centralus3-p9b8c               Ready    worker             
 ----
 $ oc get machineset -n openshift-machine-api
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -382,8 +365,6 @@ $ oc create -f machineset-azure-gpu.yaml
 oc get machineset -n openshift-machine-api
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                                          DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -404,8 +385,6 @@ $ oc get machineset -n openshift-machine-api | grep gpu
 +
 The MachineSet replica count is set to `1` so a new `Machine` object is created automatically.
 +
-.Example output
-+
 [source,terminal]
 ----
 myclustername-nc4ast4-gpu-worker-centralus1   1         1         1       1           121m
@@ -417,8 +396,6 @@ myclustername-nc4ast4-gpu-worker-centralus1   1         1         1       1     
 ----
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
-+
-.Example output
 +
 [source,terminal]
 ----

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -40,8 +40,6 @@ machineType: a2-highgpu-1g
 onHostMaintenance: Terminate
 ----
 +
-.Example `a2-highgpu-1g.json` file
-+
 [source,json]
 ----
 {
@@ -153,8 +151,6 @@ onHostMaintenance: Terminate
 $ oc get nodes
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                                                             STATUS     ROLES                  AGE     VERSION
@@ -174,8 +170,6 @@ myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      work
 $ oc get machinesets -n openshift-machine-api
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 NAME                               DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -191,8 +185,6 @@ myclustername-2pt9p-worker-f       0         0                             8h
 ----
 $ oc get machines -n openshift-machine-api | grep worker
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -249,8 +241,6 @@ to match the new `.metadata.name`.
 $ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o json | diff ocp_{product-version}_machineset-a2-highgpu-1g.json -
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 15c15
@@ -279,8 +269,6 @@ $ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o jso
 $ oc create -f ocp_{product-version}_machineset-a2-highgpu-1g.json
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 machineset.machine.openshift.io/myclustername-2pt9p-worker-gpu-a created
@@ -298,8 +286,6 @@ $ oc -n openshift-machine-api get machinesets | grep gpu
 The `MachineSet` replica count is set to `1` so a new `Machine` object is created automatically.
 
 +
-.Example output
-+
 [source,terminal]
 ----
 myclustername-2pt9p-worker-gpu-a   1         1         1       1           5h24m
@@ -311,8 +297,6 @@ myclustername-2pt9p-worker-gpu-a   1         1         1       1           5h24m
 ----
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
-+
-.Example output
 +
 [source,terminal]
 ----


### PR DESCRIPTION
4.20 cherrypick of 877357d1996bb322540c1f62760ab06d4492538c
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/115756

Note
Reason for the discrepancy in the no. of lines and files changed from the merged main branch: 
- enterprise-4.20 didn't have the gcp/gcp-legacy-preempt conditional split yet. The cherry-pick had to add the new ifdef::gcp[] Spot VM block and the ifdef::gcp-legacy-preempt[] preemptible block (with NOTEs about incompatibility). That's ~19 extra inserted lines, explaining the higher +31.
-  `modules/machineset-creating-imds-options.adoc` is missing from all cherry-picks. It applied cleanly during the cherry-pick but produced no diff — meaning the change in that file on main was already present on all version branches. 