### PR TITLE
[OSDOCS-19702]: Adding docs about cluster capabilities for HCP

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -12,7 +12,7 @@ To reduce infrastructure costs and improve cluster management efficiency, you ca
 
 A _hosted cluster_ is an {product-title} cluster with its API endpoint and control plane that are hosted on the management cluster. The hosted cluster includes the control plane and its corresponding data plane. To configure {hcp} on premises, you must install {mce} in a management cluster. By deploying the HyperShift Operator on an existing managed cluster by using the `hypershift-addon` managed cluster add-on, you can enable that cluster as a management cluster and start to create the hosted cluster. The `hypershift-addon` managed cluster add-on is enabled by default for the `local-cluster` managed cluster.
 
-You can use the {mce-short} console or the hosted control plane command-line interface (CLI), `hcp`, to create a hosted cluster. The hosted cluster is automatically imported as a managed cluster. However, you can xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[disable this automatic import feature into {mce-short}].
+You can use the {mce-short} console or the hosted control plane command-line interface (CLI), `hcp`, to create a hosted cluster. The hosted cluster is automatically imported as a managed cluster. However, you can disable this automatic import feature into {mce-short}. For more information, see "Disabling the automatic import of hosted clusters into {mce-short}".
 
 include::modules/hcp-aws-prepare.adoc[leveloffset=+1]
 
@@ -69,6 +69,12 @@ include::modules/hcp-aws-deploy-hc.adoc[leveloffset=+2]
 include::modules/hcp-create-hc-multi-zone-aws-creds.adoc[leveloffset=+2]
 
 include::modules/hc-create-aws-multi-zones.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
 
 include::modules/hcp-access-hc-aws.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
@@ -43,6 +43,12 @@ include::modules/hcp-azure-mgmt-cluster.adoc[leveloffset=+1]
 
 include::modules/hcp-azure-hosted.adoc[leveloffset=+1]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 include::modules/hcp-azure-private.adoc[leveloffset=+1]
 
 include::modules/hcp-azure-private-subnet.adoc[leveloffset=+2]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
@@ -86,4 +86,10 @@ include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
 * xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster]
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 include::modules/hcp-bm-verify.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -54,6 +54,12 @@ include::modules/hcp-bm-hc.adoc[leveloffset=+1]
 * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import[Manually importing a hosted cluster]
 * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 // About creating heterogeneous node pools on agent hosted clusters
 include::modules/hcp-ibm-power-create-heterogeneous-nodepools-agent-hc-con.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -46,6 +46,12 @@ include::modules/hcp-ibmz-create-hc.adoc[leveloffset=+1]
 * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-hc-console_hcp-deploy-bm[Creating a hosted cluster on bare metal by using the console]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 include::modules/hcp-ibm-z-infraenv.adoc[leveloffset=+1]
 
 include::modules/hcp-ibm-z-kvm-agents.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -104,4 +104,10 @@ include::modules/hcp-non-bm-hc-mirror.adoc[leveloffset=+1]
 
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 include::modules/hcp-non-bm-verify.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -82,6 +82,12 @@ include::modules/hcp-virt-create-hc-console.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-manage/hcp-manage-virt.adoc#hcp-virt-access_hcp-manage-virt[Accessing the hosted cluster]
 
+include::modules/hcp-cluster-capabilities.adoc[leveloffset=+1]
+
+include::modules/hcp-cluster-capabilities-ref.adoc[leveloffset=+2]
+
+include::modules/hcp-cluster-capabilities-proc.adoc[leveloffset=+2]
+
 include::modules/hcp-virt-ingress-dns.adoc[leveloffset=+1]
 
 include::modules/hcp-custom-dns.adoc[leveloffset=+2]

--- a/modules/hcp-aws-deploy-hc.adoc
+++ b/modules/hcp-aws-deploy-hc.adoc
@@ -34,21 +34,23 @@ $ hcp create cluster aws \
     --node-pool-replicas <node_pool_replica_count> \
     --namespace <hosted_cluster_namespace> \
     --role-arn <role_name> \
+    --disable-cluster-capabilities=<capability> \
+    --enable-cluster-capabilities=<capability> \
     --render-into <file_name>.yaml
 ----
 +
-where:
-
-`<hosted_cluster_name>`:: Specifies the name of your hosted cluster.
-`<infra_id>`:: Specifies your infrastructure name. You must provide the same value for `<hosted_cluster_name>` and `<infra_id>`. Otherwise the cluster might not appear correctly in the {mce} console.
-`<basedomain>`:: Specifies your base domain, for example, `example.com`.
-`<path_to_sts_credential_file>`:: Specifies the path to your AWS STS credentials file, for example, `/home/user/sts-creds/sts-creds.json`.
-`<path_to_pull_secret>`:: Specifies the path to your pull secret, for example, `/user/name/pullsecret`.
-`<region>`:: Specifies the AWS region name, for example, `us-east-1`.
-`<node_pool_replica_count>`:: Specifies the node pool replica count, for example, `3`.
-`<hosted_cluster_namespace>`:: Specifies that you want to create the `HostedCluster` and `NodePool` custom resource in a specific namespace. Otherwise, by default, all `HostedCluster` and `NodePool` custom resources are created in the `clusters` namespace.
-`<role_name>`:: Specifies the Amazon Resource Name (ARN), for example, `arn:aws:iam::820196288204:role/myrole`.
-`<file_name>`:: Specifies whether the EC2 instance runs on shared or single tenant hardware. The `--render-into` flag renders Kubernetes resources into the YAML file that you specify in this field. Continue to the next step to edit the YAML file.
+* `--name` specifies the name of your hosted cluster.
+* `--infra-id` specifies your infrastructure name. You must provide the same value for `<hosted_cluster_name>` and `<infra_id>`. Otherwise, the cluster might not appear correctly in the {mce} console.
+* `--base-domain` specifies your base domain, for example, `example.com`.
+* `--sts-creds` specifies the path to your AWS STS credentials file, for example, `/home/user/sts-creds/sts-creds.json`.
+* `--pull-secret` specifies the path to your pull secret, for example, `/user/name/pullsecret`.
+* `--region` specifies the {aws-short} region name, for example, `us-east-1`.
+* `--node-pool-replicas` specifies the node pool replica count, for example, `3`.
+* `--namespace` specifies that you want to create the `HostedCluster` and `NodePool` custom resource in a specific namespace. Otherwise, by default, all `HostedCluster` and `NodePool` custom resources are created in the `clusters` namespace.
+* `--role-arn` specifies the Amazon Resource Name (ARN), for example, `arn:aws:iam::820196288204:role/myrole`.
+* `--disable-cluster-capabilities` specifies that you want to disable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--enable-cluster-capabilities` specifies that you want to enable an optional capability for the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--render-into` specifies whether the EC2 instance runs on shared or single tenant hardware. The `--render-into` flag renders Kubernetes resources into the YAML file that you specify in this field. Continue to the next step to edit the YAML file.
 
 . If you included the `--render-into` flag in the previous command, edit the specified YAML file. Edit the `NodePool` specification in the YAML file to indicate whether the EC2 instance should run on shared or single-tenant hardware, similar to the following example:
 +

--- a/modules/hcp-azure-hosted.adoc
+++ b/modules/hcp-azure-hosted.adoc
@@ -51,13 +51,14 @@ $ hcp create cluster azure \
   --assign-service-principal-roles \
   --infra-json <output_infra_file> \
   --diagnostics-storage-account-type Managed \
+  --disable-cluster-capabilities=<capability> \
+  --enable-cluster-capabilities=<capability> \
   --external-dns-domain "${DNS_ZONE_NAME}"
 ----
 +
-[NOTE]
-====
-For non-production environments, you can create a hosted cluster without external DNS by omitting the `--external-dns-domain` and `--assign-service-principal-roles` flags. In that case, the API server is accessible through an {azure-short} load balancer hostname instead of a custom DNS name.
-====
+** For non-production environments, you can create a hosted cluster without external DNS by omitting the `--external-dns-domain` and `--assign-service-principal-roles` flags. In that case, the API server is accessible through an {azure-short} load balancer hostname instead of a custom DNS name.
+** The `--disable-cluster-capabilities` flag is optional. Include it when you want to disable optional capabilities in your hosted cluster. For more information, see "Capabilities for hosted clusters".
+** The `--enable-cluster-capabilities` flag is optional. Include it when you want to enable optional capabilities in your hosted cluster. For more information, see "Capabilities for hosted clusters".
 
 .Verification
 

--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -72,6 +72,8 @@ $ hcp create cluster agent \
   --control-plane-availability-policy=HighlyAvailable \
   --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image>-multi \
   --node-pool-replicas=<node_pool_replica_count> \
+  --disable-cluster-capabilities=<capability> \
+  --enable-cluster-capabilities=<capability> \
   --render \
   --render-sensitive > hosted-cluster-config.yaml
 ----
@@ -87,8 +89,10 @@ where:
 * `--ssh-key` specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 * `--namespace` specifies your hosted cluster namespace.
 * `--control-plane-availability-policy` specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
-* `--release-image` specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+* `--release-image` specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".
 * `--node-pool-replicas` specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
+* `--disable-cluster-capabilities` specifies that you want to disable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--enable-cluster-capabilities` specifies that you want to enable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
 
 . Configure the service publishing strategy. By default, hosted clusters use the `NodePort` service publishing strategy because node ports are always available without additional infrastructure. However, you can configure the service publishing strategy to use a load balancer.
 

--- a/modules/hcp-cluster-capabilities-proc.adoc
+++ b/modules/hcp-cluster-capabilities-proc.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-cluster-capabilities-proc_{context}"]
+= Setting capabilities for a hosted cluster
+
+[role="_abstract"]
+To reduce unnecessary resource consumption, you can control which optional capabilities are enabled for a hosted cluster when you create the cluster.
+
+[IMPORTANT]
+====
+Capabilities are immutable after cluster creation. You cannot change them after you create the `HostedCluster` resource.
+====
+
+You can specify which capabilities are enabled by either using the `hcp` command-line interface (CLI) or by setting the `HostedCluster` manifest.
+
+.Procedure
+
+* To specify which capabilities are enabled in a hosted cluster by using the CLI, you can add the `--disable-cluster-capabilities` flag, the `--enable-cluster-capabilities` flag, or both. The following example shows how to disable the `ImageRegistry`, `Console`, and `Ingress` capabilities and enable the `baremetal` capability while you create a hosted cluster on {aws-short} by using the `hcp` command-line interface:
++
+[source,terminal]
+----
+$ hcp create cluster aws \
+    --name my-hosted-cluster \
+    --disable-cluster-capabilities=ImageRegistry,Console,Ingress \
+    --enable-cluster-capabilities=baremetal
+----
++
+You can specify multiple capabilities as a comma-separated list. The supported values are as follows:
++
+** `ImageRegistry`
+** `openshift-samples`
+** `Insights`
+** `baremetal`
+** `Console`
+** `NodeTuning`
+** `Ingress`
+
+* To specify which capabilities are enabled in a hosted cluster by using the `HostedCluster` manifest at cluster creation time, see the following examples:
+
+** To directly disable capabilities in a hosted cluster, add the `spec.capabilities.disabled` section in the `HostedCluster` resource:
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-hosted-cluster
+  namespace: my-cluster-namespace
+spec:
+  capabilities:
+    disabled:
+      - ImageRegistry
+      - Console
+      - Ingress
+  # ...
+----
+
+** To explicitly enable a capability that is not part of the default set of capabilities, such as the `baremetal` capability, see the following example:
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-hosted-cluster
+  namespace: my-cluster-namespace
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+  # ...
+----
+
+** You can use both `enabled` and `disabled` if no capabilities are in both lists. See the following example:
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-hosted-cluster
+  namespace: my-cluster-namespace
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+    disabled:
+      - ImageRegistry
+      - openshift-samples
+  # ...
+----

--- a/modules/hcp-cluster-capabilities-ref.adoc
+++ b/modules/hcp-cluster-capabilities-ref.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-cluster-capabilities-ref_{context}"]
+= Capabilities that you can enable or disable for a hosted cluster
+
+[role="_abstract"]
+Familiarize yourself with the supported capabilities that you can enable or disable for a `HostedCluster` resource.
+
+The capabilities are described in the following table:
+
+[cols="2",options="header"]
+|===
+|Capability |Description
+
+|`ImageRegistry`
+|The OpenShift Image Registry Operator and its operands, including cloud storage infrastructure, such as S3 buckets and Identity and Access Management (IAM) users.
+
+|`openshift-samples`
+|The OpenShift Samples Operator, which manages example `ImageStreams` and templates.
+
+|`Insights`
+|The Insights Operator, which collects and uploads cluster telemetry data.
+
+|`baremetal`
+|The Bare Metal Infrastructure Operator. This capability is excluded from the default set. If needed, you must explicitly enable it.
+
+|`Console`
+|The OpenShift Web Console Operator and its operands.
+
+|`NodeTuning`
+|The Node Tuning Operator, which manages node-level performance tuning by using TuneD and performance profiles.
+
+|`Ingress`
+|The OpenShift Ingress Operator, which manages the default router of the cluster.
+|===
+
+The following rules apply when you combine capability settings:
+
+No overlap:: A capability cannot be in both the `enabled` and `disabled` lists simultaneously.
+Console requires Ingress:: You can disable the `Ingress` capability only if the `Console` capability is also disabled because the console depends on Ingress.
+Version requirement:: You must use {product-title} 4.20 or later to disable any of the following capabilities: `openshift-samples`, `Insights`, `Console`, `NodeTuning`, and `Ingress`. You can disable `ImageRegistry` and `baremetal` on versions earlier than 4.20.
+Bare metal default exclusion:: The `baremetal` capability is excluded from the default set. You can add it to the cluster by explicitly enabling it.

--- a/modules/hcp-cluster-capabilities.adoc
+++ b/modules/hcp-cluster-capabilities.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-cluster-capabilities_{context}"]
+= Capabilities for hosted clusters
+
+[role="_abstract"]
+To reduce resource consumption and prevent unnecessary Operators and operands from being deployed, administrators can enable or disable optional {product-title} components when they create a hosted cluster.
+
+When capabilities are not specified on a `HostedCluster` resource, the cluster uses the {product-title} version's `DefaultCapabilitySet` settings, excluding the `baremetal` capability. As a result, most optional components are enabled by default. 
+
+[IMPORTANT]
+====
+Capabilities are immutable after cluster creation. You cannot change them after you create the `HostedCluster` resource.
+====

--- a/modules/hcp-ibmz-create-hc.adoc
+++ b/modules/hcp-ibmz-create-hc.adoc
@@ -48,9 +48,10 @@ $ hcp create cluster agent \
   --control-plane-availability-policy=HighlyAvailable \
   --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image>-multi \
   --node-pool-replicas=<node_pool_replica_count> \
+  --disable-cluster-capabilities=<capability> \
+  --enable-cluster-capabilities=<capability> \
   --render \
-  --render-sensitive \
-  --ssh-key <home_directory>/<path_to_ssh_key>/<ssh_key> > hosted-cluster-config.yaml
+  --render-sensitive  > hosted-cluster-config.yaml
 ----
 +
 where:
@@ -64,9 +65,10 @@ where:
 * `--ssh-key` specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 * `--namespace` specifies your hosted cluster namespace.
 * `--control-plane-availability-policy` specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
-* `--release-image` specifies the supported {product-title} version that you want to use, such as `4.19.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+* `--release-image` specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".
 * `--node-pool-replicas` specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
-* `--ssh-key` specifies the path to the SSH key, such as `user/.ssh/id_rsa`.
+* `--disable-cluster-capabilities` specifies that you want to disable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--enable-cluster-capabilities` specifies that you want to enable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
 
 . Apply the changes to the hosted cluster configuration file by entering the following command:
 +

--- a/modules/hcp-non-bm-hc.adoc
+++ b/modules/hcp-non-bm-hc.adoc
@@ -44,6 +44,8 @@ $ hcp create cluster agent \
   --namespace my-hosted-cluster-namespace \
   --control-plane-availability-policy HighlyAvailable \
   --release-image=quay.io/openshift-release-dev/ocp-release:4.22.0-multi \
+  --disable-cluster-capabilities=<capability> \
+  --enable-cluster-capabilities=<capability> \
   --node-pool-replicas 3
 ----
 +
@@ -57,6 +59,8 @@ $ hcp create cluster agent \
 * `--namespace` specifies your hosted cluster namespace.
 * `--control-plane-availability-policy` specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 * `--release-image` specifies the supported {product-title} version that you want to use.
+* `--disable-cluster-capabilities` specifies that you want to disable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--enable-cluster-capabilities` specifies that you want to enable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
 * `--node-pool-replicas` specifies the node pool replica count. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, no node pools are created.
 
 .Verification

--- a/modules/hcp-virt-create-hc-cli.adoc
+++ b/modules/hcp-virt-create-hc-cli.adoc
@@ -31,6 +31,8 @@ $ hcp create cluster kubevirt \
   --arch <architecture_of_the_nodepool> \
   --release-image <ocp_release_image_for_the_cluster> \
   --image-content-sources <path_to_image_content_sources_file> \
+  --disable-cluster-capabilities=<capability> \
+  --enable-cluster-capabilities=<capability> \
   --additional-trust-bundle <path_to_ca_bundle_file>
 ----
 +
@@ -44,6 +46,8 @@ $ hcp create cluster kubevirt \
 * `--arch` defines the architecture of the node pool, for example, `s390x`. The default is `amd64`.
 * `--release-image` defines the {product-title} release image for the cluster, for example, `quay.io/openshift-release-dev/ocp-release:4.20.14-multi`. You can use the `--release-image` flag to set up the hosted cluster with a specific {product-title} release.
 * `--image-content-sources` specifies the path to a file with image content sources.
+* `--disable-cluster-capabilities` specifies that you want to disable optional capabilities. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--enable-cluster-capabilities` specifies that you want to enable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
 * `--additional-trust-bundle` specifies the path to a file with user CA bundle.
 --
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-12896
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
New content:
- Concept: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-cluster-capabilities_hcp-deploy-aws
- Reference: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-cluster-capabilities-ref_hcp-deploy-aws
- Procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-cluster-capabilities-proc_hcp-deploy-aws

Updated content:
- AWS procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-aws-deploy-hc_hcp-deploy-aws
- Azure procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-azure#hcp-azure-hosted_hcp-deploy-azure
- Bare metal procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-bm#hcp-bm-hc_hcp-deploy-bm
- Non-bare-metal procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm#hcp-non-bm-hc_hcp-deploy-non-bm
- IBM Z procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz#hcp-ibmz-create-hc_hcp-deploy-ibmz
- IBM Power procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power#hcp-bm-hc_hcp-deploy-ibm-power
- OpenShift Virtualization procedure: https://116711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt#hcp-virt-create-hc-cli_hcp-deploy-virt

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a new concept, reference, and procedure to the HCP docs about how to control which optional capabilities are included in a hosted cluster. 

It also adds related information to the cluster creation procedures for each supported platform of HCP: Azure, AWS, bare metal, non-bare-metal, IBM Power, IBM Z, and OpenShift Virtualization.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
