### PR TITLE
OSDOCS-16959-config-req-header CQA

### DIFF
--- a/authentication/identity_providers/configuring-request-header-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-request-header-identity-provider.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `request-header` identity provider to identify users from request header values, such as `X-Remote-User`. It is typically used in combination with an authenticating proxy, which sets the request header value.
+[role="_abstract"]
+Configure the `request-header` identity provider to identify users from request header values, such as `X-Remote-User`. Use this provider when an authenticating proxy validates users and sets those headers for {product-title}.
 
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
 
@@ -20,18 +21,12 @@ include::modules/identity-provider-request-header-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
-[id="example-apache-auth-config-using-request-header"]
-== Example Apache authentication configuration using request header
+include::modules/identity-provider-apache-custom-proxy-configuration.adoc[leveloffset=+1]
 
-This example configures an Apache authentication proxy for the {product-title}
-using the request header identity provider.
+include::modules/identity-provider-configuring-apache-request-header.adoc[leveloffset=+1]
 
 
-include::modules/identity-provider-apache-custom-proxy-configuration.adoc[leveloffset=+2]
-
-
-include::modules/identity-provider-configuring-apache-request-header.adoc[leveloffset=+2]

--- a/authentication/identity_providers/configuring-request-header-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-request-header-identity-provider.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Configure the `request-header` identity provider to identify users from request header values, such as `X-Remote-User`. It is typically used in combination with an authenticating proxy, which sets the request header value.
+[role="_abstract"]
+Configure the `request-header` identity provider to identify users from request header values, such as `X-Remote-User`. Use this provider when an authenticating proxy validates users and sets those headers for {product-title}.
 
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
 
@@ -20,18 +21,18 @@ include::modules/identity-provider-request-header-CR.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters, such as `mappingMethod`, that are common to all identity providers.
+* xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
-[id="example-apache-auth-config-using-request-header"]
-== Example Apache authentication configuration using request header
+include::modules/identity-provider-apache-custom-proxy-configuration.adoc[leveloffset=+1]
 
-This example configures an Apache authentication proxy for the {product-title}
-using the request header identity provider.
+include::modules/identity-provider-proxy-custom-configuration.adoc[leveloffset=+1]
 
+include::modules/identity-provider-configuring-apache-request-header.adoc[leveloffset=+1]
 
-include::modules/identity-provider-apache-custom-proxy-configuration.adoc[leveloffset=+2]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-
-include::modules/identity-provider-configuring-apache-request-header.adoc[leveloffset=+2]
+* link:https://access.redhat.com/solutions/392003[Optional channel]

--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -6,39 +6,28 @@
 [id="identity-provider-about-request-header_{context}"]
 = About request header authentication
 
-A request header identity provider identifies users from request
-header values, such as `X-Remote-User`. It is typically used in combination with
-an authenticating proxy, which sets the request header value. The
-request header identity provider cannot be combined with other identity providers
-that use direct password logins, such as htpasswd, Keystone, LDAP or basic authentication.
+[role="_abstract"]
+Request header authentication identifies users from header values such as `X-Remote-User`. An authenticating proxy with mutual TLS (mTLS) validates users and sets the identity header for {product-title}.
+
+The request header identity provider is typically used in combination with an authenticating proxy, which sets the request header value. This identity provider cannot be combined with other identity providers that use direct password logins, such as htpasswd, Keystone, LDAP or basic authentication.
 
 [NOTE]
 ====
-You can also use the request header identity provider for advanced configurations
-such as the community-supported link:https://github.com/openshift/request-header-saml-service-provider[SAML authentication].
-Note that this solution is not supported by Red Hat.
+You can also use the request header identity provider for advanced configurations such as the community-supported SAML application. This solution is not supported by Red Hat.
 ====
 
-For users to authenticate using this identity provider, they must access
-`https://_<namespace_route>_/oauth/authorize` (and subpaths) via an authenticating proxy.
-To accomplish this, configure the OAuth server to redirect unauthenticated
-requests for OAuth tokens to the proxy endpoint that proxies to
-`https://_<namespace_route>_/oauth/authorize`.
+For users to authenticate using this identity provider, they must access `https://_<namespace_route>_/oauth/authorize` and subpaths of that endpoint via an authenticating proxy. To accomplish this, configure the OAuth server to redirect unauthenticated
+requests for OAuth tokens to the proxy endpoint that proxies to `https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting browser-based login flows:
 
-* Set the `provider.loginURL` parameter to the authenticating proxy URL that
-will authenticate interactive clients and then proxy the request to
-`https://_<namespace_route>_/oauth/authorize`.
+* Set the `provider.loginURL` parameter to the authenticating proxy URL that authenticates interactive clients and then proxy the request to `https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting `WWW-Authenticate` challenges:
 
-* Set the `provider.challengeURL` parameter to the authenticating proxy URL that
-will authenticate clients expecting `WWW-Authenticate` challenges and then proxy
-the request to `https://_<namespace_route>_/oauth/authorize`.
+* Set the `provider.challengeURL` parameter to the authenticating proxy URL that authenticates clients expecting `WWW-Authenticate` challenges and then proxy the request to `https://_<namespace_route>_/oauth/authorize`.
 
-The `provider.challengeURL` and `provider.loginURL` parameters can include
-the following tokens in the query portion of the URL:
+The `provider.challengeURL` and `provider.loginURL` parameters can include the following tokens in the query portion of the URL:
 
 * `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 +
@@ -50,21 +39,18 @@ For example: [x-]`https://www.example.com/auth-proxy/oauth/authorize?${query}`
 
 [IMPORTANT]
 ====
-As of {product-title} 4.1, your proxy must support mutual TLS.
+As of {product-title} 4.1, your proxy must support mTLS.
 ====
 
 [id="sspi-windows_{context}"]
-== SSPI connection support on Microsoft Windows
+== Security Support Provider Interface connection support on Microsoft Windows
 
 ifdef::openshift-enterprise,openshift-webscale[]
 
-:FeatureName: Using SSPI connection support on Microsoft Windows
+:FeatureName: Using Security Support Provider Interface connection support on Microsoft Windows
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 endif::[]
 
-The OpenShift CLI (`oc`) supports the Security Support Provider Interface (SSPI) to allow for SSO
-flows on Microsft Windows. If you use the request header identity provider with a
-GSSAPI-enabled proxy to connect an Active Directory server to {product-title},
-users can automatically authenticate to {product-title} by using the `oc`  command
-line interface from a domain-joined Microsoft Windows computer.
+The Security Support Provider Interface (SSPI) enables the OpenShift CLI (`oc`) to support SSO
+flows on Microsoft Windows. If you use the request header identity provider with a GSSAPI-enabled proxy to connect an Active Directory server to {product-title}, users can automatically authenticate to {product-title} by using the `oc` command line interface from a domain-joined Microsoft Windows computer.

--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -6,39 +6,27 @@
 [id="identity-provider-about-request-header_{context}"]
 = About request header authentication
 
-A request header identity provider identifies users from request
-header values, such as `X-Remote-User`. It is typically used in combination with
-an authenticating proxy, which sets the request header value. The
-request header identity provider cannot be combined with other identity providers
-that use direct password logins, such as htpasswd, Keystone, LDAP or basic authentication.
+[role="_abstract"]
+Request header authentication identifies users from header values such as `X-Remote-User`. An authenticating proxy with mutual TLS (mTLS) validates users and sets the identity header for {product-title}.
+
+The request header identity provider is typically used in combination with an authenticating proxy, which sets the request header value. This identity provider cannot be combined with other identity providers that use direct password logins, such as htpasswd, Keystone, LDAP or basic authentication.
 
 [NOTE]
 ====
-You can also use the request header identity provider for advanced configurations
-such as the community-supported link:https://github.com/openshift/request-header-saml-service-provider[SAML authentication].
-Note that this solution is not supported by Red Hat.
+You can also use the request header identity provider for advanced configurations such as the community-supported SAML application. This solution is not supported by Red Hat.
 ====
 
-For users to authenticate using this identity provider, they must access
-`https://_<namespace_route>_/oauth/authorize` (and subpaths) via an authenticating proxy.
-To accomplish this, configure the OAuth server to redirect unauthenticated
-requests for OAuth tokens to the proxy endpoint that proxies to
-`https://_<namespace_route>_/oauth/authorize`.
+For users to authenticate using this identity provider, they must access `https://_<namespace_route>_/oauth/authorize` and subpaths of that endpoint through an authenticating proxy. To accomplish this, configure the OAuth server to redirect unauthenticated requests for OAuth tokens to the proxy endpoint that proxies to `https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting browser-based login flows:
 
-* Set the `provider.loginURL` parameter to the authenticating proxy URL that
-will authenticate interactive clients and then proxy the request to
-`https://_<namespace_route>_/oauth/authorize`.
+* Set the `provider.loginURL` parameter to the authenticating proxy URL that authenticates interactive clients and then proxies the request to `https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting `WWW-Authenticate` challenges:
 
-* Set the `provider.challengeURL` parameter to the authenticating proxy URL that
-will authenticate clients expecting `WWW-Authenticate` challenges and then proxy
-the request to `https://_<namespace_route>_/oauth/authorize`.
+* Set the `provider.challengeURL` parameter to the authenticating proxy URL that authenticates clients expecting `WWW-Authenticate` challenges and then proxy the request to `https://_<namespace_route>_/oauth/authorize`.
 
-The `provider.challengeURL` and `provider.loginURL` parameters can include
-the following tokens in the query portion of the URL:
+The `provider.challengeURL` and `provider.loginURL` parameters can include the following tokens in the query portion of the URL:
 
 * `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 +
@@ -50,21 +38,18 @@ For example: [x-]`https://www.example.com/auth-proxy/oauth/authorize?${query}`
 
 [IMPORTANT]
 ====
-As of {product-title} 4.1, your proxy must support mutual TLS.
+As of {product-title} 4.1, your proxy must support mTLS.
 ====
 
 [id="sspi-windows_{context}"]
-== SSPI connection support on Microsoft Windows
+== Security Support Provider Interface connection support on Microsoft Windows
 
 ifdef::openshift-enterprise,openshift-webscale[]
 
-:FeatureName: Using SSPI connection support on Microsoft Windows
+:FeatureName: Using Security Support Provider Interface connection support on Microsoft Windows
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 endif::[]
 
-The OpenShift CLI (`oc`) supports the Security Support Provider Interface (SSPI) to allow for SSO
-flows on Microsft Windows. If you use the request header identity provider with a
-GSSAPI-enabled proxy to connect an Active Directory server to {product-title},
-users can automatically authenticate to {product-title} by using the `oc`  command
-line interface from a domain-joined Microsoft Windows computer.
+The Security Support Provider Interface (SSPI) enables the {oc-first} to support SSO
+flows on Microsoft Windows. If you use the request header identity provider with a GSSAPI-enabled proxy to connect an Active Directory server to {product-title}, users can automatically authenticate to {product-title} by using the `oc` command line interface from a domain-joined Microsoft Windows computer.

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -30,12 +30,12 @@ endif::[]
 = Adding an identity provider to your cluster
 
 [role="_abstract"]
-Apply the identity provider custom resource (CR) to your cluster so users can authenticate with the configured identity provider.
+Apply the identity provider custom resource (CR) to your cluster after you define it. This step enables users to authenticate with the configured identity provider.
 
 .Prerequisites
 
-* You installed an {product-title} cluster.
-* You defined the CR for your identity provider.
+* You have access to a {product-title} cluster.
+* You have created the CR for your identity providers.
 * You are logged in as an administrator.
 
 .Procedure
@@ -53,7 +53,7 @@ If a CR does not exist, `oc apply` creates a new CR and might trigger the follow
 ====
 
 ifndef::no-username-password-login[]
-. Log in to the cluster as a user from your identity provider, entering the password when prompted. Run the following command:
+. Log in to the cluster as a user from your identity provider by running the following command. Enter the password when prompted.
 +
 [source,terminal]
 ----

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -30,12 +30,12 @@ endif::[]
 = Adding an identity provider to your cluster
 
 [role="_abstract"]
-Apply the OAuth custom resource (CR) to add an identity provider to your cluster so users can authenticate with external credentials instead of the default `kubeadmin` user.
+Apply the identity provider custom resource (CR) to your cluster after you define it. With this configuration, you can authenticate with the configured identity provider.
 
 .Prerequisites
 
-* You created an {product-title} cluster.
-* You created the custom resource (CR) for your identity providers.
+* You have access to a {product-title} cluster.
+* You have created the CR for your identity providers.
 * You are logged in as an administrator.
 
 .Procedure

--- a/modules/identity-provider-apache-custom-proxy-configuration.adoc
+++ b/modules/identity-provider-apache-custom-proxy-configuration.adoc
@@ -3,33 +3,30 @@
 // * authentication/identity_providers/configuring-request-header-identity-provider.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="identity-provider-apache-custom-proxy-configuration_{context}"]
-= Custom proxy configuration
+[id="example-apache-auth-config-using-request-header_{context}"]
+= Example Apache authentication configuration using request header
 
-Using the `mod_auth_gssapi` module is a popular way to configure the Apache
-authentication proxy using the request header identity provider; however, it is
-not required. Other proxies can easily be used if the following requirements are
+[role="_abstract"]
+Review this example to configure an Apache authentication proxy with the request header identity provider. Use it to set up a proxy that validates users and forwards trusted identity headers to {product-title}.
+
+This example configures an Apache authentication proxy for {product-title} using the request header identity provider.
+
+[id="identity-provider-apache-custom-proxy-configuration_{context}"]
+== Custom proxy configuration
+
+Review the requirements for a custom authentication proxy used with the request header identity provider. Meeting these requirements prevents header spoofing and ensures OAuth authorization flows work correctly.
+
+Using the `mod_auth_gssapi` module is a popular way to configure the Apache authentication proxy using the request header identity provider. However, it is not required. Other proxies can easily be used if the following requirements are
 met:
 
-* Block the `X-Remote-User` header from client requests to prevent spoofing.
-* Enforce client certificate authentication in the `RequestHeaderIdentityProvider`
-configuration.
-* Require the `X-Csrf-Token` header be set for all authentication requests using
-the challenge flow.
-* Make sure only the `/oauth/authorize` endpoint and its subpaths are proxied;
-redirects must be rewritten to allow the backend server to send the client to
-the correct location.
-* The URL that proxies to `\https://<namespace_route>/oauth/authorize` must end
-with `/authorize` with no trailing slash. For example, `\https://proxy.example.com/login-proxy/authorize?...`
-must proxy to `\https://<namespace_route>/oauth/authorize?...`.
-+
-* Subpaths of the URL that proxies to `\https://<namespace_route>/oauth/authorize`
-must proxy to subpaths of `\https://<namespace_route>/oauth/authorize`. For
-example, `\https://proxy.example.com/login-proxy/authorize/approve?...` must
-proxy to `\https://<namespace_route>/oauth/authorize/approve?...`.
+* Blocks the `X-Remote-User` header from client requests to prevent spoofing.
+* Enforces client certificate authentication in the `RequestHeaderIdentityProvider` configuration.
+* Requires the `X-Csrf-Token` header be set for all authentication requests using the challenge flow.
+* Ensures only the `/oauth/authorize` endpoint and subpaths of that endpoint are proxied. Redirects must be rewritten to allow the backend server to send the client to the correct location.
+* Requires the proxy URL for `\https://<namespace_route>/oauth/authorize` to end with `/authorize` with no trailing slash.
+* Ensures subpaths of the proxy authorize URL forward to matching subpaths under `\https://<namespace_route>/oauth/authorize`.
 
 [NOTE]
 ====
-The `\https://<namespace_route>` address is the route to the OAuth server and
-can be obtained by running `oc get route -n openshift-authentication`.
+The `\https://<namespace_route>` address is the route to the OAuth server and can be obtained by running `oc get route -n openshift-authentication`.
 ====

--- a/modules/identity-provider-apache-custom-proxy-configuration.adoc
+++ b/modules/identity-provider-apache-custom-proxy-configuration.adoc
@@ -3,33 +3,12 @@
 // * authentication/identity_providers/configuring-request-header-identity-provider.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="identity-provider-apache-custom-proxy-configuration_{context}"]
-= Custom proxy configuration
+[id="example-apache-auth-config-using-request-header_{context}"]
+= Example Apache authentication configuration using request header
 
-Using the `mod_auth_gssapi` module is a popular way to configure the Apache
-authentication proxy using the request header identity provider; however, it is
-not required. Other proxies can easily be used if the following requirements are
-met:
+[role="_abstract"]
+Review this example to configure an Apache authentication proxy with the request header identity provider. Use this example to set up a proxy and connect it to {product-title}.
 
-* Block the `X-Remote-User` header from client requests to prevent spoofing.
-* Enforce client certificate authentication in the `RequestHeaderIdentityProvider`
-configuration.
-* Require the `X-Csrf-Token` header be set for all authentication requests using
-the challenge flow.
-* Make sure only the `/oauth/authorize` endpoint and its subpaths are proxied;
-redirects must be rewritten to allow the backend server to send the client to
-the correct location.
-* The URL that proxies to `\https://<namespace_route>/oauth/authorize` must end
-with `/authorize` with no trailing slash. For example, `\https://proxy.example.com/login-proxy/authorize?...`
-must proxy to `\https://<namespace_route>/oauth/authorize?...`.
-+
-* Subpaths of the URL that proxies to `\https://<namespace_route>/oauth/authorize`
-must proxy to subpaths of `\https://<namespace_route>/oauth/authorize`. For
-example, `\https://proxy.example.com/login-proxy/authorize/approve?...` must
-proxy to `\https://<namespace_route>/oauth/authorize/approve?...`.
+The example configures an Apache authentication proxy for {product-title} by using the request header identity provider.
 
-[NOTE]
-====
-The `\https://<namespace_route>` address is the route to the OAuth server and
-can be obtained by running `oc get route -n openshift-authentication`.
-====
+

--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -16,7 +16,7 @@ endif::[]
 = Creating a 'ConfigMap'
 
 [role="_abstract"]
-Create a `ConfigMap` object in the `openshift-config` namespace to store the certificate authority bundle that identity providers use to validate secure connections to the remote authentication service.
+Create a `ConfigMap` object in the `openshift-config` namespace that contains the certificate authority bundle for the identity provider. {product-title} uses this bundle to validate Transport Layer Security (TLS) connections when configuring the provider.
 
 ifdef::github[]
 [NOTE]

--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -16,7 +16,7 @@ endif::[]
 = Creating a ConfigMap
 
 [role="_abstract"]
-Create a `ConfigMap` object in the `openshift-config` namespace to store the certificate authority (CA) bundle that identity providers use to validate secure connections to the remote authentication service.
+Create a `ConfigMap` object in the `openshift-config` namespace that contains the certificate authority bundle for the identity provider. {product-title} uses this bundle to validate Transport Layer Security (TLS) connections to the identity provider.
 
 ifdef::github[]
 [NOTE]

--- a/modules/identity-provider-configuring-apache-request-header.adoc
+++ b/modules/identity-provider-configuring-apache-request-header.adoc
@@ -6,14 +6,15 @@
 [id="identity-provider-configuring-apache-request-header_{context}"]
 = Configuring Apache authentication using request header
 
-This example uses the `mod_auth_gssapi` module to configure an Apache
-authentication proxy using the request header identity provider.
+[role="_abstract"]
+Configure an Apache authentication proxy with the `mod_auth_gssapi` module for the request header identity provider. Use this example to set up a proxy that validates users and forwards trusted identity headers to {product-title}.
+
+This proxy uses a client certificate to connect to the OAuth server, which is configured to trust the `X-Remote-User` header.
 
 .Prerequisites
 
-* Obtain the `mod_auth_gssapi` module from the
-link:https://access.redhat.com/solutions/392003[Optional channel].
-You must have the following packages installed on your local machine:
+* Obtain the `mod_auth_gssapi` module from the optional channel.
+* The following packages are installed on your local machine:
 +
 ** `httpd`
 ** `mod_ssl`
@@ -21,19 +22,19 @@ You must have the following packages installed on your local machine:
 ** `apr-util-openssl`
 ** `mod_auth_gssapi`
 
-* Generate a CA for validating requests that submit the trusted header. Define
-an {product-title} `ConfigMap` object containing the CA. This is done by running:
+.Procedure
+
+. Generate a CA for validating requests that submit the trusted header.
+
+. Create an {product-title} `ConfigMap` object containing the CA by running the following command:
 +
 [source,terminal]
 ----
-$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config <1>
+$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config
 ----
-<1> The CA must be stored in the `ca.crt` key of the `ConfigMap` object.
-+
-[TIP]
-====
-You can alternatively apply the following YAML to create the config map:
 
+. Optional: Apply the following YAML to create the config map:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -45,33 +46,27 @@ data:
   ca.crt: |
     <CA_certificate_PEM>
 ----
-====
++
+The certificate authority must be stored in the `ca.crt` key of the `ConfigMap` object.
 
-* Generate a client certificate for the proxy. You can generate this certificate
-by using any x509 certificate tooling. The client certificate must be signed by
-the CA you generated for validating requests that submit the trusted header.
+. Generate a client certificate for the proxy.
++
+You can generate this certificate by using any x509 certificate tooling. The client certificate must be signed by the CA you generated for validating requests that submit the trusted header.
 
-* Create the custom resource (CR) for your identity providers.
+. Create the custom resource (CR) for your identity providers.
 
-.Procedure
+. Create the certificate for the Apache configuration.
++
+The certificate that you specify as the `SSLProxyMachineCertificateFile` parameter value is the client certificate for the proxy that authenticates the proxy to the server. It must use `TLS Web Client Authentication` as the extended key type.
 
-This proxy uses a client certificate to connect to the OAuth server, which
-is configured to trust the `X-Remote-User` header.
-
-. Create the certificate for the Apache configuration. The certificate that you
-specify as the `SSLProxyMachineCertificateFile` parameter value is the proxy's
-client certificate that is used to authenticate the proxy to the server. It must
-use `TLS Web Client Authentication` as the extended key type.
-
-. Create the Apache configuration. Use the following template to provide your
-required settings and values:
+. Create the Apache configuration. Use the following template to provide your required settings and values:
 +
 [IMPORTANT]
 ====
-Carefully review the template and customize its contents to fit your
-environment.
+Carefully review the template and customize the template contents to fit your environment.
 ====
 +
+[source,conf]
 ----
 LoadModule request_module modules/mod_request.so
 LoadModule auth_gssapi_module modules/mod_auth_gssapi.so
@@ -156,11 +151,10 @@ RequestHeader unset X-Remote-User
 +
 [NOTE]
 ====
-The `\https://<namespace_route>` address is the route to the OAuth server and
-can be obtained by running `oc get route -n openshift-authentication`.
+The `\https://<namespace_route>` address is the route to the OAuth server and can be obtained by running `oc get route -n openshift-authentication`.
 ====
 
-. Update the `identityProviders` stanza in the custom resource (CR):
+. Update the `identityProviders` section of the custom resource (CR):
 +
 [source,yaml]
 ----
@@ -172,90 +166,86 @@ identityProviders:
       loginURL: "https://<namespace_route>/login-proxy/oauth/authorize?${query}"
       ca:
         name: ca-config-map
-        clientCommonNames:
-        - my-auth-proxy
-        headers:
-        - X-Remote-User
+      clientCommonNames:
+      - my-auth-proxy
+      headers:
+      - X-Remote-User
 ----
 
-. Verify the configuration.
-
-.. Confirm that you can bypass the proxy by requesting a token by supplying the
-correct client certificate and header:
+. Confirm that you can bypass the proxy when you supply the correct client certificate and header by running the following command:
 +
 [source,terminal]
 ----
-# curl -L -k -H "X-Remote-User: joe" \
+$ curl -L -k -H "X-Remote-User: joe" \
    --cert /etc/pki/tls/certs/authproxy.pem \
    https://<namespace_route>/oauth/token/request
 ----
 
-.. Confirm that requests that do not supply the client certificate fail by
-requesting a token without the certificate:
+. Confirm that requests that do not supply the client certificate fail by running the following command:
 +
 [source,terminal]
 ----
-# curl -L -k -H "X-Remote-User: joe" \
+$ curl -L -k -H "X-Remote-User: joe" \
    https://<namespace_route>/oauth/token/request
 ----
 
-.. Confirm that the `challengeURL` redirect is active:
+. Confirm that the `challengeURL` redirect is active by running the following command:
 +
 [source,terminal]
 ----
-# curl -k -v -H 'X-Csrf-Token: 1' \
+$ curl -k -v -H 'X-Csrf-Token: 1' \
    https://<namespace_route>/oauth/authorize?client_id=openshift-challenging-client&response_type=token
 ----
 +
 Copy the `challengeURL` redirect to use in the next step.
 
-.. Run this command to show a `401` response with a `WWW-Authenticate` basic
-challenge, a negotiate challenge, or both challenges:
+. Show a `401` response with a `WWW-Authenticate` basic challenge, a negotiate challenge, or both challenges by running the following command:
 +
 [source,terminal]
 ----
-# curl -k -v -H 'X-Csrf-Token: 1' \
+$ curl -k -v -H 'X-Csrf-Token: 1' \
    <challengeURL_redirect + query>
 ----
 
-.. Test logging in to the OpenShift CLI (`oc`) with and without using a Kerberos
-ticket:
-... If you generated a Kerberos ticket by using `kinit`, destroy it:
+. If you generated a Kerberos ticket by using `kinit`, destroy it by running the following command:
 +
 [source,terminal]
 ----
-# kdestroy -c cache_name <1>
+$ kdestroy -c <cache_name>
 ----
 +
-<1> Make sure to provide the name of your Kerberos cache.
-... Log in to the `oc` tool by using your Kerberos credentials:
-+
-[source,terminal]
-----
-# oc login -u <username>
-----
-+
-Enter your Kerberos password at the prompt.
-... Log out of the `oc` tool:
+Replace `cache_name` with the name of your Kerberos cache.
+
+. Log in to the OpenShift CLI (`oc`) with your Kerberos credentials by running the following command:
 +
 [source,terminal]
 ----
-# oc logout
+$ oc login -u <username>
 ----
-... Use your Kerberos credentials to get a ticket:
++
+Enter your Kerberos username and password at the prompt.
+
+. Log out of the `oc` tool by running the following command:
 +
 [source,terminal]
 ----
-# kinit
+$ oc logout
 ----
-+
-Enter your Kerberos user name and password at the prompt.
-... Confirm that you can log in to the `oc` tool:
+
+. Use your Kerberos credentials to get a ticket by running the following command:
 +
 [source,terminal]
 ----
-# oc login
+$ kinit
 ----
 +
-If your configuration is correct, you are logged in without entering separate
-credentials.
+Enter your Kerberos username and password at the prompt.
+
+. Confirm that you can log in to the `oc` tool by running the following command:
++
+[source,terminal]
+----
+$ oc login
+----
++
+If your configuration is correct, you are logged in without entering separate credentials.

--- a/modules/identity-provider-configuring-apache-request-header.adoc
+++ b/modules/identity-provider-configuring-apache-request-header.adoc
@@ -4,16 +4,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="identity-provider-configuring-apache-request-header_{context}"]
-= Configuring Apache authentication using request header
+= Configuring Apache authentication using the request header
 
-This example uses the `mod_auth_gssapi` module to configure an Apache
-authentication proxy using the request header identity provider.
+[role="_abstract"]
+Configure an Apache authentication proxy with the `mod_auth_gssapi` module for the request header identity provider. Use this example to set up a proxy that validates users and forwards trusted identity headers to {product-title}.
+
+This proxy uses a client certificate to connect to the OAuth server, which is configured to trust the `X-Remote-User` header.
 
 .Prerequisites
 
-* Obtain the `mod_auth_gssapi` module from the
-link:https://access.redhat.com/solutions/392003[Optional channel].
-You must have the following packages installed on your local machine:
+* Obtain the `mod_auth_gssapi` module from the optional channel. For more information, see "Optional channel".
+* The following packages are installed on your local machine:
 +
 ** `httpd`
 ** `mod_ssl`
@@ -21,19 +22,19 @@ You must have the following packages installed on your local machine:
 ** `apr-util-openssl`
 ** `mod_auth_gssapi`
 
-* Generate a CA for validating requests that submit the trusted header. Define
-an {product-title} `ConfigMap` object containing the CA. This is done by running:
+.Procedure
+
+. Generate a CA for validating requests that submit the trusted header.
+
+. Create an {product-title} `ConfigMap` object containing the CA by running the following command:
 +
 [source,terminal]
 ----
-$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config <1>
+$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config
 ----
-<1> The CA must be stored in the `ca.crt` key of the `ConfigMap` object.
-+
-[TIP]
-====
-You can alternatively apply the following YAML to create the config map:
 
+. Optional: Apply the following YAML to create the config map. For example:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -45,33 +46,27 @@ data:
   ca.crt: |
     <CA_certificate_PEM>
 ----
-====
++
+The certificate authority must be stored in the `ca.crt` key of the `ConfigMap` object.
 
-* Generate a client certificate for the proxy. You can generate this certificate
-by using any x509 certificate tooling. The client certificate must be signed by
-the CA you generated for validating requests that submit the trusted header.
+. Generate a client certificate for the proxy.
++
+You can generate this certificate by using any x509 certificate tooling. The client certificate must be signed by the CA you generated for validating requests that submit the trusted header.
 
-* Create the custom resource (CR) for your identity providers.
+. Create the custom resource (CR) for your identity providers.
 
-.Procedure
+. Create the certificate for the Apache configuration.
++
+The certificate that you specify as the `SSLProxyMachineCertificateFile` parameter value is the client certificate for the proxy that authenticates the proxy to the server. It must use `TLS Web Client Authentication` as the extended key type.
 
-This proxy uses a client certificate to connect to the OAuth server, which
-is configured to trust the `X-Remote-User` header.
-
-. Create the certificate for the Apache configuration. The certificate that you
-specify as the `SSLProxyMachineCertificateFile` parameter value is the proxy's
-client certificate that is used to authenticate the proxy to the server. It must
-use `TLS Web Client Authentication` as the extended key type.
-
-. Create the Apache configuration. Use the following template to provide your
-required settings and values:
+. Create the Apache configuration. Use the following template to provide your required settings and values:
 +
 [IMPORTANT]
 ====
-Carefully review the template and customize its contents to fit your
-environment.
+Carefully review the template and customize the template contents to fit your environment.
 ====
 +
+[source,terminal]
 ----
 LoadModule request_module modules/mod_request.so
 LoadModule auth_gssapi_module modules/mod_auth_gssapi.so
@@ -156,11 +151,10 @@ RequestHeader unset X-Remote-User
 +
 [NOTE]
 ====
-The `\https://<namespace_route>` address is the route to the OAuth server and
-can be obtained by running `oc get route -n openshift-authentication`.
+The `\https://<namespace_route>` address is the route to the OAuth server and can be obtained by running `oc get route -n openshift-authentication`.
 ====
 
-. Update the `identityProviders` stanza in the custom resource (CR):
+. Update the `identityProviders` section of the custom resource (CR):
 +
 [source,yaml]
 ----
@@ -172,90 +166,88 @@ identityProviders:
       loginURL: "https://<namespace_route>/login-proxy/oauth/authorize?${query}"
       ca:
         name: ca-config-map
-        clientCommonNames:
-        - my-auth-proxy
-        headers:
-        - X-Remote-User
+      clientCommonNames:
+      - my-auth-proxy
+      headers:
+      - X-Remote-User
 ----
 
-. Verify the configuration.
+.Verification
 
-.. Confirm that you can bypass the proxy by requesting a token by supplying the
-correct client certificate and header:
+. Confirm that you can bypass the proxy when you supply the correct client certificate and header by running the following command:
 +
 [source,terminal]
 ----
-# curl -L -k -H "X-Remote-User: joe" \
+$ curl -L -k -H "X-Remote-User: joe" \
    --cert /etc/pki/tls/certs/authproxy.pem \
    https://<namespace_route>/oauth/token/request
 ----
 
-.. Confirm that requests that do not supply the client certificate fail by
-requesting a token without the certificate:
+. Confirm that requests that do not supply the client certificate fail by running the following command:
 +
 [source,terminal]
 ----
-# curl -L -k -H "X-Remote-User: joe" \
+$ curl -L -k -H "X-Remote-User: joe" \
    https://<namespace_route>/oauth/token/request
 ----
 
-.. Confirm that the `challengeURL` redirect is active:
+. Confirm that the `challengeURL` redirect is active by running the following command:
 +
 [source,terminal]
 ----
-# curl -k -v -H 'X-Csrf-Token: 1' \
+$ curl -k -v -H 'X-Csrf-Token: 1' \
    https://<namespace_route>/oauth/authorize?client_id=openshift-challenging-client&response_type=token
 ----
 +
 Copy the `challengeURL` redirect to use in the next step.
 
-.. Run this command to show a `401` response with a `WWW-Authenticate` basic
-challenge, a negotiate challenge, or both challenges:
+. Show a `401` response with a `WWW-Authenticate` basic challenge, a negotiate challenge, or both challenges by running the following command:
 +
 [source,terminal]
 ----
-# curl -k -v -H 'X-Csrf-Token: 1' \
+$ curl -k -v -H 'X-Csrf-Token: 1' \
    <challengeURL_redirect + query>
 ----
 
-.. Test logging in to the OpenShift CLI (`oc`) with and without using a Kerberos
-ticket:
-... If you generated a Kerberos ticket by using `kinit`, destroy it:
+. If you generated a Kerberos ticket by using `kinit`, destroy it by running the following command:
 +
 [source,terminal]
 ----
-# kdestroy -c cache_name <1>
+$ kdestroy -c <cache_name>
 ----
 +
-<1> Make sure to provide the name of your Kerberos cache.
-... Log in to the `oc` tool by using your Kerberos credentials:
-+
-[source,terminal]
-----
-# oc login -u <username>
-----
-+
-Enter your Kerberos password at the prompt.
-... Log out of the `oc` tool:
+Replace `<cache_name>` with the name of your Kerberos cache.
+
+. Log in to the OpenShift CLI (`oc`) with your Kerberos credentials by running the following command:
 +
 [source,terminal]
 ----
-# oc logout
+$ oc login -u <username>
 ----
-... Use your Kerberos credentials to get a ticket:
++
+Enter your Kerberos username and password at the prompt.
+
+. Log out of the `oc` tool by running the following command:
 +
 [source,terminal]
 ----
-# kinit
+$ oc logout
 ----
-+
-Enter your Kerberos user name and password at the prompt.
-... Confirm that you can log in to the `oc` tool:
+
+. Use your Kerberos credentials to get a ticket by running the following command:
 +
 [source,terminal]
 ----
-# oc login
+$ kinit
 ----
 +
-If your configuration is correct, you are logged in without entering separate
-credentials.
+Enter your Kerberos username and password at the prompt.
+
+. Confirm that you can log in to the `oc` tool by running the following command:
++
+[source,terminal]
+----
+$ oc login
+----
++
+If your configuration is correct, you are logged in without entering separate credentials.

--- a/modules/identity-provider-proxy-custom-configuration.adoc
+++ b/modules/identity-provider-proxy-custom-configuration.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-request-header-identity-provider.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="identity-provider-proxy-custom-configuration_{context}"]
+= Custom proxy configuration
+
+[role="_abstract"]
+Review the requirements for a custom authentication proxy used with the request header identity provider. Meeting these requirements prevents header spoofing and ensures OAuth authorization flows work correctly.
+
+Using the `mod_auth_gssapi` module is a popular way, but not required, to configure the Apache authentication proxy by using the request header identity provider. Other proxies can easily be used if the following requirements are met:
+
+* Blocks the `X-Remote-User` header from client requests to prevent spoofing.
+* Enforces client certificate authentication in the `RequestHeaderIdentityProvider` configuration.
+* Requires the `X-Csrf-Token` header be set for all authentication requests by using the challenge flow.
+* Ensures only the `/oauth/authorize` endpoint and subpaths of that endpoint are proxied. Redirects must be rewritten to allow the backend server to send the client to the correct location.
+* Requires the proxy URL for `\https://<namespace_route>/oauth/authorize` to end with `/authorize` with no trailing slash.
+* Ensures subpaths of the proxy authorize URL forward to matching subpaths under `\https://<namespace_route>/oauth/authorize`.
+
+[NOTE]
+====
+The `\https://<namespace_route>` address is the route to the OAuth server and can be obtained by running `oc get route -n openshift-authentication`.
+====

--- a/modules/identity-provider-request-header-CR.adoc
+++ b/modules/identity-provider-request-header-CR.adoc
@@ -4,12 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="identity-provider-request-header-CR_{context}"]
-= Sample request header CR
+= Sample request header custom resource
 
-The following custom resource (CR) shows the parameters and
-acceptable values for a request header identity provider.
-
-.Request header CR
+[role="_abstract"]
+Review the sample request header `OAuth` custom resource (CR) to understand provider parameters and acceptable values before you configure the identity provider in your cluster.
 
 [source,yaml]
 ----
@@ -19,62 +17,43 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: requestheaderidp <1>
-    mappingMethod: claim <2>
+  - name: requestheaderidp
+    mappingMethod: claim
     type: RequestHeader
     requestHeader:
-      challengeURL: "https://www.example.com/challenging-proxy/oauth/authorize?${query}" <3>
-      loginURL: "https://www.example.com/login-proxy/oauth/authorize?${query}" <4>
-      ca: <5>
+      challengeURL: "https://www.example.com/challenging-proxy/oauth/authorize?${query}"
+      loginURL: "https://www.example.com/login-proxy/oauth/authorize?${query}"
+      ca:
         name: ca-config-map
-      clientCommonNames: <6>
+      clientCommonNames:
       - my-auth-proxy
-      headers: <7>
+      headers:
       - X-Remote-User
       - SSO-User
-      emailHeaders: <8>
+      emailHeaders:
       - X-Remote-User-Email
-      nameHeaders: <9>
+      nameHeaders:
       - X-Remote-User-Display-Name
-      preferredUsernameHeaders: <10>
+      preferredUsernameHeaders:
       - X-Remote-User-Login
 ----
-<1> This provider name is prefixed to the user name in the request header to
-form an identity name.
-<2> Controls how mappings are established between this provider's identities and `User` objects.
-<3> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
-that will authenticate browser-based clients and then proxy their request to
-`https://_<namespace_route>_/oauth/authorize`.
-The URL that proxies to `https://_<namespace_route>_/oauth/authorize` must end with `/authorize` (with no trailing slash),
-and also proxy subpaths, in order for OAuth approval flows to work properly.
-`${url}` is replaced with the current URL, escaped to be safe in a query parameter.
-`${query}` is replaced with the current query string.
-If this attribute is not defined, then `loginURL` must be used.
-<4> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
-that will authenticate clients which expect `WWW-Authenticate` challenges, and
-then proxy them to `https://_<namespace_route>_/oauth/authorize`.
-`${url}` is replaced with the current URL, escaped to be safe in a query parameter.
-`${query}` is replaced with the current query string.
-If this attribute is not defined, then `challengeURL` must be used.
-<5> Reference to an {product-title} `ConfigMap` object containing a PEM-encoded
-certificate bundle. Used as a trust anchor to validate the TLS
-certificates presented by the remote server.
+where:
+
+`spec.identityProviders.name`:: Specifies that the provider name is prefixed to the username in the request header to form an identity name.
+`spec.identityProviders.mappingMethod`:: Specifies how mappings are established between the identities of this provider and `User` objects.
+`spec.identityProviders.requestHeader.challengeURL`:: Specifies the URL for redirecting unauthenticated `/oauth/authorize` requests to an authenticating proxy that authenticates browser-based clients and then proxies the request to `https://_<namespace_route>_/oauth/authorize`. The URL that proxies to `https://_<namespace_route>_/oauth/authorize` must end with `/authorize` with no trailing slash and must also proxy subpaths for OAuth approval flows to work properly. `${url}` is replaced with the current URL, escaped to be safe in a query parameter. `${query}` is replaced with the current query string. If this attribute is not defined, `loginURL` must be used. This value is optional.
+`spec.identityProviders.requestHeader.loginURL`:: Specifies the URL for redirecting unauthenticated `/oauth/authorize` requests to an authenticating proxy that authenticates clients expecting `WWW-Authenticate` challenges and then proxies them to `https://_<namespace_route>_/oauth/authorize`. `${url}` is replaced with the current URL, escaped to be safe in a query parameter. `${query}` is replaced with the current query string. If this attribute is not defined, `challengeURL` must be used. This value is optional.
+`spec.identityProviders.requestHeader.ca`:: Specifies a reference to an {product-title} `ConfigMap` object containing a Privacy-Enhanced Mail (PEM)-encoded certificate bundle used as a trust anchor to validate the Transport Layer Security (TLS) certificates presented by the remote server.
 +
 [IMPORTANT]
 ====
-As of {product-title} 4.1, the `ca` field is required for this identity
-provider. This means that your proxy must support mutual TLS.
+As of {product-title} 4.1, the `ca` field is required for this identity provider. This means that your proxy must support mutual TLS.
 ====
-<6> Optional: list of common names (`cn`). If set, a valid client certificate with
-a Common Name (`cn`) in the specified list must be presented before the request headers
-are checked for user names. If empty, any Common Name is allowed. Can only be used in combination
-with `ca`.
-<7> Header names to check, in order, for the user identity. The first header containing
-a value is used as the identity. Required, case-insensitive.
-<8> Header names to check, in order, for an email address. The first header containing
-a value is used as the email address. Optional, case-insensitive.
-<9> Header names to check, in order, for a display name. The first header containing
-a value is used as the display name. Optional, case-insensitive.
-<10> Header names to check, in order, for a preferred user name, if different than the immutable
-identity determined from the headers specified in `headers`. The first header containing
-a value is used as the preferred user name when provisioning. Optional, case-insensitive.
+`spec.identityProviders.requestHeader.clientCommonNames`:: Specifies a list of common names (`cn`).
+If set, a valid client certificate with a Common Name (`cn`) in the specified list must be presented before the request headers are checked for usernames. If empty, any Common Name is allowed. Can only be used in combination with `ca`. This value is optional.
+`spec.identityProviders.requestHeader.headers`:: Specifies header names to check, in order, for the user identity.
+The first header containing a value is used as the identity. This field is required, and header matching is case-insensitive.
+`spec.identityProviders.requestHeader.emailHeaders`:: Specifies header names to check, in order, for an email address. The first header containing a value is used as the email address. Header matching is case-insensitive. This value is optional.
+`spec.identityProviders.requestHeader.nameHeaders`:: Specifies header names to check, in order, for a display name. The first header containing a value is used as the display name. Header matching is case-insensitive. This value is optional.
+`spec.identityProviders.requestHeader.preferredUsernameHeaders`:: Specifies header names to check, in order, for a preferred username, if different from the immutable identity determined from the headers specified in `headers`.
+The first header containing a value is used as the preferred username when provisioning. Header matching is case-insensitive. This value is optional.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16959

Link to docs preview:
https://116773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-request-header-identity-provider.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
