### PR TITLE
OSDOCS#20985: Update the MicroShift RNs for 4.22.7

### DIFF
--- a/microshift_release_notes/microshift-4-22-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-22-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-22-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-22-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-22-7-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-22-4-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-22-3-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-22-7-async.adoc
+++ b/modules/microshift-4-22-7-async.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-22-7-async_{context}"]
+= RHBA-2026:45112 - {microshift-short} 4.22.7 fixed issue update
+
+Issued: 30 July 2026
+
+[role="_abstract"]
+{product-title} release 4.22.7 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:45112[RHBA-2026:45112] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:44237[RHSA-2026:44237] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-22-7-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="microshift-4-22-7-known-issues_{context}"]
+== Known issues
+
+* {microshift-short} 4.22.7 images have a prioritizer compatibility issue with unsupported paths that lead to an incomplete fixed issue in the release notes. There is no workaround for OCPBUGS-98603. As a result, users should apply a system update to resolve the issue.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20985

Link to docs preview:
[4.22.7](https://116908--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-22-release-notes.html#microshift-4-22-7-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- MicroShift errata: https://access.redhat.com/errata/RHBA-2026:45112
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:44237
- Shipment MR (Microshift-bootc): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/671
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-98603 | Incomplete Bug Fix RN (CCFR template only) |


Made with [Cursor](https://cursor.com)