### PR TITLE
Replace example Bearer token with <secret> placeholder

### DIFF
--- a/modules/http-output-format.adoc
+++ b/modules/http-output-format.adoc
@@ -215,7 +215,7 @@ The log collector sends this as an HTTP POST request:
 POST /logs HTTP/1.1
 Host: logs.example.com
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Authorization: Bearer <secret>
 User-Agent: Vector/0.28.0
 
 {


### PR DESCRIPTION
## Summary
GitHub secret scanning flagged the example JWT token in `modules/http-output-format.adoc` as a potential secret. Replace with generic `<secret>` placeholder to avoid false positive security alerts.

## Changes
- Replace `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` with `<secret>` in HTTP example

## Test plan
- [x] Verify AsciiDoc still renders correctly
- [x] Confirm secret scanning alert will be resolved

## Version
Cherry pick this to standalone-logging-docs-6.6

Signed-off-by: John Wilkins <jowilkin@redhat.com>