### PR TITLE
OBSDOCS-3644 Rocket.Chat notification support Release note

### DIFF
--- a/modules/monitoring-4-22-release-notes.adoc
+++ b/modules/monitoring-4-22-release-notes.adoc
@@ -158,3 +158,10 @@ Before this update, scheduling the `metrics-server` pod on a worker node caused 
 With this release, the `metrics-server` deployment prefers control-plane nodes and tolerates their taints, which isolates the shutdown delay to control-plane infrastructure and prevents reboot delays on standard worker nodes.
 +
 link:https://issues.redhat.com/browse/OCPBUGS-48578[OCPBUGS-48578]
+
+Alertmanager now supports Rocket.Chat as a notification receiver::
+Before this update, Alertmanager did not include a dedicated Rocket.Chat receiver type. As a consequence, users who wanted to send alerts to Rocket.Chat had to either implement custom scripts on the Rocket.Chat side to use the Webhook receiver, or use the Slack receiver, which caused duplicated notifications and error messages.
++
+With this release, Alertmanager includes native support for the Rocket.Chat receiver type. As a result, you can now send alert notifications directly to Rocket.Chat without requiring custom workarounds.
++
+(link:https://redhat.atlassian.net/browse/RFE-6097[RFE-6097])


### PR DESCRIPTION
Change type: Doc update; Rocket.Chat notification support Release note

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3644

Fix versions: No CP needed

Doc Preview: https://116915--ocpdocs-pr.netlify.app/openshift-monitoring/latest/release-notes/monitoring-release-notes.html#monitoring-4-22-fixed-issues_monitoring-release-notes

SME/QE review: @simonpasquier 

Peer Review: @kaldesai 