### PR TITLE
OSDOCS-20909: Add 4.20.31 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-31.adoc
+++ b/modules/zstream-4-20-31.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-31_{context}"]
+= RHSA-2026:44263 - {product-title} {product-version}.31 bug fix and security update
+
+Issued: 28 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.31 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:44263[RHSA-2026:44263] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:44258[RHBA-2026:44258] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.31 --pullspecs
+----
+
+[id="zstream-4-20-31-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, enabling Gateway API on a cluster with an existing {product-title} Service Mesh (OSSM) installation caused the Cluster Ingress Operator to take over or duplicate the OSSM subscription, which resulted in unexpected behavior. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly without OLM subscriptions. As a result, existing OSSM installations are not affected when Gateway API is enabled.(link:https://redhat.atlassian.net/browse/OCPBUGS-82147[OCPBUGS-82147])
+
+* Before this update, when every service step could run entirely out-of-band (that is, there was no agent ramdisk), the conductor had already skipped the initial ramdisk boot. However, an internal flag still indicated that a ramdisk boot was allowed. As a consequence, steps that rebooted the node to finish their work could still trigger an agent ramdisk boot before that reboot, even though none of the steps required it. This issue caused Operators to identify an extra, unnecessary agent ramdisk boot during out-of-band service work that was disruptive and slower, such as when applying BIOS settings over the management interface. With this release, whenever all service steps are out-of-band-only, the conductor now sets that internal flag so the `no ramdisk needed` decision also applies consistently through the reboot-to-finish paths. As a result, the service-step flows do not pull in a spare agent boot. Instead, the node stays on the intended out-of-band path without the extra cycle. (link:https://redhat.atlassian.net/browse/OCPBUGS-84371[OCPBUGS-84371])
+
+* Before this update, the mutual TLS configuration on the default `IngressController` caused canary and console health checks to fail, degrading Ingress and Console Operators due to required client certificates. As a consequence, Ingress and console Operators degraded. With this release, the `IngressController` mTLS setup no longer breaks canary and console health checks. As a result, the mTLS setup no longer causes instability in the cluster, ensuring proper operation of Ingress and Console Operators. (link:https://redhat.atlassian.net/browse/OCPBUGS-88353[OCPBUGS-88353])
+
+* Before this update, the Cluster Ingress Operator (CIO) installed the OpenShift Service Mesh (OSSM) Operator through OLM to provide Gateway API support. and pinned OSSM to a specific version using the `startingCSV` parameter and manual install plan approval. As a consequence, after the OSSM was already installed, the OLM ignored the `startingCSV` parameter and resolved upgrades to the channel head, which generated install plans that the CIO never approved because the version did not match. The OSSM z-stream upgrades were then blocked, which prevented CVE fixes from being delivered to clusters using the Gateway API. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. The dependency on OLM for the Gateway API is removed and clusters that are upgraded from the OLM-based path are automatically migrated to the Sail Library during the z-stream upgrade. As a result, OSSM and Istio version management is not blocked by OLM and the CVE fixes can be shipped. (link:https://redhat.atlassian.net/browse/OCPBUGS-92038[OCPBUGS-92038])
+
+* * Before this update, the Cluster Ingress Operator (CIO) hard-coded the Operator Lifecycle Manager (OLM) `redhat-operators` catalog source name when managing the {product-title} Service Mesh (OSSM) subscription for Gateway API. In disconnected environments, the catalog source had a different name, and the CIO unconditionally overwrote it. As a consequence, Gateway API installation failed in disconnected and air-gapped environments because the OSSM subscription pointed to a catalog source that did not exist. With this release, the dependency on OLM catalog sources is removed entirely because the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. As a result, Gateway API works in disconnected environments without workarounds, if the required container images are mirrored to an accessible registry. (link:https://issues.redhat.com/browse/OCPBUGS-92041[OCPBUGS-92041])
+
+* Before this update, the Cluster Ingress Operator (CIO) depended on the Marketplace capability to install OSSM through OLM for the Gateway API. On clusters where the Marketplace capability was disabled, such as disconnected clusters that cannot reach external catalog sources, the CIO could not create or manage the OLM subscription and the Istio control plane never started. As a consequence, the Gateway API did not function on these clusters. When the GatewayClass was created, the `istiod-openshift-gateway` pod did not start. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. As a result, the dependency on the Marketplace capability is removed and the Gateway API works on disconnected clusters and other environments without the Marketplace capability, if the required container images are mirrored to an accessible registry. (link:https://issues.redhat.com/browse/OCPBUGS-92042[OCPBUGS-92042])
+
+* Before this update, the Operator used the `reflect.DeepEqual` parameter for node label comparison which required an exact label match instead of Kubernetes label selector semantics. As a consequence, the `IngressNodeFirewallNodeState` objects were not created for nodes added after the Operator startup. With this release, the `reflect.DeepEqual` parameter is replaced with the `labels.SelectorFromSet().Matches()` parameter for correct Kubernetes label selector matching. As a result, the Operator correctly creates the `IngressNodeFirewallNodeState` object for dynamically added nodes and label changes. (link:https://issues.redhat.com/browse/OCPBUGS-98955[OCPBUGS-98955])
+
+
+[id="zstream-4-20-31-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,10 +3021,13 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-// 4.20.29 RNs and updating
+// 4.20.31 RNs and updating
+include::modules/zstream-4-20-31.adoc[leveloffset=+2]
+
 // 4.20.30 RNs and updating
 include::modules/zstream-4-20-30.adoc[leveloffset=+2]
 
+// 4.20.29 RNs and updating
 include::modules/zstream-4-20-29.adoc[leveloffset=+2]
 
 // 4.20.28 release notes


### PR DESCRIPTION
Version
4.20

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20909

Doc preview link
https://116610--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-31_release-notes

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/669
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:44263 / RHBA-2026:44258


