### PR TITLE
OSDOCS-20735: CQA fixes for ROSA HCP Tutorials 10-11

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -9,9 +9,12 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-This tutorial teaches you how to configure a set of predictable IP addresses for egress cluster traffic. You can assign a consistent IP address for traffic that leaves your cluster such as security groups which require an IP-based configuration to meet security standards.
+You can configure a set of predictable IP addresses for egress cluster traffic. Assigning a consistent IP address for outbound cluster traffic is useful when external resources, such as security groups, require an IP-based configuration to meet security standards.
 
+[NOTE]
+====
 By default, {product-title} uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
+====
 
 ifdef::openshift-rosa[]
 For more information on configuring an egress IP address, see _Additional resources_.

--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -8,11 +8,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use AWS Controllers for Kubernetes (ACK) to define and use AWS service resources directly from {product-title}. With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster. For more information, see _Additional resources_.
+You can use AWS Controllers for Kubernetes (ACK) to manage AWS service resources directly from {product-title}. With ACK, you don't need to define resources outside of the cluster or run services that provide supporting capabilities.
 
-You can install various ACK Operators directly from the software catalog. This makes it easy to get started and use the Operators with your applications. This controller is a component of the AWS Controller for Kubernetes project, which is currently in developer preview.
+You can install various ACK Operators directly from the software catalog to quickly integrate AWS services with your applications.
 
-Use this tutorial to deploy the ACK S3 Operator. You can also adapt it for any other ACK Operator in the software catalog of your cluster.
+Follow this tutorial to deploy the ACK S3 Operator. You can also adapt these steps for any other ACK Operator in the catalog.
 
 include::modules/cloud-experts-using-aws-ack-environment-setup.adoc[leveloffset=+1]
 

--- a/modules/cloud-experts-using-aws-ack-clean-up.adoc
+++ b/modules/cloud-experts-using-aws-ack-clean-up.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-clean-up_{context}"]
-= Clean up
+= Clean up AWS resources
 
 [role="_abstract"]
-Clean up your AWS resources after completing this lab tutorial.
+Clean up your AWS resources after completing this tutorial.
 
 .Procedure
 . Delete the S3 bucket resource:
@@ -16,19 +16,27 @@ Clean up your AWS resources after completing this lab tutorial.
 ----
 $ oc -n ack-system delete bucket.s3.services.k8s.aws/${CLUSTER-NAME}-bucket
 ----
-+
-. Delete the ACK S3 Operator and the AWS IAM roles:
+
+. Delete the AWS Controller for Kubernetes (ACK) S3 Operator and the AWS Identity and Access Management (IAM) roles:
 +
 [source,terminal]
 ----
 $ oc -n ack-system delete subscription ack-${ACK_SERVICE}-controller
+----
++
+[source,terminal]
+----
 $ aws iam detach-role-policy \
   --role-name "ack-${ACK_SERVICE}-controller" \
   --policy-arn ${POLICY_ARN}
+----
++
+[source,terminal]
+----
 $ aws iam delete-role \
   --role-name "ack-${ACK_SERVICE}-controller"
 ----
-+
+
 . Delete the `ack-system` project:
 +
 [source,terminal]

--- a/modules/cloud-experts-using-aws-ack-environment-setup.adoc
+++ b/modules/cloud-experts-using-aws-ack-environment-setup.adoc
@@ -7,7 +7,7 @@
 = Set up your environment
 
 [role="_abstract"]
-You can use environment variables to ensure consistency across the commands within this lab.
+Set environment variables to ensure consistency across the commands within this tutorial.
 
 .Prerequisites
 * You have created a {product-title} cluster.
@@ -31,7 +31,8 @@ $ export AWS_PAGER=""
 $ export SCRATCH="/tmp/${ROSA_CLUSTER_NAME}/ack"
 $ mkdir -p ${SCRATCH}
 ----
-. Ensure all fields output correctly before moving to the next section:
+
+. Ensure all fields output correctly:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-using-aws-ack-install-ack.adoc
+++ b/modules/cloud-experts-using-aws-ack-install-ack.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-install-ack_{context}"]
-= Install the ACK S3 Controller
+= Install the ACK S3 controller
 
 [role="_abstract"]
-Use the {oc-first} to create a project for your ACK S3 Controller. 
+Configure and deploy the AWS Controllers for Kubernetes (ACK) S3 controller by installing the ACK S3 Operator and associating it with an AWS Identity and Access Management (IAM) role.
 
 .Procedure
 . Create a project to install the ACK S3 Operator into:
@@ -21,7 +21,7 @@ $ oc new-project ack-system
 +
 [NOTE]
 ====
-`ACK_WATCH_NAMESPACE` is purposefully left blank so the controller can properly watch all namespaces in the cluster.
+`ACK_WATCH_NAMESPACE` is purposely left blank so the controller can properly watch all namespaces in the cluster.
 ====
 +
 [source,terminal]
@@ -40,7 +40,7 @@ FEATURE_FLAGS=
 FEATURE_GATES=
 EOF
 ----
-+
+
 . Use the file from the previous step to create a ConfigMap:
 +
 [source,terminal]
@@ -48,7 +48,7 @@ EOF
 $ oc -n ack-system create configmap \
   --from-env-file=${SCRATCH}/config.txt ack-${ACK_SERVICE}-user-config
 ----
-+
+
 . Install the ACK S3 Operator from the software catalog:
 +
 [source,terminal]
@@ -75,7 +75,7 @@ spec:
   sourceNamespace: openshift-marketplace
 EOF
 ----
-+
+
 . Annotate the ACK S3 Operator service account with the AWS IAM role to assume and restart the deployment:
 +
 [source,terminal]
@@ -84,7 +84,9 @@ $ oc -n ack-system annotate serviceaccount ${ACK_SERVICE_ACCOUNT} \
   eks.amazonaws.com/role-arn=${ROLE_ARN} && \
   oc -n ack-system rollout restart deployment ack-${ACK_SERVICE}-controller
 ----
-+
+
+.Verification
+
 . Verify that the ACK S3 Operator is running:
 +
 [source,terminal]
@@ -92,7 +94,7 @@ $ oc -n ack-system annotate serviceaccount ${ACK_SERVICE_ACCOUNT} \
 $ oc -n ack-system get pods
 ----
 +
-.Example
+.Example output
 [source,text]
 ----
 NAME                                 READY   STATUS    RESTARTS   AGE

--- a/modules/cloud-experts-using-aws-ack-prep-aws.adoc
+++ b/modules/cloud-experts-using-aws-ack-prep-aws.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-prep-aws_{context}"]
-= Prepare your AWS Account
+= Prepare your AWS account
 
 [role="_abstract"]
-Before using your AWS controllers, you must prepare your AWS account.
+Create the AWS Identity and Access Management (IAM) trust policy and role that the AWS Controllers for Kubernetes (ACK) Operator requires to manage AWS resources from your {product-title} cluster.
 
 .Procedure
-. Create an AWS Identity and Access Management (IAM) trust policy for the ACK Operator:
+. Create an AWS IAM trust policy for the ACK Operator:
 +
 [source,terminal]
 ----
@@ -34,7 +34,7 @@ $ cat <<EOF > "${SCRATCH}/trust-policy.json"
 }
 EOF
 ----
-+
+
 . Create an AWS IAM role for the ACK Operator to assume with the `AmazonS3FullAccess` policy attached:
 +
 [NOTE]
@@ -47,8 +47,15 @@ You can find the recommended policy in each project's GitHub repository, for exa
 $ ROLE_ARN=$(aws iam create-role --role-name "ack-${ACK_SERVICE}-controller" \
    --assume-role-policy-document "file://${SCRATCH}/trust-policy.json" \
    --query Role.Arn --output text)
+----
++
+[source,terminal]
+----
 $ echo $ROLE_ARN
-
+----
++
+[source,terminal]
+----
 $ aws iam attach-role-policy --role-name "ack-${ACK_SERVICE}-controller" \
      --policy-arn ${POLICY_ARN}
 ----

--- a/modules/cloud-experts-using-aws-ack-valid-deploy.adoc
+++ b/modules/cloud-experts-using-aws-ack-valid-deploy.adoc
@@ -7,7 +7,7 @@
 = Validate the deployment
 
 [role="_abstract"]
-After installing your controller, you can verify the installation by using the {oc-first} tool.
+Verify that the controller is working correctly by deploying a test S3 bucket resource and confirming that it is created in AWS.
 
 .Procedure
 . Deploy an S3 bucket resource:
@@ -24,7 +24,7 @@ spec:
    name: ${CLUSTER-NAME}-bucket
 EOF
 ----
-+
+
 . Verify the S3 bucket was created in AWS:
 +
 [source,terminal]

--- a/modules/egress-ip-assign-ip-namespace.adoc
+++ b/modules/egress-ip-assign-ip-namespace.adoc
@@ -7,7 +7,7 @@
 = Assign an egress IP to a namespace
 
 [role="_abstract"]
-You can assign an egress IP to a namespace on your cluster by using the {oc-first} tool.
+Assign an egress IP to a namespace on your cluster to ensure that all pods inside it use a consistent, predictable address for external connections.
 
 .Procedure
 . Create a new project by running the following command:
@@ -16,7 +16,7 @@ You can assign an egress IP to a namespace on your cluster by using the {oc-firs
 ----
 $ oc new-project demo-egress-ns
 ----
-+
+
 . Create the egress rule for all pods within the namespace by running the following command:
 +
 [source,terminal]

--- a/modules/egress-ip-assigning-to-pod.adoc
+++ b/modules/egress-ip-assigning-to-pod.adoc
@@ -1,15 +1,13 @@
 // Module included in the following assemblies:
 //
 // * cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
-// Module included in the following assemblies:
-//
-// * cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-assigning-to-pod_{context}"]
 = Assign an egress IP to a pod
 
 [role="_abstract"]
-Create an egress rule to assign an egress IP to a specified pod.
+Create an egress rule to assign a consistent egress IP to a specified pod so that its outbound traffic uses a predictable IP.
 
 .Procedure
 . Create a new project by running the following command:
@@ -18,11 +16,11 @@ Create an egress rule to assign an egress IP to a specified pod.
 ----
 $ oc new-project demo-egress-pod
 ----
-+
+
 . Create the egress rule for the pod by running the following command:
 +
 [NOTE]
-==== 
+====
 `spec.namespaceSelector` is a mandatory field.
 ====
 +

--- a/modules/egress-ip-blocked-egress.adoc
+++ b/modules/egress-ip-blocked-egress.adoc
@@ -7,7 +7,7 @@
 = Test blocked egress
 
 [role="_abstract"]
-You can test if the egress is blocked by using the {oc-first} tool. This procedure is optional.
+This procedure is optional. You can test if your egress IP configuration correctly blocks traffic.
 
 .Procedure
 . Test that the traffic is successfully blocked when the egress rules do not apply by running the following command:
@@ -22,7 +22,7 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-+
+
 . Send a request to the load balancer by running the following command:
 +
 [source,terminal]
@@ -30,7 +30,8 @@ $ oc run \
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
 +
-. If the command is unsuccessful, egress is successfully blocked.
+If the command is unsuccessful, egress is successfully blocked.
+
 . Exit the pod by running the following command:
 +
 [source,terminal]

--- a/modules/egress-ip-capacity.adoc
+++ b/modules/egress-ip-capacity.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-capacity_{context}"]
-= Ensure capacity
+= Ensure IP address capacity
 
 [role="_abstract"]
-The number of IP addresses assigned to each node is limited for each public cloud provider. 
+Confirm that your nodes have available IP address capacity. Each public cloud provider limits the number of IP addresses that you can assign to each node.
 
-.Procedure 
+.Procedure
 * Verify sufficient capacity by running the following command:
 +
 [source,terminal]
@@ -23,10 +23,9 @@ $ oc get node -o json | \
         }'
 ----
 +
-*For example*:
-+
+.Example output
 [source,terminal]
----
+----
 {
   "name": "ip-10-10-145-88.ec2.internal",
   "ips": [
@@ -41,4 +40,4 @@ $ oc get node -o json | \
   ],
   "capacity": 14
 }
----
+----

--- a/modules/egress-ip-cluster-cleanup.adoc
+++ b/modules/egress-ip-cluster-cleanup.adoc
@@ -7,21 +7,21 @@
 = Clean up your cluster
 
 [role="_abstract"]
-Before moving to a different tutorial, you can clean up your cluster environment with a few commands.
+Clean up your cluster environment after testing the egress IP configuration.
 
 .Procedure
 . Clean up your cluster by running the following commands:
 +
 [source,terminal]
 ----
-$ oc delete svc demo-service -n default; \
-$ oc delete pod demo-service -n default; \
-$ oc delete project demo-egress-ns; \
-$ oc delete project demo-egress-pod; \
-$ oc delete egressip demo-egress-ns; \
+$ oc delete svc demo-service -n default
+$ oc delete pod demo-service -n default
+$ oc delete project demo-egress-ns
+$ oc delete project demo-egress-pod
+$ oc delete egressip demo-egress-ns
 $ oc delete egressip demo-egress-pod
 ----
-+
+
 . Clean up the assigned node labels by running the following command:
 +
 [WARNING]

--- a/modules/egress-ip-creating-ip-rules.adoc
+++ b/modules/egress-ip-creating-ip-rules.adoc
@@ -7,7 +7,7 @@
 = Create the egress IP rules
 
 [role="_abstract"]
-Before creating the egress IP rules, identify which egress IPs you will use.
+Configure egress IP rules to provide reserved, consistent IP addresses for your outbound cluster traffic. Before creating the egress IP rules, identify which egress IPs to use.
 
 [NOTE]
 ====

--- a/modules/egress-ip-deploy-sample-app.adoc
+++ b/modules/egress-ip-deploy-sample-app.adoc
@@ -7,7 +7,7 @@
 = Deploy a sample application
 
 [role="_abstract"]
-To test the egress IP rule, create a service that is restricted to the egress IP addresses which we have specified. This simulates an external service that is expecting a small subset of IP addresses.
+To test the egress IP rule, create a service that is restricted to the egress IP addresses that you specified. The service simulates an external service that expects a small subset of IP addresses.
 
 .Procedure
 . Run the `echoserver` command to replicate a request:
@@ -16,7 +16,7 @@ To test the egress IP rule, create a service that is restricted to the egress IP
 ----
 $ oc -n default run demo-service --image=gcr.io/google_containers/echoserver:1.4
 ----
-+
+
 . Expose the pod as a service and limit the ingress to the egress IP addresses you specified by running the following command:
 +
 [source,terminal]
@@ -52,7 +52,7 @@ spec:
     - 10.10.200.253/32
 EOF
 ----
-+
+
 . Retrieve the load balancer hostname and save it as an environment variable by running the following command:
 +
 [source,terminal]

--- a/modules/egress-ip-egress-ip-review.adoc
+++ b/modules/egress-ip-egress-ip-review.adoc
@@ -7,7 +7,7 @@
 = Review the egress IPs
 
 [role="_abstract"]
-You can list all of the egress IPs by using the {oc-first} tool.
+Review egress IP assignments to verify that each egress IP address is correctly assigned to a node.
 
 .Procedure
 * Review the egress IP assignments by running the following command:
@@ -17,8 +17,7 @@ You can list all of the egress IPs by using the {oc-first} tool.
 $ oc get egressips
 ----
 +
-*For example*:
-+
+.Example output
 [source,terminal]
 ----
 NAME              EGRESSIPS       ASSIGNED NODE                   ASSIGNED EGRESSIPS

--- a/modules/egress-ip-env-variables.adoc
+++ b/modules/egress-ip-env-variables.adoc
@@ -4,16 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-env-variables_{context}"]
-= Set your environment variables
+= Set environment variables
 
 [role="_abstract"]
-You may set environment variables to make it easier to reuse values.
+Set environment variables to ensure consistency across the commands in this tutorial.
 
 .Prerequisites
 * You have created a {product-title} cluster deployed with OVN-Kubernetes.
 * You have access to the {oc-first}.
 * You have access to the {rosa-cli-first}.
-* You have access to the link:https://jqlang.org/[`jq` JSON processor].
+* You have access to the `jq` command-line JSON processor.
 
 .Procedure
 * Set your environment variables by running the following command:
@@ -26,5 +26,13 @@ Replace the value of the `ROSA_MACHINE_POOL_NAME` variable to target a different
 [source,terminal]
 ----
 $ export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+----
++
+[source,terminal]
+----
 $ export ROSA_MACHINE_POOL_NAME=worker
 ----
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://jqlang.org/[The `jq` command-line JSON processor]

--- a/modules/egress-ip-namespace-egress.adoc
+++ b/modules/egress-ip-namespace-egress.adoc
@@ -7,7 +7,7 @@
 = Test the namespace egress
 
 [role="_abstract"]
-You can test the namespace egress by using the {oc-first} tool.
+Verify that your namespace egress IP configuration works correctly.
 
 .Procedure
 . Start an interactive shell to test the namespace egress rule:
@@ -22,23 +22,22 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-+
+
 . Send a request to the load balancer and ensure that you can successfully connect:
 +
 [source,terminal]
 ----
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
-+
-. Check the output for a successful connection: 
+
+. Check the output for a successful connection:
 +
 [NOTE]
 ====
-The `client_address` is the internal IP address of the load balancer, not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
+The `client_address` is the internal IP address of the load balancer, not your egress IP. You can verify that you have configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
 ====
 +
-*For example*:
-+
+.Example output
 [source,terminal]
 ----
 CLIENT VALUES:
@@ -59,7 +58,7 @@ user-agent=curl/7.76.1
 BODY:
 -no body in request-
 ----
-+
+
 . Exit the pod by running the following command:
 +
 [source,terminal]

--- a/modules/egress-ip-node-labels.adoc
+++ b/modules/egress-ip-node-labels.adoc
@@ -7,7 +7,7 @@
 = Label the nodes
 
 [role="_abstract"]
-You can label your nodes by using the {oc-first} tool.
+Apply labels to worker nodes for egress IP assignments.
 
 .Procedure
 . Obtain your pending egress IP assignments by running the following command:
@@ -17,8 +17,7 @@ You can label your nodes by using the {oc-first} tool.
 $ oc get egressips
 ----
 +
-*For example*:
-+
+.Example output
 [source,terminal]
 ----
 NAME              EGRESSIPS       ASSIGNED NODE   ASSIGNED EGRESSIPS
@@ -27,7 +26,7 @@ demo-egress-pod   10.10.100.254
 ----
 +
 The egress IP rule that you created only applies to nodes with the `k8s.ovn.org/egress-assignable` label. Make sure that the label is only on a specific machine pool.
-+
+
 . Assign the label to your machine pool using the following command:
 +
 [WARNING]

--- a/modules/egress-ip-pod-egress-test.adoc
+++ b/modules/egress-ip-pod-egress-test.adoc
@@ -7,7 +7,7 @@
 = Test the pod egress
 
 [role="_abstract"]
-You can test your pod's egress by using the {oc-first} tool.
+Verify that your egress IP configuration works correctly.
 
 .Procedure
 . Start an interactive shell to test the pod egress rule:
@@ -22,14 +22,14 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-+
+
 . Send a request to the load balancer by running the following command:
 +
 [source,terminal]
 ----
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
-+
+
 . Check the output for a successful connection:
 +
 [NOTE]
@@ -37,8 +37,7 @@ $ curl -s http://$LOAD_BALANCER_HOSTNAME
 The `client_address` is the internal IP address of the load balancer, not your egress IP. You can verify that you have configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
 ====
 +
-*For example*:
-+
+.Example output
 [source,terminal]
 ----
 CLIENT VALUES:
@@ -59,7 +58,7 @@ user-agent=curl/7.76.1
 BODY:
 -no body in request-
 ----
-+
+
 . Exit the pod by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.22+
5.0+
(Not adding 4.21 and 4.20 since the content doesn't touch core OCP docs).

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20735

Link to docs preview:
**ROSA HCP**
https://116867--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html
https://116867--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack.html

**ROSA Classic** - same 2 tutorials
https://116867--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html
https://116867--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack.html

QE review:
N/A

Additional information:
