### PR TITLE
OSDOCS-16997-installing-gcp-customizations# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -7,18 +7,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on {gcp-first} by using installer-provisioned infrastructure with customizations, including network configuration options. In each, you modify parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on {gcp-first} with customizations by using installer-provisioned infrastructure. You customize your cluster by modifying parameters in the `install-config.yaml` file before installation.
 
 By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations.
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
-== Prerequisites
+include::modules/installing-gcp-customizations-prerequisites.adoc[leveloffset=+1]
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[Configuring your firewall]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
@@ -89,23 +92,14 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials].
+//Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster. Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -141,17 +135,18 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-== Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -7,18 +7,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on {gcp-first} by using installer-provisioned infrastructure with customizations, including network configuration options. In each, you modify parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on {gcp-first} with customizations by using installer-provisioned infrastructure. You customize the cluster to match your environment by modifying parameters in the `install-config.yaml` file before installation.
 
 By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations.
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
-== Prerequisites
+include::modules/installing-gcp-customizations-prerequisites.adoc[leveloffset=+1]
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
@@ -89,23 +92,14 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials].
+//Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster. Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -141,17 +135,14 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -6,9 +6,10 @@
 [id="installation-gcp-marketplace_{context}"]
 = Using the {gcp-short} Marketplace offering
 
-Using the {gcp-short} Marketplace offering lets you deploy an {product-title} cluster, which is billed on pay-per-use basis (hourly, per core) through {gcp-short}, while still being supported directly by Red{nbsp}Hat.
+[role="_abstract"]
+You can deploy an {product-title} cluster through the {gcp-short} Marketplace offering, which is billed on a pay-per-use basis (hourly, per core) through {gcp-short}. Red{nbsp}Hat still provides direct support for these clusters.
 
-By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster using an {op-system} image from the {gcp-short} Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of {gcp-short} Marketplace offer.
+By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster by using an {op-system} image from the {gcp-short} Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of the {gcp-short} Marketplace offer.
 
 :platform-abbreviation: a {gcp-short}
 :platform-abbreviation-short: {gcp-short}
@@ -32,8 +33,9 @@ include::snippets/installation-marketplace-note.adoc[]
 {opp}:: `redhat-coreos-opp-413-x86-64-202305021736`
 {oke}:: `redhat-coreos-oke-413-x86-64-202305021736`
 . Save the file and reference it when deploying the cluster.
-
-.Sample `install-config.yaml` file that specifies a {gcp-short} Marketplace image for compute machines
++
+The following sample `install-config.yaml` file specifies a {gcp-short} Marketplace image for compute machines:
++
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/installing-gcp-cluster-creation.adoc
+++ b/modules/installing-gcp-cluster-creation.adoc
@@ -5,7 +5,8 @@
 [id="installing-gcp-cluster-creation_{context}"]
 = Configuring user-defined labels and tags for {gcp-short}
 
-Configuring user-defined labels and tags for {gcp-full} means that you can apply key-value pairs to your cloud resources for the purposes of organizing, managing, and automating your infrastructure.
+[role="_abstract"]
+You can apply key-value pairs as labels and tags to your {gcp-full} resources to organize, manage, and automate your {product-title} infrastructure.
 
 .Prerequisites
 
@@ -20,26 +21,29 @@ Configuring user-defined labels and tags for {gcp-full} means that you can apply
 If you set labels and tags during creation of the `install-config.yaml` configuration file, you cannot create new or update existing labels and tags after creation of the cluster.
 ====
 +
-.Sample `install-config.yaml` file
+The following sample `install-config.yaml` file defines user labels and tags:
 +
 [source,yaml]
 ----
 apiVersion: v1
-credentialsMode: Passthrough <1>
+credentialsMode: Passthrough
 platform:
  gcp:
-   userLabels: <2>
-   - key: <label_key><3>
-     value: <label_value><4>
-   userTags: <5>
-   - parentID: <OrganizationID/ProjectID><6>
+   userLabels:
+   - key: <label_key>
+     value: <label_value>
+   userTags:
+   - parentID: <OrganizationID/ProjectID>
      key: <tag_key_short_name>
      value: <tag_value_short_name>
 # ...
 ----
-<1> In passthrough mode, the Cloud Credential Operator (CCO) passes the provided cloud credential to the components that request cloud credentials. 
-<2> Adds keys and values as labels to the resources created on {gcp-short}.
-<3> Defines the label name.
-<4> Defines the label content.
-<5> Adds keys and values as tags to the resources created on {gcp-short}.
-<6> The ID of the hierarchical resource where you defined the tags at the organization or the project level.
++
+where:
++
+* `credentialsMode`: In passthrough mode, the Cloud Credential Operator (CCO) passes the provided cloud credential to the components that request cloud credentials.
+* `userLabels`: Adds keys and values as labels to the resources created on {gcp-short}.
+* `<label_key>`: Specifies the label name.
+* `<label_value>`: Specifies the label content.
+* `userTags`: Adds keys and values as tags to the resources created on {gcp-short}.
+* `<OrganizationID/ProjectID>`: Specifies the ID of the hierarchical resource where you defined the tags at the organization or the project level.

--- a/modules/installing-gcp-cluster-label-tag-reference.adoc
+++ b/modules/installing-gcp-cluster-label-tag-reference.adoc
@@ -5,7 +5,8 @@
 [id="installing-gcp-cluster-label-tag-reference_{context}"]
 = Criteria for user-defined labels and tags
 
-Before configuring user-defined labels and tags for {gcp-full}, consider the importance of meeting the requirements for these tag and labels to ensure proper resource governance.
+[role="_abstract"]
+User-defined labels and tags for {gcp-full} in {product-title} must meet specific formatting and quantity requirements for proper resource governance.
 
 The following list details the requirements for user-defined labels:
 

--- a/modules/installing-gcp-customizations-prerequisites.adoc
+++ b/modules/installing-gcp-customizations-prerequisites.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installing-gcp-customizations-prerequisites_{context}"]
+= Prerequisites
+
+[role="_abstract"]
+Your environment must meet specific infrastructure and access requirements before you install an {product-title} cluster on {gcp-short} with customizations.
+
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* You configured a {gcp-short} project to host the cluster.
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to.

--- a/modules/installing-gcp-customizations-prerequisites.adoc
+++ b/modules/installing-gcp-customizations-prerequisites.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installing-gcp-customizations-prerequisites_{context}"]
+= Prerequisites
+
+[role="_abstract"]
+Your environment must meet specific infrastructure and access requirements before you install an {product-title} cluster on {gcp-short} with customizations.
+
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You selected a cluster installation method and prepared it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You configured a {gcp-short} project to host the cluster. For more information, see "Configuring a {gcp-short} project".
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".

--- a/modules/installing-gcp-manual-modes.adoc
+++ b/modules/installing-gcp-manual-modes.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-manual-modes_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
+
+[role="_abstract"]
+By default, {product-title} stores administrator secrets in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must configure an alternative credential management strategy by using either long-term manual credentials or short-term credentials that are managed outside the cluster.
+
+* To manage long-term cloud credentials manually, follow the procedure in "Manually creating long-term credentials".
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in "Short-term credential configuration for a {gcp-short} cluster".

--- a/modules/installing-gcp-manual-modes.adoc
+++ b/modules/installing-gcp-manual-modes.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-manual-modes_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
+
+[role="_abstract"]
+By default, {product-title} stores administrator secrets in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must configure an alternative credential management strategy by using either long-term manual credentials or short-term credentials that are managed outside the cluster.
+
+* To manage long-term cloud credentials manually, follow the procedure in "Manually creating long-term credentials".
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in "Short-term credential configuration for a {gcp-short} cluster".

--- a/modules/installing-gcp-querying-labels-tags-gcp.adoc
+++ b/modules/installing-gcp-querying-labels-tags-gcp.adoc
@@ -5,7 +5,8 @@
 [id="installing-gcp-querying-labels-tags-gcp_{context}"]
 = Querying user-defined labels and tags for {gcp-short}
 
-After creating the {product-title} cluster, you can access the list of the labels and tags defined for the {gcp-short} resources  in the `infrastructures.config.openshift.io/cluster` object as shown in the following sample `infrastructure.yaml` file.
+[role="_abstract"]
+After creating the {product-title} cluster, you can query the labels and tags defined for {gcp-short} resources in the `infrastructures.config.openshift.io/cluster` object to verify your labeling configuration or reference tag values during troubleshooting.
 
 .Sample `infrastructure.yaml` file
 [source,yaml]
@@ -18,7 +19,7 @@ spec:
  platformSpec:
    type: GCP
 status:
- infrastructureName: <cluster_id><1>
+ infrastructureName: <cluster_id>
  platform: GCP
  platformStatus:
    gcp:
@@ -31,6 +32,7 @@ status:
        value: <tag_value_short_name>
    type: GCP
 ----
-<1> The cluster ID that is generated during cluster installation.
+
+Where `<cluster_id>` is the cluster ID that is generated during cluster installation.
 
 Along with the user-defined labels, resources have a label defined by the {product-title}. The format of the {product-title} labels is `kubernetes-io-cluster-<cluster_id>:owned`.

--- a/modules/installing-gcp-querying-labels-tags-gcp.adoc
+++ b/modules/installing-gcp-querying-labels-tags-gcp.adoc
@@ -5,7 +5,8 @@
 [id="installing-gcp-querying-labels-tags-gcp_{context}"]
 = Querying user-defined labels and tags for {gcp-short}
 
-After creating the {product-title} cluster, you can access the list of the labels and tags defined for the {gcp-short} resources  in the `infrastructures.config.openshift.io/cluster` object as shown in the following sample `infrastructure.yaml` file.
+[role="_abstract"]
+After creating the {product-title} cluster, you can query the labels and tags defined for {gcp-short} resources in the `infrastructures.config.openshift.io/cluster` object to verify your labeling configuration or reference tag values during troubleshooting.
 
 .Sample `infrastructure.yaml` file
 [source,yaml]
@@ -18,7 +19,7 @@ spec:
  platformSpec:
    type: GCP
 status:
- infrastructureName: <cluster_id><1>
+ infrastructureName: <cluster_id>
  platform: GCP
  platformStatus:
    gcp:
@@ -31,6 +32,7 @@ status:
        value: <tag_value_short_name>
    type: GCP
 ----
-<1> The cluster ID that is generated during cluster installation.
++
+where `<cluster_id>` is the cluster ID that is generated during cluster installation.
 
 Along with the user-defined labels, resources have a label defined by the {product-title}. The format of the {product-title} labels is `kubernetes-io-cluster-<cluster_id>:owned`.

--- a/modules/installing-gcp-short-term-creds.adoc
+++ b/modules/installing-gcp-short-term-creds.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-with-short-term-creds_{context}"]
+= Short-term credential configuration for a {gcp-short} cluster
+
+[role="_abstract"]
+To install an {product-title} cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster.
+
+Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.
+
+ifeval::["{context}" == "installing-gcp-shared-vpc"]
+[IMPORTANT]
+====
+When installing a cluster on a shared Virtual Private Cloud (VPC) by using short-lived credentials, you must grant the `compute.subnetworks.use` permission in the host project to Day 2 Operator service accounts.
+
+After using the `ccoctl` utility to generate the {gcp-short} credentials, manually grant this permission to the {cluster-capi-operator} and Machine API Operator service accounts.
+====
+endif::[]

--- a/modules/installing-gcp-short-term-creds.adoc
+++ b/modules/installing-gcp-short-term-creds.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-with-short-term-creds_{context}"]
+= Short-term credential configuration for a {gcp-short} cluster
+
+[role="_abstract"]
+To install an {product-title} cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster.
+
+Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.

--- a/modules/installing-gcp-user-defined-labels-and-tags.adoc
+++ b/modules/installing-gcp-user-defined-labels-and-tags.adoc
@@ -5,7 +5,8 @@
 [id="installing-gcp-user-defined-labels-and-tags_{context}"]
 = Managing user-defined labels and tags for {gcp-short}
 
-{gcp-first} provides labels and tags that help to identify and organize the resources created for a specific {product-title} cluster, making them easier to manage.
+[role="_abstract"]
+You can use {gcp-first} labels and tags to identify and organize the resources created for a specific {product-title} cluster.
 
 You can define labels and tags for each {gcp-short} resource only during {product-title} cluster installation.
 
@@ -19,11 +20,9 @@ User-defined labels and tags are not supported for {product-title} clusters upgr
 You cannot update the tags that are already added. Also, a new tag-supported resource creation fails if the configured tag keys or tag values are deleted.
 ====
 
-.User-defined labels
+User-defined labels and {product-title} specific labels are applied only to resources created by the {product-title} installation program and its core components, such as the following:
 
-User-defined labels and {product-title} specific labels are applied only to resources created by {product-title} installation program and its core components such as:
-
-* {gcp-short} filestore CSI Driver Operator
+* {gcp-short} FileStore CSI Driver Operator
 * {gcp-short} PD CSI Driver Operator
 * Image Registry Operator
 * Machine API provider for {gcp-short}
@@ -41,13 +40,11 @@ User-defined labels and {product-title} labels are available on the following {g
 * Filestore instance
 * Storage bucket
 
-.Limitations to user-defined labels
+User-defined labels have the following limitations:
 
 * Labels for `ComputeAddress` are supported in the {gcp-short} beta version. {product-title} does not add labels to the resource.
 
-.User-defined tags
-
-User-defined tags are applied only to resources created by {product-title} installation program and its core components, such as the following resources:
+User-defined tags are applied only to resources created by the {product-title} installation program and its core components, such as the following:
 
 * {gcp-short} FileStore CSI Driver Operator
 * {gcp-short} PD CSI Driver Operator
@@ -64,7 +61,7 @@ User-defined tags are available on the following {gcp-short} resources:
 * Filestore instance
 * Storage bucket
 
-.Limitations to the user-defined tags
+User-defined tags have the following limitations:
 
 * Tags must not be restricted to particular service accounts, because Operators create and use service accounts with minimal roles.
 * {product-title} does not create any key and value resources of the tag.
@@ -74,7 +71,7 @@ User-defined tags are available on the following {gcp-short} resources:
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about identifying the `OrganizationID`, see: link:https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id[OrganizationID]
-* For more information about identifying the `ProjectID`, see: link:https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects[ProjectID]
-* For more information about labels, see link:https://cloud.google.com/resource-manager/docs/labels-overview[Labels Overview].
-* For more information about tags, see link:https://cloud.google.com/resource-manager/docs/tags/tags-overview[Tags Overview].
+* link:https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id[Retrieving your organization ID]
+* link:https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects[Identifying projects]
+* link:https://cloud.google.com/resource-manager/docs/labels-overview[Labels overview]
+* link:https://cloud.google.com/resource-manager/docs/tags/tags-overview[Tags overview]

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -23,7 +23,9 @@ endif::[]
 = Specifying advanced network configuration
 
 [role="_abstract"]
-To integrate your {product-title} cluster with your existing network environment, you can specify advanced network configuration in a manifest before you install the cluster. Advanced network configuration can be configured only during cluster installation.
+You can use advanced network configuration for your {product-title} network plugin to integrate your cluster into your existing network environment.
+
+You can specify advanced network configuration only before you install the cluster.
 
 [IMPORTANT]
 ====
@@ -43,7 +45,7 @@ Customizing your network configuration by modifying the {product-title} manifest
 $ ./openshift-install create manifests --dir <installation_directory>
 ----
 +
-The `<installation_directory>` specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+where `<installation_directory>` specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
 
 . Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
 +
@@ -58,7 +60,10 @@ spec:
 
 . Specify the advanced network configuration for your cluster in the `cluster-network-03-config.yml` file, such as in the following example:
 +
-.Enable IPsec for the OVN-Kubernetes network provider
+--
+The following example enables IPsec for the OVN-Kubernetes network provider:
+
+
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -71,10 +76,9 @@ spec:
       ipsecConfig:
         mode: Full
 ----
+--
 
-. Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
-installation program consumes the `manifests/` directory when you create the
-Ignition config files.
+. Optional: Back up the `manifests/cluster-network-03-config.yml` file. The installation program consumes the `manifests/` directory when you create the Ignition config files.
 
 ifndef::vsphere-ipi[]
 . Remove the Kubernetes manifest files that define the control plane machines and compute `MachineSets`:
@@ -84,8 +88,7 @@ ifndef::vsphere-ipi[]
 $ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
 +
-Because you create and manage these resources yourself, you do not have
-to initialize them.
+Because you create and manage these resources yourself, you do not have to initialize them.
 +
 * You can preserve the `MachineSet` files to create compute machines by using the machine API, but you must update references to them to match your environment.
 endif::[]

--- a/modules/nw-network-config.adoc
+++ b/modules/nw-network-config.adoc
@@ -15,7 +15,7 @@
 = Network configuration phases
 
 [role="_abstract"]
-There are two phases prior to {product-title} installation where you can customize the network configuration. Customize settings in the `install-config.yaml` file and in the Cluster Network Operator manifest across two configuration phases.
+You can customize your {product-title} network plugin configuration, such as cluster network CIDR and service network ranges, during two phases before installation to integrate with your existing network environment.
 
 Phase 1:: You can customize the following network-related fields in the `install-config.yaml` file before you create the manifest files:
 +

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -302,7 +302,7 @@ One of the following additional audit log targets:
 
 `libc`:: The libc `syslog()` function of the journald process on the host.
 `udp:<host>:<port>`:: A syslog server. Replace `<host>:<port>` with the host and port of the syslog server.
-`unix:<file>`:: A Unix Domain Socket file specified by `<file>`.
+`unix:<file>`:: A UNIX Domain Socket file specified by `<file>`.
 `null`:: Do not send the audit logs to any additional target.
 
 |`syslogFacility`
@@ -355,7 +355,7 @@ The default value of `Restricted` sets the IP forwarding to drop.
 |`internalMasqueradeSubnet`
 |`string`
 |
-The masquerade IPv4 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `169.254.169.0/29`.
+The masquerade IPv4 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses and the shared gateway bridge interface. The default value is `169.254.169.0/29`.
 [IMPORTANT]
 ====
 For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` as the default masquerade subnet. For upgraded clusters, there is no change to the default masquerade subnet.
@@ -372,7 +372,7 @@ For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` as th
 |`internalMasqueradeSubnet`
 |`string`
 |
-The masquerade IPv6 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `fd69::/125`.
+The masquerade IPv6 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses and the shared gateway bridge interface. The default value is `fd69::/125`.
 [IMPORTANT]
 ====
 For {product-title} 4.17 and later versions, clusters use `fd69::/112` as the default masquerade subnet. For upgraded clusters, there is no change to the default masquerade subnet.
@@ -405,7 +405,7 @@ You can only change the configuration for your cluster network plugin during clu
 ====
 endif::operator[]
 
-.Example OVN-Kubernetes configuration with IPSec enabled
+.Example OVN-Kubernetes configuration with IPsec enabled
 [source,yaml]
 ----
 defaultNetwork:


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster on GCP with customizations](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html)
- [Prerequisites](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-customizations-prerequisites_installing-gcp-customizations)
- [Using the GCP Marketplace offering](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-marketplace_installing-gcp-customizations)
- [Alternatives to storing administrator-level secrets in the kube-system project](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-manual-modes_installing-gcp-customizations)
- [Configuring a GCP cluster to use short-term credentials](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-with-short-term-creds_installing-gcp-customizations)
- [Configuring user-defined labels and tags for GCP](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-cluster-creation_installing-gcp-customizations)
- [Criteria for user-defined labels and tags](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-cluster-label-tag-reference_installing-gcp-customizations)
- [Querying user-defined labels and tags for GCP](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-querying-labels-tags-gcp_installing-gcp-customizations)
- [Managing user-defined labels and tags for GCP](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations)
- [Specifying advanced network configuration](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#modifying-nwoperator-config-startup_installing-gcp-customizations)
- [Network configuration phases](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#nw-network-config_installing-gcp-customizations)
- [Cluster Network Operator configuration](https://116666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#nw-operator-cr_installing-gcp-customizations)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:

**Note on `cli-installing-cli` modules:** The module extraction list for this assembly references `modules/cli-installing-cli.adoc`, which does not exist. The assembly actually includes three platform-specific modules: `cli-installing-cli-linux.adoc`, `cli-installing-cli-macos.adoc`, and `cli-installing-cli-windows.adoc`. All three were linted and had vale fixes applied (for example, "execute" → "run", "command prompt" → "Command Prompt").
