### PR TITLE
OADP-8503: Removing the Velro CLI docs in OADP

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -10,7 +10,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-Use the {oadp-short} CLI plugin for all backup and restore operations, including viewing logs and descriptions. Downloading the `velero` CLI tool is not neccessary.
+Use the {oadp-short} CLI plugin for all backup and restore operations, including viewing logs and descriptions. You do not need to download the `velero` CLI tool to debug `Backup` and `Restore` custom resources (CRs) or troubleshoot failed operations.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -1,24 +1,20 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="velero-cli-tool"]
 = Velero CLI tool
-:toc:
-
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: velero-cli-tool
 :namespace: openshift-adp
 :local-product: OADP
 
-
+toc::[]
 
 [role="_abstract"]
-Download the `velero` CLI tool or access the `velero` binary in your cluster to debug `Backup` and `Restore` custom resources (CRs) and retrieve logs. This helps you to troubleshoot failed backup and restore operations.
+Download the `velero` CLI tool for advanced debugging scenarios that are not covered by the {oadp-short} CLI plugin. For common operations such as viewing backup and restore logs and descriptions, use the xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[{oadp-short} CLI plugin] instead.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
 
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+2]
-
-include::modules/velero-obtaining-by-accessing-binary.adoc[leveloffset=+1]
 
 include::modules/oadp-debugging-oc-cli.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -10,7 +10,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-Download the `velero` CLI tool for advanced debugging scenarios that are not covered by the {oadp-short} CLI plugin. For common operations such as viewing backup and restore logs and descriptions, use the {oadp-short} CLI plugin] instead.
+Use the {oadp-short} CLI plugin for all backup and restore operations, including viewing logs and descriptions. Download the `velero` CLI tool only for advanced debugging scenarios not covered by the {oadp-short} CLI plugin.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -10,7 +10,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-Download the `velero` CLI tool for advanced debugging scenarios that are not covered by the {oadp-short} CLI plugin. For common operations such as viewing backup and restore logs and descriptions, use the xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[{oadp-short} CLI plugin] instead.
+Download the `velero` CLI tool for advanced debugging scenarios that are not covered by the {oadp-short} CLI plugin. For common operations such as viewing backup and restore logs and descriptions, use the {oadp-short} CLI plugin] instead.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -10,7 +10,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-Use the {oadp-short} CLI plugin for all backup and restore operations, including viewing logs and descriptions. Download the `velero` CLI tool only for advanced debugging scenarios not covered by the {oadp-short} CLI plugin.
+Use the {oadp-short} CLI plugin for all backup and restore operations, including viewing logs and descriptions. Downloading the `velero` CLI tool is not neccessary.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
 

--- a/modules/migration-debugging-velero-resources.adoc
+++ b/modules/migration-debugging-velero-resources.adoc
@@ -7,17 +7,14 @@
 = Interpreting backup and restore output
 
 [role="_abstract"]
-Use the following information to interpret the output of backup and restore describe commands.
+Use the {oadp-short} CLI plugin to retrieve logs and descriptions of backup and restore custom resources (CRs). Use the following information to interpret the output.
 
-[NOTE]
-====
-To retrieve logs and descriptions of backup and restore custom resources (CRs), use the {oadp-short} CLI plugin:
+To retrieve backup and restore information, use the following {oadp-short} CLI plugin commands:
 
 * `oc oadp backup describe <backup_name> --details`
 * `oc oadp backup logs <backup_name>`
 * `oc oadp restore describe <restore_name> --details`
 * `oc oadp restore logs <restore_name>`
-====
 
 The following types of errors and warnings appear in describe output:
 

--- a/modules/migration-debugging-velero-resources.adoc
+++ b/modules/migration-debugging-velero-resources.adoc
@@ -2,87 +2,39 @@
 //
 // * backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="migration-debugging-velero-resources_{context}"]
-= Debugging Velero resources with the Velero CLI tool
+= Interpreting backup and restore output
 
 [role="_abstract"]
-Debug `Backup` and `Restore` custom resources (CRs) and retrieve logs with the Velero CLI tool. The Velero CLI tool provides more detailed information than the OpenShift CLI tool.
+Use the following information to interpret the output of backup and restore describe commands.
 
-.Procedure
+[NOTE]
+====
+To retrieve logs and descriptions of backup and restore custom resources (CRs), use the {oadp-short} CLI plugin:
 
-* Use the `oc exec` command to run a Velero CLI command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  <backup_restore_cr> <command> <cr_name>
-----
-+
-.Example `oc exec` command
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  backup describe 0e44ae00-5dc3-11eb-9ca8-df7e5254778b-2d8ql
-----
+* `oc oadp backup describe <backup_name> --details`
+* `oc oadp backup logs <backup_name>`
+* `oc oadp restore describe <restore_name> --details`
+* `oc oadp restore logs <restore_name>`
+====
 
-* List all Velero CLI commands by using the following `velero --help` option:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  --help
-----
+The following types of errors and warnings appear in describe output:
 
-* Retrieve the logs of a `Backup` or `Restore` CR by using the following `velero logs` command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  <backup_restore_cr> logs <cr_name>
-----
-+
-.Example `velero logs` command
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  restore logs ccc7c2d0-6017-11eb-afab-85d0007f5a19-x4lbf
-----
+* `Velero`: Messages related to the operation of Velero itself, for example, connecting to the cloud or reading a backup file.
 
-* Retrieve a summary of warnings and errors associated with a `Backup` or `Restore` CR by using the following `velero describe` command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  <backup_restore_cr> describe <cr_name>
-----
-+
-.Example `velero describe` command
-[source,terminal,subs="attributes+"]
-----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  backup describe 0e44ae00-5dc3-11eb-9ca8-df7e5254778b-2d8ql
-----
-+
-The following types of restore errors and warnings are shown in the output of a `velero describe` request:
-+
-* `Velero`: A list of messages related to the operation of Velero itself, for example, messages related to connecting to the cloud, reading a backup file, and so on
-+
-* `Cluster`:  A list of messages related to backing up or restoring cluster-scoped resources
-+
-* `Namespaces`: A list of list of messages related to backing up or restoring resources stored in namespaces
+* `Cluster`: Messages related to backing up or restoring cluster-scoped resources.
 
-+
+* `Namespaces`: Messages related to backing up or restoring resources stored in namespaces.
+
 One or more errors in one of these categories results in a `Restore` operation receiving the status of `PartiallyFailed` and not `Completed`. Warnings do not lead to a change in the completion status.
 
+Consider the following points when you encounter restore errors:
+
+* For resource-specific errors (`Cluster` and `Namespaces`), the `restore describe --details` output includes a resource list of all resources that Velero attempted to restore. For any resource that has such an error, check whether the resource exists in the cluster.
+
+* If there are `Velero` errors but no resource-specific errors, it is possible that the restore completed without problems restoring workloads. In this case, carefully validate post-restore applications.
 +
+For example, if the output contains `PodVolumeRestore` or node agent-related errors, check the status of `PodVolumeRestores` and `DataDownloads`. If none of these are failed or still running, volume data might have been fully restored.
 
-Consider the following points for these restore errors:
-
-* For resource-specific errors, that is, `Cluster` and `Namespaces` errors, the `restore describe --details` output includes a resource list that includes all resources that Velero restored. For any resource that has such an error, check if the resource is actually in the cluster.
-
-* For resource-specific errors, that is, `Cluster` and `Namespaces` errors, the `restore describe --details` output includes a resource list that includes all resources that Velero restored. For any resource that has such an error, check if the resource is actually in the cluster.
-
-* If there are `Velero` errors but no resource-specific errors in the output of a `describe` command, it is possible that the restore completed without any actual problems in restoring workloads. In this case, carefully validate post-restore applications.
-+
-For example, if the output contains `PodVolumeRestore` or node agent-related errors, check the status of `PodVolumeRestores` and `DataDownloads`. If none of these are failed or still running, then volume data might have been fully restored.
+* You can use the raw `velero` CLI for additional debugging not available through the {oadp-short} CLI plugin. For more information, see the Velero documentation.


### PR DESCRIPTION
## JIRA

* [OADP-8503](https://redhat.atlassian.net/browse/OADP-8503)

---

## Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

* OCP - main
* OCP - 4.22
* OCP - 5.0

---

## Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* [Velero CLI tool](https://116567--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.html)

---

## QE review:

- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

---