### PR TITLE
OSDOCS-20912: Add 4.15.67 z-stream release notes

### DIFF
--- a/modules/zstream-4-15-67.adoc
+++ b/modules/zstream-4-15-67.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-67_{context}"]
+= RHSA-2026:43227 - {product-title} {product-version}.67 bug fix and security update
+
+Issued: 30 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.67 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:43227[RHSA-2026:43227] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:43225[RHSA-2026:43225] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.67 --pullspecs
+----
+
+[id="zstream-4-15-67-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the ironic-agent container image was missing the `iproute` package at runtime, which provides the `ip` command required for network configuration. As a consequence, the Ironic Python Agent (IPA) failed to heartbeat to Ironic during bare-metal node cleaning, and node cleaning operations timed out. With this release, the ironic-agent container image build process is updated to retain required packages such as `iproute` and `psmisc`. As a result, IPA completes network configuration successfully and bare-metal node cleaning operations complete without timing out. (link:https://redhat.atlassian.net/browse/OCPBUGS-95071[OCPBUGS-95071])
+
+[id="zstream-4-15-67-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2814,6 +2814,10 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+
+// 4.15.67 RNs and updating
+include::modules/zstream-4-15-67.adoc[leveloffset=+2]
+
 //  4.15.66
 include::modules/zstream-4-15-66.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.15

Linked issue
https://redhat.atlassian.net/browse/OSDOCS-20912

Doc preview link
https://116614--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-67_release-notes

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/663
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15
- Errata: RHSA-2026:43227 / RHSA-2026:43225