### PR TITLE
OSDOCS-16986-5: ARCH-1: Core Architecture and Components

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -7,9 +7,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The _control plane_, which is composed of control plane machines, manages the {product-title} cluster.
+[role="_abstract"]
+You can use a _control plane_, which is composed of control plane machines, to manage the {product-title} cluster.
 The control plane machines manage workloads on the compute machines, which are also known as worker machines.
-The cluster itself manages all upgrades to the machines by the actions of the Cluster Version Operator (CVO),
+
+The cluster manages all upgrades to the machines by the actions of the Cluster Version Operator (CVO),
 ifndef::openshift-dedicated,openshift-rosa[]
 the Machine Config Operator,
 endif::openshift-dedicated,openshift-rosa[]
@@ -57,7 +59,7 @@ include::modules/arch-olm-operators.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM) concepts and resources]
-* xref:../operators/understanding/olm-understanding-software-catalog.adoc#olm-understanding-software-catalog[Understanding the software catalog].
+* xref:../operators/understanding/olm-understanding-software-catalog.adoc#olm-understanding-software-catalog[Understanding the software catalog]
 
 include::modules/etcd-overview.adoc[leveloffset=+1]
 

--- a/modules/arch-olm-operators.adoc
+++ b/modules/arch-olm-operators.adoc
@@ -6,7 +6,10 @@
 [id="olm-operators_{context}"]
 = Add-on Operators
 
-Operator Lifecycle Manager (OLM) and the software catalog are default components in {product-title} that help manage Kubernetes-native applications as Operators. Together they provide the system for discovering, installing, and managing the optional add-on Operators available on the cluster.
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) and the software catalog are default components in {product-title} that help manage Kubernetes-native applications as Operators. 
+
+Together they provide the system for discovering, installing, and managing the optional add-on Operators available on the cluster.
 
 Using the software catalog in the {product-title} web console,
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -15,7 +18,8 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 administrators with the `dedicated-admin` role
 endif::openshift-dedicated,openshift-rosa[]
-and authorized users can select Operators to install from catalogs of Operators. After installing an Operator from the software catalog, it can be made available globally or in specific namespaces to run in user applications.
+and authorized users can select Operators to install from catalogs of Operators. 
+After installing an Operator from the software catalog, you can make the Operator available globally or in specific namespaces to run in user applications.
 
 Default catalog sources are available that include Red Hat Operators, certified Operators, and community Operators.
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -29,7 +33,7 @@ can also add their own custom catalog sources, which can contain a custom set of
 ifdef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
-All Operators listed in the Operator Hub marketplace should be available for installation. These Operators are considered customer workloads, and are not monitored by Red Hat Site Reliability Engineering (SRE).
+All Operators listed in the Operator Hub marketplace should be available for installation. Red Hat considers these Operators as customer workloads, and are not monitored by Red Hat Site Reliability Engineering (SRE).
 ====
 endif::openshift-dedicated,openshift-rosa[]
 

--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -6,24 +6,33 @@
 [id="architecture-machine-roles_{context}"]
 = Machine roles in {product-title}
 
-{product-title} assigns hosts different roles. These roles define the function of the machine within the cluster. The cluster contains definitions for the standard `master` and `worker` role types.
+[role="_abstract"]
+{product-title} assigns hosts different roles. 
+These roles define the function of the machine within the cluster. 
+The cluster contains definitions for the standard `master` and `worker` role types.
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
-The cluster also contains the definition for the `bootstrap` role. Because the bootstrap machine is used only during cluster installation, its function is explained in the cluster installation documentation.
+The cluster also contains the definition for the `bootstrap` role.
+The installation program uses the bootstrap machine only during cluster deployment. 
+See the cluster installation documentation to learn more about its role.
 ====
 endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
-== Control plane and node host compatibility
-
-The {product-title} version must match between control plane host and node host. For example, in a {product-version} cluster, all control plane hosts must be {product-version} and all nodes must be {product-version}.
-
-Temporary mismatches during cluster upgrades are acceptable. For example, when upgrading from the previous {product-title} version to {product-version}, some nodes will upgrade to {product-version} before others. Prolonged skewing of control plane hosts and node hosts might expose older compute machines to bugs and missing features. Users should resolve skewed control plane hosts and node hosts as soon as possible.
-
+Control plane and node host compatibility::
++
+The {product-title} version must match between control plane host and node host. 
+For example, in a {product-version} cluster, all control plane hosts must be {product-version} and all nodes must be {product-version}.
++
+Temporary mismatches during cluster upgrades are acceptable. 
+For example, when upgrading from the previous {product-title} version to {product-version}, some nodes upgrade to {product-version} before others. 
+Prolonged skewing of control plane hosts and node hosts might expose older compute machines to bugs and missing features. 
+Users can resolve skewed control plane hosts and node hosts as soon as possible.
++
 The `kubelet` service must not be newer than `kube-apiserver`, and can be up to two minor versions older depending on whether your {product-title} version is odd or even. The table below shows the appropriate version compatibility:
-
++
 [cols="2",options="header"]
 |===
 | {product-title} version
@@ -44,32 +53,39 @@ The `kubelet` service must not be newer than `kube-apiserver`, and can be up to 
 endif::openshift-dedicated,openshift-rosa[]
 
 [id="defining-workers_{context}"]
-== Cluster workers
-
-In a Kubernetes cluster, worker nodes run and manage the actual workloads requested by Kubernetes users. The worker nodes advertise their capacity and the scheduler, which is a control plane service, determines on which nodes to start pods and containers. The following important services run on each worker node:
-
+Cluster workers::
++
+In a Kubernetes cluster, worker nodes run and manage the actual workloads requested by Kubernetes users. 
+The worker nodes advertise their capacity and the scheduler, which is a control plane service, determines on which nodes to start pods and containers. The following important services run on each worker node:
++
 * CRI-O, which is the container engine.
 * kubelet, which is the service that accepts and fulfills requests for running and stopping container workloads.
 * A service proxy, which manages communication for pods across workers.
 * The crun or runC low-level container runtime, which creates and runs containers.
-
++
 [NOTE]
 ====
 For information about how to enable runC instead of the default crun, see the documentation for creating a `ContainerRuntimeConfig` CR.
 ====
-
-In {product-title}, compute machine sets control the compute machines, which are assigned the `worker` machine role. Machines with the `worker` role drive compute workloads that are governed by a specific machine pool that autoscales them. Because {product-title} has the capacity to support multiple machine types, the machines with the `worker` role are classed as _compute_ machines. In this release, the terms _worker machine_ and _compute machine_ are used interchangeably because the only default type of compute machine is the worker machine. In future versions of {product-title}, different types of compute machines, such as infrastructure machines, might be used by default.
-
++
+In {product-title}, compute machine sets control the compute machines, which are assigned the `worker` machine role. 
+Machines with the `worker` role drive compute workloads that are governed by a specific machine pool that autoscales them. 
+Because {product-title} has the capacity to support multiple machine types, the machines with the `worker` role are classed as _compute_ machines. 
+In this release, the terms _worker machine_ and _compute machine_ are used interchangeably because the only default type of compute machine is the worker machine. 
+In future versions of {product-title}, different types of compute machines, such as infrastructure machines, might be used by default.
++
 [NOTE]
 ====
-Compute machine sets are groupings of compute machine resources under the `machine-api` namespace. Compute machine sets are configurations that are designed to start new compute machines on a specific cloud provider. Conversely, machine config pools (MCPs) are part of the Machine Config Operator (MCO) namespace. An MCP is used to group machines together so the MCO can manage their configurations and facilitate their upgrades.
+Compute machine sets are groupings of compute machine resources under the `machine-api` namespace. 
+Compute machine sets are configurations that start new compute machines on a specific cloud provider. 
+Conversely, machine config pools (MCPs) are part of the Machine Config Operator (MCO) namespace. 
+An MCP is used to group machines together so the MCO can manage their configurations and facilitate their upgrades.
 ====
 
-[id="defining-masters_{context}"]
-== Cluster control planes
-
-In a Kubernetes cluster, the _master_ nodes run services that are required to control the Kubernetes cluster. In {product-title}, the control plane is comprised of control plane machines that have a `master` machine role. They contain more than just the Kubernetes services for managing the {product-title} cluster.
-
+Cluster control planes::
++
+In a Kubernetes cluster, the _master_ nodes run services that are required to control the Kubernetes cluster. In {product-title}, the control plane consists of control plane machines that have a `master` machine role. They contain more than just the Kubernetes services for managing the {product-title} cluster.
++
 For most {product-title} clusters, control plane machines are defined by a series of standalone machine API resources.
 ifndef::openshift-dedicated,openshift-rosa[]
 For supported cloud provider and {product-title} version combinations, control planes can be managed with control plane machine sets.
@@ -77,8 +93,8 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Control planes are managed with control plane machine sets.
 endif::openshift-dedicated,openshift-rosa[]
-Extra controls apply to control plane machines to prevent you from deleting all of the control plane machines and breaking your cluster.
-
+Extra controls apply to control plane machines to prevent you from deleting all of the control plane machines and making the cluster inoperable.
++
 [NOTE]
 ====
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -88,9 +104,9 @@ ifdef::openshift-dedicated,openshift-rosa[]
 Single availability zone clusters and multiple availability zone clusters require a minimum of three control plane nodes.
 endif::openshift-dedicated,openshift-rosa[]
 ====
-
++
 Services that fall under the Kubernetes category on the control plane include the Kubernetes API server, etcd, the Kubernetes controller manager, and the Kubernetes scheduler.
-
++
 .Kubernetes services that run on the control plane
 [cols="1,2",options="header"]
 |===
@@ -113,9 +129,9 @@ one active leader at a time.
 |Kubernetes scheduler
 |The Kubernetes scheduler watches for newly created pods without an assigned node and selects the best node to host the pod.
 |===
-
++
 There are also OpenShift services that run on the control plane, which include the OpenShift API server, OpenShift controller manager, OpenShift OAuth API server, and OpenShift OAuth server.
-
++
 .OpenShift services that run on the control plane
 [cols="1,2",options="header"]
 |===
@@ -137,16 +153,16 @@ The OpenShift OAuth API server is managed by the Cluster Authentication Operator
 
 The OpenShift OAuth server is managed by the Cluster Authentication Operator.
 |===
-
++
 Some of these services on the control plane machines run as systemd services, while others run as static pods.
-
-Systemd services are appropriate for services that you need to always come up on that particular system shortly after it starts. For control plane machines, those include sshd, which allows remote login. It also includes services such as:
-
++
+Systemd services are appropriate for services that must always start on that particular system shortly after it starts. For control plane machines, such as those include sshd, that allow remote login. It also includes services such as:
++
 * The CRI-O container engine (crio), which runs and manages the containers. {product-title} {product-version} uses CRI-O instead of the Docker Container Engine.
 * Kubelet (kubelet), which accepts requests for managing containers on the machine from control plane services.
-
++
 CRI-O and Kubelet must run directly on the host as systemd services because they need to be running before you can run other containers.
-
++
 The [x-]`installer-*` and [x-]`revision-pruner-*` control plane pods must run with root permissions because they write to the `/etc/kubernetes` directory, which is owned by the root user. These pods are in the following namespaces:
 
 * `openshift-etcd`

--- a/modules/cpmso-control-plane-recovery.adoc
+++ b/modules/cpmso-control-plane-recovery.adoc
@@ -14,7 +14,9 @@ endif::[]
 = Recovery of failed control plane machines
 
 [role="_abstract"]
-The Control Plane Machine Set Operator automates the recovery of control plane machines to maintain cluster availability without manual intervention. When a control plane machine is deleted, the Operator creates a replacement with the configuration that is specified in the `ControlPlaneMachineSet` custom resource (CR).
+The Control Plane Machine Set Operator automates the recovery of control plane machines to maintain cluster availability without manual intervention. 
+
+When a control plane machine is deleted, the Operator creates a replacement with the configuration that is specified in the `ControlPlaneMachineSet` custom resource (CR).
 
 ifndef::openshift-dedicated,openshift-rosa[]
 For clusters that use control plane machine sets, you can configure a machine health check. The machine health check deletes unhealthy control plane machines so that they are replaced.

--- a/modules/etcd-overview.adoc
+++ b/modules/etcd-overview.adoc
@@ -2,36 +2,38 @@
 //
 // * architecture/control-plane.adoc
 
-
 :_mod-docs-content-type: CONCEPT
 [id="etcd-overview_{context}"]
-= Overview of etcd
+= etcd key-value store
 
-etcd is a consistent, distributed key-value store that holds small amounts of data that can fit entirely in memory. Although etcd is a core component of many projects, it is the primary data store for Kubernetes, which is the standard system for container orchestration.
+[role="_abstract"]
+etcd is a consistent, distributed key-value store that holds small amounts of data that can fit entirely in memory. 
 
-[id="etcd-benefits_{context}"]
-== Benefits of using etcd
+Although etcd is a core component of many projects, etcd is the primary data store for Kubernetes, which is the standard system for container orchestration.
 
-By using etcd, you can benefit in several ways:
-
+Benefits of using etcd::
++
+etcd provides the following benefits:
++
 * Maintain consistent uptime for your cloud-native applications, and keep them working even if individual servers fail
 * Store and replicate all cluster states for Kubernetes
 * Distribute configuration data to provide redundancy and resiliency for the configuration of nodes
 
-[id="etcd-architecture_{context}"]
-== How etcd works
-
-To ensure a reliable approach to cluster configuration and management, etcd uses the etcd Operator. The Operator simplifies the use of etcd on a Kubernetes container platform like {product-title}. With the etcd Operator, you can create or delete etcd members, resize clusters, perform backups, and upgrade etcd.
-
+How etcd works::
++
+To ensure a reliable approach to cluster configuration and management, etcd uses the etcd Operator. 
+The Operator simplifies the use of etcd on a Kubernetes container platform like {product-title}. 
+With the etcd Operator, you can create or delete etcd members, resize clusters, perform backups, and upgrade etcd.
++
 The etcd Operator observes, analyzes, and acts:
-
++
 . It observes the cluster state by using the Kubernetes API.
 . It analyzes differences between the current state and the state that you want.
 . It fixes the differences through the etcd cluster management APIs, the Kubernetes API, or both.
-
-etcd holds the cluster state, which is constantly updated. This state is continuously persisted, which leads to a high number of small changes at high frequency.
++
+etcd holds the cluster state, which is constantly updated. etcd continuously persists this state, which leads to a high number of small changes at high frequency.
 ifndef::openshift-dedicated,openshift-rosa[]
-As a result, it is critical to back the etcd cluster member with fast, low-latency I/O. For more information about best practices for etcd, see "Recommended etcd practices".
+As a result, you must back the etcd cluster member with fast, low-latency I/O. For more information about best practices for etcd, see "Recommended etcd practices".
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 As a result, Red Hat Site Reliability Engineering (SRE) backs the etcd cluster member with fast, low-latency I/O.

--- a/modules/operators-overview.adoc
+++ b/modules/operators-overview.adoc
@@ -14,9 +14,13 @@ ifndef::index[]
 = Operators in {product-title}
 endif::[]
 
-Operators are among the most important components of {product-title}. They are the preferred method of packaging, deploying, and managing services on the control plane. They can also provide advantages to applications that users run.
+[role="_abstract"]
+Operators are among the most important components of {product-title}. 
+They are the preferred method of packaging, deploying, and managing services on the control plane. 
+They can also provide advantages to applications that users run.
 
-Operators integrate with Kubernetes APIs and CLI tools such as `kubectl` and the {oc-first}. They provide the means of monitoring applications, performing health checks, managing over-the-air (OTA) updates, and ensuring that applications remain in your specified state.
+Operators integrate with Kubernetes APIs and CLI tools such as `kubectl` and the {oc-first}. 
+Operators provide the means of monitoring applications, performing health checks, managing over-the-air (OTA) updates, and ensuring that applications remain in your specified state.
 
 ifndef::index[]
 Operators also offer a more granular configuration experience. You configure each component by modifying the API that the Operator exposes instead of modifying a global configuration file.
@@ -25,7 +29,9 @@ Because CRI-O and the Kubelet run on every node, almost every other cluster func
 endif::[]
 
 ifdef::index[]
-Operators are designed specifically for Kubernetes-native applications to implement and automate common Day 1 operations, such as installation and configuration. Operators can also automate Day 2 operations, such as autoscaling up or down and creating backups. All of these activities are directed by a piece of software running on your cluster.
+Operators are designed specifically for Kubernetes-native applications to implement and automate common Day 1 operations, such as installation and configuration. 
+Operators can also automate Day 2 operations, such as autoscaling up or down and creating backups. 
+The Operator running on your cluster, directs all of these activities.
 endif::index[]
 
 While both follow similar Operator concepts and goals, Operators in {product-title} are managed by two different systems, depending on their purpose:


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16986](https://redhat.atlassian.net/browse/OSDOCS-16986)

Link to docs preview:

* https://116806--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/control-plane.html
* https://116806--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/index.html
* https://116806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane.html
* https://116806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/index.html
* https://116806--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/index.html
* https://116806--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/control-plane.html
* https://116806--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/index.html