### PR TITLE
OSSM_v3.3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ artifacts/
 update/ossm-preparing-for-rhel-10-migration.adoc
 modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
 modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc
+analysis/

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.3.5
+:SMProductVersion: 3.3.6
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.17
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.28.8
+:istio-latest: 1.28.10
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5,7 +5,7 @@ Distros: openshift-service-mesh
 Topics:
 - Name: Service Mesh 3.3 release notes
   File: ossm-release-notes
-- Name: Service Mesh 3.3 version support tables
+- Name: Service Mesh 3.3 component versions
   File: ossm-release-notes-version-support-tables
 - Name: Service Mesh 3.3 feature support tables
   File: ossm-release-notes-feature-support-tables

--- a/modules/ossm-release-notes-3-3-1.adoc
+++ b/modules/ossm-release-notes-3-3-1.adoc
@@ -9,7 +9,7 @@
 
 This release of {SMProductName} is included with the {SMProductName} Operator 3.3.1 and is supported on {ocp-product-title} 4.18-4.21. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
 
-For supported component versions for 3.3.1, see "Service Mesh version support tables".
+For supported component versions for 3.3.1, see _Service Mesh component versions_.
 
 [id="ossm-fixed-issues-3-3-1_{context}"]
 == Fixed issues

--- a/modules/ossm-release-notes-3-3-2.adoc
+++ b/modules/ossm-release-notes-3-3-2.adoc
@@ -9,7 +9,7 @@
 
 This release of {SMProductName} is included with the {SMProductName} Operator 3.3.2 and is supported on {ocp-product-title} 4.18 and later. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
 
-For supported component versions for 3.3.2, see "Service Mesh version support tables".
+For supported component versions for 3.3.2, see _Service Mesh component versions_.
 
 [id="ossm-fixed-issues-3-3-2_{context}"]
 == Fixed issues

--- a/modules/ossm-release-notes-3-3-3.adoc
+++ b/modules/ossm-release-notes-3-3-3.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 This release of {SMProductName} is included with the {SMProductName} Operator 3.3.3 and is supported on {ocp-product-title} 4.18 and later. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
 
-For supported component versions for 3.3.3, see "Service Mesh version support tables".
+For supported component versions for 3.3.3, see _Service Mesh component versions_.
 
 [id="ossm-fixed-issues-3-3-3_{context}"]
 == Fixed issues

--- a/modules/ossm-release-notes-3-3-4.adoc
+++ b/modules/ossm-release-notes-3-3-4.adoc
@@ -9,4 +9,4 @@
 [role="_abstract"]
 This release of {SMProductName} is included with the {SMProductName} Operator 3.3.4 and is supported on {ocp-product-title} 4.18-4.22. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
 
-For supported component versions for 3.3.4, see "Service Mesh version support tables".
+For supported component versions for 3.3.4, see _Service Mesh component versions_.

--- a/modules/ossm-release-notes-3-3-5.adoc
+++ b/modules/ossm-release-notes-3-3-5.adoc
@@ -9,4 +9,4 @@
 [role="_abstract"]
 This release of {SMProductName} is included with the {SMProductName} Operator 3.3.5 and is supported on {ocp-product-title} 4.18-4.22. This release addresses Common Vulnerabilities and Exposures (CVEs).
 
-For supported component versions for 3.3.5, see "Service Mesh version support tables".
+For supported component versions for 3.3.5, see _Service Mesh component versions_.

--- a/modules/ossm-release-notes-3-3-6.adoc
+++ b/modules/ossm-release-notes-3-3-6.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-3-6_{context}"]
+= {SMProductName} version 3.3.6
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.3.6 and is supported on {ocp-product-title} 4.18-4.22. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.3.6, see _Service Mesh component versions_.
+
+[id="ossm-fixed-issues-3-3-6_{context}"]
+== Fixed issues
+
+Webhook error "failed calling webhook validation.istio.io" no longer occurs::
+After the {SMProductShortName} 3.3.4 upgrade, the `istiod-default-validator` webhook did not point to the control plane if the `Istio` CR used a non-default name with the `IstioRevisionTag` set to `default`. As a consequence, attempts to update Istio networking, security, or telemetry resources failed with the error `failed calling webhook "validation.istio.io"`. Existing mesh traffic continued to function, but you were unable to change the service mesh configuration. With this release, the validating webhook references the correct control plane service. As a result, Istio resource validation succeeds in deployments that use non-default `Istio` CR names.
++
+link:https://redhat.atlassian.net/browse/OSSM-14646[OSSM-14646]

--- a/modules/ossm-release-notes-3-3-new-features-enhancements.adoc
+++ b/modules/ossm-release-notes-3-3-new-features-enhancements.adoc
@@ -10,7 +10,7 @@
 
 This release makes {SMProductName} 3.3 generally available, adds new features, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {ocp-product-title} 4.18 and later.
 
-For a list of supported component versions and support features, see "Service Mesh feature support tables".
+For a list of supported component versions and support features, see _Service Mesh feature support tables_.
 
 When upgrading from {SMProduct} 2.x, first you must migrate to version 3.0. Then, you can upgrade to version 3.1 and incrementally to version 3.3. For more information see, https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/migrating_from_service_mesh_2_to_service_mesh_3/ossm-migrating-from-service-mesh-2-to-3[Migrating from Service Mesh 2 to Service Mesh 3] in the {SMProduct} 3.0 documentation and https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/latest/html/updating/index[Updating] in the {SMProduct} 3.3 documentation.
 

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -4,10 +4,42 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ossm-release-notes-supported-versions_{context}"]
-= {SMProduct} supported versions
+= {SMProduct} component version tables
 
 [role="_abstract"]
-See the following table for information about {SMProduct} 3.3.5 supported versions.
+For {SMProduct} 3.3 and each following maintenance release, a table lists the corresponding component versions.
+
+== {SMProduct} 3.3.6 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.3.6
+
+| {SMProduct} `Istio` control plane resource
+| 1.28.10
+
+| {ocp-product-title}
+| 4.18-4.22
+
+| Envoy proxy
+| 1.36.9
+
+| `IstioCNI` resource
+| 1.28.10
+
+| `Ztunnel` resource
+| 1.28.10
+
+| Kiali Operator
+| 2.27.2
+
+| Kiali server
+| 2.22.8
+
+|===
 
 == {SMProduct} 3.3.5 supported versions
 
@@ -41,8 +73,6 @@ See the following table for information about {SMProduct} 3.3.5 supported versio
 
 |===
 
-See the following table for information about {SMProduct} 3.3.4 supported versions.
-
 == {SMProduct} 3.3.4 supported versions
 
 [cols="1,1"]
@@ -74,8 +104,6 @@ See the following table for information about {SMProduct} 3.3.4 supported versio
 |2.22.5
 
 |===
-
-See the following table for information about {SMProduct} 3.3.3 supported versions.
 
 == {SMProduct} 3.3.3 supported versions
 
@@ -109,8 +137,6 @@ See the following table for information about {SMProduct} 3.3.3 supported versio
 
 |===
 
-See the following table for information about {SMProduct} 3.3.2 supported versions.
-
 == {SMProduct} 3.3.2 supported versions
 
 [cols="1,1"]
@@ -142,8 +168,6 @@ See the following table for information about {SMProduct} 3.3.2 supported versio
 |2.22.2
 
 |===
-
-See the following table for information about {SMProduct} 3.3.1 supported versions.
 
 == {SMProduct} 3.3.1 supported versions
 
@@ -177,9 +201,7 @@ See the following table for information about {SMProduct} 3.3.1 supported versio
 
 |===
 
-See the following table for information about {SMProduct} 3.3.0 supported versions.
-
-== {SMProduct} 3.3.0 supported versions
+== {SMProduct} 3.3 supported versions
 
 [cols="1,1"]
 |===

--- a/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ossm-release-notes-version-support-tables"]
-= {SMProductShortName} version support tables
+= {SMProductShortName} component versions
 include::_attributes/common-attributes.adoc[]
 :context: ossm-release-notes-version-support-tables
 
 toc::[]
 
 [role="_abstract"]
-{SMProductVersion} version support tables offer guidance on latest versions of components in {SMProduct} 3.
+Knowing which versions of {istio}, Kiali, Envoy, and other components are included in your release of {SMProduct} helps you plan upgrades and troubleshoot compatibility issues.
 
 include::modules/ossm-release-notes-supported-versions.adoc[leveloffset=+1]
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 Review new features, compatibility updates, fixed issues, and known issues for {SMProductName} to stay informed about changes across different product versions.
 
+include::modules/ossm-release-notes-3-3-6.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-3-5.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-3-4.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-14965](https://redhat.atlassian.net/browse/OSSM-14965): OSSM 3.4.1 & 3.3.6 & 3.2.8 & 3.1.11 & 3.0.14 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.3 (no cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14965

Link to docs preview:
- https://116615--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html
- https://116615--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->