### PR TITLE
[RHDEVDOCS-7749] Release notes for Pipelines 1.23.1

### DIFF
--- a/modules/op-release-notes-1-23-1.adoc
+++ b/modules/op-release-notes-1-23-1.adoc
@@ -1,0 +1,20 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-23.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-23-1_{context}"]
+= Release notes for {pipelines-title} 1.23.1
+
+[role="_abstract"]
+{pipelines-title} General Availability (GA) 1.23.1 is available on {OCP} 4.14 and later supported versions.
+
+[id="fixed-issues-1-23-1_{context}"]
+== Fixed issues
+
+.User interface
+
+//SRVKP-12879
+Incorrect tab highlighting on the Overview page::
+Before this update, a PatternFly version mismatch between the {OCP} web console and the {pipelines-shortname} console plugin caused incorrect tab highlighting on the *Overview* page. In the pipelines list section, the interface highlighted the *Per Repository* tab when the *Per Pipeline* view was active, and vice versa. With this update, the console plugin PatternFly dependencies match the console version. As a result, the correct tab is highlighted.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12879[SRVKP-12879]

--- a/release_notes/op-release-notes-1-23.adoc
+++ b/release_notes/op-release-notes-1-23.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.23
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.23.1
+include::modules/op-release-notes-1-23-1.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.23.0
 include::modules/op-release-notes-1-23-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7749

Link to docs preview:
- [1.23.1 RNs](https://116538--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-23.html#op-release-notes-1-23-1_op-release-notes-1-23)

QE/SME review:
- [x] QE/SME has approved this change.

