### PR TITLE
TELCODOCS-2493: Add release note for SR-IOV Network Operator Ready conditions

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -373,6 +373,13 @@ MetalLB creates a `ConfigurationState` resource for the controller and for each 
 +
 For more information, see xref:../networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc#nw-metallb-checking-configuration-status_monitor-metallb-config-status[Checking MetalLB configuration status].
 
+// TELCODOCS-2493
+SR-IOV Network Operator reports Ready conditions on key custom resources::
++
+You can now monitor the health of SR-IOV Network Operator resources by using a standard `Ready` condition on `SriovNetwork`, `SriovIBNetwork`, and `SriovOperatorConfig` custom resources. Use the OpenShift CLI (`oc`) to inspect the condition status, wait for the `Ready` condition to be `True`, and troubleshoot provisioning or configuration failures from the condition `reason` and `message` fields.
++
+For more information, see xref:../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#nw-sriov-about-k8s-conditions_configuring-sriov-operator[About Ready conditions for the SR-IOV Network Operator].
+
 // TELCODOCS-2565
 Multi-network policy backend uses nftables::
 +


### PR DESCRIPTION
Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2493

Link to docs preview:
<!-- Add Netlify preview link(s) after the PR build completes. -->

QE review:
- [ ] QE has approved this change.

Additional information:
Release note only. Docs content is in #116790; cherry-pick that PR to enterprise-5.0 so the xref target resolves.