### PR TITLE
OSDOCS-16989_typos: Fix typos in AWS marketplace and edge machineset modules

### DIFF
--- a/modules/installation-aws-marketplace.adoc
+++ b/modules/installation-aws-marketplace.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 Installing an {product-title} cluster using an {aws-short} Marketplace image is available to customers who purchase the offer in North America.
 
-While the offer must be purchased in North America, you can deploy the cluster to any of the following supported paritions:
+While the offer must be purchased in North America, you can deploy the cluster to any of the following supported partitions:
 
 * Public
 * GovCloud

--- a/modules/post-install-edge-aws-extend-machineset.adoc
+++ b/modules/post-install-edge-aws-extend-machineset.adoc
@@ -15,7 +15,7 @@ The installation program sets the following labels for the `edge` machine pools 
 * `machine.openshift.io/zone-group: <value_of_ZoneGroup>`
 * `machine.openshift.io/zone-type: <value_of_ZoneType>`
 
-The following procedure details how you can create a machine set configuraton that matches the `edge` compute pool configuration.
+The following procedure details how you can create a machine set configuration that matches the `edge` compute pool configuration.
 
 .Prerequisites
 


### PR DESCRIPTION
Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16989

Link to docs preview:
[Supported AWS Marketplace regions](https://116853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-marketplace_installing-aws-account)
[Creating a machine set manifest for an AWS Local Zones or Wavelength Zones node](https://116853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html#post-install-edge-aws-extend-machineset_aws-compute-edge-zone-tasks)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
