### PR TITLE
[enterprise-4.21] OSDOCS-17049: Add DITA short descriptions for node and post-install config topics

### DIFF
--- a/modules/images-cluster-sample-imagestream-import.adoc
+++ b/modules/images-cluster-sample-imagestream-import.adoc
@@ -5,6 +5,9 @@
 [id="images-cluster-sample-imagestream-import_{context}"]
 = Configuring periodic importing of Cluster Sample Operator image stream tags
 
+[role="_abstract"]
+You can configure scheduled imports for Cluster Sample Operator image stream tags to periodically retrieve updated images and retry imports after temporary failures.
+
 You can ensure that you always have access to the latest versions of the Cluster Sample Operator images by periodically importing the image stream tags when new versions become available.
 
 .Procedure

--- a/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
+++ b/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
@@ -6,6 +6,9 @@
 [id="installation-preparing-restricted-cluster-to-gather-support-data_{context}"]
 = Preparing your cluster to gather support data
 
+[role="_abstract"]
+You can prepare a cluster on a restricted network to gather support data by importing the default must-gather image and configuring access to the mirror registry.
+
 Clusters using a restricted network must import the default must-gather image to gather debugging data for Red Hat support. The must-gather image is not imported by default, and clusters on a restricted network do not have access to the internet to pull the latest image from a remote repository.
 
 .Procedure

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -7,6 +7,9 @@
 [id="machine-health-checks-about_{context}"]
 = About machine health checks
 
+[role="_abstract"]
+You can use machine health checks to detect and remediate unhealthy machines automatically while limiting disruption to the targeted machine pool.
+
 [NOTE]
 ====
 You can only apply a machine health check to machines that are managed by compute machine sets or control plane machine sets.

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -7,6 +7,9 @@
 [id="machine-health-checks-creating_{context}"]
 = Creating a machine health check resource
 
+[role="_abstract"]
+You can create a `MachineHealthCheck` resource to monitor and automatically remediate unhealthy machines in a machine set.
+
 You can create a `MachineHealthCheck` resource for machine sets in your cluster.
 
 [NOTE]

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -7,6 +7,9 @@
 [id="machine-health-checks-resource_{context}"]
 = Sample MachineHealthCheck resource
 
+[role="_abstract"]
+You can use the sample `MachineHealthCheck` resource to configure health criteria, remediation limits, and startup timeouts for machines in a targeted pool.
+
 The `MachineHealthCheck` resource for all cloud-based installation types, and other than bare metal, resembles the following YAML file:
 
 [source,yaml]

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -8,6 +8,9 @@
 [id="machine-node-custom-partition_{context}"]
 = Adding a new {op-system} worker node with a custom `/var` partition in AWS
 
+[role="_abstract"]
+You can add an {op-system} worker node with a custom `/var` partition in AWS by creating a user data secret and a compute machine set that use the required device naming schema.
+
 {product-title} supports partitioning devices during installation by using machine configs that are processed during the bootstrap. However, if you use `/var` partitioning, the device name must be determined at installation and cannot be changed. You cannot add different instance types as nodes if they have a different device naming schema. For example, if you configured the `/var` partition with the default AWS device name for `m4.large` instances, `dev/xvdb`, you cannot directly add an AWS `m5.large` instance, as `m5.large` instances use a `/dev/nvme1n1` device by default. The device might fail to partition due to the different naming schema.
 
 The procedure in this section shows how to add a new {op-system-first} compute node with an instance that uses a different device name from what was configured at installation. You create a custom user data secret and configure a new compute machine set. These steps are specific to an AWS cluster. The principles apply to other cloud deployments also. However, the device naming schema is different for other deployments and should be determined on a per-case basis.

--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -6,6 +6,9 @@
 [id="modify-unavailable-workers_{context}"]
 = Modifying the number of unavailable worker nodes
 
+[role="_abstract"]
+You can speed up kubelet configuration rollouts on large clusters by increasing the number of worker nodes that can be unavailable during machine config pool updates.
+
 By default, only one machine is allowed to be unavailable when applying the kubelet-related configuration to the available worker nodes. For a large cluster, it can take a long time for the configuration change to be reflected. At any time, you can adjust the number of machines that are updating to speed up the process.
 
 .Procedure

--- a/modules/nodes-pods-plugins-about.adoc
+++ b/modules/nodes-pods-plugins-about.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 A device plugin is a gRPC service running on nodes that manages specific hardware resources through an extension mechanism, enabling containers to consume these devices.
 
+The device plugin provides a consistent and portable solution to consume hardware devices across clusters. The device plugin provides support for these devices through an extension mechanism, which makes these devices available to Containers, provides health checks of these devices, and securely shares them.
+
 [IMPORTANT]
 ====
 {product-title} supports the device plugin API, but the device plugin

--- a/modules/nodes-pods-plugins-device-mgr.adoc
+++ b/modules/nodes-pods-plugins-device-mgr.adoc
@@ -10,6 +10,9 @@
 [role="_abstract"]
 Device Manager advertises specialized node hardware resources through device plugins, enabling pods to consume hardware devices without requiring upstream code changes.
 
+Device Manager provides a mechanism for advertising specialized node hardware resources
+with the help of plugins known as device plugins.
+
 You can advertise specialized hardware without requiring any upstream code changes.
 
 [IMPORTANT]

--- a/modules/nodes-pods-plugins-install.adoc
+++ b/modules/nodes-pods-plugins-install.adoc
@@ -10,6 +10,9 @@
 [role="_abstract"]
 Enable Device Manager to allow device plugins to advertise specialized node hardware resources and make them available to pods without requiring code changes.
 
+Enable Device Manager to implement a device plugin to advertise specialized
+hardware without any upstream code changes.
+
 Device Manager provides a mechanism for advertising specialized node hardware resources
 with the help of plugins known as device plugins.
 

--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -6,6 +6,9 @@
 [id="nodes-vsphere-machine-set-concept-static-ip_{context}"]
 = Machine set scaling of machines with configured static IP addresses
 
+[role="_abstract"]
+You can scale machines with static IP addresses by configuring machine sets that request addresses through `IPAddressClaim` resources managed by your IP address management (IPAM) service.
+
 You can use a machine set to scale machines with configured static IP addresses.
 
 After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -6,6 +6,9 @@
 [id="nodes-vsphere-machine-set-scaling-static-ip_{context}"]
 = Using a machine set to scale machines with configured static IP addresses
 
+[role="_abstract"]
+You can scale machines that use static IP addresses by configuring a machine set to request addresses from an IP address pool.
+
 You can use a machine set to scale machines with configured static IP addresses.
 
 The example in the procedure demonstrates the use of controllers for scaling machines in a machine set.

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -6,6 +6,9 @@
 [id="nodes-vsphere-scaling-machines-static-ip_{context}"]
 = Scaling machines to use static IP addresses
 
+[role="_abstract"]
+You can add machines with pre-defined static IP addresses by creating machine resources that specify static network configuration in the machine YAML file.
+
 You can scale additional machine sets to use pre-defined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
 
 .Prerequisites

--- a/modules/recommended-node-host-practices.adoc
+++ b/modules/recommended-node-host-practices.adoc
@@ -6,6 +6,9 @@
 [id="recommended-node-host-practices_{context}"]
 = Recommended node host practices
 
+[role="_abstract"]
+You can configure the `podsPerCore` and `maxPods` parameters to control the maximum number of pods that can be scheduled on a node.
+
 The {product-title} node configuration file contains important options. For
 example, two parameters control the maximum number of pods that can be scheduled
 to a node: `podsPerCore` and `maxPods`.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can perform postinstallation node tasks to add and manage compute machines, configure node resources and hardware, improve availability, and control workload scheduling.
+
 After installing {product-title}, you can further expand and customize your
 cluster to your requirements through certain node tasks.
 

--- a/post_installation_configuration/post-install-image-config.adoc
+++ b/post_installation_configuration/post-install-image-config.adoc
@@ -7,6 +7,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure image streams, image registries, and pull secrets after installation to control how your cluster accesses, imports, and stores container images.
+
 You can update the global pull secret for your cluster by either replacing the current pull secret or appending a new pull secret. The procedure is required when users use a separate registry to store images than the registry used during installation. For more information, see "Using image pull secrets".
 
 For information about images and configuring image streams or image registries, see the following documentation:

--- a/post_installation_configuration/post-install-network-configuration.adoc
+++ b/post_installation_configuration/post-install-network-configuration.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure networking after installation to manage cluster traffic, security, connectivity, and default network policies for new projects.
+
 After installing {product-title}, you can further expand and customize your network to your requirements.
 
 [id="post-install-network-configuration-cno"]

--- a/post_installation_configuration/post-install-storage-configuration.adoc
+++ b/post_installation_configuration/post-install-storage-configuration.adoc
@@ -20,6 +20,9 @@ endif::[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure persistent storage after installation by using dynamic or static provisioning to retain application data beyond the lifetime of individual containers.
+
 After installing {product-title}, you can further expand and customize your cluster to your requirements, including storage configuration.
 
 By default, containers operate by using the ephemeral storage or transient local storage. The ephemeral storage has a lifetime limitation. To store the data for a long time, you must configure persistent storage. You can configure storage by using one of the following methods:


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/115387.

Adds DITA short descriptions (`[role=\"_abstract\"]`) to node and post-install config topics; mainly machine health checks, device plugins, node tasks, and image/network/storage post-install assemblies.

https://redhat.atlassian.net/browse/OSDOCS-17049

Version(s): 4.21

QE review:
- [ ] QE has approved this change.

Made with [Cursor](https://cursor.com)