### PR TITLE
CNV-85197: Documentation about the new component

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5136,6 +5136,8 @@ Topics:
     File: virt-exposing-downward-metrics
   - Name: Virtual machine health checks
     File: virt-monitoring-vm-health
+  - Name: Standalone observability controller
+    File: virt-standalone-observability-controller
   - Name: Runbooks
     File: virt-runbooks
 - Name: Support

--- a/modules/virt-enabling-standalone-observability-controller.adoc
+++ b/modules/virt-enabling-standalone-observability-controller.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-standalone-observability-controller.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-standalone-observability-controller_{context}"]
+= Enable the standalone observability controller
+
+[role="_abstract"]
+You can enable the standalone observability controller by setting the `deployObservabilityController` feature gate in the `HyperConverged` custom resource (CR). By enabling the standalone observability controller, you can update monitoring and alerts independently of the {VirtProductName} control plane.
+
+:FeatureName: The standalone observability controller
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have access to the cluster as a user with `cluster-admin` permissions.
+* You have installed the {oc-first}.
+
+.Procedure
+
+* Enable the `deployObservabilityController` feature gate by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
+  --type json -p '[{"op": "add", "path": "/spec/featureGates/-", \
+  "value": {"name": "deployObservabilityController"}}]'
+----
+
+.Verification
+
+* Verify that the feature gate is enabled by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
+  -o jsonpath='{.spec.featureGates}'
+----
++
+.Expected output
+[source,json]
+----
+[{"name":"deployObservabilityController"}]
+----

--- a/virt/monitoring/virt-monitoring-overview.adoc
+++ b/virt/monitoring/virt-monitoring-overview.adoc
@@ -28,6 +28,11 @@ Configure the `node-exporter` service to expose internal VM metrics and processe
 xref:../../virt/monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[VM health checks]::
 Configure readiness, liveness, and guest agent ping probes and a watchdog for VMs.
 
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+xref:../../virt/monitoring/virt-standalone-observability-controller.adoc#virt-standalone-observability-controller[Standalone observability controller]::
+Enable the standalone observability controller to update monitoring and alerts independently of the {VirtProductName} control plane.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
 xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbooks[Runbooks]::
 
 ifndef::openshift-rosa-hcp[]

--- a/virt/monitoring/virt-standalone-observability-controller.adoc
+++ b/virt/monitoring/virt-standalone-observability-controller.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-standalone-observability-controller"]
+= Standalone observability controller
+include::_attributes/common-attributes.adoc[]
+:context: virt-standalone-observability-controller
+
+toc::[]
+
+[role="_abstract"]
+You can decouple {VirtProductName} monitoring from the main deployment by using the standalone observability controller. The controller externalizes monitoring into a standalone Operator.
+
+:FeatureName: The standalone observability controller
+include::snippets/technology-preview.adoc[]
+
+The standalone observability controller provides the following capabilities:
+
+* Prometheus metrics for {VirtProductName} resources, including virtual machines, virtual machine instances, migrations, and instance types.
+* Alerting rules and recording rules, reconciled through `PrometheusRule` custom resources.
+* Metric collection endpoints, reconciled through `ServiceMonitor` custom resources.
+
+include::modules/virt-enabling-standalone-observability-controller.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
CNV v5.0.0

Issue:
https://redhat.atlassian.net/browse/CNV-85197

Link to docs preview:
https://116550--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-standalone-observability-controller.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

