### PR TITLE
OSDOCS-20910: Add 4.19.40 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-40.adoc
+++ b/modules/zstream-4-19-40.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-40_{context}"]
+= RHSA-2026:44235 - {product-title} {product-version}.40 bug fix and security update
+
+Issued: 29 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.40 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:44235[RHSA-2026:44235] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:44228[RHBA-2026:44228] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.40 --pullspecs
+----
+
+[id="zstream-4-19-40-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when Prometheus was configured to scrape targets by using client Transport Layer Security (TLS) certificates without a certificate authority (CA), the `tlsRoundTripper` component encountered a nil pointer dereference during client certificate rotation. As a consequence, Prometheus crashed with a `SIGSEGV` panic, and metric collection was interrupted until Kubernetes restarted the pod. With this release, Prometheus correctly handles client certificate rotation when no CA is configured. As a result, Prometheus no longer crashes during certificate rotation, and metric collection continues without interruption. (link:https://redhat.atlassian.net/browse/OCPBUGS-98388[OCPBUGS-98388])
+
+[id="zstream-4-19-40-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2979,6 +2979,9 @@ include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
 // 4.19.38 RNs and updating
 // 4.19.39 RNs and updating
+// 4.19.40 RNs and updating
+include::modules/zstream-4-19-40.adoc[leveloffset=+2]
+
 include::modules/zstream-4-19-39.adoc[leveloffset=+2]
 
 include::modules/zstream-4-19-38.adoc[leveloffset=+2]


### PR DESCRIPTION
Version
4.19

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20910

Doc preview link
https://116611--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-40_release-notes

Additional information
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/667
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:44235 / RHBA-2026:44228 