### PR TITLE
[3/3] OSDOCS#16925: Apply CQA for etcd (Backup and restore)

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -10,37 +10,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This document describes the process to replace a single unhealthy etcd member.
-
-This process depends on whether the etcd member is unhealthy because the machine is not running or the node is not ready, or whether it is unhealthy because the etcd pod is crashlooping.
+[role="_abstract"]
+To restore etcd quorum when a single member is unhealthy, identify the member and determine whether its machine is stopped, its node is not ready, or its pod is crashlooping. You can then follow the replacement procedure that matches that state.
 
 [NOTE]
 ====
-If you have lost the majority of your control plane hosts, follow the disaster recovery procedure to xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state] instead of this procedure.
+If you have lost the majority of your control plane hosts, follow the steps in "Restoring to a previous cluster state" instead of this procedure..
 
-If the control plane certificates are not valid on the member being replaced, then you must follow the procedure to xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[recover from expired control plane certificates] instead of this procedure.
+If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
 ====
-
-== Prerequisites
-
-* Take an xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] prior to replacing an unhealthy etcd member.
 
 // Identifying an unhealthy etcd member
 include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
 
 // Determining the state of the unhealthy etcd member
 include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
-
-== Replacing the unhealthy etcd member
-
-Depending on the state of your unhealthy etcd member, use one of the following procedures:
-
-* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node in an unhealthy cluster]
-* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
-* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy stopped baremetal etcd member]
 
 // Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
@@ -57,6 +43,7 @@ include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]
 include::modules/restore-replace-stopped-baremetal-etcd-member.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-[id="additional-resources_replacing-unhealthy-etcd-member"]
-== Additional resources
+.Additional resources
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
 * xref:../../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-etcd_deleting-machine[Quorum protection with machine lifecycle hooks]

--- a/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
+++ b/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
@@ -4,19 +4,20 @@
 
 :_mod-docs-content-type: ASSEMBLY
 [id="replace-unhealthy-etcd-member"]
-include::_attributes/common-attributes.adoc[]
 = Replacing an unhealthy etcd member
+include::_attributes/common-attributes.adoc[]
 :context: replace-unhealthy-etcd-member
 
 toc::[]
 
-The process to replace a single unhealthy etcd member depends on whether the etcd member is unhealthy because the machine is not running or the node is not ready, or because the etcd pod is crashlooping.
+[role="_abstract"]
+To restore etcd quorum when a single member is unhealthy, identify the member and determine whether its machine is stopped, its node is not ready, or its pod is crashlooping. You can then follow the replacement procedure that matches that state.
 
 [NOTE]
 ====
-If you have lost the majority of your control plane hosts, follow the disaster recovery procedure to xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state] instead of this procedure.
+If you have lost the majority of your control plane hosts, follow the steps in "Restoring to a previous cluster state" instead of this procedure..
 
-If the control plane certificates are not valid on the member being replaced, then you must follow the procedure to xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[recover from expired control plane certificates] instead of this procedure.
+If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
 ====
@@ -26,15 +27,6 @@ include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
 
 // Determining the state of the unhealthy etcd member
 include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
-
-== Replacing the unhealthy etcd member
-
-Depending on the state of your unhealthy etcd member, use one of the following procedures:
-
-* Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
-* Replacing a control plane node on an unhealthy cluster
-* Replacing an unhealthy etcd member whose etcd pod is crashlooping
-* Replacing an unhealthy stopped baremetal etcd member
 
 // Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
@@ -52,4 +44,6 @@ include::modules/restore-replace-stopped-baremetal-etcd-member.adoc[leveloffset=
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
 * xref:../../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-etcd_deleting-machine[Quorum protection with machine lifecycle hooks]

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -7,12 +7,13 @@
 [id="restore-determine-state-etcd-member_{context}"]
 = Determining the state of the unhealthy etcd member
 
+[role="_abstract"]
+Determine whether an unhealthy etcd member has a stopped machine or not-ready node, or a crashlooping pod, so you can follow the correct replacement procedure.
+
 The steps to replace an unhealthy etcd member depend on which of the following states your etcd member is in:
 
 * The machine is not running or the node is not ready
 * The etcd pod is crashlooping
-
-This procedure determines which state your etcd member is in. This enables you to know which procedure to follow to replace the unhealthy etcd member.
 
 [NOTE]
 ====
@@ -36,12 +37,13 @@ $ oc get machines -A -ojsonpath='{range .items[*]}{@.status.nodeRef.name}{"\t"}{
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal  stopped <1>
+ip-10-0-131-183.ec2.internal  stopped
 ----
-<1> This output lists the node and the status of the node's machine. If the status is anything other than `running`, then the *machine is not running*.
++
+This output lists the node and the status of the node's machine. If the status is anything other than `running`, then the *machine is not running*.
 +
 // TODO: xref
-If the *machine is not running*, then follow the _Replacing an unhealthy etcd member whose machine is not running or whose node is not ready_ procedure.
+If the *machine is not running*, then follow the steps in "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
 
 
 . Determine if the *node is not ready*.
@@ -58,9 +60,10 @@ $ oc get nodes -o jsonpath='{range .items[*]}{"\n"}{.metadata.name}{"\t"}{range 
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal	node-role.kubernetes.io/master node.kubernetes.io/unreachable node.kubernetes.io/unreachable <1>
+ip-10-0-131-183.ec2.internal	node-role.kubernetes.io/master node.kubernetes.io/unreachable node.kubernetes.io/unreachable
 ----
-<1> If the node is listed with an `unreachable` taint, then the *node is not ready*.
++
+If the node is listed with an `unreachable` taint, then the *node is not ready*.
 
 ** If the node is still reachable, then check whether the node is listed as `NotReady`:
 +
@@ -72,13 +75,14 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.35.4 <1>
+ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.35.4
 ----
-<1> If the node is listed as `NotReady`, then the *node is not ready*.
++
+If the node is listed as `NotReady`, then the *node is not ready*.
 
 +
 // TODO: xref
-If the *node is not ready*, then follow the _Replacing an unhealthy etcd member whose machine is not running or whose node is not ready_ procedure.
+If the *node is not ready*, then follow the "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready" procedure.
 
 
 . Determine if the *etcd pod is crashlooping*.
@@ -111,12 +115,13 @@ $ oc -n openshift-etcd get pods -l k8s-app=etcd
 .Example output
 [source,terminal]
 ----
-etcd-ip-10-0-131-183.ec2.internal                2/3     Error       7          6h9m <1>
+etcd-ip-10-0-131-183.ec2.internal                2/3     Error       7          6h9m
 etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          6h6m
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          6h6m
 ----
-<1> Since this status of this pod is `Error`, then the *etcd pod is crashlooping*.
++
+Since the status of the `etcd-ip-10-0-131-183.ec2.internal` pod is `Error`, then the *etcd pod is crashlooping*.
 
 +
 // TODO: xref
-If the *etcd pod is crashlooping*, then follow the _Replacing an unhealthy etcd member whose etcd pod is crashlooping_ procedure.
+If the *etcd pod is crashlooping*, then follow the steps in "Replacing an unhealthy etcd member whose etcd pod is crashlooping".

--- a/modules/restore-identify-unhealthy-etcd-member.adoc
+++ b/modules/restore-identify-unhealthy-etcd-member.adoc
@@ -7,7 +7,8 @@
 [id="restore-identify-unhealthy-etcd-member_{context}"]
 = Identifying an unhealthy etcd member
 
-You can identify if your cluster has an unhealthy etcd member.
+[role="_abstract"]
+Identify an unhealthy etcd member by checking the `EtcdMembersAvailable` status condition so you can proceed with the correct replacement procedure.
 
 .Prerequisites
 

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -7,7 +7,8 @@
 [id="restore-replace-crashlooping-etcd-member_{context}"]
 = Replacing an unhealthy etcd member whose etcd pod is crashlooping
 
-This procedure details the steps to replace an etcd member that is unhealthy because the etcd pod is crashlooping.
+[role="_abstract"]
+Replace a crashlooping etcd member by removing it from the cluster and creating a healthy replacement so the control plane can regain quorum.
 
 .Prerequisites
 
@@ -31,9 +32,10 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc debug node/ip-10-0-131-183.ec2.internal <1>
+$ oc debug node/<unhealthy_node>
 ----
-<1> Replace this with the name of the unhealthy node.
++
+Replace `<unhealthy_node>` with the name of the unhealthy etcd member.
 
 .. Change your root directory to `/host`:
 +
@@ -160,9 +162,10 @@ This command ensures that you can successfully re-create secrets and roll out th
 +
 [source,terminal]
 ----
-$ oc get secrets -n openshift-etcd | grep ip-10-0-131-183.ec2.internal <1>
+$ oc get secrets -n openshift-etcd | grep <unhealthy_node>
 ----
-<1> Pass in the name of the unhealthy etcd member that you took note of earlier in this procedure.
++
+Replace `<unhealthy_node>` with the name of the unhealthy etcd member.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
 +
@@ -203,9 +206,10 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "single-master-recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge <1>
+$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "single-master-recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
 ----
-<1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
++
+The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
 +
 When the etcd cluster Operator performs a redeployment, it ensures that all control plane nodes have a functioning etcd pod.
 

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -7,7 +7,8 @@
 [id="restore-replace-stopped-baremetal-etcd-member_{context}"]
 = Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready
 
-This procedure details the steps to replace a bare metal etcd member that is unhealthy either because the machine is not running or because the node is not ready.
+[role="_abstract"]
+Replace a bare metal etcd member whose machine is not running or whose node is not ready by removing it from the cluster and provisioning a replacement control plane machine.
 
 If you are running installer-provisioned infrastructure or you used the Machine API to create your machines, follow these steps. Otherwise you must create the new control plane node using the same method that was used to originally create it.
 
@@ -137,7 +138,6 @@ Pass in the name of the unhealthy etcd member that you took note of earlier in t
 +
 There is a peer, serving, and metrics secret as shown in the following output:
 +
-
 [source,terminal]
 ----
 etcd-peer-openshift-control-plane-2             kubernetes.io/tls   2   134m
@@ -152,7 +152,11 @@ etcd-serving-openshift-control-plane-2          kubernetes.io/tls   2   134m
 [source,terminal]
 ----
 $ oc delete secret etcd-peer-openshift-control-plane-2 -n openshift-etcd
-
+----
++
+.Example output
+[source,terminal]
+----
 secret "etcd-peer-openshift-control-plane-2" deleted
 ----
 
@@ -161,7 +165,11 @@ secret "etcd-peer-openshift-control-plane-2" deleted
 [source,terminal]
 ----
 $ oc delete secret etcd-serving-metrics-openshift-control-plane-2 -n openshift-etcd
-
+----
++
+.Example output
+[source,terminal]
+----
 secret "etcd-serving-metrics-openshift-control-plane-2" deleted
 ----
 
@@ -170,7 +178,11 @@ secret "etcd-serving-metrics-openshift-control-plane-2" deleted
 [source,terminal]
 ----
 $ oc delete secret etcd-serving-openshift-control-plane-2 -n openshift-etcd
-
+----
++
+.Example output
+[source,terminal]
+----
 secret "etcd-serving-openshift-control-plane-2" deleted
 ----
 
@@ -187,13 +199,14 @@ $ oc get machines -n openshift-machine-api -o wide
 [source,terminal]
 ----
 NAME                              PHASE     TYPE   REGION   ZONE   AGE     NODE                               PROVIDERID                                                                                              STATE
-examplecluster-control-plane-0    Running                          3h11m   openshift-control-plane-0   baremetalhost:///openshift-machine-api/openshift-control-plane-0/da1ebe11-3ff2-41c5-b099-0aa41222964e   externally provisioned <1>
+examplecluster-control-plane-0    Running                          3h11m   openshift-control-plane-0   baremetalhost:///openshift-machine-api/openshift-control-plane-0/da1ebe11-3ff2-41c5-b099-0aa41222964e   externally provisioned
 examplecluster-control-plane-1    Running                          3h11m   openshift-control-plane-1   baremetalhost:///openshift-machine-api/openshift-control-plane-1/d9f9acbc-329c-475e-8d81-03b20280a3e1   externally provisioned
 examplecluster-control-plane-2    Running                          3h11m   openshift-control-plane-2   baremetalhost:///openshift-machine-api/openshift-control-plane-2/3354bdac-61d8-410f-be5b-6a395b056135   externally provisioned
 examplecluster-compute-0          Running                          165m    openshift-compute-0         baremetalhost:///openshift-machine-api/openshift-compute-0/3d685b81-7410-4bb3-80ec-13a31858241f         provisioned
 examplecluster-compute-1          Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
-<1> This is the control plane machine for the unhealthy node, `examplecluster-control-plane-2`.
++
+`examplecluster-control-plane-0` is the control plane machine for the unhealthy node, `examplecluster-control-plane-2`.
 
 . Ensure that the Bare Metal Operator is available by running the following command:
 +
@@ -283,7 +296,11 @@ examplecluster-compute-1          Running                          165m    opens
 [source,terminal]
 ----
 $ oc get nodes
-
+----
++
+.Example output
+[source,terminal]
+----
 NAME                     STATUS ROLES   AGE   VERSION
 openshift-control-plane-0 Ready master 3h24m v1.35.4
 openshift-control-plane-1 Ready master 3h24m v1.35.4
@@ -347,10 +364,13 @@ After the inspection is complete, the `BareMetalHost` object is created and avai
 . Verify the creation process using available `BareMetalHost` objects:
 +
 [source,terminal]
-
 ----
 $ oc get bmh -n openshift-machine-api
-
+----
++
+.Example output
+[source,terminal]
+----
 NAME                      STATE                  CONSUMER                      ONLINE ERROR   AGE
 openshift-control-plane-0 externally provisioned examplecluster-control-plane-0 true         4h48m
 openshift-control-plane-1 externally provisioned examplecluster-control-plane-1 true         4h48m
@@ -358,7 +378,6 @@ openshift-control-plane-2 available              examplecluster-control-plane-3 
 openshift-compute-0       provisioned            examplecluster-compute-0       true         4h48m
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
-
 
 .. Verify that a new machine has been created:
 +
@@ -371,13 +390,14 @@ $ oc get machines -n openshift-machine-api -o wide
 [source,terminal]
 ----
 NAME                                   PHASE     TYPE   REGION   ZONE   AGE     NODE                              PROVIDERID                                                                                            STATE
-examplecluster-control-plane-0         Running                          3h11m   openshift-control-plane-0   baremetalhost:///openshift-machine-api/openshift-control-plane-0/da1ebe11-3ff2-41c5-b099-0aa41222964e   externally provisioned <1>
+examplecluster-control-plane-0         Running                          3h11m   openshift-control-plane-0   baremetalhost:///openshift-machine-api/openshift-control-plane-0/da1ebe11-3ff2-41c5-b099-0aa41222964e   externally provisioned
 examplecluster-control-plane-1         Running                          3h11m   openshift-control-plane-1   baremetalhost:///openshift-machine-api/openshift-control-plane-1/d9f9acbc-329c-475e-8d81-03b20280a3e1   externally provisioned
 examplecluster-control-plane-2         Running                          3h11m   openshift-control-plane-2   baremetalhost:///openshift-machine-api/openshift-control-plane-2/3354bdac-61d8-410f-be5b-6a395b056135   externally provisioned
 examplecluster-compute-0               Running                          165m    openshift-compute-0         baremetalhost:///openshift-machine-api/openshift-compute-0/3d685b81-7410-4bb3-80ec-13a31858241f         provisioned
 examplecluster-compute-1               Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
-<1> The new machine, `clustername-8qw5l-master-3` is being created and is ready after the phase changes from `Provisioning` to `Running`.
++
+The new machine is being created and is ready after the phase changes from `Provisioning` to `Running`.
 +
 It should take a few minutes for the new machine to be created. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
 
@@ -411,7 +431,6 @@ $ oc get nodes
 .Example output
 [source,terminal]
 ----
-$ oc get nodes
 NAME                     STATUS ROLES   AGE   VERSION
 openshift-control-plane-0 Ready master 4h26m v1.35.4
 openshift-control-plane-1 Ready master 4h26m v1.35.4
@@ -465,10 +484,10 @@ If the output from the previous command only lists two pods, you can manually fo
 +
 [source,terminal]
 ----
-$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge <1>
+$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
 ----
 +
-<1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
+The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
 +
 To verify there are exactly three etcd members, connect to the running etcd container, passing in the name of a pod that was not on the affected node. In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
 +

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -7,7 +7,8 @@
 [id="restore-replace-stopped-etcd-member_{context}"]
 = Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 
-This procedure details the steps to replace an etcd member that is unhealthy either because the machine is not running or because the node is not ready.
+[role="_abstract"]
+Replace an etcd member whose machine is not running or whose node is not ready by removing it from the cluster and provisioning a replacement control plane machine.
 
 [NOTE]
 ====
@@ -87,7 +88,7 @@ Take note of the ID and the name of the unhealthy etcd member because these valu
 +
 [source,terminal]
 ----
-sh-4.2# etcdctl member remove 6fc1e7c9db35841d
+sh-4.2# etcdctl member remove <etcd_member_id>
 ----
 +
 .Example output
@@ -154,9 +155,10 @@ $ oc delete node ip-10-0-131-183.ec2.internal
 +
 [source,terminal]
 ----
-$ oc get secrets -n openshift-etcd | grep ip-10-0-131-183.ec2.internal <1>
+$ oc get secrets -n openshift-etcd | grep <unhealthy_node>
 ----
-<1> Pass in the name of the unhealthy etcd member that you took note of earlier in this procedure.
++
+Replace `<unhealthy_node>` with the name of the unhealthy etcd member that you took note of earlier in this procedure. The examples throughout this procedure use `ip-10-0-131-183.ec2.interal` as the name of the unhealthy etcd member.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
 +
@@ -215,22 +217,24 @@ $ oc get machines -n openshift-machine-api -o wide
 [source,terminal]
 ----
 NAME                                        PHASE     TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
-clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped <1>
+clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped
 clustername-8qw5l-master-1                  Running   m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-154-204.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running   m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-164-97.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba   running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running   m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> This is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
++
+`clustername-8qw5l-master-0` is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
 
 .. Delete the machine of the unhealthy member:
 +
 [source,terminal]
 ----
-$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
+$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0
 ----
-<1> Specify the name of the control plane machine for the unhealthy node.
++
+Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the unhealthy node.
 +
 A new machine is automatically provisioned after deleting the machine of the unhealthy member.
 
@@ -247,12 +251,13 @@ $ oc get machines -n openshift-machine-api -o wide
 NAME                                        PHASE          TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
 clustername-8qw5l-master-1                  Running        m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-154-204.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running        m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-164-97.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba   running
-clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-133-53.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8   running <1>
+clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-133-53.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8   running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running        m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> The new machine, `clustername-8qw5l-master-3` is being created and is ready once the phase changes from `Provisioning` to `Running`.
++
+The new machine, `clustername-8qw5l-master-3`, is being created and is ready once the phase changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 +
@@ -278,25 +283,27 @@ $ oc get machines -n openshift-machine-api -o wide
 [source,terminal]
 ----
 NAME                                        PHASE     TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
-clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped <1>
+clustername-8qw5l-master-0                  Running   m4.xlarge   us-east-1   us-east-1a   3h37m   ip-10-0-131-183.ec2.internal   aws:///us-east-1a/i-0ec2782f8287dfb7e   stopped
 clustername-8qw5l-master-1                  Running   m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-154-204.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running   m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-164-97.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba   running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running   m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> This is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
++
+`clustername-8qw5l-master-0` is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
 
 .. Save the machine configuration to a file on your file system:
 +
 [source,terminal]
 ----
-$ oc get machine clustername-8qw5l-master-0 \ <1>
+$ oc get machine clustername-8qw5l-master-0 \
     -n openshift-machine-api \
     -o yaml \
     > new-master-machine.yaml
 ----
-<1> Specify the name of the control plane machine for the unhealthy node.
++
+Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the unhealthy node.
 
 .. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
 
@@ -359,9 +366,10 @@ metadata:
 +
 [source,terminal]
 ----
-$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
+$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0
 ----
-<1> Specify the name of the control plane machine for the unhealthy node.
++
+Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the unhealthy node.
 
 .. Verify that the machine was deleted:
 +
@@ -401,12 +409,13 @@ $ oc get machines -n openshift-machine-api -o wide
 NAME                                        PHASE          TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
 clustername-8qw5l-master-1                  Running        m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-154-204.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
 clustername-8qw5l-master-2                  Running        m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-164-97.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba   running
-clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-133-53.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8   running <1>
+clustername-8qw5l-master-3                  Provisioning   m4.xlarge   us-east-1   us-east-1a   85s     ip-10-0-133-53.ec2.internal    aws:///us-east-1a/i-015b0888fe17bc2c8   running
 clustername-8qw5l-worker-us-east-1a-wbtgd   Running        m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
 clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
-<1> The new machine, `clustername-8qw5l-master-3` is being created and is ready once the phase changes from `Provisioning` to `Running`.
++
+The new machine, `clustername-8qw5l-master-3`, is being created and is ready once the phase changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 
@@ -455,9 +464,10 @@ If the output from the previous command only lists two pods, you can manually fo
 +
 [source,terminal]
 ----
-$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge <1>
+$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
 ----
-<1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
++
+The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
 
 . Verify that there are exactly three etcd members.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16925](https://redhat.atlassian.net/browse/OSDOCS-16925)

Link to docs preview:
TBD

QE review:
- [ ] QE has approved this change.

Additional information:

There are three PRs to fully update the content for the etcd Backup and restore book. This is part three of three.