### PR TITLE
TELCODOCS-2493: Document Ready conditions for SR-IOV Network Operator CRDs

### DIFF
--- a/modules/nw-sriov-about-k8s-conditions.adoc
+++ b/modules/nw-sriov-about-k8s-conditions.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-sriov-about-k8s-conditions_{context}"]
+= About Ready conditions for the SR-IOV Network Operator
+
+[role="_abstract"]
+You can monitor the health and readiness of SR-IOV Network Operator resources by using `Ready` conditions in the resource status.
+
+Conditions give a consistent, machine-readable view of whether a resource has reached the required state, so that you can automate workflows and troubleshoot failures without relying only on Operator logs.
+
+The SR-IOV Network Operator reports a `Ready` condition on the following objects:
+
+* `SriovNetwork`
+* `SriovIBNetwork`
+* `SriovOperatorConfig`
+
+The following table describes the possible `Ready` condition values for each object.
+
+.SR-IOV Network Operator Ready condition
+[cols="2,3,3a",options="header"]
+|===
+|Object
+|`Ready` status
+|Description
+
+|`SriovNetwork`
+|`True`
+|The Operator created a valid `NetworkAttachmentDefinition` object and the Ethernet network is ready for pods to use.
+
+|`SriovNetwork`
+|`False`
+|Provisioning failed. Common reasons include a missing or invalid `NetworkAttachmentDefinition` object or a target namespace that does not exist.
+
+|`SriovIBNetwork`
+|`True`
+|The Operator created a valid `NetworkAttachmentDefinition` object and the InfiniBand network is ready for pods to use.
+
+|`SriovIBNetwork`
+|`False`
+|Provisioning failed. Common reasons include a missing or invalid `NetworkAttachmentDefinition` object or a target namespace that does not exist.
+
+|`SriovOperatorConfig`
+|`True`
+|The Operator reconciled the configuration successfully.
+
+|`SriovOperatorConfig`
+|`False`
+|The Operator could not reconcile the configuration, or the requested configuration is not supported.
+|===
+
+When the `Ready` condition is `False`, the condition `reason` and `message` fields identify the failure. The following reasons are commonly reported:
+
+.Common Ready condition reasons
+[cols="2,3,3a",options="header"]
+|===
+|Reason
+|Applies to
+|Description
+
+|`NetworkReady`
+|`SriovNetwork`, `SriovIBNetwork`
+|The Operator provisioned the `NetworkAttachmentDefinition` object and the network is ready.
+
+|`NetworkAttachmentDefinitionNotFound`
+|`SriovNetwork`, `SriovIBNetwork`
+|The expected `NetworkAttachmentDefinition` object was not found.
+
+|`NetworkAttachmentDefinitionInvalid`
+|`SriovNetwork`, `SriovIBNetwork`
+|The `NetworkAttachmentDefinition` object is invalid or the Operator could not apply it.
+
+|`NamespaceNotFound`
+|`SriovNetwork`, `SriovIBNetwork`
+|The target namespace for the network does not exist.
+
+|`OperatorConfigReady`
+|`SriovOperatorConfig`
+|The Operator configuration reconciled successfully.
+
+|`OperatorConfigSyncFailed`
+|`SriovOperatorConfig`
+|The Operator failed to synchronize the configuration.
+
+|`UnsupportedConfiguration`
+|`SriovOperatorConfig`
+|The requested Operator configuration is not supported.
+|===
+
+You can use the OpenShift CLI (`oc`) to inspect these conditions and wait for resources to become ready. For example, automation can wait for an `SriovNetwork` object to report `Ready` before attaching pods to the secondary network.

--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/hardware_networks/configuring-sriov-operator.adoc
+// * networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-sriov-configuring-operator_{context}"]
@@ -44,4 +44,15 @@ where:
 ----
 $ oc apply -f sriovOperatorConfig.yaml
 ----
+
+.Verification
+
+* Confirm that the `SriovOperatorConfig` object is ready by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovoperatorconfig default -n openshift-sriov-network-operator
+----
++
+A value of `True` in the `Ready` column indicates that the Operator reconciled the configuration successfully.
 

--- a/modules/nw-sriov-monitoring-conditions-proc.adoc
+++ b/modules/nw-sriov-monitoring-conditions-proc.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-monitoring-conditions-proc_{context}"]
+= Checking SR-IOV Network Operator status with Ready conditions
+
+[role="_abstract"]
+You can check the `Ready` condition on `SriovNetwork`, `SriovIBNetwork`, and `SriovOperatorConfig` objects to confirm that the SR-IOV Network Operator applied your configuration. You can also wait for the condition before you attach workloads or continue automation.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have logged in as a user with `cluster-admin` privileges.
+* You have installed the SR-IOV Network Operator.
+* You have an `SriovNetwork`, `SriovIBNetwork`, or `SriovOperatorConfig` object to check.
+
+.Procedure
+
+. Check the `Ready` column for network resources by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovnetwork,sriovibnetwork -n openshift-sriov-network-operator
+----
++
+Example output:
++
+[source,terminal]
+----
+NAME                                                 AGE   READY
+sriovnetwork.sriovnetwork.openshift.io/net-attach-1  5m    True
+
+NAME                                                   AGE   READY
+sriovibnetwork.sriovnetwork.openshift.io/ib-attach-1   5m    True
+----
+
+. Check the `Ready` column for the Operator configuration by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovoperatorconfig -n openshift-sriov-network-operator
+----
++
+Example output:
++
+[source,terminal]
+----
+NAME      AGE   READY
+default   1d    True
+----
+
+. Inspect the condition details for a network resource by running the following command:
++
+[source,terminal]
+----
+$ oc describe sriovnetwork <network_name> -n openshift-sriov-network-operator
+----
++
+Example output:
++
+[source,terminal]
+----
+Status:
+  Conditions:
+    Last Transition Time:  2026-07-27T15:40:00Z
+    Message:               NetworkAttachmentDefinition is provisioned and ready
+    Observed Generation:   1
+    Reason:                NetworkReady
+    Status:                True
+    Type:                  Ready
+----
+
+. Optional: Wait for a network resource to become ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait sriovnetwork/<network_name> -n openshift-sriov-network-operator \
+  --for=condition=Ready --timeout=2m
+----
++
+Replace `<network_name>` with the name of your `SriovNetwork` or `SriovIBNetwork` object. For an InfiniBand network, use `sriovibnetwork/<network_name>`.
+
+. Optional: Wait for the Operator configuration to become ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait sriovoperatorconfig/default -n openshift-sriov-network-operator \
+  --for=condition=Ready --timeout=2m
+----
+
+.Troubleshooting
+
+* If the `Ready` condition is `False`, review the `Reason` and `Message` fields from the `oc describe` output.
+* For network resources, confirm that the target namespace exists and that the related `SriovNetworkNodePolicy` object and device configuration are valid.
+* For the `SriovOperatorConfig` object, correct unsupported configuration values and check the SR-IOV Network Operator pod logs in the `openshift-sriov-network-operator` namespace.

--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -102,6 +102,8 @@ Use caution when disabling the SR-IOV Network Operator Admission Controller webh
 == Additional resources
 
 * xref:../../networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc#configuring-multi-network-policy[Configuring multi-network policy]
+* xref:../../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#nw-sriov-about-k8s-conditions_configuring-sriov-operator[About Ready conditions for the SR-IOV Network Operator]
+* xref:../../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#nw-sriov-monitoring-conditions-proc_configuring-sriov-operator[Checking SR-IOV Network Operator status with Ready conditions]
 
 [id="about-sriov-next-steps"]
 == Next steps

--- a/networking/hardware_networks/configuring-sriov-ib-attach.adoc
+++ b/networking/hardware_networks/configuring-sriov-ib-attach.adoc
@@ -13,6 +13,11 @@ Before you perform any tasks in the following documentation, ensure that you xre
 
 include::modules/nw-sriov-ibnetwork-object.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#nw-sriov-monitoring-conditions-proc_configuring-sriov-operator[Checking SR-IOV Network Operator status with Ready conditions]
+
 include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]

--- a/networking/hardware_networks/configuring-sriov-net-attach.adoc
+++ b/networking/hardware_networks/configuring-sriov-net-attach.adoc
@@ -20,6 +20,8 @@ include::modules/nw-sriov-network-object.adoc[leveloffset=+1]
 
 * xref:../../networking/hardware_networks/configuring-namespaced-sriov-resources.adoc#introduction-to-namespaced-sriovnetwork-resources_configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources]
 
+* xref:../../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#nw-sriov-monitoring-conditions-proc_configuring-sriov-operator[Checking SR-IOV Network Operator status with Ready conditions]
+
 include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]

--- a/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
+++ b/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
@@ -15,6 +15,12 @@ include::modules/nw-sriov-configuring-operator.adoc[leveloffset=+1]
 // SR-IOV Network Operator config custom resource
 include::modules/nw-sriov-operator-cr.adoc[leveloffset=+1]
 
+// About Ready conditions for the SR-IOV Network Operator
+include::modules/nw-sriov-about-k8s-conditions.adoc[leveloffset=+1]
+
+// Checking SR-IOV Network Operator status with Ready conditions
+include::modules/nw-sriov-monitoring-conditions-proc.adoc[leveloffset=+1]
+
 // About the Network Resources Injector
 include::modules/about-network-resource-injector.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2493

Link to docs preview:
https://116790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html
https://116790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-ib-attach.html
https://116790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach.html
https://116790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html

QE review:
- [ ] QE has approved this change.

Additional information:
Documents the Ready condition on SriovNetwork, SriovIBNetwork, and SriovOperatorConfig, with a monitoring procedure. Release note will be added on the 5.0 docs branch. OVSNetwork is omitted (not supported downstream).