### PR TITLE
[6.5] OBSDOCS-2755: Document LokiStack sizing guidance and component scaling

### DIFF
--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -7,7 +7,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
 You can configure a `LokiStack` custom resource (CR) to store application, audit, and infrastructure-related logs.
 
 include::snippets/loki-statement-snip.adoc[leveloffset=+1]
@@ -18,14 +17,13 @@ Before configuring LokiStack, review the deployment sizing guidance and configur
 ====
 
 //Loki storage STS
-[id="installing-log-storage-loki-sts"]
-== Deploying a Loki log store on a cluster that uses short-term credentials
+include::modules/about-loki-storage-sts.adoc[leveloffset=+1]
 
-include::modules/about-loki-storage-sts.adoc[leveloffset=+2]
+include::modules/logging-identity-federation.adoc[leveloffset=+1]
 
-include::modules/logging-identity-federation.adoc[leveloffset=+2]
-include::modules/logging-create-loki-cr-console.adoc[leveloffset=+2,tag=!pre-5.9]
-include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+2]
+include::modules/logging-create-loki-cr-console.adoc[leveloffset=+1,tag=!pre-5.9]
+
+include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+1]
 
 include::modules/logging-loki-log-access.adoc[leveloffset=+1,tag=!NetObservMode]
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]

--- a/configuring/loki-query-performance-troubleshooting.adoc
+++ b/configuring/loki-query-performance-troubleshooting.adoc
@@ -3,11 +3,12 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 
-:toc: 
-[id="loki-query-performance-troubleshooting_{context}"]
+[id="loki-query-performance-troubleshooting"]
 = Loki query performance troubleshooting
 
 :context: loki-query-performance-troubleshooting
+
+toc::[]
 
 This documentation details methods for optimizing your Logging stack to improve query performance and provides steps for troubleshooting.
 

--- a/configuring/tuning-the-log-store.adoc
+++ b/configuring/tuning-the-log-store.adoc
@@ -14,6 +14,8 @@ Configure advanced settings for Loki to optimize reliability, performance, scala
 
 * You have created a `LokiStack` custom resource.
 
+include::modules/understanding-lokistack-dashboards.adoc[leveloffset=+1]
+
 //Enhanced reliability and performance
 include::modules/about-loki-reliability-performance.adoc[leveloffset=+1]
 
@@ -29,6 +31,8 @@ include::modules/loki-restart-hardening.adoc[leveloffset=+2]
 
 //Advanced deployment and scalability
 include::modules/about-loki-advanced-deployment.adoc[leveloffset=+1]
+
+include::modules/loki-sizing-vs-component-scaling.adoc[leveloffset=+2]
 
 include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
 

--- a/installing/installing-the-loki-operator.adoc
+++ b/installing/installing-the-loki-operator.adoc
@@ -9,10 +9,7 @@ toc::[]
 [role="_abstract"]
 The {loki-op} deploys and manages a `LokiStack` instance that serves as the log store for {logging}. You can install the {loki-op} by using the {oc-first} or the {ocp-product-title} web console.
 
-[NOTE]
-====
-Before installing the {loki-op}, review the Loki deployment sizing guidance to determine the appropriate size for your workload. See Additional resources for sizing information.
-====
+Before installing the {loki-op}, review the xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing] guidance to choose an appropriate initial size for your deployment.
 
 include::modules/logging-loki-storage.adoc[leveloffset=+1]
 

--- a/installing/loki-deployment-sizing.adoc
+++ b/installing/loki-deployment-sizing.adoc
@@ -7,7 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Before you install the {loki-op}, choose an initial `LokiStack` deployment size based on your cluster size. After installation, you measure actual log volume and adjust the deployment size as needed. Starting with an appropriate initial size ensures a smooth deployment and minimizes the need for resizing.
+This topic provides guidance for both pre-installation and post-installation sizing:
+
+* Before installation, choose an initial deployment size using the baseline recommendations. You cannot accurately predict log volume before installation.
+* After installation, measure actual log volume using Prometheus metrics and the LokiStack dashboards, and then adjust the deployment size as needed.
+
+Starting with an appropriate initial size ensures a smooth deployment and minimizes the need for resizing.
+
+If your deployment exceeds the capacity of the chosen size, you can either increase the LokiStack size or scale individual components. For guidance on when to resize versus scale components, see xref:../configuring/tuning-the-log-store.adoc#loki-sizing-vs-component-scaling_tuning-the-log-store[LokiStack sizing versus component scaling].
 
 include::modules/understanding-loki-sizing.adoc[leveloffset=+1]
 
@@ -32,3 +39,5 @@ include::modules/loki-sizing-interpretation-guide.adoc[leveloffset=+2]
 * xref:../installing/verifying-cluster-prerequisites.adoc#verifying-cluster-prerequisites[Verifying cluster prerequisites for logging]
 * xref:../installing/configuring-storage-for-lokistack.adoc#configuring-storage-for-lokistack[Configuring object storage for LokiStack]
 * xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]
+* link:https://access.redhat.com/solutions/7092615[How to estimate the LokiStack deployment sizing needed in RHOCP 4]
+* link:https://access.redhat.com/solutions/7092616[How to estimate the LokiStack storage size needed in RHOCP 4]

--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -31,8 +31,8 @@ $ oc create secret generic logging-loki-aws \
   --from-literal=forcepathstyle="true"
 ----
 
-logging-loki-aws::
-  `logging-loki-aws` is the name of the secret.
+[id="AWS_storage_STS_{context}"]
+= AWS storage for STS enabled clusters
 
 forcepathstyle::
   {aws-short} endpoints (those ending in `.amazonaws.com`) use a virtual-hosted style by default, which is equivalent to setting the `forcepathstyle` attribute to `false`. Conversely, non-AWS endpoints use a path style, equivalent to setting  `forcepathstyle` attribute to `true`. If you need to use a virtual-hosted style with non-AWS S3 services, you must explicitly set `forcepathstyle` to `false`.

--- a/modules/logging-loki-storage-azure.adoc
+++ b/modules/logging-loki-storage-azure.adoc
@@ -32,7 +32,7 @@ environment::
   Supported environment values are `AzureGlobal`, `AzureChinaCloud`, `AzureGermanCloud`, or `AzureUSGovernment`.
 
 [id="azure_storage_workload_id_{context}"]
-== Azure storage for {entra-first} enabled clusters
+= Azure storage for {entra-first} enabled clusters
 
 If your cluster has {entra-first} enabled, the Cloud Credential Operator (CCO) supports short-term authentication using {entra-short}.
 

--- a/modules/loki-sizing-vs-component-scaling.adoc
+++ b/modules/loki-sizing-vs-component-scaling.adoc
@@ -1,0 +1,122 @@
+// Module included in the following assemblies:
+//
+// * configuring/tuning-the-log-store.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="loki-sizing-vs-component-scaling_{context}"]
+= LokiStack sizing vs component scaling
+
+[role="_abstract"]
+You can adjust LokiStack capacity by changing the overall t-shirt size or by scaling individual component replicas. Understanding when to use each approach helps optimize resources and maintain performance.
+
+[id="changing-lokistack-size_{context}"]
+== Changing the LokiStack size
+
+Changing the t-shirt size (`1x.pico`, `1x.extra-small`, `1x.small`, `1x.medium`) adjusts CPU, memory, and replica counts for all components proportionally. This is the recommended approach for most sizing adjustments.
+
+When to change the t-shirt size:
+
+* Log ingestion rate has increased beyond the current size capacity (for example, 100 GB/day → 500 GB/day)
+* Query performance degrades due to insufficient resources across multiple components
+* You are scaling the entire logging infrastructure up or down
+
+How to change the size:
+
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small  # Change from 1x.extra-small
+----
+
+Changing the size initiates a rolling restart of all Loki components. Plan sizing changes during maintenance windows.
+
+[id="scaling-individual-components_{context}"]
+== Scaling individual components
+
+You can override the default replica count for specific components using `spec.template.<component>.replicas`. This provides fine-grained control for workload-specific optimizations.
+
+When to scale individual components:
+
+Read-heavy workload (many queries, low ingestion)::
+Increase `querier` and `queryFrontend` replicas to handle query load without changing the overall size.
+
+Write-heavy workload (high ingestion, few queries)::
+Increase `distributor` and `ingester` replicas to handle write throughput.
+
+High-availability requirements::
+Increase gateway replica count for redundancy at the query entry point.
+
+Cost optimization::
+Scale down non-critical components (for example, `ruler` if not using alerting rules) while maintaining ingestion capacity.
+
+Example: Scaling queriers for read-heavy workload:
+
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small
+  template:
+    querier:
+      replicas: 4  # Override default for 1x.small (normally 2)
+    queryFrontend:
+      replicas: 3  # Override default for 1x.small (normally 2)
+----
+
+[IMPORTANT]
+====
+Component replica overrides remain unchanged when you change the size. If you change from `1x.small` to `1x.medium`, the `querier` and `queryFrontend` overrides remain at 4 and 3 replicas instead of adopting the `1x.medium` defaults. Remove explicit replica settings to return to size-based defaults.
+====
+
+[id="decision-guide-sizing-vs-scaling_{context}"]
+== Decision guide
+
+Use the following decision guide to choose between changing the size and scaling components:
+
+[cols="2,3,3",options="header"]
+|===
+|Scenario
+|Recommended Action
+|Reason
+
+|Log ingestion rate exceeds size capacity
+|Change t-shirt size
+|All components need proportional scaling
+
+|High query latency but ingestion is fine
+|Scale `querier` and `queryFrontend` replicas
+|Targeted fix avoids over-provisioning ingesters/distributors
+
+|High ingestion latency but queries are fine
+|Scale `distributor` and `ingester` replicas
+|Targeted fix avoids over-provisioning query components
+
+|Adding alerting rules (ruler enabled)
+|No action needed initially; monitor ruler CPU
+|Ruler resources scale with the t-shirt size
+
+|Want to optimize costs
+|Scale down unused components (for example, `ruler` if unused)
+|Fine-grained control reduces waste
+
+|Unsure what component is bottleneck
+|Change t-shirt size
+|Safer default that scales everything proportionally
+|===
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]
+* xref:../installing/loki-deployment-sizing.adoc#calculating-sizing-after-installation_loki-deployment-sizing[Calculating sizing after installation]
+* xref:../configuring/loki-query-performance-troubleshooting.adoc#loki-query-performance-troubleshooting[Loki query performance troubleshooting]
+* xref:../configuring/tuning-the-log-store.adoc#tuning-the-log-store[Tuning the log store]

--- a/modules/loki-sizing.adoc
+++ b/modules/loki-sizing.adoc
@@ -12,6 +12,11 @@ Loki sizing follows the `1x.<size>` format to specify deployment capacity and pe
 
 Sizing for Loki follows the format of `1x.<size>` where the value `1x` is number of instances and `<size>` specifies performance capabilities.
 
+[NOTE]
+====
+Starting in {logging} 6.6, the `1x.extra-small` and `1x.small` deployment sizes use 3 Loki ingesters instead of 2. This increases the total disk requests for these sizes compared to earlier versions.
+====
+
 The `1x.pico` configuration defines a single Loki deployment with minimal resource and limit requirements, offering high availability (HA) support for all Loki components. This configuration is suited for deployments that do not require a single replication factor or auto-compaction.
 
 Disk requests are similar across size configurations, allowing customers to test different sizes to determine the best fit for their deployment needs.

--- a/modules/understanding-loki-sizing.adoc
+++ b/modules/understanding-loki-sizing.adoc
@@ -19,7 +19,9 @@ QPS (Queries Per Second) measures the rate of log queries against your LokiStack
 * Alert rule evaluations running continuously
 * API queries from monitoring and observability tools
 
-A single user running multiple dashboards can generate 10-20 QPS. The sizing table shows average QPS at 200ms query latency.
+A single user running multiple dashboards can generate 10-20 QPS. The xref:../installing/loki-deployment-sizing.adoc#loki-sizing_loki-deployment-sizing[LokiStack sizing table] shows average QPS at 200ms query latency.
+
+After you install the `LokiStack`, you can view actual QPS metrics on the *LokiStack Reads* and *LokiStack Writes* dashboards. In the {ocp-product-title} web console, navigate to *Observe* → *Dashboards*. The *LokiStack Writes* dashboard is particularly important for scaling decisions, as it shows the write load on LokiStack components receiving logs from the collector. For more information about the available dashboards, see xref:../configuring/tuning-the-log-store.adoc#understanding-lokistack-dashboards_tuning-the-log-store[Understanding LokiStack dashboards].
 
 [id="log-volume-affects-sizing_{context}"]
 == How log volume affects sizing
@@ -28,7 +30,7 @@ Log volume directly impacts the resources required for Loki components:
 
 Ingestion rate (GB/day):: Drives ingester CPU and memory requirements. Higher log volume requires more ingesters to handle the write load.
 
-Retention period:: Drives object storage capacity. Retention multiplied by daily log volume determines total storage needed (for example, 100 GB/day × 30 days = 3 TB storage).
+Retention period:: Drives object storage capacity. Loki compresses logs using the Snappy algorithm with a typical compression factor of 5-7x. Calculate storage as: daily log volume ÷ 6 × retention days (for example, 100 GB per day ÷ 6 × 30 days = 500 GB storage). Actual compression varies based on log content. For detailed guidance, see link:https://access.redhat.com/solutions/7136279[How to estimate the LokiStack storage size needed in RHOCP 4].
 
 Query time range:: Affects querier resource requirements. Queries across longer time ranges require more memory and CPU to process results.
 
@@ -48,27 +50,30 @@ For example, the `1x.medium` size requires:
 [id="determining-initial-deployment-size_{context}"]
 == Determining initial deployment size
 
-Because log volume cannot be predicted before installation, use these baseline recommendations:
+You cannot accurately estimate log volume before installation because log production depends on application verbosity, infrastructure events, and audit configuration, not cluster size. Start with a conservative initial size and adjust after measuring actual log volume.
 
-Small clusters (≤10 nodes)::
-Start with `1x.extra-small` size
+Use these baseline recommendations for initial deployment:
 
-Medium to large clusters (>10 nodes)::
-Start with `1x.medium` size
+Production clusters with typical workloads::
+Start with `1x.small` size. This provides capacity for 500 GB/day and allows headroom for log volume spikes.
 
-Single-node OpenShift (SNO) or edge::
-Start with `1x.pico` size (minimum viable deployment)
+Development, test, or low-traffic clusters::
+Start with `1x.extra-small` size. This handles 100 GB/day and can be resized up after monitoring actual usage.
+
+Single-node OpenShift (SNO) or edge deployments::
+Start with `1x.pico` size. This is the minimum viable deployment (50 GB/day) for resource-constrained environments.
 
 [IMPORTANT]
 ====
-You cannot accurately estimate log volume before installation. Factors that make pre-installation sizing impossible:
+Factors that make pre-installation log volume estimation impossible:
 
-* A single pod can produce 100 GB/day of logs
-* Log volume varies dramatically based on application verbosity, not pod count
-* Infrastructure logs (journald) and audit logs are not produced by containers
-* Cluster activity (pod creation/deletion) affects log volume independently of workload size
+* A single verbose application pod can produce 100 GB per day of logs
+* Log volume varies dramatically based on application log levels (DEBUG vs ERROR)
+* Infrastructure logs (systemd-journald) and audit logs are not produced by containers
+* Cluster activity (pod creation/deletion/restart) generates variable log volume
+* Storage backend performance affects ingestion rate and query performance
 
-Start with a baseline size and adjust after monitoring actual log production.
+After installation, use the procedure in xref:../installing/loki-deployment-sizing.adoc#calculating-sizing-after-installation_loki-deployment-sizing[Calculating sizing after installation] to measure actual log volume and adjust the size.
 ====
 
 [id="calculating-sizing-after-installation_{context}"]
@@ -80,20 +85,25 @@ After the logging stack is running, calculate the correct size based on observed
 
 . Wait at least 24 hours after installation to capture representative log volume patterns.
 
-. Query the actual log ingestion rate using Prometheus:
+. Query the actual log ingestion rate at the Loki distributor using Prometheus:
 +
 [source,terminal]
 ----
-sum by (component_name) (rate(vector_component_sent_bytes_total{component_type="loki", component_kind="sink"}[5m]))
+sum(increase(loki_distributor_bytes_received_total[24h])) / 1024 / 1024 / 1024
 ----
++
+This query returns the total GB ingested per day. The measurement occurs at the Loki distributor, which is the entry point for all logs. Using a 24-hour window provides a more accurate daily average than shorter sampling periods.
 
-. Convert the rate to GB/day and compare against the sizing table:
+. Compare the result against the sizing table and choose the appropriate size:
 +
 [source,terminal]
 ----
-# Example: If query returns 5242880 bytes/second
-# = 5242880 * 86400 / 1073741824 = ~421 GB/day
-# → Requires 1x.small (500 GB/day capacity)
+# Example: The query returns 421 GB
+# → Requires 1x.small (500 GB per day capacity)
+#
+# If the value falls between sizes (for example, 550 GB):
+# → Either choose 1x.medium (2 TB per day capacity)
+# → Or choose 1x.small and scale distributor/ingester replicas
 ----
 
 . Update the `LokiStack` CR with the new size if needed:

--- a/modules/understanding-lokistack-dashboards.adoc
+++ b/modules/understanding-lokistack-dashboards.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * configuring/tuning-the-log-store.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="understanding-lokistack-dashboards_{context}"]
+= Understanding LokiStack dashboards
+
+[role="_abstract"]
+When you deploy a `LokiStack` custom resource, the {loki-op} automatically creates four Grafana dashboards that provide observability into Loki performance and resource usage. These dashboards help you monitor ingestion rates, query performance, storage operations, and retention policies.
+
+[id="accessing-lokistack-dashboards_{context}"]
+== Accessing the LokiStack dashboards
+
+The dashboards are available in the {ocp-product-title} web console. Navigate to *Observe* → *Dashboards*. Filter by "LokiStack" to see all four dashboards.
+
+[id="lokistack-writes-dashboard_{context}"]
+== Writes dashboard
+
+The *LokiStack Writes* dashboard shows log ingestion and write-path performance metrics:
+
+* *Write QPS (queries per second)*: The rate of log ingestion requests to the distributor and ingester components.
+* *Write latency*: The time to process and acknowledge log writes.
+* *Ingester metrics*: Memory usage, active streams, and flush operations.
+* *Distributor metrics*: Request rate, batch size, and forwarding latency.
+
+Use this dashboard to identify write-path bottlenecks, such as distributor overload or ingester memory pressure.
+
+[id="lokistack-reads-dashboard_{context}"]
+== Reads dashboard
+
+The *LokiStack Reads* dashboard shows log query and read-path performance metrics:
+
+* *Read QPS (queries per second)*: The rate of query requests through the gateway, query-frontend, and querier components.
+* *Query latency*: The time to execute queries at each component (p50, p99, p999 percentiles).
+* *Cache hit rates*: Effectiveness of query result and chunk caching.
+* *Querier metrics*: Active queries, queue depth, and resource usage.
+
+This dashboard provides the QPS metrics referenced in the xref:../installing/loki-deployment-sizing.adoc#loki-sizing_loki-deployment-sizing[LokiStack sizing table]. The sizing table shows average QPS at 200ms query latency, which corresponds to the query-frontend latency metrics in this dashboard.
+
+Use this dashboard to identify read-path bottlenecks, such as slow queries, insufficient querier replicas, or poor cache performance.
+
+[id="lokistack-chunks-dashboard_{context}"]
+== Chunks dashboard
+
+The *LokiStack Chunks* dashboard shows chunk storage and compaction metrics:
+
+* *Chunk operations*: Upload rate, download rate, and operation latency to object storage
+* *Chunk cache*: Hit rates and eviction rates for the chunk cache
+* *Compactor metrics*: Compaction job duration, objects processed, and delete operations
+* *Storage metrics*: Object storage request rates and error rates
+
+Use this dashboard to monitor object storage performance and identify storage-related bottlenecks or misconfigurations.
+
+[id="lokistack-retention-dashboard_{context}"]
+== Retention dashboard
+
+The *LokiStack Retention* dashboard shows log retention and deletion metrics:
+
+* *Retention period*: Configured and actual retention for each tenant
+* *Delete operations*: Rate of log deletion and compaction cleanup
+* *Storage reclamation*: Space freed by retention policy enforcement
+* *Compactor status*: Active compaction jobs and completion times
+
+Use this dashboard to verify that retention policies are working as expected and to monitor storage growth trends.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/loki-deployment-sizing.adoc#what-is-qps_loki-deployment-sizing[What is QPS (Queries Per Second)?]
+* xref:../installing/loki-deployment-sizing.adoc#calculating-sizing-after-installation_loki-deployment-sizing[Calculating sizing after installation]
+* xref:../configuring/loki-query-performance-troubleshooting.adoc#loki-query-performance-troubleshooting[Loki query performance troubleshooting]


### PR DESCRIPTION
Cherry-pick of #114433 to standalone-logging-docs-6.5

Addresses r2d2rnd review comments and DITA validation fixes.

**Changes:**
- Add LokiStack Writes dashboard reference for scaling decisions
- Fix compression factor from 10:1 to 5-7x based on upstream docs
- Add note about Loki 6.6 using 3 ingesters
- Add cross-reference to sizing vs component scaling section
- Fix DITA nested section validation errors

**Manual conflict resolutions:**
- Kept environment definition list in Azure storage module
- Applied DITA heading level fix (== to =) for Azure Entra section
- Applied compression factor fix to retention period calculation
- Applied DITA leveloffset fix for STS storage includes

Signed-off-by: John Wilkins <jowilkin@redhat.com>