### PR TITLE
OSDOCS-17039: OCI edge assisted installer CQA

### DIFF
--- a/installing/installing_oci_edge/installing-c3-assisted-installer.adoc
+++ b/installing/installing_oci_edge/installing-c3-assisted-installer.adoc
@@ -19,6 +19,13 @@ include::modules/installing-oci-edge-infra-support.adoc[leveloffset=+1]
 // Overview
 include::modules/c3-assisted-installer-overview.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Access and considerations (Oracle documentation)]
+
+* link:https://catalog.redhat.com/cloud/detail/216977[Oracle Cloud Infrastructure]
+
 // Preparing the Bastian server
 include::modules/c3-assisted-installer-preparing-bastion-server.adoc[leveloffset=+1]
 
@@ -26,12 +33,7 @@ include::modules/c3-assisted-installer-preparing-bastion-server.adoc[leveloffset
 include::modules/c3-assisted-installer-running-script-via-home.adoc[leveloffset=+1]
 
 // Preparing the OpenShift image
-[id="c3-assisted-installer-preparing-image_{context}"]
-== Preparing the {oci} image
-
-Generate the {product-title} ISO image in the {ai-full} on the Red{nbsp}Hat portal. Then, convert the image to an {oci-edge-no-rt} compatible image and upload it to the *Custom Images* page of your {oci-edge-no-rt} environment.
-
-You can generate, convert and upload the image on your laptop and not on the bastion server or within environments such as Oracle Solution Center.
+include::modules/c3-assisted-installer-preparing-image.adoc[leveloffset=+1]
 
 include::modules/c3-assisted-installer-preparing-image-generating.adoc[leveloffset=+2]
 
@@ -41,11 +43,7 @@ include::modules/c3-assisted-installer-preparing-image-converting.adoc[leveloffs
 include::modules/c3-assisted-installer-running-script-via-region.adoc[leveloffset=+1]
 
 // Completing the installation
-
-[id="c3-ai-completing-installation_{context}"]
-== Completing the installation by using the {ai-full} web console
-
-After you configure the infrastructure, the instances are now running and are ready to be registered with Red{nbsp}Hat.
+include::modules/c3-assisted-installer-completing-installation.adoc[leveloffset=+1]
 
 include::modules/c3-assisted-installer-completing-installation-nodes.adoc[leveloffset=+2]
 

--- a/modules/c3-assisted-installer-completing-installation.adoc
+++ b/modules/c3-assisted-installer-completing-installation.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: CONCEPT
+[id="c3-ai-completing-installation_{context}"]
+= Completing the installation by using the {ai-full} web console
+
+[role="_abstract"]
+After you configure the infrastructure, the instances are now running and are ready to be registered with Red{nbsp}Hat.

--- a/modules/c3-assisted-installer-overview.adoc
+++ b/modules/c3-assisted-installer-overview.adoc
@@ -11,27 +11,29 @@ You can install {product-title} on {oci-edge-no-rt} by using the {ai-full}.
 
 For an alternative installation method, see "Installing a cluster on {oci-edge} by using the Agent-based Installer".
 
-.Preinstallation considerations
+Preinstallation considerations::
 
-* Ensure that your installation meets the prerequisites specified for Oracle. For details, see the "Access and Considerations" section in the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].
+* Ensure that your installation meets the prerequisites specified for Oracle. For details, see the "Access and Considerations" section in the Oracle documentation.
 
-* Ensure that your infrastructure is certified and uses a compatible cloud instance type. For details, see link:https://catalog.redhat.com/cloud/detail/216977[Oracle Cloud Infrastructure].
+* Ensure that your infrastructure is certified and uses a compatible cloud instance type. For details, see "Oracle Cloud Infrastructure".
 
 * Ensure that you are performing the installation on a virtual machine.
 
-.Installation process
+Installation process::
 
 The installation process builds a bastion host within the designated compartment of the {product-title} cluster. The bastion host is used to run two Terraform scripts:
-
++
+--
 * The first script builds IAM Resources in the {oci} Home region of the {oci-edge} system (two Dynamic Groups and one Policy).
 
 * The second script builds the infrastructure resources on the {oci-edge} system to support the {product-title} cluster, including the {product-title} VCN, public and private subnets, load balancers, Internet GW, NAT GW, and DNS server. The script includes all the resources needed to activate the control plane nodes and compute nodes that form a cluster.
-
+--
++
 The bastion host is installed in the designated {product-title} Compartment and configured to communicate through a designated {oci-edge} DRG Subnet or Internet GW Subnet within the {oci-edge} parent tenancy.
-
++
 The installation process subsequently provisions three control plane (master) nodes and three compute (worker) nodes, together with the external and internal Load Balancers that form the cluster. This is the standard implementation for {oci-edge-no-rt}.
 
-.Main steps
+Main steps::
 
 The main steps of the procedure are as follows:
 

--- a/modules/c3-assisted-installer-preparing-bastion-server.adoc
+++ b/modules/c3-assisted-installer-preparing-bastion-server.adoc
@@ -23,4 +23,4 @@ By implementing a bastion host, you can securely and efficiently manage access t
 
 .Additional resources
 
-* link:https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm[Quick start - Installing the CLI (Oracle documentation)].
+* link:https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm[Quick start - Installing the CLI (Oracle documentation)]

--- a/modules/c3-assisted-installer-preparing-image-converting.adoc
+++ b/modules/c3-assisted-installer-preparing-image-converting.adoc
@@ -16,5 +16,5 @@ Store.
 . Upload the {oci} image to an {oci} bucket, and generate a Pre-Authenticated Request (PAR) URL.
 . Import the {oci} image to the {oci-edge} portal.
 . Copy the Oracle Cloud Identifier (OCID) of the image for use in the next procedure.
-
++
 For the full procedure, see step 6 - 8 in the "OpenShift Image Preparation" section of the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].

--- a/modules/c3-assisted-installer-preparing-image.adoc
+++ b/modules/c3-assisted-installer-preparing-image.adoc
@@ -1,0 +1,9 @@
+
+:_mod-docs-content-type: CONCEPT
+[id="c3-assisted-installer-preparing-image_{context}"]
+= Preparing the {oci} image
+
+[role="_abstract"]
+Generate the {product-title} ISO image in the {ai-full} on the Red{nbsp}Hat portal. Then, convert the image to an {oci-edge-no-rt} compatible image and upload it to the *Custom Images* page of your {oci-edge-no-rt} environment.
+
+You can generate, convert and upload the image on your laptop and not on the bastion server or within environments such as Oracle Solution Center.

--- a/modules/c3-assisted-installer-running-script-via-home.adoc
+++ b/modules/c3-assisted-installer-running-script-via-home.adoc
@@ -26,5 +26,5 @@ These resources include dynamic groups, policies, and tags.
 . Ensure that you have access to the source environment, and that your C3 certificate has been exported.
 
 . Run the `createInfraResources.tf` Terraform script.
-
++
 For the full procedure, see the "Terraform Script Execution Part-1 (Run Script via Home Region)" section in the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].

--- a/modules/c3-assisted-installer-running-script-via-region.adoc
+++ b/modules/c3-assisted-installer-running-script-via-region.adoc
@@ -22,6 +22,6 @@ This procedure deploys a cluster consisting of three control plane (master) and 
 . Update the labels for the control plane and compute nodes.
 
 . Stop and restart the instances one by one on the {oci-edge} portal.
-
++
 For the full procedure, see the "Terraform Script Execution - Part 2" section in the link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_assisted_installer.pdf?source=:em:nl:mt::::PCATP[Oracle documentation].
 


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI edge content. This PR resolves remaining errors in Assisted Installer content.

QE review: Not required

Previews: https://116686--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-assisted-installer.html