### PR TITLE
OSDOCS-20798: Fix broken cross-references in web console docs

### DIFF
--- a/web_console/dynamic-plugin/content-security-policy.adoc
+++ b/web_console/dynamic-plugin/content-security-policy.adoc
@@ -14,10 +14,6 @@ You can specify Content Security Policy (CSP) directives for your dynamic plugin
 [IMPORTANT]
 ====
 The console currently uses the `Content-Security-Policy-Report-Only` response header, so the browser will only warn about CSP violations in the web console and enforcement of CSP policies will be limited. CSP violations will be logged in the browser console, but the associated CSP directives will not be enforced. This feature is behind a `feature-gate`, so you will need to manually enable it.
-
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
-endif::openshift-rosa-hcp,openshift-rosa[]
 ====
 
 include::modules/csp-overview.adoc[leveloffset=+1]
@@ -27,4 +23,7 @@ include::modules/csp-overview.adoc[leveloffset=+1]
 == Additional resources
 
 * link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy[Content Security Policy (CSP)]
+ifndef::openshift-rosa-hcp,openshift-rosa[]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console]
+endif::openshift-rosa-hcp,openshift-rosa[]
 

--- a/web_console/dynamic-plugin/content-security-policy.adoc
+++ b/web_console/dynamic-plugin/content-security-policy.adoc
@@ -16,7 +16,7 @@ You can specify Content Security Policy (CSP) directives for your dynamic plugin
 The console currently uses the `Content-Security-Policy-Report-Only` response header, so the browser will only warn about CSP violations in the web console and enforcement of CSP policies will be limited. CSP violations will be logged in the browser console, but the associated CSP directives will not be enforced. This feature is behind a `feature-gate`, so you will need to manually enable it.
 
 ifndef::openshift-rosa-hcp,openshift-rosa[]
-For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling-features[Enabling feature sets using the web console].
+For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
 endif::openshift-rosa-hcp,openshift-rosa[]
 ====
 

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -28,7 +28,7 @@ include::modules/enabling-developer-perspective_web-console.adoc[leveloffset=+1]
 .Additional resources
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* xref:../welcome/learn_more_about_openshift.adoc#cluster-administrator[Learn more about Cluster Administrator]
+* xref:../welcome/learn_more_about_openshift.adoc#learn_more_about_openshift[Learn more about Cluster Administrator]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
 * xref:../web_console/using-dashboard-to-get-cluster-information.adoc#using-dashboard-to-get-cluster-info[Viewing cluster information]


### PR DESCRIPTION
- fixes two preexisting broken xrefs surfaced by repo-wide xref scan (found while working on OSDOCS-16917/16918/16919)
- `web_console/dynamic-plugin/content-security-policy.adoc`: anchor referenced stale context (`nodes-cluster-enabling-features` instead of `nodes-cluster-enabling`)
- `web_console/web-console-overview.adoc`: anchor pointed to section-level id (`cluster-administrator`) that no longer exists after I restrucured `welcome/learn_more_about_openshift.adoc` to prep for DITA migration; repointed to page-level anchor (`learn_more_about_openshift`)

Note: Same scan surfaced larger, systemic issue: roughly 290 broken xrefs across repo pointing to `rest_api/objects/index.adoc` (auto-generated API reference whose heading-ID convention changed). Out of scope here; needs root-cause fix, tracked in [OSDOCS-20798](https://redhat.atlassian.net/browse/OSDOCS-20798).

**Test plan**
- [ ] Confirm `nodes-cluster-enabling-features-console_nodes-cluster-enabling` resolves in built docs.
- [ ] Confirm `learn_more_about_openshift` resolves in built docs.



<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20798
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:  Mechanical anchor/xref corrections only; no change to doc meaning. QE/SME review not required.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
