### PR TITLE
OCPBUGS-99753: Fixed the broken link in installation-launching-instal…

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -458,8 +458,8 @@ ifdef::azure[]
 +
 [IMPORTANT]
 ====
-All Azure resources that are available through public endpoints are subject to resource name restrictions, and you cannot create resources that use certain terms. For a list of terms that Azure restricts, see
-link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resourcename[Resolve reserved resource name errors] in the Azure documentation.
+All {azure-short} resources that are available through public endpoints are subject to resource name restrictions, and you cannot create resources that use certain terms. For a list of terms that Azure restricts, see
+link:https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-reserved-resource-name[Resolve errors for reserved resource names] in the {azure-short} documentation.
 ====
 endif::azure[]
 ifdef::gcp[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-99753](https://redhat.atlassian.net/browse/OCPBUGS-99753)

Link to docs preview:

* https://116947--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-default.html

- [x] SME has approved this change.

