### PR TITLE
OSSM_v3.4.1

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.4
+:SMProductVersion: 3.4.1
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.17

--- a/modules/ossm-release-notes-3-4-1.adoc
+++ b/modules/ossm-release-notes-3-4-1.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-notes-3-4-1_{context}"]
+= {SMProductName} version 3.4.1
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator {SMProductVersion} and is supported on {ocp-product-title} 4.20 and later versions. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions in {SMProductShortName} {SMProductVersion}, see _Service Mesh component versions_.
+
+[id="ossm-fixed-issues-3-4-1_{context}"]
+== Fixed issues
+
+Webhook error "failed calling webhook validation.istio.io" no longer occurs::
+After the {SMProductShortName} 3.3.4 upgrade, the `istiod-default-validator` webhook did not point to the control plane if the `Istio` CR used a non-default name with the `IstioRevisionTag` set to `default`. As a consequence, attempts to update Istio networking, security, or telemetry resources failed with the error `failed calling webhook "validation.istio.io"`. Existing mesh traffic continued to function, but you were unable to change the service mesh configuration. With this release, the validating webhook references the correct control plane service. As a result, Istio resource validation succeeds in deployments that use non-default `Istio` CR names.
++
+link:https://redhat.atlassian.net/browse/OSSM-14646[OSSM-14646]

--- a/modules/ossm-release-notes-3-4-new-features-enhancements.adoc
+++ b/modules/ossm-release-notes-3-4-new-features-enhancements.adoc
@@ -9,7 +9,10 @@
 [role="_abstract"]
 This release makes {SMProductName} 3.4 generally available, adds new features, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {ocp-product-title} 4.20 and later versions.
 
-For a list of supported component versions and support features, see _Service Mesh feature support tables_.
+For lists of supported component versions and feature support levels, see:
+
+* _Service Mesh component versions_
+* _Service Mesh feature support tables_
 
 
 {SMProductShortName} compatibility with Red Hat Enterprise Linux 10::

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,7 +7,39 @@
 = Component version tables
 
 [role="_abstract"]
-For {SMProduct} {SMProductVersion} and each maintenance release, a table lists the corresponding component versions.
+For {SMProduct} 3.4 and each following maintenance release, a table lists the corresponding component versions.
+
+== {SMProduct} 3.4.1 component versions
+
+[cols="1,1"]
+|===
+| Component | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.4.1
+
+| {SMProduct} `Istio` control plane resource
+| 1.30.3
+
+| {ocp-product-title}
+| 4.20 and later
+
+| Envoy proxy
+| 1.38.3
+
+| `IstioCNI` resource
+| 1.30.3
+
+| `Ztunnel` resource
+| 1.30.3
+
+| Kiali Operator
+| 2.27.2
+
+| Kiali server
+| 2.27.2
+
+|===
 
 == {SMProduct} 3.4 component versions
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 Review new features, compatibility updates, fixed issues, and known issues for {SMProductName} to stay informed about changes across different product versions.
 
+include::modules/ossm-release-notes-3-4-1.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-4-new-features-enhancements.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-4-technology-preview-features.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-14965](https://redhat.atlassian.net/browse/OSSM-14965): OSSM 3.4.1 & 3.3.6 & 3.2.8 & 3.1.11 & 3.0.14 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.4 (no cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14965

Link to docs preview:
- https://116609--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html
- https://116609--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
