### PR TITLE
RHCL 1.5: Egress gateway Technology Preview guides

### DIFF
--- a/deployment/rhcl-egress-credential-injection.adoc
+++ b/deployment/rhcl-egress-credential-injection.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="rhcl-egress-credential-injection"]
+= Injecting credentials into egress requests
+:context: rhcl-egress-credential-injection
+
+toc::[]
+
+[role="_abstract"]
+You can use `AuthPolicy` with an egress gateway to inject credentials into requests to external services. This guide demonstrates credential injection using HashiCorp Vault as the credential source.
+
+:FeatureName: Egress gateway
+include::snippets/technology-preview.adoc[]
+
+include::modules/con-rhcl-egress-credential-injection.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-vault-setup.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-credential-injection.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-per-identity-credentials.adoc[leveloffset=+1]
+
+include::modules/ref-rhcl-egress-credential-security.adoc[leveloffset=+1]
+
+[id="additional-resources_rhcl-egress-credential-injection"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../deployment/rhcl-egress-gateway.adoc#rhcl-egress-gateway[Configuring an egress gateway]
+* xref:../deployment/rhcl-egress-dns-routing.adoc#rhcl-egress-dns-routing[Configuring DNS routing for an egress gateway]

--- a/deployment/rhcl-egress-dns-routing.adoc
+++ b/deployment/rhcl-egress-dns-routing.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="rhcl-egress-dns-routing"]
+= Configuring DNS routing for an egress gateway
+:context: rhcl-egress-dns-routing
+
+toc::[]
+
+[role="_abstract"]
+You can configure how workload pods route traffic through an egress gateway to external services. {prodname} supports multiple routing approaches depending on whether the application can be modified to use an internal hostname.
+
+:FeatureName: Egress gateway
+include::snippets/technology-preview.adoc[]
+
+include::modules/con-rhcl-egress-dns-routing.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-internal-hostname.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-dns-coredns.adoc[leveloffset=+1]
+
+include::modules/ref-rhcl-egress-dns-alternatives.adoc[leveloffset=+1]
+
+[id="additional-resources_rhcl-egress-dns-routing"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../deployment/rhcl-egress-gateway.adoc#rhcl-egress-gateway[Configuring an egress gateway]
+* xref:../deployment/rhcl-egress-credential-injection.adoc#rhcl-egress-credential-injection[Injecting credentials into egress requests]
+* xref:../deployment/coredns.adoc#rhcl-using-on-prem-dns-coredns[Using on-premise DNS with CoreDNS]

--- a/deployment/rhcl-egress-gateway.adoc
+++ b/deployment/rhcl-egress-gateway.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="rhcl-egress-gateway"]
+= Configuring an egress gateway
+:context: rhcl-egress-gateway
+
+toc::[]
+
+[role="_abstract"]
+You can configure an egress gateway to control, secure, and monitor outbound traffic from your cluster to external services using {prodname} policies.
+
+:FeatureName: Egress gateway
+include::snippets/technology-preview.adoc[]
+
+include::modules/con-rhcl-egress-gateway.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-gateway-setup.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-rate-limiting.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-workload-identity.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-egress-per-workload-rl.adoc[leveloffset=+1]
+
+include::modules/ref-rhcl-egress-considerations.adoc[leveloffset=+1]
+
+[id="additional-resources_rhcl-egress-gateway"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../deployment/rhcl-egress-dns-routing.adoc#rhcl-egress-dns-routing[Configuring DNS routing for an egress gateway]
+* xref:../deployment/rhcl-egress-credential-injection.adoc#rhcl-egress-credential-injection[Injecting credentials into egress requests]

--- a/modules/con-rhcl-egress-credential-injection.adoc
+++ b/modules/con-rhcl-egress-credential-injection.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-credential-injection.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-rhcl-egress-credential-injection_{context}"]
+= About credential injection for egress
+
+[role="_abstract"]
+Credential injection extends the workload identity pattern by adding Vault integration. After validating the Kubernetes service account token of a workload, Authorino uses the validated identity to fetch per-workload credentials from HashiCorp Vault and inject them into outbound requests.
+
+This approach ensures that:
+
+* External API credentials are never stored in the application or its configuration.
+* Each workload identity receives its own credential from a per-identity Vault path.
+* The service account token of the workload is replaced with the external credential before the request reaches the external service.
+
+.Request flow
+
+The following describes the credential injection request flow:
+
+. An internal workload sends an HTTP request to the egress gateway with `Authorization: Bearer <sa-token>`.
+. The gateway triggers an `ext_authz` check with Authorino.
+. Authorino validates the Kubernetes service account token of the workload through TokenReview.
+. Authorino authenticates to Vault using the service account token of the workload through the Vault Kubernetes auth method.
+. Authorino reads the external credential from Vault and overwrites the `Authorization` header through `response.success.headers`.
+. The egress gateway originates TLS and forwards the request with the external credential to the external service.

--- a/modules/con-rhcl-egress-dns-routing.adoc
+++ b/modules/con-rhcl-egress-dns-routing.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-dns-routing.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-rhcl-egress-dns-routing_{context}"]
+= About DNS routing for egress gateways
+
+[role="_abstract"]
+You can choose different routing approaches to direct workload pod traffic through an egress gateway to external services. The approaches are independent of how the egress gateway was deployed.
+
+{prodname} supports the following routing approaches:
+
+Internal hostname (recommended)::
+The application uses the cluster-internal service name of the egress gateway as the hostname. The gateway rewrites the host header and routes the request to the real external service with TLS origination. This approach requires no DNS configuration and works on any platform.
+
+Pod DNS with CoreDNS::
+The application uses the real external hostname transparently. Workload pods are configured with a custom `dnsConfig` that uses a CoreDNS instance as their nameserver. A `DNSPolicy` on the egress gateway creates DNS records that resolve the external hostname to the gateway IP. Use this approach when the application cannot be changed to use an internal hostname.
+
+The examples in this guide use the following resources:
+
+[cols="1,2",options="header"]
+|===
+| Resource | Value
+
+| Gateway namespace
+| `gateway-system`
+
+| Gateway name
+| `kuadrant-egressgateway`
+
+| {service-mesh}-created service
+| `kuadrant-egressgateway-istio.gateway-system.svc.cluster.local`
+
+| External service
+| `httpbin.org`
+|===

--- a/modules/con-rhcl-egress-gateway.adoc
+++ b/modules/con-rhcl-egress-gateway.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-rhcl-egress-gateway_{context}"]
+= About egress gateways
+
+[role="_abstract"]
+An egress gateway provides centralized control over outbound traffic from your cluster to external services. {prodname} extends {service-mesh} egress gateways with rate limiting, workload identity, and credential injection policies using Gateway API resources.
+
+[NOTE]
+====
+Egress gateway support requires {service-mesh} as the Gateway API provider. The Cluster Ingress Operator is not supported for egress use cases.
+====
+
+With an egress gateway, you can:
+
+* Apply rate limits to outbound requests using `RateLimitPolicy` resources.
+* Identify internal workloads making outbound requests using Kubernetes `TokenReview` authentication via `AuthPolicy` resources.
+* Fetch external API credentials from a secret store and inject them into outbound requests.
+* Monitor egress traffic health with metrics and access logs.
+
+.Egress gateway traffic flow
+
+The following describes the typical flow of an egress request:
+
+. An internal workload sends an HTTP request to the egress gateway.
+. The gateway applies {prodname} policies, such as rate limiting and authentication.
+. The gateway originates TLS to the external service using a `DestinationRule` resource.
+. The external service receives the request over HTTPS and responds.
+
+.User-managed resources
+
+The egress gateway infrastructure consists of the following resources that you create and manage:
+
+[cols="1,3",options="header"]
+|===
+| Resource | Purpose
+
+| `Gateway`
+| Defines the egress gateway with `gatewayClassName: istio` and a `ClusterIP` service type.
+
+| `ServiceEntry`
+| Registers the external service in the {service-mesh} service registry, making the hostname routable.
+
+| `DestinationRule`
+| Configures TLS origination so the gateway establishes TLS to the external service.
+
+| `HTTPRoute`
+| Routes traffic matching the external hostname through the gateway to the external service.
+|===
+
+.Automatically managed resources
+
+{prodname} automatically generates the following resources to enforce policies:
+
+[cols="1,3",options="header"]
+|===
+| Resource | Purpose
+
+| `WasmPlugin`, `EnvoyFilter`
+| Data plane policy enforcement.
+
+| `AuthConfig`, Limitador limits
+| Policy decisions consumed by Authorino and Limitador.
+|===

--- a/modules/proc-rhcl-egress-credential-injection.adoc
+++ b/modules/proc-rhcl-egress-credential-injection.adoc
@@ -1,0 +1,138 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-credential-injection.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-credential-injection_{context}"]
+= Configuring credential injection with Vault
+
+[role="_abstract"]
+Configure an `AuthPolicy` that authenticates workloads through Kubernetes TokenReview, fetches per-identity credentials from HashiCorp Vault, and injects them into outbound requests. The Vault path is constructed dynamically from the namespace and service account name of the workload, so different workloads get different credentials.
+
+.Prerequisites
+
+* An egress gateway is deployed and operational.
+* A test client pod is available in the `egress-test` namespace.
+* HashiCorp Vault is deployed and configured for egress credential injection, including the Kubernetes auth method, an `egress-read` policy, and an `egress-workload` role. For instructions, see xref:proc-rhcl-egress-vault-setup_{context}[Deploying and configuring Vault for egress credential injection].
+
+.Procedure
+
+. Export the egress gateway address:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Apply the `AuthPolicy` to the egress `HTTPRoute`:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: httpbin-external-auth
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: httpbin-external
+  rules:
+    authentication:
+      "workload-identity":
+        kubernetesTokenReview:
+          audiences:
+            - "https://kubernetes.default.svc.cluster.local"
+    metadata:
+      vault_login:
+        http:
+          url: "http://vault.vault.svc.cluster.local:8200/v1/auth/kubernetes/login"
+          method: POST
+          contentType: application/json
+          body:
+            expression: '"{\"jwt\": \"" + request.headers.authorization.substring(7) + "\", \"role\": \"egress-workload\"}"'
+        priority: 0
+      vault_secret:
+        http:
+          urlExpression: '"http://vault.vault.svc.cluster.local:8200/v1/secret/data/egress/" + auth.metadata.vault_login.auth.metadata.service_account_namespace + "/" + auth.metadata.vault_login.auth.metadata.service_account_name'
+          method: GET
+          headers:
+            X-Vault-Token:
+              expression: 'auth.metadata.vault_login.auth.client_token'
+        priority: 1
+    authorization:
+      vault_credential_check:
+        patternMatching:
+          patterns:
+          - predicate: 'has(auth.metadata.vault_secret.data)'
+    response:
+      success:
+        headers:
+          authorization:
+            plain:
+              expression: '"Bearer " + auth.metadata.vault_secret.data.data.api_key'
+EOF
+----
++
+The `AuthPolicy` performs the following steps:
++
+* `authentication.workload-identity` validates the Kubernetes service account token of the workload through TokenReview. Unauthenticated requests are rejected with a `401` status code.
+* `metadata.vault_login` (priority 0) posts the service account token to the Vault Kubernetes auth endpoint. Vault validates the token and returns a scoped client token based on the namespace and service account of the workload.
+* `metadata.vault_secret` (priority 1, runs after `vault_login`) reads the external credential from Vault at a path derived from the namespace and service account of the workload name, such as `secret/egress/egress-test/default`. Each workload identity gets its own credential.
+* `authorization.vault_credential_check` verifies the Vault credential fetch succeeded. If the service account of the workload is not authorized by the Vault policy, the request is denied with a `403` status code.
+* `response.success.headers.authorization` overwrites the `Authorization` header with the external credential. The service account token of the workload never reaches the external service.
+
+.Verification
+
+. Verify that a request without a token is rejected:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- curl -s -o /dev/null -w "%{http_code}" \
+    -H "Host: httpbin.org" http://${EGRESS_IP}/get
+----
++
+Expected output: `401`
+
+. Verify that an authorized workload's credential is injected:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- sh -c '
+curl -s -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+The response headers show the injected credential, such as `Authorization: Bearer sk-test-openai-key-for-egress`, instead of the service account token of the workload.
+
+. Verify that a workload from an unauthorized namespace is rejected:
++
+[source,terminal]
+----
+$ oc run bad-client --image=curlimages/curl:latest -n default --restart=Never \
+    --command -- sleep infinity
+$ oc wait --for=condition=Ready pod/bad-client -n default --timeout=30s
+----
++
+[source,terminal]
+----
+$ oc exec bad-client -n default -- sh -c '
+curl -s -o /dev/null -w "%{http_code}" -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+Expected output: `403`
+
+. Clean up the test pod:
++
+[source,terminal]
+----
+$ oc delete pod bad-client -n default
+----

--- a/modules/proc-rhcl-egress-dns-coredns.adoc
+++ b/modules/proc-rhcl-egress-dns-coredns.adoc
@@ -1,0 +1,191 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-dns-routing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-dns-coredns_{context}"]
+= Routing egress traffic using CoreDNS
+
+[role="_abstract"]
+You can route egress traffic transparently by configuring workload pods to use a CoreDNS instance as their nameserver. A `DNSPolicy` on the egress gateway creates DNS records that resolve the external hostname to the gateway IP. Use this approach when the application cannot be changed to use an internal hostname.
+
+.How it works
+
+When a workload sends a request using the real external hostname:
+
+. The pod `dnsConfig` directs the DNS query to the CoreDNS instance.
+. CoreDNS resolves the external hostname to the egress gateway IP.
+. The egress gateway receives the HTTP request with the real `Host` header.
+. The `HTTPRoute` matches on the external hostname.
+. The `DestinationRule` initiates TLS to the external service.
+. The external service responds.
+
+Split DNS is handled by design: workload pods use CoreDNS, which returns the gateway IP, while the gateway pod uses standard cluster DNS, which returns the real external IP. These separate resolution paths prevent routing loops.
+
+.Prerequisites
+
+* An egress gateway is deployed with a `ServiceEntry`, `DestinationRule`, and `Gateway` resource.
+* The DNS Operator is installed. The DNS Operator is included with {prodname}.
+* CoreDNS is deployed. For deployment instructions, see xref:../deployment/coredns.adoc#rhcl-using-on-prem-dns-coredns[Using on-premise DNS with CoreDNS].
+* The {oc-first} is installed.
+* You have administrator privileges on the {ocp} cluster.
+
+.Procedure
+
+. Configure the CoreDNS instance with a zone block for the external hostname and a forward block for all other queries. Add the following to the CoreDNS `Corefile` configuration:
++
+[source,text,subs="+quotes"]
+----
+httpbin.org {
+    kuadrant
+}
+. {
+    forward . _<cluster_dns_ip>_
+}
+----
++
+Replace `_<cluster_dns_ip>_` with your cluster DNS service IP. On {ocp}, retrieve the IP by running the following command:
++
+[source,terminal]
+----
+$ oc get svc dns-default -n openshift-dns -o jsonpath='{.spec.clusterIP}'
+----
++
+The `httpbin.org` zone block serves egress records through the kuadrant plugin. The `.` block forwards all other queries, including `*.svc.cluster.local`, to the cluster DNS so that pods can still resolve cluster-internal services. Add one zone block per external hostname that should be routed through the egress gateway.
+
+. Update the egress gateway listener to specify the external hostname. `DNSPolicy` reads listener hostnames to create DNS records:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kuadrant-egressgateway
+  namespace: gateway-system
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: httpbin
+      port: 80
+      protocol: HTTP
+      hostname: httpbin.org
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+----
++
+Add one listener per external hostname that should be routed through the egress gateway.
+
+. Create a CoreDNS provider secret with the external hostname as the zone:
++
+[source,terminal]
+----
+$ oc create secret generic dns-provider-credentials-coredns \
+    --namespace=gateway-system \
+    --type=kuadrant.io/coredns \
+    --from-literal=ZONES="httpbin.org"
+----
+
+. Create a `DNSPolicy` targeting the egress gateway. The `DNSPolicy` reads the listener hostnames and the gateway status address and creates a `DNSRecord` mapping the external hostname to the gateway IP:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: DNSPolicy
+metadata:
+  name: egress-dns
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: kuadrant-egressgateway
+  providerRefs:
+    - name: dns-provider-credentials-coredns
+EOF
+----
++
+The DNS Operator processes the resulting `DNSRecord` and publishes it to the CoreDNS instance, which serves it to pods.
+
++
+[NOTE]
+====
+The `HTTPRoute` from the egress gateway setup already matches `httpbin.org` and routes to the external service. No changes to the `HTTPRoute` are needed.
+====
+
+. Configure workload pods with `dnsPolicy: None` and a `dnsConfig` pointing to the CoreDNS instance:
++
+[source,yaml,subs="+quotes"]
+----
+spec:
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - "_<kuadrant_coredns_ip>_"
+    searches:
+      - _<namespace>_.svc.cluster.local
+      - svc.cluster.local
+      - cluster.local
+----
++
+Replace `_<kuadrant_coredns_ip>_` with the CoreDNS service `ClusterIP`. Retrieve the IP by running the following command:
++
+[source,terminal]
+----
+$ oc get svc kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.spec.clusterIP}'
+----
++
+Replace `_<namespace>_` with the namespace of the workload pod.
++
+[IMPORTANT]
+====
+Use only the CoreDNS IP as the nameserver. Do not add the cluster DNS as a second nameserver. Some resolver implementations, such as musl libc used by Alpine-based images, send queries to all nameservers simultaneously and use whichever responds first, which can bypass the egress routing. The CoreDNS instance forwards non-egress queries to the cluster DNS through the `.` forward block, so all DNS resolution continues to work.
+====
+
+.TLS considerations
+
+This approach has the same TLS model as the internal hostname approach:
+
+* *Application to gateway:* Plain HTTP. The application sends unencrypted HTTP. DNS resolves the external hostname to the gateway IP within the cluster.
+* *Gateway to external service:* TLS origination. The `DestinationRule` establishes a TLS connection to the external service.
+
+The application must send HTTP, not HTTPS, for {prodname} policies to inspect request headers. If the application sends HTTPS, the gateway cannot terminate TLS because it does not hold a certificate for the external hostname, and policies cannot inspect the encrypted traffic.
+
+.Verification
+
+. Send a request from a pod with custom `dnsConfig` using the real external hostname:
++
+[source,terminal]
+----
+$ oc exec egress-dns-test -- curl -s http://httpbin.org/get
+----
++
+The response confirms the traffic went through the egress gateway:
++
+[source,json]
+----
+{
+  "headers": {
+    "Host": "httpbin.org",
+    "X-Envoy-Decorator-Operation": "httpbin.org:443/*"
+  },
+  "url": "https://httpbin.org/get"
+}
+----
++
+* `X-Envoy-Decorator-Operation: httpbin.org:443/*` confirms the request was routed through the egress gateway.
+* `url: https://httpbin.org/get` confirms TLS origination occurred at the gateway.
+
+. Verify that cluster DNS resolution continues to work through the forward block:
++
+[source,terminal]
+----
+$ oc exec egress-dns-test -- nslookup kubernetes.default.svc.cluster.local
+----
++
+The output should resolve to the Kubernetes API server `ClusterIP`.

--- a/modules/proc-rhcl-egress-gateway-setup.adoc
+++ b/modules/proc-rhcl-egress-gateway-setup.adoc
@@ -1,0 +1,171 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-gateway-setup_{context}"]
+= Deploying an egress gateway
+
+[role="_abstract"]
+Deploy the egress gateway infrastructure to route outbound traffic from your cluster to an external service through a centralized gateway. This procedure uses `httpbin.org` as an example external service.
+
+.Prerequisites
+
+* {prodname} is installed on the {ocp} cluster.
+* {service-mesh} is installed and configured on the {ocp} cluster.
+* The {oc-first} is installed.
+* You have administrator privileges on the {ocp} cluster.
+
+.Procedure
+
+. Create the `Gateway` resource with a `ClusterIP` service type. Egress traffic originates inside the cluster, so no external IP is needed:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kuadrant-egressgateway
+  namespace: gateway-system
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+----
+
+. Create the `ServiceEntry` resource to register the external service in the {service-mesh} service registry:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: httpbin-external
+  namespace: gateway-system
+spec:
+  hosts:
+    - httpbin.org
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+EOF
+----
+
+. Create the `DestinationRule` resource to configure TLS origination. The gateway establishes TLS to the external service on behalf of the application:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: httpbin-external
+  namespace: gateway-system
+spec:
+  host: httpbin.org
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: httpbin.org
+EOF
+----
+
+. Create the `HTTPRoute` resource to route traffic through the gateway to the external service:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-external
+  namespace: gateway-system
+spec:
+  parentRefs:
+    - name: kuadrant-egressgateway
+      namespace: gateway-system
+  hostnames:
+    - httpbin.org
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: httpbin.org
+      backendRefs:
+        - group: networking.istio.io
+          kind: Hostname
+          name: httpbin.org
+          port: 443
+EOF
+----
++
+The `Hostname` backend is provided by the `ServiceEntry`. The `URLRewrite` filter ensures the correct `Host` header reaches the external service.
+
+. Wait for the gateway to be ready:
++
+[source,terminal]
+----
+$ oc wait --timeout=5m -n gateway-system gateway/kuadrant-egressgateway --for=condition=Programmed
+----
+
+. Export the gateway address for use in subsequent procedures:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+.Verification
+
+. Create a test namespace and deploy a test client pod:
++
+[source,terminal]
+----
+$ oc create namespace egress-test
+----
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-client
+  namespace: egress-test
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:latest
+      command: ["sleep", "infinity"]
+  restartPolicy: Never
+EOF
+----
++
+[source,terminal]
+----
+$ oc wait --timeout=2m -n egress-test pod/test-client --for=condition=Ready
+----
+
+. Send a request through the egress gateway to verify connectivity:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- \
+    curl -s -o /dev/null -w "%{http_code}" -H "Host: httpbin.org" http://${EGRESS_IP}/get
+----
++
+Expected output: `200`

--- a/modules/proc-rhcl-egress-internal-hostname.adoc
+++ b/modules/proc-rhcl-egress-internal-hostname.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-dns-routing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-internal-hostname_{context}"]
+= Routing egress traffic using an internal hostname
+
+[role="_abstract"]
+You can route egress traffic by configuring the application to use the cluster-internal service name of the egress gateway as the hostname. The gateway rewrites the host header and routes the request to the real external service with TLS origination. This is the recommended approach because it requires no DNS configuration and has the most straightforward TLS model.
+
+.How it works
+
+When a workload sends a request to the internal service name:
+
+. Kubernetes DNS resolves the internal service name to the egress gateway `ClusterIP`.
+. The egress gateway receives the plain HTTP request.
+. The `HTTPRoute` matches the request and the `URLRewrite` filter sets the `Host` header to the real external hostname.
+. The `DestinationRule` initiates TLS to the external service.
+. The external service receives the request over HTTPS and responds.
+
+No additional DNS configuration is needed. When {service-mesh} provisions the egress gateway, it creates a Kubernetes service named `kuadrant-egressgateway-istio` in the namespace of the gateway. Any pod can resolve this service automatically.
+
+.Prerequisites
+
+* An egress gateway is deployed with a `ServiceEntry`, `DestinationRule`, and `Gateway` resource.
+* The {oc-first} is installed.
+
+.Procedure
+
+. Optional: If a friendlier hostname is preferred, create an `ExternalName` service that aliases the gateway service:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-egress
+  namespace: _<application_namespace>_
+spec:
+  type: ExternalName
+  externalName: kuadrant-egressgateway-istio.gateway-system.svc.cluster.local
+EOF
+----
++
+Replace `_<application_namespace>_` with the namespace where your application runs. Applications in that namespace can then use `http://httpbin-egress/get`. This creates a DNS alias within the cluster, not a transparent override of the real external hostname. The application must still be configured to use this alias instead of the original hostname.
+
+. Create the `HTTPRoute` that matches the internal service name and rewrites the `Host` header to the real external hostname. This replaces the `HTTPRoute` deployed during egress gateway setup:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-internal-hostname
+  namespace: gateway-system
+spec:
+  parentRefs:
+    - name: kuadrant-egressgateway
+      namespace: gateway-system
+  hostnames:
+    - kuadrant-egressgateway-istio.gateway-system.svc.cluster.local
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: httpbin.org
+      backendRefs:
+        - group: networking.istio.io
+          kind: Hostname
+          name: httpbin.org
+          port: 443
+EOF
+----
++
+The `URLRewrite` filter changes the `Host` header from the internal hostname to `httpbin.org`, and the `Hostname` backend routes the request to the real external service.
++
+[NOTE]
+====
+The `Gateway` listener does not restrict by hostname, so it accepts traffic on any host, including the internal service name.
+====
+
+.TLS considerations
+
+This approach has the most straightforward TLS model:
+
+* *Application to gateway:* Plain HTTP. The application sends unencrypted HTTP to the egress gateway `ClusterIP`. Traffic stays within the cluster network.
+* *Gateway to external service:* TLS origination. The `DestinationRule` establishes a TLS connection to the external service with the appropriate SNI.
+
+The application does not need to handle TLS certificates for the external service.
+
+.Verification
+
+* Send a request from a pod using the internal service name:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- \
+    curl -s http://kuadrant-egressgateway-istio.gateway-system.svc.cluster.local/get
+----
++
+The response confirms the flow works end-to-end:
++
+[source,json]
+----
+{
+  "headers": {
+    "Host": "httpbin.org",
+    "X-Envoy-Original-Host": "kuadrant-egressgateway-istio.gateway-system.svc.cluster.local"
+  },
+  "url": "https://httpbin.org/get"
+}
+----
++
+* `Host: httpbin.org` confirms the `URLRewrite` correctly rewrote the host header.
+* `X-Envoy-Original-Host` preserves the original internal hostname.
+* `url: https://httpbin.org/get` confirms TLS origination occurred.

--- a/modules/proc-rhcl-egress-per-identity-credentials.adoc
+++ b/modules/proc-rhcl-egress-per-identity-credentials.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-credential-injection.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-per-identity-credentials_{context}"]
+= Verifying per-identity credential isolation
+
+[role="_abstract"]
+Different workload identities automatically get different credentials from Vault. The `urlExpression` in the `AuthPolicy` constructs the Vault path from the namespace and service account name of the workload. You can verify this behavior by storing a different credential for another namespace and testing.
+
+.Prerequisites
+
+* An egress gateway is deployed with the credential injection `AuthPolicy` applied.
+* HashiCorp Vault is deployed with the Kubernetes auth method configured.
+
+.Procedure
+
+. Export the egress gateway address:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Add the new namespace to the Vault role:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault write auth/kubernetes/role/egress-workload \
+    bound_service_account_names=default \
+    bound_service_account_namespaces=egress-test,workload-b \
+    policies=egress-read \
+    ttl=1h
+----
+
+. Store a different credential for the new namespace:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault kv put secret/egress/workload-b/default \
+    api_key=sk-different-key-for-workload-b
+----
+
+. Deploy a workload in the new namespace:
++
+[source,terminal]
+----
+$ oc create namespace workload-b
+----
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-client-b
+  namespace: workload-b
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:latest
+      command: ["sleep", "infinity"]
+  restartPolicy: Never
+EOF
+----
++
+[source,terminal]
+----
+$ oc wait --for=condition=Ready pod/test-client-b -n workload-b --timeout=60s
+----
+
+.Verification
+
+. Verify that the original workload receives its credential:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- sh -c '
+curl -s -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+The response shows `Authorization: Bearer sk-test-openai-key-for-egress`.
+
+. Verify that the new workload receives a different credential:
++
+[source,terminal]
+----
+$ oc exec test-client-b -n workload-b -- sh -c '
+curl -s -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+The response shows `Authorization: Bearer sk-different-key-for-workload-b`.

--- a/modules/proc-rhcl-egress-per-workload-rl.adoc
+++ b/modules/proc-rhcl-egress-per-workload-rl.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-per-workload-rl_{context}"]
+= Applying per-workload rate limiting
+
+[role="_abstract"]
+With workload identity established through `AuthPolicy`, you can give each workload its own rate limit bucket. The `RateLimitPolicy` uses the service account username as a counter, so each workload identity is tracked independently.
+
+.Prerequisites
+
+* An egress gateway is deployed and operational.
+* An `AuthPolicy` with `kubernetesTokenReview` authentication is applied to the egress `HTTPRoute`.
+* A test client pod is available in the `egress-test` namespace.
+
+.Procedure
+
+. Export the egress gateway address:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Apply a `RateLimitPolicy` that uses the service account username of the workload as a counter:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: RateLimitPolicy
+metadata:
+  name: egress-per-workload
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: httpbin-external
+  limits:
+    per-workload:
+      rates:
+        - limit: 5
+          window: 10s
+      counters:
+        - expression: "auth.identity.username"
+EOF
+----
++
+Each service account gets an independent bucket of 5 requests every 10 seconds. For example, `system:serviceaccount:team-a:default` and `system:serviceaccount:team-b:default` are tracked separately. The identity is stable across pod restarts and reschedules.
+
+.Verification
+
+* Send requests in a loop with the service account token and observe per-workload rate limiting:
++
+[source,terminal]
+----
+$ for i in $(seq 1 10); do
+    oc exec test-client -n egress-test -- sh -c '
+      curl -s -o /dev/null -w "%{http_code}" \
+          -H "Host: httpbin.org" \
+          -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+          http://'"${EGRESS_IP}"'/get
+    '
+    sleep 0.5
+  done
+----
++
+The first 5 requests return `200`. Subsequent requests return `429` until the 10-second window resets.
+
+.Identity path reference
+
+The resolved identity contains the following fields. `AuthPolicy` selectors and `RateLimitPolicy` expressions resolve identity paths differently because they are evaluated by different engines.
+
+[cols="1,2,2,2",options="header"]
+|===
+| Field | Example value | AuthPolicy selector | RateLimitPolicy expression
+
+| Username
+| `system:serviceaccount:egress-test:default`
+| `auth.identity.user.username`
+| `auth.identity.username`
+
+| UID
+| `425214f1-cf45-...`
+| `auth.identity.user.uid`
+| `auth.identity.uid`
+
+| Groups
+| `[system:serviceaccounts, system:serviceaccounts:egress-test]`
+| `auth.identity.user.groups`
+| `auth.identity.groups`
+|===
+
+[NOTE]
+====
+`AuthPolicy` uses the full TokenReview structure, such as `auth.identity.user.username`, while `RateLimitPolicy` counter expressions use a flattened representation, such as `auth.identity.username`. This is by design because the two are evaluated by different engines: Authorino and wasm-shim.
+====

--- a/modules/proc-rhcl-egress-rate-limiting.adoc
+++ b/modules/proc-rhcl-egress-rate-limiting.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-rate-limiting_{context}"]
+= Applying rate limiting to egress traffic
+
+[role="_abstract"]
+You can apply a `RateLimitPolicy` to an egress `Gateway` or `HTTPRoute` to limit the rate of outbound requests to external services. Rate limiting on egress uses the same attachment model as ingress: a gateway-level policy sets defaults for all routes, while a route-level policy can override those defaults for a specific route. The following example attaches a rate limit to an `HTTPRoute`.
+
+[NOTE]
+====
+The `source.address` counter expression cannot be used for egress rate limiting because it includes the ephemeral port, giving each connection its own bucket. Use workload identity with `auth.identity.username` for per-workload limiting instead.
+====
+
+.Prerequisites
+
+* An egress gateway is deployed and operational.
+* A test client pod is available in the `egress-test` namespace.
+
+.Procedure
+
+. Export the egress gateway address:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Apply a `RateLimitPolicy` to the egress `HTTPRoute`:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: RateLimitPolicy
+metadata:
+  name: egress-ratelimit
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: httpbin-external
+  limits:
+    global:
+      rates:
+        - limit: 5
+          window: 10s
+EOF
+----
++
+This limits all traffic through the `httpbin-external` route to 5 requests every 10 seconds, regardless of which workload is sending.
+
+.Verification
+
+* Send requests in a loop and observe the rate limit being enforced:
++
+[source,terminal]
+----
+$ for i in $(seq 1 10); do
+    oc exec test-client -n egress-test -- \
+        curl -s -o /dev/null -w "%{http_code}" -H "Host: httpbin.org" http://${EGRESS_IP}/get
+    sleep 0.5
+  done
+----
++
+The first 5 requests return `200`. Subsequent requests return `429` until the 10-second window resets.
+
+.Additional information
+
+Standard `RateLimitPolicy` patterns such as per-route, gateway-level, and conditional rate limiting with `when` predicates all work on egress traffic. For more information about rate limiting configurations, see xref:../deployment/deployment.adoc#rhcl-config-deploy-gateway-policies[Configure and deploy gateway policies].

--- a/modules/proc-rhcl-egress-vault-setup.adoc
+++ b/modules/proc-rhcl-egress-vault-setup.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-credential-injection.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-vault-setup_{context}"]
+= Deploying and configuring Vault for egress credential injection
+
+[role="_abstract"]
+Deploy a HashiCorp Vault instance and configure the Kubernetes auth method so that Authorino can authenticate workloads and fetch per-identity credentials for egress requests.
+
+[NOTE]
+====
+The following procedure deploys Vault in dev mode for testing purposes. Dev mode runs Vault in-memory without TLS and uses a static root token. For production deployments, see the HashiCorp Vault documentation.
+====
+
+.Prerequisites
+
+* An egress gateway is deployed and operational.
+* A test client pod is available in the `egress-test` namespace.
+* The {oc-first} is installed.
+* Helm is installed.
+
+.Procedure
+
+. Add the HashiCorp Helm repository:
++
+[source,terminal]
+----
+$ helm repo add hashicorp https://helm.releases.hashicorp.com
+$ helm repo update hashicorp
+----
+
+. Deploy Vault in dev mode:
++
+[source,terminal]
+----
+$ helm install vault hashicorp/vault \
+    --set "server.dev.enabled=true" \
+    --set "server.dev.devRootToken=root" \
+    -n vault --create-namespace --wait --timeout=5m
+----
+
+. Wait for the Vault pod to be ready:
++
+[source,terminal]
+----
+$ oc wait --timeout=2m -n vault pod/vault-0 --for=condition=Ready
+----
+
+. Store a test credential at a per-identity Vault path. The path follows the pattern `secret/egress/<namespace>/<service-account-name>`:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault kv put secret/egress/egress-test/default \
+    api_key=sk-test-openai-key-for-egress
+----
+
+. Enable the Kubernetes auth method in Vault:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault auth enable kubernetes
+----
+
+. Configure the Kubernetes auth method with the cluster API server address:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault write auth/kubernetes/config \
+    kubernetes_host="https://kubernetes.default.svc:443"
+----
+
+. Create a Vault policy that grants read access to egress secrets:
++
+[source,terminal]
+----
+$ oc exec -i vault-0 -n vault -- vault policy write egress-read /dev/stdin <<'POLICY'
+path "secret/data/egress/*" {
+  capabilities = ["read"]
+}
+POLICY
+----
+
+. Create a Vault role that binds workload service accounts to the policy. This role authorizes workloads from the `egress-test` namespace:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault write auth/kubernetes/role/egress-workload \
+    bound_service_account_names=default \
+    bound_service_account_namespaces=egress-test \
+    policies=egress-read \
+    ttl=1h
+----
++
+To authorize workloads from additional namespaces, add them to the `bound_service_account_namespaces` list as a comma-separated value.
+
+.Verification
+
+. Verify that the Kubernetes auth method is enabled:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault auth list
+----
++
+The output should include `kubernetes/` in the list of auth methods.
+
+. Verify that the egress-workload role is configured:
++
+[source,terminal]
+----
+$ oc exec vault-0 -n vault -- vault read auth/kubernetes/role/egress-workload
+----
++
+The output should show `bound_service_account_namespaces` including `egress-test`.

--- a/modules/proc-rhcl-egress-workload-identity.adoc
+++ b/modules/proc-rhcl-egress-workload-identity.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-egress-workload-identity_{context}"]
+= Authenticating workloads with TokenReview
+
+[role="_abstract"]
+In egress scenarios, the clients are internal workloads. You can identify which workload is making a request by using Kubernetes TokenReview via `AuthPolicy`. Every pod has a service account token mounted automatically, so no API keys need to be distributed.
+
+The workload sends its service account token in the `Authorization` header. `AuthPolicy` validates the token and exposes the identity of the workload, including namespace and service account name, for use by other policies. Requests without a valid service account token are rejected with a `401` status code.
+
+.Prerequisites
+
+* An egress gateway is deployed and operational.
+* A test client pod is available in the `egress-test` namespace.
+
+.Procedure
+
+. Export the egress gateway address:
++
+[source,terminal]
+----
+$ export EGRESS_IP=$(oc get gtw kuadrant-egressgateway -n gateway-system \
+    -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Apply an `AuthPolicy` to authenticate workloads and restrict egress access to specific namespaces:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: workload-identity
+  namespace: gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: httpbin-external
+  rules:
+    authentication:
+      "workload-sa":
+        kubernetesTokenReview:
+          audiences:
+            - "https://kubernetes.default.svc.cluster.local"
+    authorization:
+      "allowed-namespaces":
+        patternMatching:
+          patterns:
+            - predicate: auth.identity.user.username.startsWith('system:serviceaccount:egress-test:')
+    response:
+      success:
+        filters:
+          "identity":
+            json:
+              properties:
+                username:
+                  selector: auth.identity.user.username
+EOF
+----
++
+* `authentication.workload-sa` validates the service account token via TokenReview. Unauthenticated requests are rejected with a `401` status code.
+* `authorization.allowed-namespaces` restricts access to workloads from the `egress-test` namespace. Workloads from other namespaces are rejected with a `403` status code. Add additional patterns with `||` to allow more namespaces.
+* `response.success.filters.identity` exposes the resolved identity as dynamic metadata. This is required for policies that reference `auth.identity.*` expressions, such as per-workload rate limiting.
+
+.Verification
+
+. Verify that an authorized workload receives a `200` response:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- sh -c '
+curl -s -o /dev/null -w "%{http_code}" \
+    -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+Expected output: `200`
+
+. Verify that a request without a token is rejected:
++
+[source,terminal]
+----
+$ oc exec test-client -n egress-test -- \
+    curl -s -o /dev/null -w "%{http_code}" -H "Host: httpbin.org" http://${EGRESS_IP}/get
+----
++
+Expected output: `401`
+
+. Verify that a workload from an unauthorized namespace is rejected:
++
+[source,terminal]
+----
+$ oc run bad-client --image=curlimages/curl:latest -n default --restart=Never \
+    --command -- sleep infinity
+$ oc wait --for=condition=Ready pod/bad-client -n default --timeout=30s
+----
++
+[source,terminal]
+----
+$ oc exec bad-client -n default -- sh -c '
+curl -s -o /dev/null -w "%{http_code}" -H "Host: httpbin.org" \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    http://'"${EGRESS_IP}"'/get
+'
+----
++
+Expected output: `403`
+
+. Clean up the test pod:
++
+[source,terminal]
+----
+$ oc delete pod bad-client -n default
+----

--- a/modules/ref-rhcl-egress-considerations.adoc
+++ b/modules/ref-rhcl-egress-considerations.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-gateway.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-rhcl-egress-considerations_{context}"]
+= Egress gateway considerations and limitations
+
+[role="_abstract"]
+Review the following considerations and limitations before deploying an egress gateway with {prodname}.
+
+.ClusterIP compared to LoadBalancer
+
+The egress gateway examples use the `networking.istio.io/service-type: ClusterIP` annotation because egress traffic originates inside the cluster and no external IP is needed. If workloads in other clusters need to reach this egress gateway, use `LoadBalancer` instead.
+
+.Applications must send HTTP
+
+For {prodname} policies to inspect request headers and apply rate limiting, the application must send plain HTTP to the egress gateway. The `DestinationRule` handles TLS origination to the external service. If the application sends HTTPS directly, the gateway cannot inspect the encrypted traffic and policies cannot be enforced.
+
+.Resource ownership
+
+The following table summarizes which resources you manage and which resources {prodname} manages automatically:
+
+[cols="1,1,3",options="header"]
+|===
+| Resource | Managed by | Purpose
+
+| `Gateway`
+| User
+| Egress gateway infrastructure.
+
+| `ServiceEntry`
+| User
+| Registers external service in {service-mesh}.
+
+| `DestinationRule`
+| User
+| TLS origination configuration.
+
+| `HTTPRoute`
+| User
+| Routes traffic to external service.
+
+| `AuthPolicy`, `RateLimitPolicy`
+| User
+| Policy definitions.
+
+| `WasmPlugin`, `EnvoyFilter`
+| {prodname}
+| Policy enforcement in the data plane.
+
+| `AuthConfig`, Limitador limits
+| {prodname}
+| Policy decisions consumed by Authorino and Limitador.
+|===
+
+.Limitations
+
+* Egress gateway support requires {service-mesh} as the Gateway API provider. The Cluster Ingress Operator is not supported for egress.
+* `ServiceEntry` and `DestinationRule` resources are user-managed. {prodname} does not create or manage these {service-mesh} resources.

--- a/modules/ref-rhcl-egress-credential-security.adoc
+++ b/modules/ref-rhcl-egress-credential-security.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-credential-injection.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-rhcl-egress-credential-security_{context}"]
+= Credential injection security model
+
+[role="_abstract"]
+Review the security model for egress credential injection to understand how access control is enforced at multiple layers.
+
+.Two-layer access control
+
+Access control is enforced at two independent layers:
+
+[cols="1,3",options="header"]
+|===
+| Layer | Description
+
+| Kubernetes TokenReview
+| Authorino validates the service account token of the workload. Requests without a valid token are rejected with a `401` status code.
+
+| Vault Kubernetes auth
+| Vault validates the service account token independently and checks it against the role's `bound_service_account_names` and `bound_service_account_namespaces`. Only workloads in authorized namespaces get credentials. Unauthorized workloads are rejected with a `403` status code.
+|===
+
+No shared tokens or API keys are involved. Each workload authenticates with its own Kubernetes identity and receives its own credential from a per-identity Vault path.
+
+.Credential management
+
+External API keys must be stored in Vault at the correct per-identity path (`secret/egress/<namespace>/<sa-name>`) before workloads can use them. This is typically a platform team responsibility. To allow workload teams to manage their own credentials, grant scoped Vault write access per namespace, such as `secret/data/egress/<namespace>/*`.

--- a/modules/ref-rhcl-egress-dns-alternatives.adoc
+++ b/modules/ref-rhcl-egress-dns-alternatives.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * deployment/rhcl-egress-dns-routing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-rhcl-egress-dns-alternatives_{context}"]
+= Alternative DNS routing approaches
+
+[role="_abstract"]
+In addition to the internal hostname and CoreDNS approaches, you can use the following alternatives to route egress traffic through a gateway.
+
+.hostAliases
+
+Kubernetes pods support `hostAliases` to add entries to `/etc/hosts`. This can map an external hostname to the egress gateway IP per pod:
+
+[source,yaml,subs="+quotes"]
+----
+spec:
+  hostAliases:
+    - ip: "_<egress_gateway_ip>_"
+      hostnames:
+        - "httpbin.org"
+----
+
+Replace `_<egress_gateway_ip>_` with the egress gateway `ClusterIP`.
+
+This approach requires no additional tools and works on any platform, but the gateway IP is hardcoded in every pod spec. If the gateway service is recreated and gets a new IP, all pods need redeployment. The CoreDNS approach avoids this problem because `DNSRecord` updates propagate automatically.
+
+.Sidecar-based routing
+
+If workloads are already enrolled in the {service-mesh} with sidecar injection, traffic can be routed through the egress gateway using a `VirtualService` with the `mesh` gateway. The sidecar proxy intercepts outbound connections and routes them to the egress gateway transparently without requiring DNS changes. This is a native {service-mesh} pattern but requires mesh membership, which adds resource overhead per pod. Consider this option only if your workloads already use sidecar injection.


### PR DESCRIPTION
Version(s):
RHCL 1.5

## Summary

Draft from engineering — three egress gateway TP guides ported from upstream Kuadrant docs to downstream RHCL format. Technically verified against the upstream codebase and tested on a Kind cluster. Happy to hand off for style/structure rework.

**Guides:**
- **Configuring an egress gateway** — setup, rate limiting, workload identity
- **Configuring DNS routing for an egress gateway** — internal hostname (recommended) and CoreDNS approaches
- **Injecting credentials into egress requests** — Vault integration with Kubernetes auth method

**Files:**
- 3 assemblies in `deployment/`
- 16 modules in `modules/` (5 concept, 8 procedure, 3 reference)

**What was verified:**
- All YAML examples validated against upstream API types
- All commands executed successfully on a Kind cluster (kubectl as oc stand-in)
- Style review: IBM Style Guide, Red Hat Supplementary Style Guide compliance
- All xref targets resolve to existing files in rhcl-docs-main
- Technology Preview admonitions on all three assemblies

**Topic map not updated** — placement TBD (new "Egress gateway" section or entries under "Deploy Red Hat Connectivity Link").

**Upstream tracking:**
- Source docs: https://github.com/Kuadrant/kuadrant-operator/tree/main/doc/user-guides/egress
- Tracking issue: https://github.com/Kuadrant/kuadrant-operator/issues/2151

Reviewers:
- [ ] SME has approved this change.
- [ ] QE has approved this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)