### PR TITLE
OSDOCS-16997-installing-restricted-networks-gcp# CQA

### DIFF
--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -24,16 +24,25 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* You created a registry on your mirror host and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Creating a registry on your mirror host]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating and maintaining long-term credentials]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -70,8 +79,7 @@ include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 [id="installation-requirements-user-infra_{context}"]
 == Requirements for a cluster with user-provisioned infrastructure
 
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
 
 This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
 
@@ -172,13 +180,10 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configuring image streams for the Cluster Samples Operator and the must-gather tool]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -24,25 +24,31 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You created a registry on your mirror host and obtained the `imageContentSources` data for your version of {product-title}. For more information, see "Mirroring images for a disconnected installation".
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`. For more information, see "Configuring your firewall for {product-title}".
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can manually create and maintain long-term credentials. For more information, see "Manually creating long-term credentials".
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-[id="installation-restricted-networks-gcp-user-infra-config-project"]
-== Configuring your {gcp-short} project
-
-Before you can install {product-title}, you must configure a {gcp-first} project to host it.
+include::modules/installation-gcp-user-infra-config-project.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 
@@ -67,13 +73,7 @@ include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
+include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 
@@ -108,14 +108,11 @@ include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[lev
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra[Optional: Adding the ingress DNS records]
+* xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installation-gcp-user-infra-adding-ingress_installing-restricted-networks-gcp[Adding the ingress DNS records]
 
-[id="installation-restricted-networks-gcp-user-infra-exporting-common-variables"]
-== Exporting common variables
+include::modules/installation-extracting-infraid.adoc[leveloffset=+1]
 
-include::modules/installation-extracting-infraid.adoc[leveloffset=+2]
-
-include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+2]
+include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+1]
 
 include::modules/installation-creating-gcp-vpc.adoc[leveloffset=+1]
 
@@ -170,15 +167,13 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configuring image streams for the Cluster Samples Operator and the must-gather tool]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -55,20 +55,13 @@ endif::[]
 You can install {product-title} {product-version} in a restricted network without an active internet connection to obtain software components. Restricted network installations can use installer-provisioned or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
 ifndef::ibm-power,ibm-cloud[]
-If you choose to perform a restricted network installation on a cloud platform, you
-still require access to its cloud APIs. Some cloud functions, like
-Amazon Web Service's Route 53 DNS and IAM services, require internet access.
+If you choose to perform a restricted network installation on a cloud platform, you still require access to its cloud APIs. Some cloud functions, such as Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
-Depending on your network, you might require less internet
-access for an installation on bare metal hardware, Nutanix, or on VMware vSphere.
+Depending on your network, you might require less internet access for an installation on bare-metal hardware, Nutanix, or on VMware vSphere.
 endif::ibm-power,ibm-cloud[]
 
 ifndef::ibm-cloud[]
-To complete a restricted network installation, you must create a registry that
-mirrors the contents of the {product-registry} and contains the
-installation media. You can create this registry on a mirror host, which can
-access both the internet and your closed network, or by using other methods
-that meet your restrictions.
+To complete a restricted network installation, you must create a registry that mirrors the contents of the {product-registry} and contains the installation media. You can create this registry on a mirror host, which can access both the internet and your closed network, or by using other methods that meet your restrictions.
 endif::ibm-cloud[]
 
 ifndef::ipi[]

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -55,20 +55,13 @@ endif::[]
 You can install {product-title} {product-version} in a restricted network without an active internet connection to obtain software components. Restricted network installations can use installer-provisioned or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
 ifndef::ibm-power,ibm-cloud[]
-If you choose to perform a restricted network installation on a cloud platform, you
-still require access to its cloud APIs. Some cloud functions, like
-Amazon Web Service's Route 53 DNS and IAM services, require internet access.
+If you choose to perform a restricted network installation on a cloud platform, you still require access to its cloud APIs. Some cloud functions, such as Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
-Depending on your network, you might require less internet
-access for an installation on bare metal hardware, Nutanix, or on VMware vSphere.
+Depending on your network, you might require less internet access for an installation on bare-metal hardware, Nutanix, or on VMware vSphere.
 endif::ibm-power,ibm-cloud[]
 
 ifndef::ibm-cloud[]
-To complete a restricted network installation, you must create a registry that
-mirrors the contents of the {product-registry} and contains the
-installation media. You can create this registry on a mirror host, which can
-access both the internet and your closed network, or by using other methods
-that meet your restrictions.
+To complete a restricted network installation, you must create a registry that mirrors the contents of the {product-registry} and contains the installation media. You can create this registry on a mirror host, which can access both the internet and your closed network, or by using other methods that meet your restrictions.
 endif::ibm-cloud[]
 
 ifndef::ipi[]
@@ -92,8 +85,7 @@ You complete the installation using a bastion host or portable device that can a
 [id="access-to-a-mirror-registry_{context}"]
 == Access to a mirror registry
 
-To complete a restricted network installation, you must create a registry that
-mirrors the contents of the {product-registry} and contains the installation media.
+To complete a restricted network installation, you must create a registry that mirrors the contents of the {product-registry} and contains the installation media.
 
 You can create this registry on a mirror host, which can access both the internet and your restricted network, or by using other methods that meet your organization's security restrictions.
 

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -20,7 +20,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-disk-partitioning-upi-templates_{context}"]
-= Optional: Creating a separate `/var` partition
+= Creating a separate `/var` partition
 
 [role="_abstract"]
 To isolate growing storage for containers, etcd, or logs, you can optionally create a separate `/var` partition on worker nodes before you generate Ignition configs.

--- a/modules/installation-gcp-user-infra-config-project.adoc
+++ b/modules/installation-gcp-user-infra-config-project.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-user-infra-config-project_{context}"]
+= Configuring your {gcp-short} project
+
+[role="_abstract"]
+Before you can install {product-title}, you must configure a {gcp-first} project to host it. Proper project configuration provides the API services, service account, and permissions that the installation requires.

--- a/modules/installation-infrastructure-manager-vpc.adoc
+++ b/modules/installation-infrastructure-manager-vpc.adoc
@@ -8,13 +8,9 @@
 = Infrastructure Manager template for the VPC
 
 [role="_abstract"]
-You can use the following Infrastructure Manager template to deploy the VPC that you need for your {product-title} cluster:
+You can use the following `01_vpc.tf` Infrastructure Manager template to deploy the VPC that you need for your {product-title} cluster:
 
-.`01_vpc.tf` Infrastructure Manager template
-[%collapsible]
-====
 [source,terraform]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/upi/gcp/01_vpc/01_vpc.tf[]
 ----
-====

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -247,10 +247,7 @@ endif::baremetal,baremetal-restricted,ibm-z,ibm-power,three-node-cluster[]
 
 ifdef::gcp,aws,azure,ash[]
 ifndef::user-infra-vpc[]
-. Optional: If you do not want
-link:https://github.com/openshift/cluster-ingress-operator[the Ingress Operator]
-to create DNS records on your behalf, remove the `privateZone` and `publicZone`
-sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
+. Optional: If you do not want link:https://github.com/openshift/cluster-ingress-operator[the Ingress Operator] to create DNS records on your behalf, remove the `privateZone` and `publicZone` sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
 endif::user-infra-vpc[]
 ifdef::user-infra-vpc[]
 . Remove the `privateZone` sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
@@ -347,9 +344,7 @@ Later, you must update your bootstrap ignition to include the CA.
 endif::ash[]
 
 ifdef::azure-user-infra[]
-. When configuring Azure on user-provisioned infrastructure, you must export
-some common variables defined in the manifest files to use later in the Azure
-Resource Manager (ARM) templates:
+. When configuring Azure on user-provisioned infrastructure, you must export some common variables defined in the manifest files to use later in the Azure Resource Manager (ARM) templates:
 +
 .. Export the infrastructure ID by using the following command:
 +

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -8,13 +8,13 @@
 [id="minimum-required-permissions-upi-gcp_{context}"]
 = Required {gcp-short} permissions for user-provisioned infrastructure
 
-When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
+[role="_abstract"]
+Your {gcp-short} service account requires permissions to create and manage user-provisioned {product-title} infrastructure. You can attach the `Owner` role to grant all permissions, or create a custom role with only the minimum permissions your organization's security policies require.
 
 If your organization's security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the user-provisioned infrastructure for creating and deleting the {product-title} cluster.
 
-.Required permissions for creating network resources
-[%collapsible]
-====
+The following permissions are required for creating network resources:
+
 * `compute.addresses.create`
 * `compute.addresses.createInternal`
 * `compute.addresses.delete`
@@ -51,11 +51,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.subnetworks.list`
 * `compute.subnetworks.use`
 * `compute.subnetworks.useExternalIp`
-====
 
-.Required permissions for creating load balancer resources
-[%collapsible]
-====
+The following permissions are required for creating load balancer resources:
+
 * `compute.backendServices.create`
 * `compute.backendServices.get`
 * `compute.backendServices.list`
@@ -75,11 +73,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.targetTcpProxies.create`
 * `compute.targetTcpProxies.get`
 * `compute.targetTcpProxies.use`
-====
 
-.Required permissions for creating DNS resources
-[%collapsible]
-====
+The following permissions are required for creating DNS resources:
+
 * `dns.changes.create`
 * `dns.changes.get`
 * `dns.managedZones.create`
@@ -89,11 +85,9 @@ If your organization's security policies require a more restrictive set of permi
 * `dns.resourceRecordSets.create`
 * `dns.resourceRecordSets.list`
 * `dns.resourceRecordSets.update`
-====
 
-.Required permissions for creating Service Account resources
-[%collapsible]
-====
+The following permissions are required for creating Service Account resources:
+
 * `iam.serviceAccountKeys.create`
 * `iam.serviceAccountKeys.delete`
 * `iam.serviceAccountKeys.get`
@@ -106,11 +100,9 @@ If your organization's security policies require a more restrictive set of permi
 * `resourcemanager.projects.get`
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
-====
 
-.Required permissions for creating compute resources
-[%collapsible]
-====
+The following permissions are required for creating compute resources:
+
 * `compute.disks.create`
 * `compute.disks.get`
 * `compute.disks.list`
@@ -131,11 +123,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.instances.use`
 * `compute.machineTypes.get`
 * `compute.machineTypes.list`
-====
 
-.Required for creating storage resources
-[%collapsible]
-====
+The following permissions are required for creating storage resources:
+
 * `storage.buckets.create`
 * `storage.buckets.delete`
 * `storage.buckets.get`
@@ -144,11 +134,9 @@ If your organization's security policies require a more restrictive set of permi
 * `storage.objects.delete`
 * `storage.objects.get`
 * `storage.objects.list`
-====
 
-.Required permissions for creating health check resources
-[%collapsible]
-====
+The following permissions are required for creating health check resources:
+
 * `compute.healthChecks.create`
 * `compute.healthChecks.get`
 * `compute.healthChecks.list`
@@ -160,11 +148,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.regionHealthChecks.create`
 * `compute.regionHealthChecks.get`
 * `compute.regionHealthChecks.useReadOnly`
-====
 
-.Required permissions to get {gcp-short} zone and region related information
-[%collapsible]
-====
+The following permissions are required to get {gcp-short} zone and region related information:
+
 * `compute.globalOperations.get`
 * `compute.regionOperations.get`
 * `compute.regions.get`
@@ -172,52 +158,38 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.zoneOperations.get`
 * `compute.zones.get`
 * `compute.zones.list`
-====
 
-.Required permissions for checking services and quotas
-[%collapsible]
-====
+The following permissions are required for checking services and quotas:
+
 * `monitoring.timeSeries.list`
 * `serviceusage.quotas.get`
 * `serviceusage.services.list`
-====
 
-.Required IAM permissions for installation
-[%collapsible]
-====
+The following IAM permission is required for installation:
+
 * `iam.roles.get`
-====
 
-.Required permissions when authenticating without a service account key
-[%collapsible]
-====
+The following permission is required when authenticating without a service account key:
+
 * `iam.serviceAccounts.signBlob`
-====
 
-.Required permissions when providing Key Management Service (KMS) key rings
-[%collapsible]
-====
+The following permission is required when providing Key Management Service (KMS) key rings:
+
 * `cloudkms.keyRings.list`
-====
 
-.Required Images permissions for installation
-[%collapsible]
-====
+The following Images permissions are required for installation:
+
 * `compute.images.create`
 * `compute.images.delete`
 * `compute.images.get`
 * `compute.images.list`
-====
 
-.Optional permission for running gather bootstrap
-[%collapsible]
-====
+The following permission is optional for running gather bootstrap:
+
 * `compute.instances.getSerialPortOutput`
-====
 
-.Required permissions for deleting network resources
-[%collapsible]
-====
+The following permissions are required for deleting network resources:
+
 * `compute.addresses.delete`
 * `compute.addresses.deleteInternal`
 * `compute.addresses.list`
@@ -238,11 +210,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.routes.list`
 * `compute.subnetworks.delete`
 * `compute.subnetworks.list`
-====
 
-.Required permissions for deleting load balancer resources
-[%collapsible]
-====
+The following permissions are required for deleting load balancer resources:
+
 * `compute.backendServices.delete`
 * `compute.backendServices.list`
 * `compute.regionBackendServices.delete`
@@ -251,32 +221,26 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.targetPools.list`
 * `compute.targetTcpProxies.delete`
 * `compute.targetTcpProxies.list`
-====
 
-.Required permissions for deleting DNS resources
-[%collapsible]
-====
+The following permissions are required for deleting DNS resources:
+
 * `dns.changes.create`
 * `dns.managedZones.delete`
 * `dns.managedZones.get`
 * `dns.managedZones.list`
 * `dns.resourceRecordSets.delete`
 * `dns.resourceRecordSets.list`
-====
 
-.Required permissions for deleting Service Account resources
-[%collapsible]
-====
+The following permissions are required for deleting Service Account resources:
+
 * `iam.serviceAccounts.delete`
 * `iam.serviceAccounts.get`
 * `iam.serviceAccounts.list`
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
-====
 
-.Required permissions for deleting compute resources
-[%collapsible]
-====
+The following permissions are required for deleting compute resources:
+
 * `compute.disks.delete`
 * `compute.disks.list`
 * `compute.instanceGroups.delete`
@@ -285,45 +249,35 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.instances.list`
 * `compute.instances.stop`
 * `compute.machineTypes.list`
-====
 
-.Required for deleting storage resources
-[%collapsible]
-====
+The following permissions are required for deleting storage resources:
+
 * `storage.buckets.delete`
 * `storage.buckets.getIamPolicy`
 * `storage.buckets.list`
 * `storage.objects.delete`
 * `storage.objects.list`
-====
 
-.Required permissions for deleting health check resources
-[%collapsible]
-====
+The following permissions are required for deleting health check resources:
+
 * `compute.healthChecks.delete`
 * `compute.healthChecks.list`
 * `compute.httpHealthChecks.delete`
 * `compute.httpHealthChecks.list`
 * `compute.regionHealthChecks.delete`
 * `compute.regionHealthChecks.list`
-====
 
-.Required Images permissions for deletion
-[%collapsible]
-====
+The following Images permissions are required for deletion:
+
 * `compute.images.delete`
 * `compute.images.list`
-====
 
-.Required permissions to get Region related information
-[%collapsible]
-====
+The following permission is required to get Region related information:
+
 * `compute.regions.get`
-====
 
-.Required Deployment Manager permissions
-[%collapsible]
-====
+The following Deployment Manager permissions are required:
+
 * config.deployments.create
 * config.deployments.delete
 * config.deployments.get
@@ -332,4 +286,3 @@ If your organization's security policies require a more restrictive set of permi
 * config.resources.list
 * cloudbuild.builds.create
 * cloudbuild.builds.get
-====


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster on GCP in a disconnected environment with user-provisioned infrastructure](https://116909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html)
- [About installations in restricted networks](https://116909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html#installation-about-restricted-networks_installing-restricted-networks-gcp)
- [Creating the Kubernetes manifest and Ignition config files](https://116909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html#installation-user-infra-generate-k8s-manifest-ignition_installing-restricted-networks-gcp)
- [Optional: Creating a separate /var partition](https://116909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html#installation-disk-partitioning-upi-templates_installing-restricted-networks-gcp)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
