### PR TITLE
OSDOCS-20759: Remove duplicate --ssh-key from hcp create cluster agent example

### DIFF
--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -65,7 +65,7 @@ $ hcp create cluster agent \
   --pull-secret=<path_to_pull_secret> \
   --agent-namespace=<hosted_control_plane_namespace> \
   --base-domain=<base_domain> \
-  --api-server-address=api.<hosted_cluster_name>.<base_domain>
+  --api-server-address=api.<hosted_cluster_name>.<base_domain> \
   --etcd-storage-class=<etcd_storage_class> \
   --ssh-key=<path_to_ssh_key> \
   --namespace=<hosted_cluster_namespace> \
@@ -73,8 +73,7 @@ $ hcp create cluster agent \
   --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image>-multi \
   --node-pool-replicas=<node_pool_replica_count> \
   --render \
-  --render-sensitive \
-  --ssh-key <home_directory>/<path_to_ssh_key>/<ssh_key> > hosted-cluster-config.yaml
+  --render-sensitive > hosted-cluster-config.yaml
 ----
 +
 where:
@@ -90,7 +89,6 @@ where:
 * `--control-plane-availability-policy` specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 * `--release-image` specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
 * `--node-pool-replicas` specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
-* `--ssh-key` specifies the path to the SSH key, such as `user/.ssh/id_rsa`.
 
 . Configure the service publishing strategy. By default, hosted clusters use the `NodePort` service publishing strategy because node ports are always available without additional infrastructure. However, you can configure the service publishing strategy to use a load balancer.
 


### PR DESCRIPTION
Version(s):
4.22 / main

Issue:
https://issues.redhat.com/browse/OSDOCS-20759

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

Additional information:
Removes the duplicate `--ssh-key` flag from the `hcp create cluster agent` command example in the bare metal hosted control planes documentation. Also adds a missing line-continuation backslash after `--api-server-address` and removes the unused placeholder explanation for the duplicate flag.


