### PR TITLE
OCPBUGS-100046: Add Nutanix credential rotation procedure

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
@@ -31,5 +31,6 @@ An {aws-short}, global {azure-short}, or {gcp-short} cluster that uses manual mo
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}]
 * xref:../../installing/installing_ibm_cloud/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for {ibm-cloud-name}]
 * xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#manually-create-iam-nutanix_installing-nutanix-installer-provisioned[Configuring IAM for Nutanix]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-rotating-nutanix-creds_changing-cloud-credentials-configuration[Updating Nutanix credentials]
 * xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[About the Cloud Credential Operator in manual mode with short-term credentials for components]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#preparing-manual-creds-update[Preparing to update a cluster with manually maintained credentials]

--- a/modules/manually-rotating-nutanix-creds.adoc
+++ b/modules/manually-rotating-nutanix-creds.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/changing-cloud-credentials-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="manually-rotating-nutanix-creds_{context}"]
+= Updating Nutanix credentials
+
+[role="_abstract"]
+{product-title} on the Nutanix platform only supports the Cloud Credential Operator (CCO) in Manual mode. Nutanix credentials are not dynamically minted or rotated by the platform, they are static secrets that you update directly. Whether you are rotating the password for the existing Nutanix account or replacing it with a different account, the procedure is the same.
+
+Nutanix credentials are consumed independently by up to three components. Update the secret for each component that is deployed in your cluster.
+
+.Prerequisites
+
+* You have changed or replaced the Nutanix Prism Central or Prism Element account used by your cluster.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Back up the existing secrets before making any changes:
++
+[source,terminal]
+----
+$ oc get secret nutanix-credentials -n openshift-machine-api -o yaml > nutanix-credentials-machine-api-backup.yaml
+$ oc get secret nutanix-credentials -n openshift-cloud-controller-manager -o yaml > nutanix-credentials-ccm-backup.yaml
+----
+
+. Update the secret used by the Machine API, which manages compute machine provisioning:
++
+[source,terminal]
+----
+$ oc edit secret nutanix-credentials -n openshift-machine-api
+----
++
+[source,yaml]
+----
+stringData:
+  credentials: |
+    [{"type":"basic_auth","data":{"prismCentral":{"username":"<new_username>","password":"<new_password>"},"prismElements":null}}]
+----
+
+. Update the secret used by the Cloud Controller Manager, which manages node lifecycle and topology, using the same JSON format as the previous step:
++
+[source,terminal]
+----
+$ oc edit secret nutanix-credentials -n openshift-cloud-controller-manager
+----
+
+. Check whether the Nutanix CSI Driver Operator is deployed in your cluster:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-cluster-csi-drivers
+----
++
+If Nutanix CSI pods are present, this component uses a separate secret with a different format. Back up and update it:
++
+[source,terminal]
+----
+$ oc get secret ntnx-secret -n openshift-cluster-csi-drivers -o yaml > ntnx-secret-backup.yaml
+$ oc edit secret ntnx-secret -n openshift-cluster-csi-drivers
+----
++
+[source,yaml]
+----
+stringData:
+  key: <prism_element_address>:<prism_element_port>:<new_username>:<new_password>
+----
+
+.Verification
+
+* Confirm the new credentials took effect. None of the Machine API, Cloud Controller Manager, or CSI driver require a restart after their secret is updated, each re-reads the secret on its next operation. For example, scale a compute machine set or create a test persistent volume claim, and monitor its status:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api
+$ oc get pvc
+----

--- a/post_installation_configuration/changing-cloud-credentials-configuration.adoc
+++ b/post_installation_configuration/changing-cloud-credentials-configuration.adoc
@@ -58,6 +58,13 @@ include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
 * xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html#cco-mode-passthrough[The Cloud Credential Operator in passthrough mode]
 * xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere[vSphere CSI Driver Operator]
 
+//Updating Nutanix credentials
+include::modules/manually-rotating-nutanix-creds.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#manually-create-iam-nutanix_installing-nutanix-installer-provisioned[Configuring IAM for Nutanix]
+
 [id="post-install-remove-cloud-creds_{context}"]
 == Removing cloud provider credentials
 //TODO: split out rotate, maintain, and remove and bumpe everything up one level


### PR DESCRIPTION
## Summary
- Adds a new module documenting how to update or replace Nutanix Prism credentials on an already-installed cluster
- Nutanix is completely absent from the credential-rotation coverage in "Changing the cloud provider credentials configuration", despite being a fully supported platform
- Cross-links the new section from the CCO manual-mode overview page in both directions

## Why this approach
The existing `manually-rotating-cloud-creds.adoc` module is built around a single root secret per platform (`aws-creds`, `vsphere-creds`, etc.) shown in a two-column table, gated by mint/passthrough AsciiDoc conditionals. Nutanix does not fit that shape: it needs up to three separate secrets (`nutanix-credentials` in `openshift-machine-api`, the same name again in `openshift-cloud-controller-manager`, and a differently-formatted `ntnx-secret` in `openshift-cluster-csi-drivers` if the CSI driver is deployed), and it only supports Manual mode, not mint or passthrough.

IBM Cloud has the same characteristic, Manual-mode-only, doesn't fit the shared table, and already has its own dedicated module (`refreshing-service-ids-ibm-cloud.adoc`) included directly in this assembly. This PR follows that existing precedent rather than trying to extend the shared table's structure.

The secret names, namespaces, and JSON/string formats were verified against `openshift/installer` and `openshift/machine-api-provider-nutanix` source, and confirmed on a live Nutanix cluster: the Cloud Credential Operator only permits `ManualCredentialsMode` for Nutanix (`pkg/types/validation/installconfig.go`), and none of the three components require a restart after their secret is updated, each was observed picking up new credentials on its next reconcile or operation without a pod restart.

While writing this, found that PowerVS (also Manual-mode-only) has the identical gap, filed separately as OCPBUGS-100048 since its secret mechanics have not been verified the same way.

## Test plan
- [x] Verified against source: `openshift/installer`'s `validPlatformCredentialsModes` confirms Nutanix only allows `ManualCredentialsMode`
- [x] Verified against source: `openshift/machine-api-provider-nutanix` reads the credentials secret fresh on every machine reconcile, no in-memory cache
- [x] Verified live: deployed the Nutanix CSI Operator on a real Nutanix-backed OpenShift cluster, updated `ntnx-secret` on a running (68-minute-old, unrestarted) controller pod, and the next `CreateVolume` call succeeded using the new credentials
- [x] Cross-checked secret names/formats against existing Assisted Installer product documentation for consistency (a separate, unrelated bug found in that doc is filed as OCPBUGS-100047)

OCPBUGS-100046: https://issues.redhat.com/browse/OCPBUGS-100046