### PR TITLE
OSDOCS-17049: Move cluster-tasks nested sections into DITA reference…

### DIFF
--- a/modules/post-install-adding-nodes-assisted.adoc
+++ b/modules/post-install-adding-nodes-assisted.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-assisted_{context}"]
+= Adding worker nodes to clusters managed by the Assisted Installer
+
+[role="_abstract"]
+Add worker nodes to Assisted Installer clusters by using OpenShift Cluster Manager, the REST API, or a manual ISO process.
+
+For clusters managed by the Assisted Installer, you can add worker nodes by using the {cluster-manager-first} console, the Assisted Installer REST API or you can manually add worker nodes using an ISO image and cluster Ignition config files.
+
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-sno-clusters_add-workers[Adding worker nodes using the OpenShift Cluster Manager]
+
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#adding-worker-nodes-using-the-assisted-installer-api[Adding worker nodes using the Assisted Installer REST API]
+
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers[Manually adding worker nodes to a SNO cluster]

--- a/modules/post-install-adding-nodes-ipi.adoc
+++ b/modules/post-install-adding-nodes-ipi.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-ipi_{context}"]
+= Adding worker nodes to installer-provisioned infrastructure clusters
+
+[role="_abstract"]
+Add worker nodes to installer-provisioned infrastructure clusters by scaling machine sets or provisioning bare-metal hosts.
+
+For installer-provisioned infrastructure clusters, you can manually or automatically scale the `MachineSet` object to match the number of available bare-metal hosts.
+
+To add a bare-metal host, you must configure all network prerequisites, configure an associated `baremetalhost` object, then provision the worker node to the cluster. You can add a bare-metal host manually or by using the web console.
+
+* xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-web-console_managing-bare-metal-hosts[Adding worker nodes using the web console]
+
+* xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-yaml_managing-bare-metal-hosts[Adding worker nodes using YAML in the web console]
+
+* xref:../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#preparing-the-bare-metal-node_bare-metal-expanding[Manually adding a worker node to an installer-provisioned infrastructure cluster]

--- a/modules/post-install-adding-nodes-mce.adoc
+++ b/modules/post-install-adding-nodes-mce.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-mce_{context}"]
+= Adding worker nodes to clusters managed by the multicluster engine for Kubernetes
+
+[role="_abstract"]
+Add worker nodes to multicluster engine for Kubernetes clusters by using the dedicated console.
+
+For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#on-prem-creating-your-cluster-with-the-console[Creating your cluster with the console]

--- a/modules/post-install-adding-nodes-on-prem.adoc
+++ b/modules/post-install-adding-nodes-on-prem.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-iso_{context}"]
+= Adding worker nodes to an on-premise cluster
+
+[role="_abstract"]
+Add worker nodes to an on-premise {product-title} cluster by using the OpenShift CLI to generate an ISO image.
+
+For on-premise clusters, you can add worker nodes by using the {product-title} CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
+Any configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
+
+Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
+
+xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]

--- a/modules/post-install-adding-nodes-upi.adoc
+++ b/modules/post-install-adding-nodes-upi.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-upi_{context}"]
+= Adding worker nodes to user-provisioned infrastructure clusters
+
+[role="_abstract"]
+Add worker nodes to user-provisioned infrastructure clusters by using an ISO image and Ignition config files.
+
+For user-provisioned infrastructure clusters, you can add worker nodes by using a {op-system-base} or {op-system} ISO image and connecting it to your cluster using cluster Ignition config files. For RHEL worker nodes, the following example uses Ansible playbooks to add worker nodes to the cluster. For RHCOS worker nodes, the following example uses an ISO image and network booting to add worker nodes to the cluster.
+
+* xref:../post_installation_configuration/node-tasks.adoc#post-install-config-adding-fcos-compute[Adding RHCOS worker nodes to a user-provisioned infrastructure cluster]

--- a/modules/post-install-additional-config-resources.adoc
+++ b/modules/post-install-additional-config-resources.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="additional-configuration-resources_{context}"]
+= Additional configuration resources
+
+[role="_abstract"]
+Review the additional configuration resources that represent a single instance of a particular {product-title} component.
+
+These configuration resources represent a single instance of a particular component. In some cases, you can request multiple
+instances by creating multiple instances of the resource. In other cases, the Operator can use only a specific
+resource instance name in a specific namespace. Reference the component-specific
+documentation for details on how and when you can create additional resource instances.
+
+[cols="2a,2a,2a,8a",options="header"]
+|===
+|Resource name
+|Instance name
+|Namespace
+|Description
+
+|`alertmanager.monitoring.coreos.com`
+|`main`
+|`openshift-monitoring`
+|Controls the link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/latest/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Alertmanager] deployment parameters.
+
+|`ingresscontroller.operator.openshift.io`
+|`default`
+|`openshift-ingress-operator`
+|Configures xref:../networking/networking_operators/ingress-operator.adoc#configuring-ingress-controller[Ingress Operator] behavior such as domain, number of replicas, certificates, and controller placement.
+
+|===

--- a/modules/post-install-cluster-config-resources.adoc
+++ b/modules/post-install-cluster-config-resources.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="configuration-resources_{context}"]
+= Cluster configuration resources
+
+[role="_abstract"]
+Review the globally scoped cluster configuration resources that control major features of an {product-title} cluster.
+
+All cluster configuration resources are globally scoped (not namespaced) and named `cluster`.
+////
+Config changes should not require coordinated changes between config resources, if you find
+yourself struggling to update these docs to explain coordinated changes, please reach out
+to @api-approvers (github) or #forum-api-review (slack).
+////
+
+[cols="2a,8a",options="header"]
+|===
+|Resource name
+|Description
+
+|`apiserver.config.openshift.io`
+|Provides API server configuration such as xref:../security/certificates/api-server.adoc#api-server-certificates[certificates and certificate authorities].
+
+|`authentication.config.openshift.io`
+|Controls the xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[identity provider] and authentication configuration for the cluster.
+
+|`build.config.openshift.io`
+|Controls default and enforced xref:../cicd/builds/build-configuration.adoc#build-configuration[configuration] for all builds on the cluster.
+
+|`console.config.openshift.io`
+|Configures the behavior of the web console interface, including the xref:../web_console/configuring-web-console.adoc#configuring-web-console[logout behavior].
+
+|`featuregate.config.openshift.io`
+|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[FeatureGates]
+so that you can use Tech Preview features.
+
+|`image.config.openshift.io`
+|Configures how specific xref:../openshift_images/image-configuration.adoc#image-configuration[image registries] should be treated (allowed, disallowed, insecure, CA details).
+
+|`ingress.config.openshift.io`
+|Configuration details related to xref:../networking/networking_operators/ingress-operator.adoc#nw-installation-ingress-config-asset_ingress-operator[routing] such as the default domain for routes.
+
+|`oauth.config.openshift.io`
+|Configures identity providers and other behavior related to xref:../authentication/configuring-internal-oauth.adoc#configuring-internal-oauth[internal OAuth server] flows.
+
+|`project.config.openshift.io`
+|Configures xref:../applications/projects/configuring-project-creation.adoc#configuring-project-creation[how projects are created] including the project template.
+
+|`proxy.config.openshift.io`
+|Defines proxies to be used by components needing external network access.  Note: not all components currently consume this value.
+
+|`scheduler.config.openshift.io`
+|Configures xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[scheduler] behavior such as profiles and default node selectors.
+
+|===

--- a/modules/post-install-informational-resources.adoc
+++ b/modules/post-install-informational-resources.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="informational-resources_{context}"]
+= Informational Resources
+
+[role="_abstract"]
+Review the informational resources that you can use to retrieve information about an {product-title} cluster.
+
+You use these resources to retrieve information about the cluster. Some configurations might require you to edit these resources directly.
+
+[cols="2a,2a,8a",options="header"]
+|===
+|Resource name|Instance name|Description
+
+|`clusterversion.config.openshift.io`
+|`version`
+|In {product-title} {product-version}, you must not customize the `ClusterVersion`
+resource for production clusters. Instead, follow the process to
+xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[update a cluster].
+
+|`dns.config.openshift.io`
+|`cluster`
+|You cannot modify the DNS settings for your cluster. You can
+xref:../networking/networking_operators/dns-operator.adoc#nw-dns-operator-status_dns-operator[check the DNS Operator status].
+
+|`infrastructure.config.openshift.io`
+|`cluster`
+|Configuration details allowing the cluster to interact with its cloud provider.
+
+|`network.config.openshift.io`
+|`cluster`
+|You cannot modify your cluster networking after installation. To customize your network, follow the process to
+xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[customize networking during installation].
+
+|===

--- a/modules/post-install-operator-config-resources.adoc
+++ b/modules/post-install-operator-config-resources.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This file is a navigation file - xrefs are allowed in this type of module, but it must only ever be included from one location
+
+:_mod-docs-content-type: REFERENCE
+[id="operator-configuration-resources_{context}"]
+= Operator configuration resources
+
+[role="_abstract"]
+Review the cluster-scoped Operator configuration resources that control the behavior of specific {product-title} components.
+
+These configuration resources are cluster-scoped instances, named `cluster`, which control the behavior of a specific component as
+owned by a particular Operator.
+
+[cols="2a,8a",options="header"]
+|===
+|Resource name
+|Description
+
+|`consoles.operator.openshift.io`
+|Controls console appearance such as branding customizations
+
+|`config.imageregistry.operator.openshift.io`
+|Configures xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview_configuring-registry-operator[{product-registry} settings] such as public routing, log levels, proxy settings, resource constraints, replica counts, and storage type.
+
+|`config.samples.operator.openshift.io`
+|Configures the
+xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Samples Operator]
+to control which example image streams and templates are installed on the cluster.
+
+|===

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -22,190 +22,28 @@ You modify the configuration resources to configure the major features of the cl
 
 For current documentation of the settings that you control by using these resources, use the `oc explain` command, for example `oc explain builds --api-version=config.openshift.io/v1`
 
-[id="configuration-resources_{context}"]
-=== Cluster configuration resources
+include::modules/post-install-cluster-config-resources.adoc[leveloffset=+2]
 
-All cluster configuration resources are globally scoped (not namespaced) and named `cluster`.
-////
-Config changes should not require coordinated changes between config resources, if you find
-yourself struggling to update these docs to explain coordinated changes, please reach out
-to @api-approvers (github) or #forum-api-review (slack).
-////
+include::modules/post-install-operator-config-resources.adoc[leveloffset=+2]
 
-[cols="2a,8a",options="header"]
-|===
-|Resource name
-|Description
+include::modules/post-install-additional-config-resources.adoc[leveloffset=+2]
 
-|`apiserver.config.openshift.io`
-|Provides API server configuration such as xref:../security/certificates/api-server.adoc#api-server-certificates[certificates and certificate authorities].
-
-|`authentication.config.openshift.io`
-|Controls the xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[identity provider] and authentication configuration for the cluster.
-
-|`build.config.openshift.io`
-|Controls default and enforced xref:../cicd/builds/build-configuration.adoc#build-configuration[configuration] for all builds on the cluster.
-
-|`console.config.openshift.io`
-|Configures the behavior of the web console interface, including the xref:../web_console/configuring-web-console.adoc#configuring-web-console[logout behavior].
-
-|`featuregate.config.openshift.io`
-|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[FeatureGates]
-so that you can use Tech Preview features.
-
-|`image.config.openshift.io`
-|Configures how specific xref:../openshift_images/image-configuration.adoc#image-configuration[image registries] should be treated (allowed, disallowed, insecure, CA details).
-
-|`ingress.config.openshift.io`
-|Configuration details related to xref:../networking/networking_operators/ingress-operator.adoc#nw-installation-ingress-config-asset_ingress-operator[routing] such as the default domain for routes.
-
-|`oauth.config.openshift.io`
-|Configures identity providers and other behavior related to xref:../authentication/configuring-internal-oauth.adoc#configuring-internal-oauth[internal OAuth server] flows.
-
-|`project.config.openshift.io`
-|Configures xref:../applications/projects/configuring-project-creation.adoc#configuring-project-creation[how projects are created] including the project template.
-
-|`proxy.config.openshift.io`
-|Defines proxies to be used by components needing external network access.  Note: not all components currently consume this value.
-
-|`scheduler.config.openshift.io`
-|Configures xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[scheduler] behavior such as profiles and default node selectors.
-
-|===
-
-[id="operator-configuration-resources_{context}"]
-=== Operator configuration resources
-
-These configuration resources are cluster-scoped instances, named `cluster`, which control the behavior of a specific component as
-owned by a particular Operator.
-
-[cols="2a,8a",options="header"]
-|===
-|Resource name
-|Description
-
-|`consoles.operator.openshift.io`
-|Controls console appearance such as branding customizations
-
-|`config.imageregistry.operator.openshift.io`
-|Configures xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview_configuring-registry-operator[{product-registry} settings] such as public routing, log levels, proxy settings, resource constraints, replica counts, and storage type.
-
-|`config.samples.operator.openshift.io`
-|Configures the
-xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Samples Operator]
-to control which example image streams and templates are installed on the cluster.
-
-|===
-
-[id="additional-configuration-resources_{context}"]
-=== Additional configuration resources
-
-These configuration resources represent a single instance of a particular component. In some cases, you can request multiple
-instances by creating multiple instances of the resource. In other cases, the Operator can use only a specific
-resource instance name in a specific namespace. Reference the component-specific
-documentation for details on how and when you can create additional resource instances.
-
-[cols="2a,2a,2a,8a",options="header"]
-|===
-|Resource name
-|Instance name
-|Namespace
-|Description
-
-|`alertmanager.monitoring.coreos.com`
-|`main`
-|`openshift-monitoring`
-|Controls the link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/latest/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Alertmanager] deployment parameters.
-
-|`ingresscontroller.operator.openshift.io`
-|`default`
-|`openshift-ingress-operator`
-|Configures xref:../networking/networking_operators/ingress-operator.adoc#configuring-ingress-controller[Ingress Operator] behavior such as domain, number of replicas, certificates, and controller placement.
-
-|===
-
-[id="informational-resources_{context}"]
-=== Informational Resources
-
-You use these resources to retrieve information about the cluster. Some configurations might require you to edit these resources directly.
-
-[cols="2a,2a,8a",options="header"]
-|===
-|Resource name|Instance name|Description
-
-|`clusterversion.config.openshift.io`
-|`version`
-|In {product-title} {product-version}, you must not customize the `ClusterVersion`
-resource for production clusters. Instead, follow the process to
-xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[update a cluster].
-
-|`dns.config.openshift.io`
-|`cluster`
-|You cannot modify the DNS settings for your cluster. You can
-xref:../networking/networking_operators/dns-operator.adoc#nw-dns-operator-status_dns-operator[check the DNS Operator status].
-
-|`infrastructure.config.openshift.io`
-|`cluster`
-|Configuration details allowing the cluster to interact with its cloud provider.
-
-|`network.config.openshift.io`
-|`cluster`
-|You cannot modify your cluster networking after installation. To customize your network, follow the process to
-xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[customize networking during installation].
-
-|===
+include::modules/post-install-informational-resources.adoc[leveloffset=+2]
 
 [id="adding-worker-nodes_{context}"]
 == Adding worker nodes
 
 After you deploy your {product-title} cluster, you can add worker nodes to scale cluster resources. There are different ways you can add worker nodes depending on the installation method and the environment of your cluster.
 
-[id="adding-nodes-iso_{context}"]
-=== Adding worker nodes to an on-premise cluster
+include::modules/post-install-adding-nodes-on-prem.adoc[leveloffset=+2]
 
-For on-premise clusters, you can add worker nodes by using the {product-title} CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
-This process can be used regardless of how you installed your cluster.
+include::modules/post-install-adding-nodes-ipi.adoc[leveloffset=+2]
 
-You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
-Any configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
+include::modules/post-install-adding-nodes-upi.adoc[leveloffset=+2]
 
-Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
+include::modules/post-install-adding-nodes-assisted.adoc[leveloffset=+2]
 
-xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]
-
-=== Adding worker nodes to installer-provisioned infrastructure clusters
-
-For installer-provisioned infrastructure clusters, you can manually or automatically scale the `MachineSet` object to match the number of available bare-metal hosts.
-
-To add a bare-metal host, you must configure all network prerequisites, configure an associated `baremetalhost` object, then provision the worker node to the cluster. You can add a bare-metal host manually or by using the web console.
-
-* xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-web-console_managing-bare-metal-hosts[Adding worker nodes using the web console]
-
-* xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-yaml_managing-bare-metal-hosts[Adding worker nodes using YAML in the web console]
-
-* xref:../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#preparing-the-bare-metal-node_bare-metal-expanding[Manually adding a worker node to an installer-provisioned infrastructure cluster]
-
-=== Adding worker nodes to user-provisioned infrastructure clusters
-
-For user-provisioned infrastructure clusters, you can add worker nodes by using a {op-system-base} or {op-system} ISO image and connecting it to your cluster using cluster Ignition config files. For RHEL worker nodes, the following example uses Ansible playbooks to add worker nodes to the cluster. For RHCOS worker nodes, the following example uses an ISO image and network booting to add worker nodes to the cluster.
-
-* xref:../post_installation_configuration/node-tasks.adoc#post-install-config-adding-fcos-compute[Adding RHCOS worker nodes to a user-provisioned infrastructure cluster]
-
-=== Adding worker nodes to clusters managed by the Assisted Installer
-
-For clusters managed by the Assisted Installer, you can add worker nodes by using the {cluster-manager-first} console, the Assisted Installer REST API or you can manually add worker nodes using an ISO image and cluster Ignition config files.
-
-* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-sno-clusters_add-workers[Adding worker nodes using the OpenShift Cluster Manager]
-
-* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#adding-worker-nodes-using-the-assisted-installer-api[Adding worker nodes using the Assisted Installer REST API]
-
-* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers[Manually adding worker nodes to a SNO cluster]
-
-=== Adding worker nodes to clusters managed by the multicluster engine for Kubernetes
-
-For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#on-prem-creating-your-cluster-with-the-console[Creating your cluster with the console]
+include::modules/post-install-adding-nodes-mce.adoc[leveloffset=+2]
 
 [id="post-install-adjust-worker-nodes"]
 == Adjust worker nodes


### PR DESCRIPTION
… modules

Extract assembly-body tables and navigational xref lists into single-use REFERENCE modules so NestedSection and ConceptLink Vale checks pass while keeping the xrefs.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
