### PR TITLE
[enterprise-4.22] OSDOCS-17043: Restore block titles removed in error

### DIFF
--- a/modules/cco-manual-upgrade-annotation.adoc
+++ b/modules/cco-manual-upgrade-annotation.adoc
@@ -27,7 +27,7 @@ Modify the `CloudCredential` resource to include an `upgradeable-to` annotation.
 $ oc edit cloudcredential cluster
 ----
 +
-*Text to add:*
+.Text to add
 +
 [source,yaml]
 ----

--- a/modules/machineset-azure-confidential-vms.adoc
+++ b/modules/machineset-azure-confidential-vms.adoc
@@ -36,6 +36,7 @@ For more information about related features and functionality, see the {azure-fu
 
 . Edit the following section under the `providerSpec` field:
 +
+.Sample configuration
 --
 [source,yaml]
 ----

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -21,7 +21,7 @@ Before you upgrade a cluster with manually maintained credentials, you must crea
 . Create YAML files with secrets for any `CredentialsRequest` custom resources that the new release image adds. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object.
 +
 --
-*Sample AWS `CredentialsRequest` object with secrets*
+.Sample AWS `CredentialsRequest` object with secrets
 
 [source,yaml]
 ----
@@ -48,7 +48,7 @@ spec:
   ...
 ----
 
-*Sample AWS `Secret` object*
+.Sample AWS `Secret` object
 
 [source,yaml]
 ----
@@ -65,7 +65,7 @@ data:
 =====
 Global Azure and Azure Stack Hub use the same `CredentialsRequest` object and secret formats.
 =====
-*Sample Azure `CredentialsRequest` object with secrets*
+.Sample Azure `CredentialsRequest` object with secrets
 
 [source,yaml]
 ----
@@ -88,7 +88,7 @@ spec:
   ...
 ----
 
-*Sample Azure `Secret` object*
+.Sample Azure `Secret` object
 
 [source,yaml]
 ----
@@ -106,7 +106,7 @@ data:
   azure_resourcegroup: <base64_encoded_azure_resourcegroup>
   azure_region: <base64_encoded_azure_region>
 ----
-*Sample {gcp-short} `CredentialsRequest` object with secrets*
+.Sample {gcp-short} `CredentialsRequest` object with secrets
 
 [source,yaml]
 ----
@@ -131,7 +131,7 @@ spec:
   ...
 ----
 
-*Sample {gcp-short} `Secret` object*
+.Sample {gcp-short} `Secret` object
 
 [source,yaml]
 ----

--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -24,6 +24,7 @@ For more information about the supported instance types, see the following NVIDI
 $ oc get nodes
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE     VERSION
@@ -42,6 +43,7 @@ ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17
 $ oc get machinesets -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                        DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -56,6 +58,7 @@ preserve-dsoc12r4-ktjfc-worker-us-east-2b   2         2         2       2       
 $ oc get machines -n openshift-machine-api | grep worker
 ----
 +
+.Example output
 [source,terminal]
 ----
 preserve-dsoc12r4-ktjfc-worker-us-east-2a-dts8r      Running   m5.xlarge   us-east-2   us-east-2a   3d11h
@@ -104,6 +107,7 @@ to match the new `.metadata.name`.
 $ oc -n openshift-machine-api get preserve-dsoc12r4-ktjfc-worker-us-east-2a -o json | diff preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a.json -
 ----
 +
+.Example output
 [source,terminal]
 ----
 10c10
@@ -138,6 +142,7 @@ $ oc -n openshift-machine-api get preserve-dsoc12r4-ktjfc-worker-us-east-2a -o j
 $ oc create -f preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a.json
 ----
 +
+.Example output
 [source,terminal]
 ----
 machineset.machine.openshift.io/preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a created
@@ -155,6 +160,7 @@ $ oc -n openshift-machine-api get machinesets | grep gpu
 The MachineSet replica count is set to `1` so a new `Machine` object is created automatically.
 
 +
+.Example output
 [source,terminal]
 ----
 preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a   1         1         1       1           4m21s
@@ -167,6 +173,7 @@ preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a   1         1         1       1   
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
 +
+.Example output
 [source,terminal]
 ----
 preserve-dsoc12r4-ktjfc-worker-gpu-us-east-2a    running    g4dn.xlarge   us-east-2   us-east-2a  4m36s

--- a/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
+++ b/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
@@ -26,6 +26,7 @@ The NFD Operator identifies hardware device features in nodes. It solves the gen
 $ oc get pods -n openshift-nfd
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                       READY    STATUS     RESTARTS   AGE

--- a/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
@@ -45,6 +45,7 @@ By default, {azure-full} subscriptions do not have a quota for the {azure-full} 
 $ oc get machineset -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                              DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -68,6 +69,7 @@ $ oc get machineset -n openshift-machine-api myclustername-worker-centralus1 -o 
 $ cat machineset-azure.yaml
 ----
 +
+.Example `machineset-azure.yaml` file
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -164,6 +166,7 @@ $ cp machineset-azure.yaml machineset-azure-gpu.yaml
 
 * Change `.spec.template.spec.providerSpec.value.vmSize` to `Standard_NC4as_T4_v3`.
 +
+.Example `machineset-azure-gpu.yaml` file
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -250,6 +253,7 @@ status:
 $ diff machineset-azure.yaml machineset-azure-gpu.yaml
 ----
 +
+.Example output
 [source,terminal]
 ----
 14c14
@@ -277,6 +281,7 @@ $ diff machineset-azure.yaml machineset-azure-gpu.yaml
 $ oc create -f machineset-azure-gpu.yaml
 ----
 +
+.Example output
 [source,terminal]
 ----
 machineset.machine.openshift.io/myclustername-nc4ast4-gpu-worker-centralus1 created
@@ -289,6 +294,7 @@ machineset.machine.openshift.io/myclustername-nc4ast4-gpu-worker-centralus1 crea
 $ oc get machineset -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                               DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -305,6 +311,7 @@ clustername-n6n4r-worker-centralus3                1         1         1       1
 $ oc get machines -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                                PHASE     TYPE                   REGION      ZONE   AGE
@@ -324,6 +331,7 @@ myclustername-worker-centralus3-p9b8c               Running   Standard_D4s_v3   
 $ oc get nodes
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES                  AGE     VERSION
@@ -343,6 +351,7 @@ myclustername-worker-centralus3-p9b8c               Ready    worker             
 $ oc get machineset -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                   DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -365,6 +374,7 @@ $ oc create -f machineset-azure-gpu.yaml
 oc get machineset -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                          DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -385,6 +395,7 @@ $ oc get machineset -n openshift-machine-api | grep gpu
 +
 The MachineSet replica count is set to `1` so a new `Machine` object is created automatically.
 +
+.Example output
 [source,terminal]
 ----
 myclustername-nc4ast4-gpu-worker-centralus1   1         1         1       1           121m
@@ -397,6 +408,7 @@ myclustername-nc4ast4-gpu-worker-centralus1   1         1         1       1     
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
 +
+.Example output
 [source,terminal]
 ----
 myclustername-nc4ast4-gpu-worker-centralus1-w9bqn   Running   Standard_NC4as_T4_v3   centralus   1      21m

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -40,6 +40,7 @@ machineType: a2-highgpu-1g
 onHostMaintenance: Terminate
 ----
 +
+.Example `a2-highgpu-1g.json` file
 [source,json]
 ----
 {
@@ -151,6 +152,7 @@ onHostMaintenance: Terminate
 $ oc get nodes
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                                                             STATUS     ROLES                  AGE     VERSION
@@ -170,6 +172,7 @@ myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      work
 $ oc get machinesets -n openshift-machine-api
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                               DESIRED   CURRENT   READY   AVAILABLE   AGE
@@ -186,6 +189,7 @@ myclustername-2pt9p-worker-f       0         0                             8h
 $ oc get machines -n openshift-machine-api | grep worker
 ----
 +
+.Example output
 [source,terminal]
 ----
 myclustername-2pt9p-worker-a-mxtnz       Running   n2-standard-4   us-central1   us-central1-a   8h
@@ -241,6 +245,7 @@ to match the new `.metadata.name`.
 $ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o json | diff ocp_{product-version}_machineset-a2-highgpu-1g.json -
 ----
 +
+.Example output
 [source,terminal]
 ----
 15c15
@@ -269,6 +274,7 @@ $ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o jso
 $ oc create -f ocp_{product-version}_machineset-a2-highgpu-1g.json
 ----
 +
+.Example output
 [source,terminal]
 ----
 machineset.machine.openshift.io/myclustername-2pt9p-worker-gpu-a created
@@ -286,6 +292,7 @@ $ oc -n openshift-machine-api get machinesets | grep gpu
 The `MachineSet` replica count is set to `1` so a new `Machine` object is created automatically.
 
 +
+.Example output
 [source,terminal]
 ----
 myclustername-2pt9p-worker-gpu-a   1         1         1       1           5h24m
@@ -298,6 +305,7 @@ myclustername-2pt9p-worker-gpu-a   1         1         1       1           5h24m
 $ oc -n openshift-machine-api get machines | grep gpu
 ----
 +
+.Example output
 [source,terminal]
 ----
 myclustername-2pt9p-worker-gpu-a-wxcr6   Running   a2-highgpu-1g   us-central1   us-central1-a   5h25m


### PR DESCRIPTION
4.22 cherrypick of https://github.com/openshift/openshift-docs/commit/e1986680227629f1b54c25504d72ce4651c23ddc
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/116797

Reason for changes from https://github.com/openshift/openshift-docs/pull/116797:
- `machineset-osp-adding-bare-metal.adoc` is not included in this cherry-pick as it doesn't exist in 4.22.
- `nw-ingress-gateway-api-manage-succession.adoc`: the change applied cleanly with no diff because the bold-to-block-title fix (Example output: → .Example output) was already present on
enterprise-4.22. The original erroneous change was only on 4.20 and 4.21, so there was nothing to restore on 4.22.