### PR TITLE
OSDOCS-16997-installing-gcp-user-infra-vpc# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on {gcp-first} that uses infrastructure that you provide. In this context, a cluster installed into a shared VPC is a cluster that is configured to use a VPC from a project different from where the cluster is being deployed.
 
-A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IPs from that network. For more information about shared VPC, see link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview] in the {gcp-short} documentation.
+A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IPs from that network.
 
 The steps for performing a user-provided infrastructure installation into a shared VPC are outlined here. Several Infrastructure Manager templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods.
 
@@ -20,16 +20,26 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
-* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* If you use a firewall and plan to use the Telemetry service, you configured the firewall to allow the sites that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials.
+* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. If you do not provide a private hosted zone, the installation program will provision one automatically.
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials]
+* link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview ({gcp-short} documentation)]
+* link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding ({gcp-short} documentation)]
 
 include::modules/csr-management.adoc[leveloffset=+1]
 
@@ -57,8 +67,7 @@ include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 [id="installation-requirements-user-infra_{context}"]
 == Requirements for a cluster with user-provisioned infrastructure
 
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
 
 This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
 
@@ -195,10 +204,6 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on {gcp-first} that uses infrastructure that you provide. In this context, a cluster installed into a shared VPC is a cluster that is configured to use a VPC from a project different from where the cluster is being deployed.
 
-A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IPs from that network. For more information about shared VPC, see link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview] in the {gcp-short} documentation.
+A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IPs from that network.
 
 The steps for performing a user-provided infrastructure installation into a shared VPC are outlined here. Several Infrastructure Manager templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods.
 
@@ -20,25 +20,32 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
-* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* If you use a firewall and plan to use the Telemetry service, you configured the firewall to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials. For more information, see "Manually creating long-term credentials".
+* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. If you do not provide a private hosted zone, the installation program will provision one automatically.
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials]
+* link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview ({gcp-short} documentation)]
+* link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding ({gcp-short} documentation)]
+
 include::modules/csr-management.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-[id="installation-gcp-user-infra-config-project-vpc"]
-== Configuring the {gcp-short} project that hosts your cluster
-
-Before you can install {product-title}, you must configure a {gcp-full} project to host it.
+include::modules/installation-gcp-user-infra-config-project-vpc.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 
@@ -54,13 +61,7 @@ include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
+include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 
@@ -108,12 +109,9 @@ include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[lev
 .Additional resources
 ////
 
-[id="installation-gcp-user-infra-exporting-common-variables-vpc"]
-== Exporting common variables
+include::modules/installation-extracting-infraid.adoc[leveloffset=+1]
 
-include::modules/installation-extracting-infraid.adoc[leveloffset=+2]
-
-include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+2]
+include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+1]
 
@@ -165,24 +163,7 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-user-infra-adding-ingress.adoc[leveloffset=+1]
 
-[id="installation-gcp-user-infra-vpc-adding-firewall-rules"]
-== Adding ingress firewall rules
-The cluster requires several firewall rules. If you do not use a shared VPC, these rules are created by the Ingress Controller via the {gcp-short} cloud provider. When you use a shared VPC, you can either create cluster-wide firewall rules for all services now or create each rule based on events, when the cluster requests access. By creating each rule when the cluster requests access, you know exactly which firewall rules are required. By creating cluster-wide firewall rules, you can apply the same rule set across multiple clusters.
-
-If you choose to create each rule based on events, you must create firewall rules after you provision the cluster and during the life of the cluster when the console notifies you that rules are missing. Events that are similar to the following event are displayed, and you must add the firewall rules that are required:
-
-[source,terminal]
-----
-$ oc get events -n openshift-ingress --field-selector="reason=LoadBalancerManualChange"
-----
-
-.Example output
-[source,terminal]
-----
-Firewall change required by security admin: `gcloud compute firewall-rules create k8s-fw-a26e631036a3f46cba28f8df67266d55 --network example-network --description "{\"kubernetes.io/service-name\":\"openshift-ingress/router-default\", \"kubernetes.io/service-ip\":\"35.237.236.234\"}\" --allow tcp:443,tcp:80 --source-ranges 0.0.0.0/0 --target-tags exampl-fqzq7-master,exampl-fqzq7-worker --project example-project`
-----
-
-If you encounter issues when creating these rule-based events, you can configure the cluster-wide firewall rules while your cluster is running.
+include::modules/installation-gcp-user-infra-vpc-adding-firewall-rules.adoc[leveloffset=+1]
 
 include::modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules.adoc[leveloffset=+2]
 
@@ -193,12 +174,9 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules.adoc
+++ b/modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules.adoc
@@ -6,6 +6,7 @@
 [id="installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules_{context}"]
 = Creating cluster-wide firewall rules for a shared VPC in {gcp-short}
 
+[role="_abstract"]
 You can create cluster-wide firewall rules to allow the access that the {product-title} cluster requires.
 
 [WARNING]

--- a/modules/installation-extracting-infraid.adoc
+++ b/modules/installation-extracting-infraid.adoc
@@ -68,8 +68,7 @@ endif::[]
 
 [role="_abstract"]
 ifdef::aws,gcp[]
-The Ignition config files contain a unique cluster identifier that you can use to uniquely identify your cluster in {cp-first}. The infrastructure name is also used to locate the appropriate {cp} resources during an {product-title} installation.
-The provided {cp-template} templates contain references to this infrastructure name, so you must extract it.
+The Ignition config files contain a unique cluster identifier that you can use to uniquely identify your cluster in {cp-first}. The infrastructure name is also used to locate the appropriate {cp} resources during an {product-title} installation. The provided {cp-template} templates contain references to this infrastructure name, so you must extract it.
 endif::aws,gcp[]
 
 ifdef::azure[]
@@ -77,13 +76,12 @@ The Ignition config files contain a unique cluster identifier that you can use t
 endif::azure[]
 
 ifdef::vsphere[]
-The Ignition config files contain a unique cluster identifier that you can use to
-uniquely identify your cluster in {cp-first}. If you plan to use the cluster identifier as the name of your virtual machine folder, you must extract it.
+The Ignition config files contain a unique cluster identifier that you can use to uniquely identify your cluster in {cp-first}. If you plan to use the cluster identifier as the name of your virtual machine folder, you must extract it.
 endif::vsphere[]
 
 [WARNING]
 ====
-Do not run the `openshift-install create manifests` command again after creating any {gcp-short} resources. Running the command again generates a new cluster identifier, which will cause errors in existing resources. If you need to regenerate the manifests because you modified the `install-config.yaml` file, delete any {gcp-short} resources you created and recreate them with the new cluster identifier.
+Do not run the `openshift-install create manifests` command again after creating any {gcp-short} resources. Running the command again generates a new cluster identifier, which will cause errors in existing resources. If you need to regenerate the manifests because you modified the `install-config.yaml` file, delete any {gcp-short} resources you created and re-create them with the new cluster identifier.
 ====
 
 .Prerequisites

--- a/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
+++ b/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
@@ -6,6 +6,7 @@
 [id="installation-gcp-user-infra-config-host-project-vpc_{context}"]
 = Configuring the {gcp-short} project that hosts your shared VPC network
 
+[role="_abstract"]
 If you use a shared Virtual Private Cloud (VPC) to host your {product-title} cluster in {gcp-first}, you must configure the project that hosts it.
 
 [NOTE]

--- a/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
+++ b/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
@@ -6,7 +6,8 @@
 [id="installation-gcp-user-infra-config-host-project-vpc_{context}"]
 = Configuring the {gcp-short} project that hosts your shared VPC network
 
-If you use a shared Virtual Private Cloud (VPC) to host your {product-title} cluster in {gcp-first}, you must configure the project that hosts it.
+[role="_abstract"]
+If you use a shared Virtual Private Cloud (VPC) to host your {product-title} cluster in {gcp-first}, you must configure the host project with the service account and permissions that are required to install a cluster into the shared VPC network.
 
 [NOTE]
 ====

--- a/modules/installation-gcp-user-infra-config-project-vpc.adoc
+++ b/modules/installation-gcp-user-infra-config-project-vpc.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-user-infra-config-project-vpc_{context}"]
+= Configuring the {gcp-short} project that hosts your cluster
+
+[role="_abstract"]
+Before you can install {product-title}, you must configure a {gcp-full} project to host it. Proper project configuration provides the API services, service account, and permissions that the installation requires.

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -6,6 +6,7 @@
 [id="installation-gcp-user-infra-shared-vpc-config-yaml_{context}"]
 = Sample customized `install-config.yaml` file for {gcp-short}
 
+[role="_abstract"]
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [IMPORTANT]
@@ -16,9 +17,9 @@ This sample YAML file is provided for reference only. You must obtain your `inst
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
-controlPlane: <2>
-  hyperthreading: Enabled <3> <4>
+baseDomain: example.com
+controlPlane:
+  hyperthreading: Enabled
   name: master
   platform:
     gcp:
@@ -26,12 +27,12 @@ controlPlane: <2>
       zones:
       - us-central1-a
       - us-central1-c
-      tags: <5>
+      tags:
       - control-plane-tag1
       - control-plane-tag2
   replicas: 3
-compute: <2>
-- hyperthreading: Enabled <3>
+compute:
+- hyperthreading: Enabled
   name: worker
   platform:
     gcp:
@@ -39,7 +40,7 @@ compute: <2>
       zones:
       - us-central1-a
       - us-central1-c
-      tags: <5>
+      tags:
       - compute-tag1
       - compute-tag2
   replicas: 0
@@ -51,51 +52,51 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <6>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   gcp:
     defaultMachinePlatform:
-      tags: <5>
+      tags:
       - global-tag1
       - global-tag2
-    projectID: openshift-production <7>
-    region: us-central1 <8>
+    projectID: openshift-production
+    region: us-central1
 pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
-publish: Internal <11>
+fips: false
+sshKey: ssh-ed25519 AAAA...
+publish: Internal
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
-publish: Internal <10>
+sshKey: ssh-ed25519 AAAA...
+publish: Internal
 endif::openshift-origin[]
 ----
-<1> Specify the public DNS on the host project.
-<2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+* `baseDomain`: Specify the public DNS on the host project.
+* `controlPlane` and `compute`: If you do not provide these parameters and values, the installation program provides the default value.
+* The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+* `hyperthreading`: Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
-<6> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<7> Specify the main project where the VM instances reside.
-<8> Specify the region that your VPC network is in.
+* `tags`: Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
+* `networkType`: The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+* `projectID`: Specify the main project where the VM instances reside.
+* `region`: Specify the region that your VPC network is in.
 ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+* `fips`: Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 --
 include::snippets/fips-snippet.adoc[]
 --
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+* `sshKey`: You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+* `sshKey`: You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -103,10 +104,8 @@ endif::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifndef::openshift-origin[]
-<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
+* `publish`: How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`. To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
+* `publish`: How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`. To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -6,6 +6,7 @@
 [id="installation-gcp-user-infra-shared-vpc-config-yaml_{context}"]
 = Sample customized `install-config.yaml` file for {gcp-short}
 
+[role="_abstract"]
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [IMPORTANT]
@@ -16,9 +17,9 @@ This sample YAML file is provided for reference only. You must obtain your `inst
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
-controlPlane: <2>
-  hyperthreading: Enabled <3> <4>
+baseDomain: example.com
+controlPlane:
+  hyperthreading: Enabled
   name: master
   platform:
     gcp:
@@ -26,12 +27,12 @@ controlPlane: <2>
       zones:
       - us-central1-a
       - us-central1-c
-      tags: <5>
+      tags:
       - control-plane-tag1
       - control-plane-tag2
   replicas: 3
-compute: <2>
-- hyperthreading: Enabled <3>
+compute:
+- hyperthreading: Enabled
   name: worker
   platform:
     gcp:
@@ -39,7 +40,7 @@ compute: <2>
       zones:
       - us-central1-a
       - us-central1-c
-      tags: <5>
+      tags:
       - compute-tag1
       - compute-tag2
   replicas: 0
@@ -51,51 +52,53 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <6>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   gcp:
     defaultMachinePlatform:
-      tags: <5>
+      tags:
       - global-tag1
       - global-tag2
-    projectID: openshift-production <7>
-    region: us-central1 <8>
+    projectID: openshift-production
+    region: us-central1
 pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
-publish: Internal <11>
+fips: false
+sshKey: ssh-ed25519 AAAA...
+publish: Internal
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
-publish: Internal <10>
+sshKey: ssh-ed25519 AAAA...
+publish: Internal
 endif::openshift-origin[]
 ----
-<1> Specify the public DNS on the host project.
-<2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+where:
+
+`baseDomain`:: Specifies the public DNS on the host project.
+`controlPlane`:: Specifies the parameters that apply to control plane machines. The `controlPlane` section is a single mapping. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used. If you do not provide these parameters and values, the installation program provides the default value.
+`compute`:: Specifies the parameters that apply to compute machines. The `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. If you do not provide these parameters and values, the installation program provides the default value.
+`hyperthreading`:: Specifies whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
-<6> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<7> Specify the main project where the VM instances reside.
-<8> Specify the region that your VPC network is in.
+`tags`:: Specifies a set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter. This parameter is optional.
+`networkType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`projectID`:: Specifies the main project where the VM instances reside.
+`region`:: Specifies the region that your VPC network is in.
 ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+`fips`:: Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 --
 include::snippets/fips-snippet.adoc[]
 --
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+`sshKey`:: Specifies the `sshKey` value that you use to access the machines in your cluster. This parameter is optional.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+`sshKey`:: Specifies the `sshKey` value that you use to access the machines in your cluster. This parameter is optional.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -103,10 +106,8 @@ endif::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifndef::openshift-origin[]
-<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
+`publish`:: Specifies how to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`. To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program can no longer access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
+`publish`:: Specifies how to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`. To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program can no longer access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]

--- a/modules/installation-gcp-user-infra-vpc-adding-firewall-rules.adoc
+++ b/modules/installation-gcp-user-infra-vpc-adding-firewall-rules.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-user-infra-vpc-adding-firewall-rules_{context}"]
+= Adding ingress firewall rules
+
+[role="_abstract"]
+The cluster requires several firewall rules. If you do not use a shared VPC, the Ingress Controller creates these rules by using the {gcp-short} cloud provider. When you use a shared VPC, you must create the rules yourself so that traffic can reach the cluster services.
+
+You can either create cluster-wide firewall rules for all services now or create each rule based on events, when the cluster requests access. By creating each rule when the cluster requests access, you know exactly which firewall rules are required. By creating cluster-wide firewall rules, you can apply the same rule set across multiple clusters.
+
+If you choose to create each rule based on events, you must create firewall rules after you provision the cluster and during the life of the cluster when the console notifies you that rules are missing. Events that are similar to the following event are displayed, and you must add the firewall rules that are required:
+
+[source,terminal]
+----
+$ oc get events -n openshift-ingress --field-selector="reason=LoadBalancerManualChange"
+----
+
+.Example output
+[source,terminal]
+----
+Firewall change required by security admin: `gcloud compute firewall-rules create k8s-fw-a26e631036a3f46cba28f8df67266d55 --network example-network --description "{\"kubernetes.io/service-name\":\"openshift-ingress/router-default\", \"kubernetes.io/service-ip\":\"35.237.236.234\"}\" --allow tcp:443,tcp:80 --source-ranges 0.0.0.0/0 --target-tags exampl-fqzq7-master,exampl-fqzq7-worker --project example-project`
+----
+
+If you encounter issues when creating these rule-based events, you can configure the cluster-wide firewall rules while your cluster is running.

--- a/modules/installation-infrastructure-manager-bootstrap.adoc
+++ b/modules/installation-infrastructure-manager-bootstrap.adoc
@@ -8,13 +8,9 @@
 = Infrastructure Manager template for the bootstrap machine
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the bootstrap machine that you need for your {product-title} cluster:
+You can use the following `04_bootstrap.tf` Infrastructure Manager template to deploy the bootstrap machine that you need for your {product-title} cluster:
 
-.`04_bootstrap.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/04_bootstrap/04_bootstrap.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-control-plane.adoc
+++ b/modules/installation-infrastructure-manager-control-plane.adoc
@@ -8,13 +8,9 @@
 = Infrastructure Manager template for control plane machines
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the control plane machines that you need for your {product-title} cluster:
+You can use the following `05_control_plane.tf` Infrastructure Manager template to deploy the control plane machines that you need for your {product-title} cluster:
 
-.`05_control_plane.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/05_control_plane/05_control_plane.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-ext-lb.adoc
+++ b/modules/installation-infrastructure-manager-ext-lb.adoc
@@ -9,13 +9,9 @@
 = Infrastructure Manager template for the external load balancer
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the external load balancer that you need for your {product-title} cluster:
+You can use the following `02_lb_ext.tf` Infrastructure Manager template to deploy the external load balancer that you need for your {product-title} cluster:
 
-.`02_lb_ext.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/02_lb_ext/02_lb_ext.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-firewall-rules.adoc
+++ b/modules/installation-infrastructure-manager-firewall-rules.adoc
@@ -7,13 +7,9 @@
 = Infrastructure Manager template for firewall rules and IAM roles
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the firewall rules and IAM roles that you need for your {product-title} cluster:
+You can use the following `03_security.tf` Infrastructure Manager template to deploy the firewall rules and IAM roles that you need for your {product-title} cluster:
 
-.`03_security.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/03_security/03_security.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-int-lb.adoc
+++ b/modules/installation-infrastructure-manager-int-lb.adoc
@@ -9,13 +9,9 @@
 = Infrastructure Manager template for the internal load balancer
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the internal load balancer that you need for your {product-title} cluster:
+You can use the following `02_lb_int.tf` Infrastructure Manager template to deploy the internal load balancer that you need for your {product-title} cluster:
 
-.`02_lb_int.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/02_lb_int/02_lb_int.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-private-dns.adoc
+++ b/modules/installation-infrastructure-manager-private-dns.adoc
@@ -7,13 +7,9 @@
 = Infrastructure Manager template for the private DNS
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the private DNS that you need for your {product-title} cluster:
+You can use the following `02_dns.tf` Infrastructure Manager template to deploy the private DNS that you need for your {product-title} cluster:
 
-.`02_dns.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/02_dns/02_dns.tf[]
 ----
-====

--- a/modules/installation-infrastructure-manager-worker.adoc
+++ b/modules/installation-infrastructure-manager-worker.adoc
@@ -8,13 +8,9 @@
 = Infrastructure Manager template for worker machines
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the worker machines that you need for your {product-title} cluster:
+You can use the following `06_worker.tf` Infrastructure Manager template to deploy the worker machines that you need for your {product-title} cluster:
 
-.`06_worker.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/06_worker/06_worker.tf[]
 ----
-====

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-requirements-user-infra_{context}"]
+= Requirements for a cluster with user-provisioned infrastructure
+
+[role="_abstract"]
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines. Reviewing these requirements before deployment helps you provision machines that meet the minimum resource needs of the cluster.


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster into a shared VPC on GCP using Infrastructure Manager templates](https://116906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html)
- [Configuring the GCP project that hosts your shared VPC network](https://116906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-config-host-project-vpc_installing-gcp-user-infra-vpc)
- [Sample customized install-config.yaml file for GCP](https://116906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-shared-vpc-config-yaml_installing-gcp-user-infra-vpc)
- [Extracting the infrastructure name](https://116906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-extracting-infraid_installing-gcp-user-infra-vpc)
- [Creating cluster-wide firewall rules for a shared VPC in GCP](https://116906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules_installing-gcp-user-infra-vpc)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
