### PR TITLE
OSDOCS-20902: Add 4.21.26 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-26.adoc
+++ b/modules/zstream-4-21-26.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-26_{context}"]
+= RHSA-2026:44267 - {product-title} {product-version}.26 bug fix and security update
+
+Issued: 28 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.26 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:44267[RHSA-2026:44267] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:44260[RHBA-2026:44260] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.26 --pullspecs
+----
+
+[id="zstream-4-21-26-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Operator used the `reflect.DeepEqual` parameter for node label comparison which required an exact label match instead of Kubernetes label selector semantics. As a consequence, the `IngressNodeFirewallNodeState` objects were not created for nodes added after the Operator startup. With this release, the `reflect.DeepEqual` parameter is replaced with the `labels.SelectorFromSet().Matches()` parameter for correct Kubernetes label selector matching. As a result, the Operator correctly creates the `IngressNodeFirewallNodeState` object for dynamically added nodes and label changes. (link:https://redhat.atlassian.net/browse/OCPBUGS-94092[OCPBUGS-94092])
+
+* Before this update, the Cluster Ingress Operator (CIO) log level was changed from `DEBUG` to `INFO`, but the `recorder.Event()` function calls continued to be echoed by controller-runtime only at the `DEBUG` level. As a consequence, operational events such as certificate lifecycle, DNS record changes, and IngressController status updates were no longer visible in the Operator logs. With this release, explicit `log.Info()` function calls are added alongside each `recorder.Event()` function call. As a result, the same information is emitted at `INFO` level and the operational events are visible in the Operator logs at `INFO` level.(link:https://redhat.atlassian.net/browse/OCPBUGS-94189[OCPBUGS-94189])
+
+* Before this update, when OVN-Kubernetes updated NetworkPolicy address sets for User Defined Networks, address set updates could fail with an `object not found` error if the address set was missing from the local cache. As a consequence, pods on affected User Defined Networks could fail service connectivity and health checks, and a restart of `ovnkube-controller` was required to recover. With this release, address set updates no longer treat a missing cache entry as a hard failure and allow the address set to be created when needed. As a result, NetworkPolicy address sets for User Defined Networks update correctly without requiring an `ovnkube-controller` restart. (link:https://redhat.atlassian.net/browse/OCPBUGS-98398[OCPBUGS-98398])
+
+* Before this update, the Cluster Ingress Operator on {product-title} 4.21 pinned Istio to v1.27.3, which was missing security fixes available in newer patch releases. As a consequence, Gateway API deployments ran an Istio control plane with known CVE vulnerabilities that had already been fixed upstream. With this release, the default Istio version is updated from v1.27.3 to v1.27.8, which includes the latest security fixes for the 1.27 stream. As a result, Gateway API deployments on {product-title} 4.21 run Istio v1.27.8 with important CVE fixes applied. (link:https://redhat.atlassian.net/browse/OCPBUGS-98966[OCPBUGS-98966])
+
+* Before this update, when you navigated to the *Cluster Dashboard Overview* page and clicked the *Insights* window on the *Status* card, an underlying UI component rendered the text incorrectly. As a consequence, the icons for the four severity levels (*Critical*, *Important*, *Moderate*, and *Low*) appeared, but the actual issue counts and the links to the *Insights* advisor were missing. With this release, the link component inside the *Insights* severity window is updated to ensure that the text and links render properly. As a result, each severity level in the *Insights* window now successfully displays its icon, the correct issue count, and a clickable link to the *Insights* advisor. (link:https://redhat.atlassian.net/browse/OCPBUGS-99163[OCPBUGS-99163])
+
+[id="zstream-4-21-26-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,10 +44,13 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-// 4.21.24 RNs and updating
+// 4.21.26 RNs and updating
+include::modules/zstream-4-21-26.adoc[leveloffset=+2]
+
 // 4.21.25 RNs and updating
 include::modules/zstream-4-21-25.adoc[leveloffset=+2]
 
+// 4.21.24 RNs and updating
 include::modules/zstream-4-21-24.adoc[leveloffset=+2]
 
 // 4.21.23 RNs and updating


### PR DESCRIPTION
Version
4.21

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20902

Doc Preview link
https://116604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-26_release-notes

Additional information
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/670
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:44267 / RHBA-2026:44260 
