### PR TITLE
OSDOCS-17039: OCI edge agent installer CQA

### DIFF
--- a/installing/installing_oci_edge/installing-c3-agent-based-installer.adoc
+++ b/installing/installing_oci_edge/installing-c3-agent-based-installer.adoc
@@ -14,21 +14,7 @@ The following procedures describe a cluster installation on {oci-c3} as an examp
 // Supported Oracle Edge Cloud Infrastructures
 include::modules/installing-oci-edge-infra-support.adoc[leveloffset=+1]
 
-[id="abi-oci-c3-process-checklist_{context}"]
-== Installation process workflow
-
-The following workflow describes a high-level outline for the process of installing an {product-title} cluster on {oci-edge-no-rt} using the Agent-based Installer:
-
-. Create {oci-first-no-rt} resources and services (Oracle).
-. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
-. Generate the agent ISO image (Red{nbsp}Hat).
-. Convert the ISO image to an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-edge-no-rt} system (Oracle).
-. Disconnected environments: Prepare a web server that is accessible by {oci-edge-no-rt} instances (Red{nbsp}Hat).
-. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
-. Configure your firewall for {product-title} (Red{nbsp}Hat).
-. Create control plane nodes and configure load balancers (Oracle).
-. Create compute nodes and configure load balancers (Oracle).
-. Verify that your cluster runs on {oci-edge-no-rt} (Oracle).
+include::modules/installing-oci-edge-agent-workflow.adoc[leveloffset=+1]
 
 // Creating Compute Cloud@Customer infrastructure resources and services
 include::modules/abi-c3-resources-services.adoc[leveloffset=+1]

--- a/modules/installing-oci-edge-agent-workflow.adoc
+++ b/modules/installing-oci-edge-agent-workflow.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: CONCEPT
+[id="abi-oci-c3-process-checklist_{context}"]
+= Installation process workflow
+
+[role="_abstract"]
+To better understand the process, see a high-level outline of installing an {product-title} cluster on {oci-edge-no-rt} using the Agent-based Installer.
+
+The following workflow describes the general installation process:
+
+. Create {oci-first-no-rt} resources and services (Oracle).
+. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
+. Generate the agent ISO image (Red{nbsp}Hat).
+. Convert the ISO image to an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-edge-no-rt} system (Oracle).
+. Disconnected environments: Prepare a web server that is accessible by {oci-edge-no-rt} instances (Red{nbsp}Hat).
+. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
+. Configure your firewall for {product-title} (Red{nbsp}Hat).
+. Create control plane nodes and configure load balancers (Oracle).
+. Create compute nodes and configure load balancers (Oracle).
+. Verify that your cluster runs on {oci-edge-no-rt} (Oracle).


### PR DESCRIPTION
[OSDOCS-17039](https://redhat.atlassian.net/browse/OSDOCS-17039)

Version(s): 4.20+

CQA fixes for OCI edge content. This PR resolves remaining errors in Agent-based Installer content.

QE review: Not required

Previews: https://116696--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-agent-based-installer.html