### PR TITLE
OSSM_v3.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ artifacts/
 modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
 modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc
 update/ossm-preparing-for-rhel-10-migration.adoc
+analysis/

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.2.7
+:SMProductVersion: 3.2.8
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.17

--- a/modules/ossm-release-notes-3-2-8.adoc
+++ b/modules/ossm-release-notes-3-2-8.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-2-8_{context}"]
+= {SMProductName} version 3.2.8
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.2.8 and is supported on {ocp-product-title} 4.18-4.22. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.2.8, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,40 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.2.8 supported versions.
+
+== {SMProduct} 3.2.8 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.2.8
+
+| {SMProduct} `Istio` control plane resource
+| 1.27.9
+
+| {ocp-product-title}
+| 4.18-4.22
+
+| Envoy proxy
+| 1.35.14
+
+| `IstioCNI` resource
+| 1.27.9
+
+| `Ztunnel` resource
+| 1.27.9
+
+| Kiali Operator
+| 2.27.2
+
+| Kiali server
+| 2.17.12
+
+|===
+
 See the following table for information about {SMProduct} 3.2.7 supported versions.
 
 == {SMProduct} 3.2.7 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-2-8.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-2-7.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-2-6.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-14965](https://redhat.atlassian.net/browse/OSSM-14965): OSSM 3.4.1 & 3.3.6 & 3.2.8 & 3.1.11 & 3.0.14 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.2 (No cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14965

Link to docs preview:
- https://116624--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html
- https://116624--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->