### PR TITLE
Fix CQA P9: Shorten 10 abstracts to meet 300-character limit

### DIFF
--- a/configuring/configuring-openshift-builds.adoc
+++ b/configuring/configuring-openshift-builds.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Platform engineers can customize source code location, build strategy, parameters, output settings, retention rules, and volumes in a `Build` custom resource (CR). A `Build` CR enables consistent build pod configuration and provides a namespace-scoped method for managing build execution on the cluster.
+Platform engineers can customize source code location, build strategy, parameters, output settings, retention rules, and volumes in a `Build` custom resource (CR) to manage build execution consistently across the cluster.
 
 include::modules/con-configure-build-inputs.adoc[leveloffset=+1]
 

--- a/modules/con-configure-build-inputs.adoc
+++ b/modules/con-configure-build-inputs.adoc
@@ -7,9 +7,7 @@
 = Build input configuration
 
 [role="_abstract"]
-Build inputs define the source materials and configuration that {builds-shortname} uses to create container images.
-Understanding build inputs helps you control what goes into your builds and how they are constructed.
-You can customize inputs to match your specific workflow and security requirements.
+Build inputs define the source materials and configuration that {builds-shortname} uses to create container images. You can customize inputs to control build content and match your workflow and security requirements.
 
 Build inputs include several types of configuration that control how you build your container images.
 The Containerfile defines the build instructions and base image layers.

--- a/modules/con-what-is-openshift-builds.adoc
+++ b/modules/con-what-is-openshift-builds.adoc
@@ -7,6 +7,6 @@
 = What is OpenShift Builds?
 
 [role="_abstract"]
-Containerized application development requires image builds that are consistent, secure, and repeatable across environments. {builds-shortname} helps address these requirements by providing standardized build workflows that support automation, reusable build strategies, and integration with {ocp-product-title}.
+{builds-shortname} provides standardized build workflows that support automation, reusable build strategies, and integration with {ocp-product-title}. This enables consistent, secure, and repeatable container image builds across environments.
 
 By reducing the need for custom build scripts and manual configuration, {builds-shortname} helps developers create container images more efficiently while enabling administrators to apply secure and consistent build practices at scale.

--- a/modules/ob-controller-settings.adoc
+++ b/modules/ob-controller-settings.adoc
@@ -7,7 +7,7 @@
 = Controller settings
 
 [role="_abstract"]
-The controller is configured on the {ocp-product-title} cluster with some default values. However, you can set or modify controller settings by using environment variables defined in the `controller.yaml` file. These environment variables control timeouts, container images, Git behavior, and resource reconciliation for the build controller.
+You can set or modify controller settings by using environment variables defined in the `controller.yaml` file. These environment variables control timeouts, container images, Git behavior, and resource reconciliation for the build controller.
 
 .Controller settings
 [options="header"]

--- a/modules/ob-defining-retention-parameters-in-build-run.adoc
+++ b/modules/ob-defining-retention-parameters-in-build-run.adoc
@@ -7,7 +7,7 @@
 = Configure retention parameters
 
 [role="_abstract"]
-Use retention parameters in your `BuildRun` custom resource (CR) to automatically delete completed build runs. The `retention.ttlAfterFailed` parameter sets how long a failed build run remains before deletion, and `retention.ttlAfterSucceeded` sets the duration for successful build runs. These parameters help manage cluster resources by cleaning up old build artifacts.
+Use retention parameters in your `BuildRun` custom resource (CR) to automatically delete completed build runs. Set `retention.ttlAfterFailed` for failed builds and `retention.ttlAfterSucceeded` for successful builds to manage cluster resources.
 [source,yaml]
 ----
 apiVersion: shipwright.io/v1beta1

--- a/modules/ob-example-configuration-for-defining-parameter-values.adoc
+++ b/modules/ob-example-configuration-for-defining-parameter-values.adoc
@@ -7,7 +7,7 @@
 = Example configuration for defining parameter values
 
 [role="_abstract"]
-Build strategies support parameters that you can configure with specific values in a `Build` custom resource (CR). You can assign values to both string and array parameters. Parameters allow you to customize build behavior, such as storage drivers, build arguments, and registry locations, without modifying the build strategy itself.
+Build strategies support parameters that you can configure with specific values in a `Build` custom resource (CR). Parameters allow you to customize build behavior without modifying the build strategy itself.
 
 Define parameters in a `ClusterBuildStrategy` CR::
 The following example shows a `ClusterBuildStrategy` CR with several parameters:

--- a/modules/ob-histogram-metrics.adoc
+++ b/modules/ob-histogram-metrics.adoc
@@ -7,7 +7,7 @@
 = Histogram metrics
 
 [role="_abstract"]
-To use custom buckets for the build controller, you must set the environment variable for a particular histogram metric. Environment variables are available for build run establishment duration, completion duration, and ramp-up duration metrics. Custom buckets allow you to tune metric granularity for monitoring and observability.
+Set environment variables to use custom buckets for histogram metrics. Custom buckets allow you to tune metric granularity for build run establishment, completion, and ramp-up duration.
 
 .Histogram metrics
 [options="header"]

--- a/modules/ob-release-notes-1-8.adoc
+++ b/modules/ob-release-notes-1-8.adoc
@@ -2,7 +2,7 @@
 // * about/ob-release-notes.adoc
 :_mod-docs-content-type: REFERENCE
 [id="ob-release-notes-1-8_{context}"]
-= Release notes for {builds-shortname} 1.8
+= Release notes for builds 1.8
 
 [role="_abstract"]
 {builds-shortname} 1.8 is now available on {ocp-product-title} 4.17.

--- a/modules/ob-role-based-access-control.adoc
+++ b/modules/ob-role-based-access-control.adoc
@@ -8,7 +8,7 @@
 = Role-based access control for builds
 
 [role="_abstract"]
-{builds-title} installation includes two cluster-wide roles for managing access to build resources: `shipwright-build-aggregate-view` for read access and `shipwright-build-aggregate-edit` for write access. These roles integrate with Kubernetes role-based access control (RBAC) to control who can view, create, and modify build strategies and build runs.
+{builds-title} installation includes two cluster-wide roles: `shipwright-build-aggregate-view` for read access and `shipwright-build-aggregate-edit` for write access. These roles integrate with Kubernetes RBAC to control access to build strategies and build runs.
 
 By default, {builds-title} installation includes the following two cluster-wide roles for using {builds-shortname} objects:
 

--- a/reference/api-specifications-and-examples.adoc
+++ b/reference/api-specifications-and-examples.adoc
@@ -8,8 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a platform engineer or application developer, use the API specifications and examples to understand the structure and fields of Build, `BuildRun`, `BuildStrategy`, and `ClusterBuildStrategy` custom resources.
-These reference materials help you configure builds correctly and troubleshoot configuration issues.
+Use the API specifications and examples to understand the structure and fields of Build, `BuildRun`, `BuildStrategy`, and `ClusterBuildStrategy` custom resources to configure builds correctly and troubleshoot issues.
 
 include::modules/con-build-resource-field-reference.adoc[leveloffset=+1]
 

--- a/work_with_builds/build-container-images-for-your-application.adoc
+++ b/work_with_builds/build-container-images-for-your-application.adoc
@@ -8,9 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can build container images for your applications by using different build strategies that {builds-shortname} provides.
-You can also use Open Container Initiative (OCI) artifacts to build container images.
-{builds-shortname} supports standard network environments and network-restricted environments where builds must use mirrored registries and proxy settings.
+You can build container images by using build strategies and OCI artifacts that {builds-shortname} provides. {builds-shortname} supports standard and network-restricted environments with mirrored registries and proxy settings.
 
 include::modules/ob-container-image-build-strategies-for-your-application.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Shortened abstracts in 10 build-related files to meet CQA parameter P9 requirement (300-character maximum). Removed redundant explanations while preserving key information about functionality and purpose.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
