### PR TITLE
OSDOCS-16997-installing-gcp-user-infra# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -19,15 +19,22 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* If you use a firewall and plan to use the Telemetry service, you configured it to allow the sites that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials.
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating and maintaining long-term credentials]
 
 include::modules/csr-management.adoc[leveloffset=+1]
 
@@ -35,8 +42,6 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 [id="installation-gcp-user-infra-config-project"]
 == Configuring your {gcp-short} project
-
-Before you can install {product-title}, you must configure a {gcp-first} project to host it.
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 
@@ -64,8 +69,7 @@ include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 [id="installation-requirements-user-infra_{context}"]
 == Requirements for a cluster with user-provisioned infrastructure
 
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
 
 This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
 
@@ -180,10 +184,11 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
 * xref:../../networking/networking_operators/ingress-operator.adoc#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress[Configuring Global Access for an Ingress Controller on {gcp-short}]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -19,24 +19,28 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* If you use a firewall and plan to use the Telemetry service, you configured the firewall to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials. For more information, see "Manually creating long-term credentials".
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials]
+
 include::modules/csr-management.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-[id="installation-gcp-user-infra-config-project"]
-== Configuring your {gcp-short} project
-
-Before you can install {product-title}, you must configure a {gcp-first} project to host it.
+include::modules/installation-gcp-user-infra-config-project.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 
@@ -61,13 +65,7 @@ include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
+include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 
@@ -110,14 +108,11 @@ include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[lev
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra[Optional: Adding the ingress DNS records]
+* xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra[Adding the ingress DNS records]
 
-[id="installation-gcp-user-infra-exporting-common-variables"]
-== Exporting common variables
+include::modules/installation-extracting-infraid.adoc[leveloffset=+1]
 
-include::modules/installation-extracting-infraid.adoc[leveloffset=+2]
-
-include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+2]
+include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+1]
 
 include::modules/installation-creating-gcp-vpc.adoc[leveloffset=+1]
 
@@ -178,12 +173,10 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
 * xref:../../networking/networking_operators/ingress-operator.adoc#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress[Configuring Global Access for an Ingress Controller on {gcp-short}]

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -116,12 +116,12 @@ endif::ibm-z,ibm-z-kvm[]
 +
 [NOTE]
 ====
-You must approve your CSRs within an hour of adding the machines to the cluster. If you do not approve them within an hour, the certificates rotate, and more than two certificates are present for each node. You must approve all of these certificates. After the client CSR is approved, the kubelet creates a secondary CSR for the serving certificate, which requires manual approval. The subsequent serving certificate renewal requests are then automatically approved by the `machine-approver` if the Kubelet requests a new certificate with identical parameters.
+You must approve your CSRs within an hour of adding the machines to the cluster. If you do not approve them within an hour, the certificates rotate, and more than two certificates are present for each node. You must approve all of these certificates. After the client CSR is approved, the kubelet creates a secondary CSR for the serving certificate, which requires manual approval. The subsequent serving certificate renewal requests are then automatically approved by the `machine-approver` if the kubelet requests a new certificate with identical parameters.
 ====
 +
 [NOTE]
 ====
-For clusters running on platforms that are not machine API enabled, such as bare metal and other user-provisioned infrastructure, you must implement a method of automatically approving the kubelet serving certificate requests (CSRs). If a request is not approved, then the `oc exec`, `oc rsh`, and `oc logs` commands cannot succeed, because a serving certificate is required when the API server connects to the kubelet. Any operation that contacts the Kubelet endpoint requires this certificate approval to be in place. The method must watch for new CSRs, confirm that the CSR was submitted by the `node-bootstrapper` service account in the `system:node` or `system:admin` groups, and confirm the identity of the node.
+For clusters running on platforms that are not machine API enabled, such as bare metal and other user-provisioned infrastructure, you must implement a method of automatically approving the kubelet serving certificate requests (CSRs). If a request is not approved, then the `oc exec`, `oc rsh`, and `oc logs` commands cannot succeed, because a serving certificate is required when the API server connects to the kubelet. Any operation that contacts the kubelet endpoint requires this certificate approval to be in place. The method must watch for new CSRs, confirm that the CSR was submitted by the `node-bootstrapper` service account in the `system:node` or `system:admin` groups, and confirm the identity of the node.
 ====
 +
 ** To approve them individually, run the following command for each valid CSR:
@@ -227,7 +227,7 @@ endif::ibm-power[]
 +
 [NOTE]
 ====
-You might need to wait a few minutes after approval of the server CSRs for the machines to transition to the `Ready` status.
+You might need to wait a few minutes after approval of the server CSRs for the machines to reach the `Ready` status.
 ====
 
 ifeval::["{context}" == "installing-ibm-z"]

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -227,7 +227,7 @@ endif::ibm-power[]
 +
 [NOTE]
 ====
-You might need to wait a few minutes after approval of the server CSRs for the machines to transition to the `Ready` status.
+You might need to wait a few minutes after approval of the server CSRs for the machines to reach the `Ready` status.
 ====
 
 ifeval::["{context}" == "installing-ibm-z"]

--- a/modules/installation-gcp-install-cli.adoc
+++ b/modules/installation-gcp-install-cli.adoc
@@ -7,8 +7,8 @@
 [id="installation-gcp-install-cli_{context}"]
 = Installing and configuring CLI tools for {gcp-short}
 
-To install {product-title} on {gcp-first} using user-provisioned
-infrastructure, you must install and configure the CLI tools for {gcp-short}.
+[role="_abstract"]
+Before you deploy {product-title} on {gcp-first} with user-provisioned infrastructure, you must set up the required CLI tools to create and manage your cloud resources.
 
 .Prerequisites
 

--- a/modules/installation-gcp-user-infra-adding-ingress.adoc
+++ b/modules/installation-gcp-user-infra-adding-ingress.adoc
@@ -14,21 +14,18 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-gcp-user-infra-adding-ingress_{context}"]
-ifndef::shared-vpc[]
-= Optional: Adding the ingress DNS records
-
-endif::shared-vpc[]
-ifdef::shared-vpc[]
 = Adding the ingress DNS records
 
-endif::shared-vpc[]
-
+[role="_abstract"]
 ifndef::shared-vpc[]
-If you removed the DNS zone configuration when creating Kubernetes manifests and generating Ignition configs, you must manually create DNS records that point at the ingress load balancer. You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+If you removed the DNS zone configuration when creating Kubernetes manifests and generating Ignition configs, you must manually create DNS records that point at the ingress load balancer.
+
+You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
 endif::[]
 ifdef::shared-vpc[]
-DNS zone configuration is removed when creating Kubernetes manifests and generating Ignition configs. You must manually create DNS records that point at the ingress load balancer. You can create either a wildcard
-`*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+DNS zone configuration is removed when creating Kubernetes manifests and generating Ignition configs. You must manually create DNS records that point at the ingress load balancer.
+
+You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
 endif::[]
 
 .Prerequisites

--- a/modules/installation-gcp-user-infra-adding-ingress.adoc
+++ b/modules/installation-gcp-user-infra-adding-ingress.adoc
@@ -14,21 +14,18 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-gcp-user-infra-adding-ingress_{context}"]
-ifndef::shared-vpc[]
-= Optional: Adding the ingress DNS records
-
-endif::shared-vpc[]
-ifdef::shared-vpc[]
 = Adding the ingress DNS records
 
-endif::shared-vpc[]
-
+[role="_abstract"]
 ifndef::shared-vpc[]
-If you removed the DNS zone configuration when creating Kubernetes manifests and generating Ignition configs, you must manually create DNS records that point at the ingress load balancer. You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+If you removed the DNS zone configuration when creating Kubernetes manifests and generating Ignition configs, you must manually create DNS records that point at the ingress load balancer so that external clients can reach the applications that run on your cluster.
+
+You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
 endif::[]
 ifdef::shared-vpc[]
-DNS zone configuration is removed when creating Kubernetes manifests and generating Ignition configs. You must manually create DNS records that point at the ingress load balancer. You can create either a wildcard
-`*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+DNS zone configuration is removed when creating Kubernetes manifests and generating Ignition configs. You must manually create DNS records that point at the ingress load balancer so that external clients can reach the applications that run on your cluster.
+
+You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
 endif::[]
 
 .Prerequisites

--- a/modules/installation-gcp-user-infra-completing.adoc
+++ b/modules/installation-gcp-user-infra-completing.adoc
@@ -7,9 +7,8 @@
 [id="installation-gcp-user-infra-installation_{context}"]
 = Completing a {gcp-short} installation on user-provisioned infrastructure
 
-After you start the {product-title} installation on {gcp-first}
-user-provisioned infrastructure, you can monitor the cluster events until the
-cluster is ready.
+[role="_abstract"]
+After you start the {product-title} installation on {gcp-first} user-provisioned infrastructure, you can monitor the cluster events until the cluster is ready.
 
 .Prerequisites
 
@@ -21,16 +20,16 @@ cluster is ready.
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete
 ----
++
+where `<installation_directory>` specifies the path to the directory that you stored the installation files in.
 +
 .Example output
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the cluster to initialize...
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you
-stored the installation files in.
 +
 [IMPORTANT]
 ====

--- a/modules/installation-gcp-user-infra-completing.adoc
+++ b/modules/installation-gcp-user-infra-completing.adoc
@@ -7,9 +7,8 @@
 [id="installation-gcp-user-infra-installation_{context}"]
 = Completing a {gcp-short} installation on user-provisioned infrastructure
 
-After you start the {product-title} installation on {gcp-first}
-user-provisioned infrastructure, you can monitor the cluster events until the
-cluster is ready.
+[role="_abstract"]
+After you start the {product-title} installation on {gcp-first} user-provisioned infrastructure, you can monitor the cluster events to confirm that the installation completes successfully and the cluster is ready for use.
 
 .Prerequisites
 
@@ -21,16 +20,16 @@ cluster is ready.
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete
 ----
++
+where `<installation_directory>` specifies the path to the directory that you stored the installation files in.
 +
 .Example output
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the cluster to initialize...
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you
-stored the installation files in.
 +
 [IMPORTANT]
 ====

--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -7,7 +7,7 @@
 = Creating the {op-system} cluster image for the {gcp-short} infrastructure
 
 [role="_abstract"]
-You must use a valid {op-system-first} image for {gcp-first} for your {product-title} nodes.
+You must use a valid {op-system-first} image for {gcp-first} on your {product-title} nodes.
 
 .Prerequisites
 

--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -7,7 +7,7 @@
 = Creating the {op-system} cluster image for the {gcp-short} infrastructure
 
 [role="_abstract"]
-You must use a valid {op-system-first} image for {gcp-first} for your {product-title} nodes.
+To deploy {product-title} nodes on {gcp-first}, you must create a valid {op-system-first} image in your {gcp-short} project because {op-system} images are not pre-published on {gcp-short}.
 
 .Prerequisites
 

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -7,7 +7,8 @@
 [id="installation-gcp-user-infra-wait-for-bootstrap_{context}"]
 = Removing bootstrap resources in {gcp-short}
 
-After you create all of the required infrastructure in {gcp-first}, wait for the bootstrap process to complete on the machines that you provisioned by using the Ignition config files. The installation program created the Ignition config files.
+[role="_abstract"]
+After the bootstrap process is complete on your {gcp-first} infrastructure, you can remove the bootstrap resources that are no longer needed for your {product-title} cluster.
 
 .Prerequisites
 
@@ -21,11 +22,16 @@ After you create all of the required infrastructure in {gcp-first}, wait for the
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
-    --log-level info <2>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \
+    --log-level info
 ----
-<1> For `<installation_directory>`, specify the path to the directory where you stored the installation files.
-<2> To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
++
+where:
++
+--
+* `<installation_directory>` specifies the path to the directory where you stored the installation files.
+* `--log-level` specifies the log level. To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
+--
 +
 If the command exits without a `FATAL` warning, your production control plane has initialized.
 

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -7,7 +7,8 @@
 [id="installation-gcp-user-infra-wait-for-bootstrap_{context}"]
 = Removing bootstrap resources in {gcp-short}
 
-After you create all of the required infrastructure in {gcp-first}, wait for the bootstrap process to complete on the machines that you provisioned by using the Ignition config files. The installation program created the Ignition config files.
+[role="_abstract"]
+After the bootstrap process completes on your {gcp-first} infrastructure, you can remove the bootstrap resources to reclaim the capacity that they consume, because the cluster no longer requires them.
 
 .Prerequisites
 
@@ -21,11 +22,16 @@ After you create all of the required infrastructure in {gcp-first}, wait for the
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
-    --log-level info <2>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \
+    --log-level info
 ----
-<1> For `<installation_directory>`, specify the path to the directory where you stored the installation files.
-<2> To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
++
+where:
++
+--
+`<installation_directory>`:: Specifies the path to the directory where you stored the installation files.
+`--log-level`:: Specifies the log level. To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
+--
 +
 If the command exits without a `FATAL` warning, your production control plane has initialized.
 

--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -56,9 +56,7 @@ For a cluster that contains user-provisioned infrastructure, you must deploy all
 |Hosts |Description
 
 |One temporary bootstrap machine
-|The cluster requires the bootstrap machine to deploy the {product-title} cluster
-on the three control plane machines. You can remove the bootstrap machine after
-you install the cluster.
+|The cluster requires the bootstrap machine to deploy the {product-title} cluster on the three control plane machines. You can remove the bootstrap machine after you install the cluster.
 
 |Three control plane machines
 |The control plane machines run the Kubernetes and {product-title} services that form the control plane.
@@ -81,8 +79,7 @@ ifdef::ibm-z[]
 To improve high availability of your cluster, distribute the control plane machines over different hypervisor instances on at least two physical machines.
 endif::ibm-z[]
 ifndef::ibm-z[]
-To maintain high availability of your cluster, use separate physical hosts for
-these cluster machines.
+To maintain high availability of your cluster, use separate physical hosts for these cluster machines.
 endif::ibm-z[]
 ====
 

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -86,8 +86,7 @@ endif::[]
 
 ifndef::azure,gcp[]
 ifdef::ibm-z[]
-During the initial boot, the machines require an HTTP or HTTPS server to
-establish a network connection to download their Ignition config files.
+During the initial boot, the machines require an HTTP or HTTPS server to establish a network connection to download their Ignition config files.
 
 The machines are configured with static IP addresses. No DHCP server is required. Ensure that the machines have persistent IP addresses and hostnames.
 endif::ibm-z[]
@@ -109,7 +108,7 @@ ifndef::ibm-z,azure[]
 [id="installation-host-names-dhcp-user-infra_{context}"]
 == Setting the cluster node hostnames through DHCP
 
-On {op-system-first} machines, the hostname is set through NetworkManager. By default, the machines obtain their hostname through DHCP. If the hostname is not provided by DHCP, set statically through kernel arguments, or another method, it is obtained through a reverse DNS lookup. Reverse DNS lookup occurs after the network has been initialized on a node and can take time to resolve. Other system services can start prior to this and detect the hostname as `localhost` or similar. You can avoid this by using DHCP to provide the hostname for each cluster node.
+On {op-system-first} machines, the hostname is set through NetworkManager. By default, the machines obtain their hostname through DHCP. If the hostname is not provided by DHCP, set statically through kernel arguments, or another method, it is obtained through a reverse DNS lookup. Reverse DNS lookup occurs after the network has been initialized on a node and can take time to resolve. Other system services can start before this and detect the hostname as `localhost` or similar. You can avoid this by using DHCP to provide the hostname for each cluster node.
 
 Additionally, setting the hostnames through DHCP can bypass any manual DNS record name configuration errors in environments that have a DNS split-horizon implementation.
 endif::ibm-z,azure[]

--- a/modules/installation-user-infra-exporting-common-variables.adoc
+++ b/modules/installation-user-infra-exporting-common-variables.adoc
@@ -7,7 +7,8 @@
 [id="installation-user-infra-exporting-common-variables_{context}"]
 = Exporting common variables for Infrastructure Manager templates
 
-You must export a common set of variables that are used with the provided Infrastructure Manager templates used to assist in installing a cluster with user-provisioned infrastructure on {gcp-first}.
+[role="_abstract"]
+You must export a common set of variables for the Infrastructure Manager templates that you use to install a cluster with user-provisioned infrastructure on {gcp-first}.
 
 [NOTE]
 ====

--- a/modules/installation-user-infra-exporting-common-variables.adoc
+++ b/modules/installation-user-infra-exporting-common-variables.adoc
@@ -7,7 +7,8 @@
 [id="installation-user-infra-exporting-common-variables_{context}"]
 = Exporting common variables for Infrastructure Manager templates
 
-You must export a common set of variables that are used with the provided Infrastructure Manager templates used to assist in installing a cluster with user-provisioned infrastructure on {gcp-first}.
+[role="_abstract"]
+You must export a common set of variables that the Infrastructure Manager templates reference to provision the resources for a cluster that uses user-provisioned infrastructure on {gcp-first}.
 
 [NOTE]
 ====

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -8,7 +8,8 @@
 [id="minimum-required-permissions-upi-gcp_{context}"]
 = Required {gcp-short} permissions for user-provisioned infrastructure
 
-When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
+[role="_abstract"]
+Your {gcp-short} service account requires specific permissions to create and manage user-provisioned {product-title} infrastructure. You can attach the `Owner` role to grant all required permissions, or create a custom role with only the minimum permissions that your organization's security policies require.
 
 If your organization's security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the user-provisioned infrastructure for creating and deleting the {product-title} cluster.
 


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster on user-provisioned infrastructure in GCP](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html)
- [Required machines for cluster installation](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-machine-requirements_installing-gcp-user-infra)
- [Installing and configuring CLI tools for GCP](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-install-cli_installing-gcp-user-infra)
- [Required GCP permissions for user-provisioned infrastructure](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#minimum-required-permissions-upi-gcp_installing-gcp-user-infra)
- [Networking requirements for user-provisioned infrastructure](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-network-user-infra_installing-gcp-user-infra)
- [Exporting common variables for Infrastructure Manager templates](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-user-infra-exporting-common-variables_installing-gcp-user-infra)
- [Creating the RHCOS cluster image for the GCP infrastructure](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-rhcos_installing-gcp-user-infra)
- [Removing bootstrap resources in GCP](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra)
- [Adding the ingress DNS records](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra)
- [Completing a GCP installation on user-provisioned infrastructure](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-installation_installing-gcp-user-infra)
- [Approving the certificate signing requests for your machines](https://116800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-approve-csrs_installing-gcp-user-infra)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
