### PR TITLE
OBSDOCS-3677: Fix incorrect ObjectBucketClaim storageClassName for Ceph RGW LokiStack docs

### DIFF
--- a/modules/configuring-ceph-rgw-for-lokistack.adoc
+++ b/modules/configuring-ceph-rgw-for-lokistack.adoc
@@ -27,11 +27,11 @@ metadata:
   namespace: openshift-logging
 spec:
   generateBucketName: loki-bucket-odf
-  storageClassName: openshift-storage.ceph.rbd
+  storageClassName: ocs-storagecluster-ceph-rgw
 ----
 +
 spec.storageClassName::
-  For {rh-storage} deployments, use `openshift-storage.ceph.rbd` for block storage. The object storage endpoint is provided via Ceph RGW (RADOS Gateway), also known as NooBaa in Rook implementations.
+  For {rh-storage} deployments that use Ceph Object Gateway (RGW), set `ocs-storagecluster-ceph-rgw` on the `ObjectBucketClaim`. For Multicloud Object Gateway (NooBaa), use `openshift-storage.noobaa.io` instead. Do not use a Ceph RBD block StorageClass such as `ocs-storagecluster-ceph-rbd` on an `ObjectBucketClaim`; use RBD only for `LokiStack.spec.storageClassName` (WAL and temporary PVCs).
 
 . Get the bucket properties and credentials from the associated `ConfigMap` and `Secret` objects.
 
@@ -51,7 +51,7 @@ $ oc create -n openshift-logging secret generic logging-loki-s3 \
 +
 [NOTE]
 ====
-If using the default {rh-storage-first} Ceph RGW endpoint (NooBaa service in Rook deployments), you might need to use the service CA certificate.
+If using the default {rh-storage-first} Ceph RGW endpoint, you might need to use the service CA certificate.
 ====
 
 .Verification

--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -36,7 +36,7 @@ spec:
 +
 [NOTE]
 ====
-The `openshift-storage.noobaa.io` StorageClass is specific to {rh-storage} NooBaa deployments. This provides the block storage for LokiStack PVCs. The object storage endpoint is provided separately via Ceph RGW (RADOS Gateway).
+The `openshift-storage.noobaa.io` StorageClass provisions an `ObjectBucketClaim` through Multicloud Object Gateway (NooBaa). For Ceph Object Gateway (RGW), use `ocs-storagecluster-ceph-rgw` instead. Use a block StorageClass such as `ocs-storagecluster-ceph-rbd` only in `LokiStack.spec.storageClassName` for WAL and temporary PVCs.
 ====
 
 . Get bucket properties from the associated `ConfigMap` object by running the following command:


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/OBSDOCS-3677

## Summary
- Corrects the Ceph RGW `ObjectBucketClaim` example that incorrectly used `openshift-storage.ceph.rbd` (block storage).
- Uses `ocs-storagecluster-ceph-rgw` for RGW OBCs and documents `openshift-storage.noobaa.io` as the NooBaa/MCG alternative.
- Clarifies that RBD belongs on `LokiStack.spec.storageClassName` (WAL/temporary PVCs), not on the OBC.
- Fixes a related incorrect note in the ODF/NooBaa storage module that described NooBaa as providing block storage.

## Files
- `modules/configuring-ceph-rgw-for-lokistack.adoc`
- `modules/logging-loki-storage-odf.adoc`

## Why
RBD StorageClasses provision PVCs via CSI (`openshift-storage.rbd.csi.ceph.com`). OBC StorageClasses for ODF are:
- `ocs-storagecluster-ceph-rgw` (Ceph RGW)
- `openshift-storage.noobaa.io` (MCG/NooBaa)

## Test plan
- [ ] Preview AsciiDoc / docs build for the Installing Logging storage chapter
- [ ] Confirm rendered OBC example shows `ocs-storagecluster-ceph-rgw`
- [ ] Confirm notes no longer equate RGW with NooBaa or describe RBD/NooBaa as interchangeable for OBCs