### PR TITLE
OCPBUGS-99754: Updated a broken link to now point to the Broadcom docs

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -33,7 +33,7 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 
 [IMPORTANT]
 ====
-You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-8756D419-A878-4AE0-9183-C6D5A91A8FB1.html[Edit Time Configuration for a Host] in the VMware documentation.
+You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vcenter-and-host-management/host-configuration-host-management/synchronizing-clocks-on-the-vsphere-network-host-management/editing-time-configuration-for-a-host-host-management.html[Editing the Time Configuration Settings of Your ESXi Host (Broadcom documentation)].
 ====
 
 .Minimum supported vSphere version for VMware components


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-99754

Link to docs preview:

* https://116943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-infrastructure_ipi-vsphere-installation-reqs
* https://116943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-infrastructure_upi-vsphere-installation-reqs

- [x] SME has approved this change.


