### PR TITLE
OBSDOCS-3628: Fix Vale and DITA compliance issues (6.6 cherry-pick)

### DIFF
--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -14,20 +14,21 @@ include::snippets/loki-statement-snip.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-Before configuring LokiStack, review the deployment sizing guidance and configure your object storage backend. See Additional resources for detailed information.
+Before configuring LokiStack, review the xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[deployment sizing guidance] and xref:../installing/configuring-storage-for-lokistack.adoc#configuring-storage-for-lokistack[configure your object storage backend].
 ====
 
 //Loki storage STS
 [id="installing-log-storage-loki-sts"]
-== Deploying a Loki log store on a cluster that uses short-term credentials
-
-include::modules/about-loki-storage-sts.adoc[leveloffset=+2]
+include::modules/about-loki-storage-sts.adoc[leveloffset=+1]
 
 include::modules/logging-identity-federation.adoc[leveloffset=+2]
+
 include::modules/logging-create-loki-cr-console.adoc[leveloffset=+2,tag=!pre-5.9]
+
 include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+2]
 
 include::modules/logging-loki-log-access.adoc[leveloffset=+1,tag=!NetObservMode]
+
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]
 
 //Enhanced reliability and performance
@@ -37,9 +38,13 @@ include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[levelof
 Use the following configurations to ensure reliability and efficiency of Loki in production.
 
 include::modules/loki-pod-placement.adoc[leveloffset=+2]
+
 include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+2]
+
 include::modules/logging-loki-retention.adoc[leveloffset=+2]
+
 include::modules/loki-memberlist-ip.adoc[leveloffset=+2]
+
 include::modules/loki-restart-hardening.adoc[leveloffset=+2]
 //include::modules/enabling-automatic-stream-sharding.adoc[leveloffset=+2]
 
@@ -50,7 +55,9 @@ include::modules/loki-restart-hardening.adoc[leveloffset=+2]
 You can configure high availability, scalability, and error handling for Loki.
 
 include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
+
 include::modules/loki-zone-fail-recovery.adoc[leveloffset=+2]
+
 include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
 
 [id="loki-network-policies-for-added-security_{context}"]
@@ -73,4 +80,5 @@ include::modules/integrating-loki-network-policy-with-external-systems.adoc[leve
 You can configure log-based alerts for Loki by creating an `AlertingRule` custom resource (CR).
 
 include::modules/loki-rbac-rules-permissions.adoc[leveloffset=+2]
+
 include::modules/enabling-loki-alerts.adoc[leveloffset=+2]

--- a/modules/about-azure-logs-ingestion-api.adoc
+++ b/modules/about-azure-logs-ingestion-api.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-azure-logs-ingestion-api_{context}"]
+= About the Azure Monitor Logs Ingestion API
+
+[role="_abstract"]
+The Azure Monitor Logs Ingestion API provides a modern, secure method for forwarding logs to Azure Monitor. This API uses Data Collection Rules (DCR) to define log schemas and routing, replacing the Data Collector API.
+
+[IMPORTANT]
+====
+Microsoft will disable the Data Collector API on September 14, 2026. If you currently use the `azureMonitor` output type, you must migrate to `azureLogsIngestion` before this date to avoid service disruption.
+====
+
+The `azureLogsIngestion` output type implements this API and offers the following advantages over the deprecated `azureMonitor` output:
+
+Enhanced security:: Support for {entra-id} Workload Identity allows pod-based authentication without managing shared secrets. Service principal authentication with client secrets remains available for environments that require it.
+
+Schema flexibility:: DCRs allow you to define custom log schemas that match your organization's requirements. You can specify which field receives the timestamp, supporting standard schemas such as `TimeGenerated` or specialized schemas such as ASIM that use `EventStartTime`.
+
+Improved reliability:: The Logs Ingestion API provides better error handling and status reporting compared to the Data Collector API.
+
+Azure integration:: DCRs integrate with Azure's monitoring and compliance frameworks, providing centralized management of log ingestion rules across your organization.
+
+The deprecated `azureMonitor` output type uses the Data Collector API. Microsoft will disable this API on September 14, 2026. Existing deployments that use `azureMonitor` should migrate to `azureLogsIngestion` before this date.
+
+Both output types can coexist during the migration period. You can configure both outputs in the same `ClusterLogForwarder` custom resource (CR) to validate the new configuration before removing the deprecated output.

--- a/modules/logging-forwarding-azure-logs-ingestion.adoc
+++ b/modules/logging-forwarding-azure-logs-ingestion.adoc
@@ -1,0 +1,185 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="logging-forwarding-azure-logs-ingestion_{context}"]
+= Forward logs to Azure Monitor using the Logs Ingestion API
+
+[role="_abstract"]
+Forward logs to Azure Monitor by using the Logs Ingestion API with Data Collection Rules. This procedure shows how to configure the `azureLogsIngestion` output type with client secret authentication. For workload identity authentication, see the example at the end of this procedure.
+
+.Prerequisites
+
+* You have an Azure account with permissions to create and manage Azure Monitor resources.
+* You created a Data Collection Rule (DCR) in your Azure Log Analytics workspace.
+* You obtained the following information from your DCR:
+** DCR immutable ID
+** Stream name
+** Data collection endpoint URL
+* You created a {entra-id} service principal with the **Monitoring Metrics Publisher** role assigned to your DCR.
+* You obtained the following {entra-id} credentials:
+** Tenant ID
+** Client ID
+** Client secret (for client secret authentication)
+* You installed the {clo}.
+* You installed the {oc-first}.
+* You have administrator access.
+
+.Procedure
+
+. Create a secret containing your {entra-id} client secret:
++
+[source,terminal]
+----
+$ oc create secret generic azure-entra-secret \
+  --from-literal=client-secret=<your_client_secret> \
+  -n openshift-logging
+----
+
+. Create a `ClusterLogForwarder` custom resource (CR) or edit your existing CR. Replace the following values with your Azure configuration:
++
+--
+* Replace `<data_collection_endpoint>` and `<region>` with your data collection endpoint URL. Find this URL in the Azure portal under your DCR details or run `az monitor data-collection endpoint show`.
+* Replace the `dcrImmutableId` value with your DCR immutable ID. Find this ID in the Azure portal under the DCR JSON view or run `az monitor data-collection rule show`.
+* Replace the `streamName` value with the stream name you defined in your DCR. The stream name must match exactly, including the `Custom-` prefix and `_CL` suffix if your DCR uses them.
+* Replace the `tenantId` value with your {entra-id} tenant ID.
+* Replace the `clientId` value with your {entra-id} application (client) ID.
+* The `secretName` value should match the name of the secret you created in step 1.
+--
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-MyApplicationLogs_CL"
+      authentication:
+        type: clientSecret
+        clientSecret:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+          secret:
+            secretName: azure-entra-secret
+            key: client-secret
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----
+
+. Apply the CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Check the `ClusterLogForwarder` status:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging -o jsonpath='{.status.conditions}' | jq
+----
++
+Look for conditions indicating successful configuration and log delivery.
+
+. Verify that logs appear in your Azure Log Analytics workspace:
+.. Log in to the Azure portal.
+.. Navigate to your Log Analytics workspace.
+.. Run a query against your custom log table to verify that logs are being ingested:
++
+[source,text]
+----
+MyApplicationLogs_CL
+| take 10
+----
+
+*Using workload identity authentication*
+
+If your environment supports {entra-id} Workload Identity, you can configure authentication without storing credentials in cluster secrets. Replace the values with your Azure configuration as described in the main procedure.
+
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-MyApplicationLogs_CL"
+      authentication:
+        type: workloadIdentity
+        workloadIdentity:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----
++
+Workload identity authentication requires additional {entra-id} configuration, including a federated identity credential that trusts your {product-title} cluster's OIDC issuer.
+
+*Configuring custom timestamp field*
+
+Some Azure Monitor schemas use different timestamp field names. For example, ASIM (Azure Sentinel Information Model) schemas use `EventStartTime` instead of the default `TimeGenerated`. Replace the values with your Azure configuration as described in the main procedure. The `timestampField` specifies the destination field for the timestamp in your DCR table schema. Common values are `TimeGenerated` (default), `Timestamp` (previous versions), or `EventStartTime` (ASIM).
+
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: azure-logs-forwarder
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+  - name: azure-logs-ingestion
+    type: azureLogsIngestion
+    url: https://<data_collection_endpoint>.<region>.monitor.azure.com
+    azureLogsIngestion:
+      dcrImmutableId: "dcr-1234567890abcdef1234567890abcdef"
+      streamName: "Custom-AsimStream_CL"
+      timestampField: "EventStartTime"
+      authentication:
+        type: clientSecret
+        clientSecret:
+          tenantId: "12345678-1234-1234-1234-123456789012"
+          clientId: "87654321-4321-4321-4321-210987654321"
+          secret:
+            secretName: azure-entra-secret
+            key: client-secret
+  pipelines:
+  - name: application-logs
+    inputRefs:
+    - application
+    outputRefs:
+    - azure-logs-ingestion
+----


### PR DESCRIPTION
# [OBSDOCS-3628](https://redhat.atlassian.net/browse/OBSDOCS-3628): Fix Vale and DITA compliance issues (6.6 cherry-pick)

Manual cherry-pick of #116457 to standalone-logging-docs-6.6.

## Conflicts Resolved

While not entirely clear to me, when GitHub was acting flaky recently, the modules/about-azure-logs-ingestion-api.adoc and modules/logging-forwarding-azure-logs-ingestion.adoc modules (along with 8 other Azure modules) were deleted in [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) PR. It seems like git did the rebase incorrectly or there was a workflow error.

- [OBSDOCS-3375](https://redhat.atlassian.net/browse/OBSDOCS-3375) (merged 2026-06-XX): Intentionally added these Azure modules to document Azure Monitor Logs Ingestion API
- [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) (merged 2026-07-14): Deleted the same Azure modules on the 6.6 release branch with no explanation

See original PR #116457 for full details.

## Testing

- [x] Cherry-pick conflicts resolved manually
- [x] Azure modules restored (corrects [OBSDOCS-3539](https://redhat.atlassian.net/browse/OBSDOCS-3539) deletion)  
- [x] 6.6 release notes structure preserved

Signed-off-by: John Wilkins <jowilkin@redhat.com>