### PR TITLE
OSDOCS-20911: Add 4.16.67 z-stream release notes

### DIFF
--- a/modules/zstream-4-16-67.adoc
+++ b/modules/zstream-4-16-67.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-67_{context}"]
+= RHSA-2026:43331 - {product-title} {product-version}.67 bug fix and security update
+
+Issued: 30 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.67 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:43331[RHSA-2026:43331] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.67 --pullspecs
+----
+
+[id="zstream-4-16-67-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Machine API Operator used the `infraID-rg` resource group name when it created a default image ID. As a consequence, clusters with a resource group that did not use that name received an incorrect default machine set, which prevented the provisioning of the machines. With this release, the Machine API Operator reads the resource group from the infrastructure configuration. As a result, the correct image ID is generated and the machine set can scale the machines. (link:https://redhat.atlassian.net/browse/OCPBUGS-98439[OCPBUGS-98439])
+
+[id="zstream-4-16-67-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,8 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.67 RNs and updating
+include::modules/zstream-4-16-67.adoc[leveloffset=+2]
 
 // 4.16.68 RNs and updating
 include::modules/zstream-4-16-68.adoc[leveloffset=+2]


### PR DESCRIPTION
Version
4.16

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20911

Doc preview link
https://116613--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-67_release-notes

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/665
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16
- Errata: RHSA-2026:43331 / RHBA-2026:43329 
