### PR TITLE
OBSDOCS-3671: Activate Troubleshoot category with JTBD-aligned assemblies

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -167,15 +167,14 @@ Topics:
 #  File: logging-node-selectors
 #- Name: Using tolerations to control logging pod placement
 #  File: logging-taints-tolerations
-#---
-#Name: Troubleshooting logging
-#Dir: troubleshooting
-#Topics:
-#- Name: Viewing Logging status
-#  File: cluster-logging-cluster-status
-#- Name: Troubleshooting log forwarding
-#  File: log-forwarding-troubleshooting
-#- Name: Troubleshooting logging alerts
-#  File: troubleshooting-logging-alerts
-#- Name: Viewing Elasticsearch log store status
-#  File: cluster-logging-log-store-status
+---
+Name: Troubleshoot
+Dir: troubleshooting
+Distros: openshift-logging
+Topics:
+- Name: Troubleshoot the installation
+  File: troubleshoot-installation
+- Name: Troubleshoot log forwarding
+  File: troubleshoot-log-forwarding
+- Name: Troubleshoot logging alerts
+  File: troubleshoot-logging-alerts

--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -58,7 +58,7 @@ include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
 
 include::modules/loki-zone-fail-recovery.adoc[leveloffset=+2]
 
-include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
+include::modules/troubleshoot-loki-rate-limit-errors.adoc[leveloffset=+2]
 
 [id="loki-network-policies-for-added-security_{context}"]
 == Loki network policies for added security

--- a/configuring/tuning-the-log-store.adoc
+++ b/configuring/tuning-the-log-store.adoc
@@ -34,7 +34,7 @@ include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
 
 include::modules/loki-zone-fail-recovery.adoc[leveloffset=+2]
 
-include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
+include::modules/troubleshoot-loki-rate-limit-errors.adoc[leveloffset=+2]
 
 //Loki network policies for added security
 include::modules/about-loki-network-security.adoc[leveloffset=+1]

--- a/installing/installing-the-red-hat-openshift-logging-operator.adoc
+++ b/installing/installing-the-red-hat-openshift-logging-operator.adoc
@@ -23,12 +23,12 @@ include::modules/enabling-the-logs-tab.adoc[leveloffset=+1]
 
 include::modules/verifying-logging-installation.adoc[leveloffset=+1]
 
-include::modules/troubleshooting-logging-installation.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]
+
+* xref:../troubleshooting/troubleshoot-installation.adoc#troubleshoot-installation[Troubleshoot the installation]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-log-forwarding[Configuring log forwarding]
 

--- a/modules/troubleshoot-installation-symptoms.adoc
+++ b/modules/troubleshoot-installation-symptoms.adoc
@@ -1,0 +1,173 @@
+// Module included in the following assemblies:
+//
+// * troubleshooting/troubleshoot-installation.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="troubleshoot-installation-symptoms_{context}"]
+[id="troubleshooting-installation-symptoms_{context}"]
+= Troubleshoot installation symptoms
+
+[role="_abstract"]
+Use this reference to diagnose common installation issues. Many installation failures occur when cluster prerequisites are not met before operator installation.
+
+ResolutionFailed on the Loki Operator subscription::
++
+*Symptom*: The Loki Operator subscription shows `ResolutionFailed` status.
++
+*Cause*: Incorrect channel name or source catalog.
++
+*Resolution*:
++
+--
+. Verify available channels by running the following command:
++
+[source,terminal]
+----
+$ oc get packagemanifest loki-operator -n openshift-marketplace
+----
+
+. Ensure the subscription uses `source: redhat-operators` (not the community catalog).
+--
+
+LokiStack pods stuck in Pending state::
++
+*Symptom*: After creating the `LokiStack` custom resource, pods remain in `Pending` state and never start.
++
+*Cause*: No `StorageClass` exists, or the specified `StorageClass` does not support dynamic provisioning.
++
+*Common on*: {sno} deployments and edge clusters.
++
+*Resolution*:
++
+--
+. Verify that a `StorageClass` exists by running the following command:
++
+[source,terminal]
+----
+$ oc get storageclass
+----
++
+If no `StorageClass` is listed, you must configure storage before `LokiStack` can deploy.
+
+. For {sno} or edge deployments without dynamic storage, see "Configuring local storage for single-node and edge deployments".
+
+. For multi-node clusters, see "Verifying StorageClass availability".
+--
+
+LokiStack shows Ready but logs are not stored::
++
+*Symptom*: The `LokiStack` custom resource shows `Ready: True`, operators are installed, but logs disappear and are not stored or queryable.
++
+*Cause*: Object storage is not configured or the object storage secret is incorrect.
++
+*Resolution*:
++
+--
+`LokiStack` requires TWO separate types of storage:
+
+* **Block storage (StorageClass)**: For internal PVCs
+* **Object storage (S3-compatible)**: For actual log data
+
+See "Configuring object storage for LokiStack" to configure the S3-compatible backend and create the storage secret.
+--
+
+Logs are silently dropped with no error::
++
+*Symptom*: The `LokiStack` shows `Ready: True`, operators are installed, log collector pods are running, but logs are silently dropped and never appear in queries.
++
+*Cause*: Missing TLS CA bundle for object storage, or incorrect object storage permissions.
++
+*Resolution*:
++
+--
+. If using self-signed certificates or private CA for object storage, see "Configuring object storage for LokiStack" to configure the CA bundle.
+
+. Verify that the object storage credentials have all required S3 permissions. See "Object storage permissions requirements".
+--
+
+Certificate verify failed error in collector logs::
++
+*Symptom*: The `ClusterLogForwarder` custom resource shows `Ready: True`, but no logs appear in `LokiStack` or other HTTP-based sinks. The collector logs show the following error:
++
+[source,terminal]
+----
+error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2123:: self-signed certificate in certificate chain
+----
++
+*Cause*: The `tls.ca` block is missing or incorrect in the `ClusterLogForwarder` output configuration.
++
+*Resolution*:
++
+--
+Add the `tls.ca` block to your `ClusterLogForwarder` output:
+
+[source,yaml]
+----
+spec:
+  outputs:
+  - name: default-lokistack
+    type: lokiStack
+    tls:
+      ca:
+        configMapName: logging-loki-gateway-ca-bundle
+        key: service-ca.crt
+----
+
+The Loki Operator creates the `logging-loki-gateway-ca-bundle` `ConfigMap` automatically. For self-signed certificates on external outputs, reference your custom CA `ConfigMap`.
+--
+
+429 Too Many Requests in collector logs::
++
+*Symptom*: The collector logs show `429 Too Many Requests` responses and the collector retries requests.
++
+*Cause*: The collector is sending logs faster than the `LokiStack` or destination sink can process them.
++
+*Common during*:
++
+--
+* Initial deployment when the collector flushes a backlog of accumulated logs
+* After restoring connectivity to a `LokiStack` that was temporarily unavailable
+--
++
+*Resolution*:
++
+--
+This condition resolves automatically. The collector retries with exponential back-off. On a `1x.demo` `LokiStack`, the backlog typically clears within several minutes. Larger `LokiStack` sizes clear backlogs faster.
+--
+
+No Logs tab under Observe::
++
+*Symptom*: After installing operators and creating `LokiStack`, the *Logs* tab does not appear under *Observe* in the web console.
++
+*Cause*: The {coo-full} is not installed, or the `UIPlugin` custom resource was not created.
++
+*Resolution*:
++
+--
+Both steps are required to enable the web console logs interface:
+
+. See "Installing the Cluster Observability Operator".
+
+. After the operator is installed, create the `UIPlugin` custom resource as described in the installation procedure.
+--
+
+ClusterLogForwarder Ready but no logs appear::
++
+*Symptom*: The `ClusterLogForwarder` status shows `Ready: True` but no logs appear in `LokiStack` or destination sinks.
++
+*Cause*: The `ClusterLogForwarder` validation passes even when the collector cannot connect to `LokiStack`. The most common cause is missing TLS CA configuration.
++
+*Resolution*:
++
+--
+. Check the collector pod logs by running the following command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-logging -l app.kubernetes.io/component=collector --tail=50
+----
+
+. Look for TLS certificate errors or connection failures.
+
+. If you see certificate errors, add the `tls.ca` block to your `ClusterLogForwarder` output as described in "Certificate verify failed error in collector logs."
+--

--- a/modules/troubleshoot-loki-rate-limit-errors.adoc
+++ b/modules/troubleshoot-loki-rate-limit-errors.adoc
@@ -1,0 +1,87 @@
+// Module is included in the following assemblies:
+//
+// * troubleshooting/troubleshoot-log-forwarding.adoc
+// * configuring/configuring-the-log-store.adoc
+// * configuring/tuning-the-log-store.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshoot-loki-rate-limit-errors_{context}"]
+[id="loki-rate-limit-errors_{context}"]
+= Troubleshoot Loki rate limit errors
+
+[role="_abstract"]
+Resolve Loki rate limit errors when the Log Forwarder API sends large message blocks that exceed ingestion limits.
+
+If the Log Forwarder API forwards a large block of messages that exceeds the rate limit to Loki, Loki generates rate limit (`429`) errors.
+
+These errors can occur during normal operation. For example, when adding the {logging} to a cluster that already has some logs, rate limit errors might occur while the {logging} tries to process all of the existing log entries. In this case, if the rate of addition of new logs is less than the total rate limit, the historical data is eventually ingested, and the rate limit errors are resolved without requiring user intervention.
+
+In cases where the rate limit errors continue to occur, you can fix the issue by modifying the `LokiStack` custom resource (CR).
+
+[IMPORTANT]
+====
+The `LokiStack` CR is not available on Grafana-hosted Loki. These instructions do not apply to Grafana-hosted Loki servers.
+====
+
+.Prerequisites
+
+* The Log Forwarder API is configured to forward logs to Loki.
+
+* Your system sends a block of messages that is larger than 2 MB to Loki. For example:
++
+[source,text]
+----
+"values":[["1630410392689800468","{\"kind\":\"Event\",\"apiVersion\":\
+.......
+......
+......
+......
+\"received_at\":\"2021-08-31T11:46:32.800278+00:00\",\"version\":\"1.7.4 1.6.0\"}},\"@timestamp\":\"2021-08-31T11:46:32.799692+00:00\",\"viaq_index_name\":\"audit-write\",\"viaq_msg_id\":\"MzFjYjJkZjItNjY0MC00YWU4LWIwMTEtNGNmM2E5ZmViMGU4\",\"log_type\":\"audit\"}"]]}]}
+----
+
+* After you enter `oc logs -n openshift-logging -l component=collector`, the collector logs in your cluster show a line containing one of the following error messages:
++
+[source,text]
+----
+429 Too Many Requests Ingestion rate limit exceeded
+----
++
+.Example Vector error message
+[source,text]
+----
+2023-08-25T16:08:49.301780Z  WARN sink{component_kind="sink" component_id=default_loki_infra component_type=loki component_name=default_loki_infra}: vector::sinks::util::retries: Retrying after error. error=Server responded with an error: 429 Too Many Requests internal_log_rate_limit=true
+----
++
+The error is also visible on the receiving end. For example, in the `LokiStack` ingester pod:
++
+.Example Loki ingester error message
+[source,text]
+----
+level=warn ts=2023-08-30T14:57:34.155592243Z caller=grpc_logging.go:43 duration=1.434942ms method=/logproto.Pusher/Push err="rpc error: code = Code(429) desc = entry with timestamp 2023-08-30 14:57:32.012778399 +0000 UTC ignored, reason: 'Per stream rate limit exceeded (limit: 3MB/sec) while attempting to ingest for stream
+----
+
+.Procedure
+
+* Update the `ingestionBurstSize` and `ingestionRate` fields in the `LokiStack` CR:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  limits:
+    global:
+      ingestion:
+        ingestionBurstSize: 16
+        ingestionRate: 8
+# ...
+----
++
+spec.limits.global.ingestion.ingestionBurstSize;;
+  The `ingestionBurstSize` field defines the maximum local rate-limited sample size per distributor replica in MB. This value is a hard limit. Set this value to at least the maximum logs size expected in a single push request. Single requests that are larger than the `ingestionBurstSize` value are not permitted.
++
+spec.limits.global.ingestion.ingestionRate;;
+  The `ingestionRate` field is a soft limit on the maximum amount of ingested samples per second in MB. Rate limit errors occur if the rate of logs exceeds the limit, but the collector retries sending the logs. If the total average is lower than the limit, the system recovers and errors are resolved without user intervention.

--- a/modules/troubleshoot-lokistack-alerts.adoc
+++ b/modules/troubleshoot-lokistack-alerts.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * troubleshooting/troubleshoot-logging-alerts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshoot-lokistack-alerts_{context}"]
+[id="troubleshooting-lokistack-alerts_{context}"]
+= Troubleshoot LokiStack alerts
+
+[role="_abstract"]
+When a `LokiStack` alert fires, you can use diagnostic commands to investigate the root cause and apply remediation steps.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Set an environment variable for your `LokiStack` custom resource name:
++
+[source,terminal]
+----
+$ LOKISTACK_NAME="logging-loki"
+----
++
+[NOTE]
+====
+This example assumes the `LokiStack` custom resource is named `logging-loki`. If your `LokiStack` has a different name, adjust the variable value accordingly.
+====
+
+. View the `LokiStack` status to identify issues:
++
+[source,terminal]
+----
+$ oc -n openshift-logging get lokistack ${LOKISTACK_NAME} -o yaml
+----
++
+Review the `status.conditions` section for any warnings or errors.
+
+. Check the detailed status of the `LokiStack` resource:
++
+[source,terminal]
+----
+$ oc -n openshift-logging describe lokistack ${LOKISTACK_NAME}
+----
++
+Look for conditions with `status: "False"` or recent events indicating problems.
+
+. List all `LokiStack` pods and their status:
++
+[source,terminal]
+----
+$ oc -n openshift-logging get pods -l app.kubernetes.io/instance=${LOKISTACK_NAME}
+----
++
+Verify that all component pods (distributor, ingester, querier, query-frontend, index-gateway, compactor, gateway) are in `Running` state.
+
+. Examine the logs of the affected component:
++
+[source,terminal]
+----
+$ oc -n openshift-logging logs <pod_name>
+----
++
+Replace `<pod_name>` with the name of the pod from the alert labels or the pod that is experiencing issues.
+
+. For storage-related alerts, verify backend storage connectivity:
++
+.. Check if the storage secret exists and contains valid credentials:
++
+[source,terminal]
+----
+$ oc -n openshift-logging get secret ${LOKISTACK_NAME}-<storage_type> -o yaml
+----
++
+Replace `<storage_type>` with your storage backend (for example, `aws`, `azure`, `gcp`, or `s3`).
+
+.. Review recent events for storage access errors:
++
+[source,terminal]
+----
+$ oc -n openshift-logging get events --sort-by=.lastTimestamp | grep -i storage
+----
+
+. For rate limit alerts (`LokiTenantRateLimit`), check which limits are being exceeded:
++
+.. Navigate to the {ocp-product-title} web console.
+
+.. Go to *Observe* -> *Metrics*.
+
+.. Run the following PromQL query:
++
+[source,promql]
+----
+sum by (tenant, reason) (irate(loki_discarded_samples_total[2m]))
+----
++
+This shows which tenant limits are causing samples to be discarded, including the specific reason for each tenant.
+
+. Common remediation actions based on alert type:
++
+* *Storage connectivity issues*: Verify storage credentials, network policies, and firewall rules
+* *Rate limit errors*: Adjust tenant limits in the `LokiStack` custom resource
+* *High load*: Increase the number of queriers or ingesters
+* *Component failures*: Check pod logs and restart failing components

--- a/troubleshooting/troubleshoot-installation.adoc
+++ b/troubleshooting/troubleshoot-installation.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="troubleshoot-installation"]
+[id="troubleshooting-installation"]
+= Troubleshoot the installation
+include::_attributes/common-attributes.adoc[]
+:context: troubleshoot-installation
+
+toc::[]
+
+[role="_abstract"]
+Diagnose and resolve common installation issues. Most installation failures occur when cluster prerequisites are not met before installing operators.
+
+[IMPORTANT]
+====
+Many silent installation failures are caused by missing storage prerequisites. Verify that your cluster meets both storage requirements before installing operators:
+
+* **Block storage (StorageClass)**: For `LokiStack` internal PVCs
+* **Object storage (S3-compatible)**: For actual log data
+
+See "Verifying cluster prerequisites for logging" for complete prerequisites.
+====
+
+include::modules/troubleshoot-installation-symptoms.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_troubleshoot-installation"]
+== Additional resources
+
+* xref:../installing/verifying-cluster-prerequisites.adoc#verifying-cluster-prerequisites[Verifying cluster prerequisites for logging]
+* xref:../installing/verifying-cluster-prerequisites.adoc#verifying-default-storageclass_verifying-cluster-prerequisites[Verifying StorageClass availability]
+* xref:../installing/verifying-cluster-prerequisites.adoc#configuring-local-storage-for-sno_verifying-cluster-prerequisites[Configuring local storage for single-node and edge deployments]
+* xref:../installing/verifying-cluster-prerequisites.adoc#object-storage-permissions-requirements_verifying-cluster-prerequisites[Object storage permissions requirements]
+* xref:../installing/configuring-storage-for-lokistack.adoc#configuring-storage-for-lokistack[Configuring object storage for LokiStack]
+* xref:../installing/installing-the-cluster-observability-operator.adoc#installing-the-cluster-observability-operator[Installing the Cluster Observability Operator]
+* xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the Loki Operator]
+* xref:../installing/installing-the-red-hat-openshift-logging-operator.adoc#installing-the-red-hat-openshift-logging-operator[Installing the Red Hat OpenShift Logging Operator]
+* link:https://access.redhat.com/solutions/7062821[Support cases caused by unclear storage requirements (Red Hat Knowledgebase)]
+* link:https://access.redhat.com/solutions/7075815[Required permissions for LokiStack object storage (Red Hat Knowledgebase)]

--- a/troubleshooting/troubleshoot-log-forwarding.adoc
+++ b/troubleshooting/troubleshoot-log-forwarding.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="troubleshoot-log-forwarding"]
+[id="log-forwarding-troubleshooting"]
+= Troubleshoot log forwarding
+include::_attributes/common-attributes.adoc[]
+:context: troubleshoot-log-forwarding
+
+toc::[]
+
+[role="_abstract"]
+Diagnose and resolve log forwarding issues.
+
+include::modules/troubleshoot-loki-rate-limit-errors.adoc[leveloffset=+1]

--- a/troubleshooting/troubleshoot-logging-alerts.adoc
+++ b/troubleshooting/troubleshoot-logging-alerts.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="troubleshoot-logging-alerts"]
+[id="troubleshooting-logging-alerts"]
+= Troubleshoot logging alerts
+include::_attributes/common-attributes.adoc[]
+:context: troubleshoot-logging-alerts
+
+toc::[]
+
+[role="_abstract"]
+Diagnose and resolve logging alerts that fire on your cluster.
+
+include::modules/troubleshoot-lokistack-alerts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_troubleshoot-logging-alerts"]
+== Additional resources
+
+* xref:../configuring/configuring-the-log-store.adoc#configuring-the-log-store[Configuring the log store]
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]
+* xref:../logging_alerts/default-logging-alerts.adoc#default-logging-alerts[Default logging alerts]
+* xref:../logging_alerts/custom-logging-alerts.adoc#custom-logging-alerts[Custom logging alerts]
+* link:https://loki-operator.dev/docs/sop.md[LokiStack Standard Operating Procedures]


### PR DESCRIPTION
## Summary

Activates the Troubleshoot category in OpenShift Logging documentation with three focused assemblies aligned with the JTBD (Jobs-to-be-Done) framework.

## Changes

### Topic Map Updates
- **Category name**: "Troubleshoot" (imperative, matches CCS lifecycle categories)
- **3 assemblies activated**:
  1. Troubleshoot the installation
  2. Troubleshoot log forwarding  
  3. Troubleshoot logging alerts

### New Content

#### 1. Troubleshoot the installation
- **New assembly**: `troubleshooting/troubleshoot-installation.adoc`
- **New module**: `modules/troubleshoot-installation-symptoms.adoc` (definition list structure)
- **Preserves all 5 original symptoms** from embedded troubleshooting table
- **Adds 3 new symptoms** based on prerequisites analysis:
  - LokiStack pods stuck in Pending (missing StorageClass - common on SNO)
  - LokiStack Ready but logs not stored (missing object storage)
  - Logs silently dropped (missing CA bundle or permissions)
- Each symptom includes: what user sees, why it happens, how to fix with plain text references to requirement topics
- Removed embedded troubleshooting from `installing/installing-the-red-hat-openshift-logging-operator.adoc`
- Added xref to Troubleshoot category in Installing assembly Additional resources

#### 2. Troubleshoot log forwarding
- **Assembly**: `troubleshooting/troubleshoot-log-forwarding.adoc`
- **Module**: `modules/troubleshoot-loki-rate-limit-errors.adoc` (renamed from `loki-rate-limit-errors.adoc`)
- Removed deprecated Fluentd redeployment module reference
- Fixed DITA compliance (moved include directive, added abstract)

#### 3. Troubleshoot logging alerts
- **Assembly**: `troubleshooting/troubleshoot-logging-alerts.adoc`
- **New module**: `modules/troubleshoot-lokistack-alerts.adoc`
- **Addresses all review feedback from PR #116470**:
  - Uses environment variable pattern instead of hardcoding LokiStack CR name
  - Replaced grep with PromQL query for discarded samples: `sum by (tenant, reason) (irate(loki_discarded_samples_total[2m]))`
  - Fixed list formatting (proper AsciiDoc bullets)
  - Links to https://loki-operator.dev/docs/sop.md (Red Hat maintained) instead of GitHub
  - Links in Additional resources section per modular docs standards

### Deprecated Content Removed
- `troubleshooting/cluster-logging-cluster-status.adoc` (Elasticsearch/Kibana/Fluentd only)
- Reference to non-existent `cluster-logging-log-store-status.adoc`
- `redeploying-fluentd-pods.adoc` module include (deprecated Fluentd content)

### Consistency Updates for DITA Migration
- **Filenames**: All use imperative "troubleshoot-" prefix (aligned with titles)
- **IDs**: Updated to "troubleshoot-*" pattern with legacy IDs kept as anchors for backward compatibility
- **Topic names**: Imperative form without gerunds ("Troubleshoot" not "Troubleshooting")
- **Link standards**: Plain text references in procedure steps, xrefs only in Additional resources
- **Context variables**: Updated to match new naming

### Related File Updates
- `configuring/configuring-the-log-store.adoc`: Updated module reference to `troubleshoot-loki-rate-limit-errors.adoc`
- `configuring/tuning-the-log-store.adoc`: Updated module reference to `troubleshoot-loki-rate-limit-errors.adoc`

## TODO - Follow-up Work

Related to PR #116570 (Configure category restructure):

1. **Loki rate limit troubleshooting duplication**: 
   - Oscar (r2d2rnd) noted in PR #116470 review: "The section 'Troubleshooting Loki rate limit errors' should be removed from 'Configuring the log store'"
   - Currently `troubleshoot-loki-rate-limit-errors.adoc` appears in both:
     - `configuring/configuring-the-log-store.adoc` (embedded)
     - `troubleshooting/troubleshoot-log-forwarding.adoc` (centralized)
   - **Action needed**: Remove from configuring-the-log-store.adoc in PR #116570 or follow-up PR

2. **Other embedded troubleshooting in Configure**:
   - `configuring/configuring-log-forwarding.adoc`:
     - `troubleshooting-log-collection.adoc` (TLS cert, 429 rate limit, collector not running, debug logging)
     - `cross-account-log-forwarding-troubleshooting.adoc` (AWS cross-account issues)
   - `configuring/cluster-logging-collector.adoc`:
     - `troubleshooting-collector-metrics-cardinality.adoc` (advanced cardinality diagnostic)
   - `configuring/loki-query-performance-troubleshooting.adoc`:
     - Entire assembly for query performance troubleshooting

**Recommendation**: Address Configure embedded troubleshooting consolidation after PR #116570 merges to avoid conflicts.

## Testing

- ✅ **Build**: `bash scripts/prow-smoke-test.sh --validate openshift-logging` - All Successful
- ✅ **DITA compliance**: All assemblies and modules follow modular docs standards
- ✅ **Vale**: 0 errors, 0 warnings on new troubleshooting content
- ✅ **Cross-references**: All xrefs validated against actual file paths

## Related PRs

- **Closes**: #116470 (LokiStack alert troubleshooting - content ported with review feedback addressed)
- **Related**: #116570 (Configure category restructure - TODO items should be addressed after merge)

## JIRA

**Ticket**: [OBSDOCS-3671](https://redhat.atlassian.net/browse/OBSDOCS-3671)

**Version**: 6.6

Activates Troubleshoot category per ideal hierarchy guidance.

Signed-off-by: John Wilkins <jowilkin@redhat.com>