### PR TITLE
OSDOCS-20908: Add 4.18.50 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-50.adoc
+++ b/modules/zstream-4-18-50.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-50_{context}"]
+= RHSA-2026:44233 - {product-title} {product-version}.50 bug fix and security update
+
+Issued: 29 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.50 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:44233[RHSA-2026:44233] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:44227[RHBA-2026:44227] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.50 --pullspecs
+----
+
+[id="zstream-4-18-50-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-50-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,10 +3064,13 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-// 4.18.48 RNs and updating
+// 4.18.50 RNs and updating
+include::modules/zstream-4-18-50.adoc[leveloffset=+2]
+
 // 4.18.49 RNs and updating
 include::modules/zstream-4-18-49.adoc[leveloffset=+2]
 
+// 4.18.48 RNs and updating
 include::modules/zstream-4-18-48.adoc[leveloffset=+2]
 
 // 4.18.47 RNs and updating


### PR DESCRIPTION
Version
4.18

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20908

Doc preview link
https://116612--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-50_release-notes


Additional information
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/666
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:44233 / RHBA-2026:44227

