### PR TITLE
OSDOCS-16950#CQA work Stor6 - LVMS assembly

### DIFF
--- a/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -7,17 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{lvms-first} uses LVM2 through the `TopoLVM CSI` driver to dynamically provision local storage on a cluster with limited resources.
-
-You can create volume groups, persistent volume claims (PVCs), volume snapshots, and volume clones by using {lvms}.
+{lvms-first} uses LVM2 through the `TopoLVM CSI` driver to dynamically provision local storage on a cluster with limited resources. With {lvms}, you can create volume groups, persistent volume claims (PVCs), snapshots, and clones.
 
 //deploying/requirements with RHACM
 include::modules/lvms-about-lvm-storage-installation.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
 
 include::modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc[leveloffset=+2]
 
@@ -27,28 +20,18 @@ include::modules/lvms-installing-logical-volume-manager-operator-disconnected-en
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../disconnected/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
-
-* xref:../../disconnected/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift]
-
 * xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
-
 * xref:../../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2[Creating the image set configuration]
-
 * xref:../../disconnected/about-installing-oc-mirror-v2.adoc#using-oc-mirror_about-installing-oc-mirror-v2[Mirroring an image set to a mirror registry]
-
 * xref:../../openshift_images/image-configuration.adoc#images-configuration-registry-mirror_image-configuration[Configuring image registry repository mirroring]
-
 * xref:../../openshift_images/image-streams-manage.adoc#images-imagestream-use_image-configuration[Why use imagestreams]
+* xref:../../updating/understanding_updates/intro-to-updates.adoc#update-service-overview_understanding-openshift-updates[About the OpenShift Update Service]
 
 include::modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
 
 include::modules/static-device-discovery-in-lvms.adoc[leveloffset=+1]
@@ -67,15 +50,10 @@ include::modules/lvms-about-lvmcluster-cr.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/configuring_and_managing_logical_volumes/index#overview-of-chunk-size_creating-and-managing-thin-provisioned-volumes[Overview of chunk size]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#limitations-to-configure-size-of-devices_logical-volume-manager-storage[Limitations to configure the size of the devices used in {lvms}]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reusing-vg-from-prev-installation_logical-volume-manager-storage[Reusing a volume group from the previous {lvms} installation]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
-
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
 // Limitations to configure the size of the devices to be used in LVM Storage
@@ -86,13 +64,13 @@ include::modules/lvms-about-adding-devices-to-a-vg.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
+* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems[{op-system-base} documentation]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_storage_devices/managing-raid_managing-storage-devices#creating-a-software-raid-on-an-installed-system_managing-raid[Creating a software RAID on an installed system]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_storage_devices/managing-raid_managing-storage-devices#replacing-a-failed-disk-in-raid_managing-raid[Replacing a failed disk in RAID]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_storage_devices/managing-raid_managing-storage-devices#repairing-raid-disks_managing-raid[Repairing RAID disks]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-raid_installing-customizing[Configuring a RAID-enabled data volume]
-
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-storage_installing-customizing[About disk encryption]
-
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-storage-procedure_installing-customizing[Configuring disk encryption and mirroring]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
 
 // About removing devices and device classes from a volume group
@@ -108,27 +86,26 @@ include::modules/lvms-about-creating-lvmcluster-cr.adoc[leveloffset=+1]
 // Reusing a volume group from the previous LVM Storage installation
 include::modules/lvms-reusing-vg-from-prev-installation.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/grouping-lvm-objects-with-tags_configuring-and-managing-logical-volumes#doc-wrapper[Grouping LVM objects with tags]
+
 include::modules/lvms-creating-lvms-cluster-using-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
 
 include::modules/lvms-creating-lvms-cluster-using-web-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
 
 include::modules/lvms-creating-lvmcluster-using-rhacm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
 
 // Deleting the LVMCluster custom resource
@@ -163,44 +140,31 @@ include::modules/lvms-about-scaling-storage-of-clusters.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
 
 include::modules/lvms-scaling-storage-of-clusters-using-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
 
 include::modules/lvms-scaling-storage-of-clusters-using-web-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
 
 include::modules/lvms-scaling-storage-of-clusters-using-rhacm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
 
 // Expanding PVCs
@@ -208,9 +172,7 @@ include::modules/lvms-scaling-storage-expand-pvc.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-about-scaling-storage-of-cluster_logical-volume-manager-storage[Ways to scale up the storage of clusters]
-
 * xref:../../storage/expanding-persistent-volumes.adoc#add-volume-expansion_expanding-persistent-volumes[Enabling volume expansion support]
 
 // Deleting PVC
@@ -221,7 +183,6 @@ include::modules/lvms-about-volume-snapshots.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features]
 
 include::modules/lvms-creating-volume-snapshots.adoc[leveloffset=+2]
@@ -243,8 +204,14 @@ include::modules/lvms-updating-lvms.adoc[leveloffset=+1]
 //Monitoring
 include::modules/lvms-monitoring-logical-volume-manager-operator.adoc[leveloffset=+1]
 
-// Uninstalling LVM Storage
+[role="_additional-resources"]
+.Additional resources
+* https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/observability/index[Observability]
+* https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/observability/index#adding-custom-metrics[Adding custom metrics]
 
+include::modules/lvms-about-volume-metrics-alerts.adoc[leveloffset=+1]
+
+// Uninstalling LVM Storage
 include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-cli.adoc[leveloffset=+1]
 
 include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+1]
@@ -256,7 +223,6 @@ include::modules/lvms-download-log-files-and-diagnostics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool]
 
 //Troubleshooting local persistent storage using LVM Storage
@@ -269,23 +235,24 @@ include::modules/lvms-troubleshooting-recovering-from-missing-lvms-or-operator-c
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-creating-lvmcluster-cr_logical-volume-manager-storage[Ways to create an `LVMCluster` custom resource]
 
 include::modules/lvms-troubleshooting-recovering-from-node-failure.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_logical-volume-manager-storage[Performing a forced clean-up]
 
 include::modules/lvms-troubleshooting-recovering-from-disk-failure.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_logical-volume-manager-storage[Performing a forced clean-up]
 
 include::modules/lvms-troubleshooting-performing-a-forced-cleanup.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]


### PR DESCRIPTION
Split from #115159. CQA updates for LVMS assembly file (xrefs, AR sections, short description).

Merge LAST after all module PRs:
- #116568 (installation)
- #116573 (LVMCluster CR)
- #116574 (provisioning/scaling)
- #116575 (snapshots/clones)
- #116576 (updating/monitoring/uninstalling)
- #116577 (troubleshooting)

Original PR with all files: https://github.com/openshift/openshift-docs/pull/115159
Jira: https://issues.redhat.com/browse/OSDOCS

**Note:** The Prow validate-portal check will fail until all module PRs are merged. The assembly file includes modules that are new files not yet on main (e.g., `lvms-about-volume-metrics-alerts.adoc`). This PR should be rebased and merged last.