### PR TITLE
[2/3] OSDOCS#16925: Apply CQA for etcd (Backup and restore)

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
@@ -11,39 +11,47 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can restore your {product-title} cluster after a disaster by choosing the recovery path for etcd quorum loss, expired certificates, or rollback to an earlier state. Choose the option that matches your failure type before you begin recovery.
+To return your cluster to a working state after quorum loss, control plane failure, or expired certificates, follow the disaster recovery procedures for your situation. You can restore etcd quorum, restore the cluster from an etcd snapshot, or recover from expired control plane certificates.
 
 [IMPORTANT]
 ====
 Disaster recovery requires you to have at least one healthy control plane host.
 ====
 
-Quorum restoration:: This solution handles situations where you have lost the majority of your control plane hosts, leading to etcd quorum loss and the cluster going offline. This solution does not require an etcd backup.
-+
-[NOTE]
-====
-If you have a majority of your control plane nodes still available and have an etcd quorum, you can replace a single unhealthy etcd member instead of performing quorum restoration.
-====
+// Restoring etcd quorum for high availability clusters
+include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+1]
 
-Restoring to an earlier cluster state:: This solution handles situations where you want to restore your cluster to an earlier state, for example, if an administrator deletes something critical. If you have taken an etcd backup, you can restore your cluster to an earlier state.
-+
-[WARNING]
-====
-Restoring to an earlier cluster state is a destructive and destabilizing action to take on a running cluster. This procedure should only be used as a last resort.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
+* xref:../../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
 
-Before you restore, understand the impact a state rollback can have on your cluster.
-====
+// About restoring to a previous cluster state
+include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
 
-Recovering from expired control plane certificates:: This solution handles situations where your control plane certificates have expired. For example, if you shut down your cluster before the first certificate rotation, which occurs 24 hours after installation, your certificates are not rotated and expire. You can follow this procedure to recover from expired control plane certificates.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
 
-// Testing restore procedures
+// Restoring to a previous cluster state for a single node
+include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+1]
+
+// Restoring to a previous cluster state
+include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
+
+include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
+
+// Recovering from expired control plane certificates
+include::modules/dr-recover-expired-control-plane-certs.adoc[leveloffset=+1]
+
+//Testing restore procedures
 include::modules/dr-testing-restore-procedures.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.adoc#dr-quorum-restoration[Quorum restoration]
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-scenario-2-restoring-cluster-state-about_dr-restoring-cluster-state[About restoring cluster state]
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]

--- a/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
+++ b/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
@@ -4,65 +4,47 @@
 
 :_mod-docs-content-type: ASSEMBLY
 [id="etcd-disaster-recovery"]
-include::_attributes/common-attributes.adoc[]
 = Disaster recovery
+include::_attributes/common-attributes.adoc[]
 :context: etcd-disaster-recovery
 
 toc::[]
 
-The disaster recovery documentation provides information for administrators on how to recover from several disaster situations that might occur with their {product-title} cluster. As an administrator, you might need to follow one or more of the following procedures to return your cluster to a working state.
+[role="_abstract"]
+To return your cluster to a working state after quorum loss, control plane failure, or expired certificates, follow the disaster recovery procedures for your situation. You can restore etcd quorum, restore the cluster from an etcd snapshot, or recover from expired control plane certificates.
 
 [IMPORTANT]
 ====
 Disaster recovery requires you to have at least one healthy control plane host.
 ====
 
-[id="etcd-dr-quorum"]
-== Quorum restoration
-
-You can use the `quorum-restore.sh` script to restore etcd quorum on clusters that are offline due to quorum loss. When quorum is lost, the {product-title} API becomes read-only. After quorum is restored, the {product-title} API returns to read/write mode.
-
 // Restoring etcd quorum for high availability clusters
-include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+2]
+include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
 * xref:../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
-
-[NOTE]
-====
-If you have a majority of your control plane nodes still available and have an etcd quorum, xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[replace a single unhealthy etcd member].
-====
-
-[id="etcd-dr-restore"]
-== Restoring to a previous cluster state
-
-To restore the cluster to a previous state, you must have previously backed up the `etcd` data by creating a snapshot. You will use this snapshot to restore the cluster state. For more information, see "Backing up etcd data".
-
-If applicable, you might also need to xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[recover from expired control plane certificates].
-
-[WARNING]
-====
-Restoring to a previous cluster state is a destructive and destablizing action to take on a running cluster. This procedure should only be used as a last resort.
-
-Before performing a restore, see "About restoring to a previous cluster state" for more information on the impact to the cluster.
-====
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
 
 // About restoring to a previous cluster state
-include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+2]
+include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
 
 // Restoring to a previous cluster state for a single node
-include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+2]
+include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+1]
 
 // Restoring to a previous cluster state
-include::modules/dr-restoring-cluster-state.adoc[leveloffset=+2]
+include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
 
-include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+2]
+include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
 
 // Recovering from expired control plane certificates
 include::modules/dr-recover-expired-control-plane-certs.adoc[leveloffset=+1]

--- a/modules/dr-recover-expired-control-plane-certs.adoc
+++ b/modules/dr-recover-expired-control-plane-certs.adoc
@@ -44,9 +44,7 @@ In the example output, CSRs with a `SIGNERNAME` of `kubernetes.io/kubelet-servin
 $ oc describe csr <csr_name>
 ----
 +
-where:
-
-`<csr_name>`:: Specifies the name of a CSR from the list of current CSRs.
+`<csr_name>` is the name of a CSR from the list of current CSRs.
 
 . Approve each valid `node-bootstrapper` CSR by running the following command:
 +

--- a/modules/dr-restoring-cluster-state-about.adoc
+++ b/modules/dr-restoring-cluster-state-about.adoc
@@ -15,6 +15,8 @@ You can use an etcd backup to restore your cluster to an earlier state. This can
 * The cluster has lost the majority of control plane hosts and quorum.
 * An administrator has deleted something critical and must restore to recover the cluster.
 
+If applicable, you might also need to recover from expired control plane certificates.
+
 [WARNING]
 ====
 Restoring to an earlier cluster state is a destructive and destabilizing action to take on a running cluster. This should only be used as a last resort.

--- a/modules/dr-restoring-etcd-quorum-ha.adoc
+++ b/modules/dr-restoring-etcd-quorum-ha.adoc
@@ -7,7 +7,13 @@
 [id="dr-restoring-etcd-quorum-ha_{context}"]
 = Restoring etcd quorum for high availability clusters
 
+[role="_abstract"]
 You can use the `quorum-restore.sh` script to restore etcd quorum on clusters that are offline due to quorum loss. When quorum is lost, the {product-title} API becomes read-only. After quorum is restored, the {product-title} API returns to read/write mode.
+
+[NOTE]
+====
+If you have a majority of your control plane nodes still available and have an etcd quorum, replace a single unhealthy etcd member.
+====
 
 The `quorum-restore.sh` script instantly brings back a new single-member etcd cluster based on its local data directory and marks all other members as invalid by retiring the previous cluster identifier. No prior backup is required to restore the control plane from.
 
@@ -93,26 +99,27 @@ $ oc get machines -n openshift-machine-api -o wide
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                                        PHASE     TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
-clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped <1>
+clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped
 clustername-8qw5l-master-1                  Running   m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-143-125.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running   m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-154-194.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba  running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running   m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> This is the control plane machine for the offline node, `ip-10-0-131-183.ec2.internal`.
++
+`clustername-8qw5l-master-0` is the control plane machine for the offline node, `ip-10-0-131-183.ec2.internal`.
 
 .. Delete the machine of the offline node by running:
 +
 [source,terminal]
 ----
-$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
+$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0
 ----
-<1> Specify the name of the control plane machine for the offline node.
++
+Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the offline node.
 +
 A new machine is automatically provisioned after deleting the machine of the offline node.
 
@@ -124,18 +131,18 @@ $ oc get machines -n openshift-machine-api -o wide
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                                        PHASE          TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
 clustername-8qw5l-master-1                  Running        m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-143-125.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running        m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-154-194.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba  running
-clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-173-171.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8  running <1>
+clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-173-171.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8  running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running        m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> The new machine, `clustername-8qw5l-master-3` is being created and is ready after the phase changes from `Provisioning` to `Running`.
++
+The new machine, `clustername-8qw5l-master-3`, is being created and is ready after the phase changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator will automatically synchronize when the machine or node returns to a healthy state.
 

--- a/modules/manually-restoring-cluster-etcd-backup.adoc
+++ b/modules/manually-restoring-cluster-etcd-backup.adoc
@@ -7,6 +7,9 @@
 [id="manually-restoring-cluster-etcd-backup_{context}"]
 = Restoring a cluster manually from an etcd backup
 
+[role="_abstract"]
+Manually restore your cluster from an etcd backup by starting a three-member etcd cluster on existing control plane nodes, without re-creating nodes as required by the standard restore procedure.
+
 The restore procedure described in the section "Restoring to a previous cluster state": 
 
 * Requires the complete recreation of 2 control plane nodes, which might be a complex procedure for clusters installed with the UPI installation method, since an UPI installation does not create any `Machine` or `ControlPlaneMachineset` for the control plane nodes.
@@ -182,9 +185,8 @@ The port used must be 2380 and not 2379. The port 2379 is used for etcd database
 .Example output
 [source,terminal,subs="attributes+"]
 ----
-<ETCD_NAME_0>=<ETCD_NODE_PEER_URL_0>,<ETCD_NAME_1>=<ETCD_NODE_PEER_URL_1>,<ETCD_NAME_2>=<ETCD_NODE_PEER_URL_2> <1>
+<ETCD_NAME_0>=<ETCD_NODE_PEER_URL_0>,<ETCD_NAME_1>=<ETCD_NODE_PEER_URL_1>,<ETCD_NAME_2>=<ETCD_NODE_PEER_URL_2>
 ----
-<1> Specifies the `ETCD_NODE_PEER_URL` values from each control plane host.
 +
 The `<ETCD_INITIAL_CLUSTER>` value remains same across all control plane hosts. The same value is required in the next steps on every control plane host.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16925](https://redhat.atlassian.net/browse/OSDOCS-16925)

Link to docs preview:
TBD

QE review:
- [ ] QE has approved this change.

Additional information:

There are three PRs to fully update the content for the etcd Backup and restore book. This is part two of three.