### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/modules/nodes-containers-dev-fuse-configuring.adoc
+++ b/modules/nodes-containers-dev-fuse-configuring.adoc
@@ -9,13 +9,13 @@
 [role="_abstract"]
 You can grant an unprivileged pod the capability to perform Filesystem in Userspace (FUSE) mounts by exposing the `/dev/fuse` device. With this setup, an unprivileged user within the pod can use tools such as `podman` with storage drivers such as `fuse-overlayfs` by mimicking privileged build capabilities in a secure and efficient manner without granting full privileged access to the pod.
 
-You expose the `/dev/fuse` device by adding the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation to your pod definition.
+You expose the `/dev/fuse` device by adding the `devices.crio.io: "/dev/fuse"` annotation to your pod definition.
 
 .Procedure
 
 . Define the pod with `/dev/fuse` access:
 +
-.. Create a YAML file named `fuse-builder-pod.yaml` with the following content: 
+.. Create a YAML file named `fuse-builder-pod.yaml` with the following content:
 +
 [source,yaml]
 ----
@@ -24,7 +24,7 @@ kind: Pod
 metadata:
   name: fuse-builder-pod
   annotations:
-    io.kubernetes.cri-o.Devices: "/dev/fuse"
+    devices.crio.io: "/dev/fuse"
 spec:
   containers:
   - name: build-container
@@ -37,7 +37,7 @@ spec:
 +
 where:
 +
-`metadata.annotations`:: Specifies that the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation makes the FUSE device available.
+`metadata.annotations`:: Specifies that the `devices.crio.io: "/dev/fuse"` annotation makes the FUSE device available.
 `spec.containers.image`:: Specifies a container that uses an image that includes `podman` (for example, `quay.io/podman/stable`).
 `spec.containers.args`:: Specifies a command to keep the container running so you can `exec` into it.
 `spec.containers.securityContext`:: Specifies a `securityContext` that runs the container as an unprivileged user (for example, `runAsUser: 1000`).
@@ -70,7 +70,7 @@ $ oc get pods fuse-builder-pod
 $ oc exec -ti fuse-builder-pod -- /bin/bash
 ----
 +
-You are now inside the container. 
+You are now inside the container.
 
 .. Because the default working directory might not be writable by an unprivileged user, change to a writable directory such as `/tmp` by running the following commands:
 +


### PR DESCRIPTION
Version(s): all

Issue: https://github.com/cri-o/cri-o/issues/10194

Link to docs preview: N/A

QE review:
- [ ] QE has approved this change.

Additional information:
CRI-O migrated its annotations from v1 (`io.kubernetes.cri-o.*`) to v2 (`*.crio.io`) in December 2025. The old format is deprecated. This PR updates the `io.kubernetes.cri-o.Devices` annotation to its v2 equivalent `devices.crio.io`.