### PR TITLE
[OSDOCS-20987]: Document Agent-based Installer rendezvous host port 8090/TCP

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-using-iscsi.adoc
+++ b/installing/installing_with_agent_based_installer/installing-using-iscsi.adoc
@@ -29,6 +29,7 @@ include::modules/installing-ocp-agent-prereqs.adoc[leveloffset=+1]
 * xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 * xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking-ports_preparing-to-install-with-agent-based-installer[Port requirements for the rendezvous host]
 
 // Downloading the Agent-based Installer
 include::modules/installing-ocp-agent-download.adoc[leveloffset=+1]

--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -19,6 +19,7 @@ include::modules/installing-ocp-agent-prereqs.adoc[leveloffset=+1]
 * xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 * xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking-ports_preparing-to-install-with-agent-based-installer[Port requirements for the rendezvous host]
 
 // Downloading the Agent-based Installer
 include::modules/installing-ocp-agent-download.adoc[leveloffset=+1]

--- a/installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
@@ -22,6 +22,7 @@ include::modules/installing-ocp-agent-prereqs.adoc[leveloffset=+1]
 * xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 * xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking-ports_preparing-to-install-with-agent-based-installer[Port requirements for the rendezvous host]
 
 // Downloading the Agent-based Installer
 include::modules/installing-ocp-agent-download.adoc[leveloffset=+1]

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -102,6 +102,8 @@ include::modules/agent-install-load-balancing-none.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking-ports_preparing-to-install-with-agent-based-installer[Port requirements for the rendezvous host]
+
 * xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 
 * link:https://access.redhat.com/articles/4207611[Deploying OpenShift 4.x on non-tested platforms using the bare metal install method (Red{nbsp}Hat Knowledgebase article)]

--- a/modules/agent-install-load-balancing-none.adoc
+++ b/modules/agent-install-load-balancing-none.adoc
@@ -52,6 +52,11 @@ Configure the following ports on both the front and back of the load balancers:
 
 |===
 +
+[IMPORTANT]
+====
+The Agent-based Installer requires TCP port `8090` to be open between all hosts and the rendezvous host so that the hosts can access the Assisted Service API. Port `8090` is required only during the discovery and bootstrap phases. For more information, see "Port requirements for the rendezvous host".
+====
++
 [NOTE]
 ====
 The load balancer must be configured to take a maximum of 30 seconds from the

--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -20,6 +20,30 @@ By default, Podman uses a subnet of `10.88.0.0/16` as a bridge network.
 Do not set the `network.machineNetwork.cidr` parameter to include this address range, otherwise a conflict causes the cluster installation to fail.
 ====
 
+[id="agent-install-networking-ports_{context}"]
+== Port requirements for the rendezvous host
+
+During the discovery and bootstrap phases of an installation, all the hosts connect to the Assisted Service that runs on the rendezvous host. Configure your firewall to allow the following traffic from each host to the rendezvous host:
+
+.Ports required to reach the Assisted Service on the rendezvous host
+[cols="2a,2a,5a",options="header"]
+|===
+|Port
+|Protocol
+|Description
+
+|`8090`
+|TCP
+|Assisted Service API. Hosts use this port to register with the Assisted Service, report hardware information, and retrieve installation instructions.
+|===
+
+[NOTE]
+====
+Port `8090` is required only during installation. After installation completes, the Assisted Service is no longer exposed on the rendezvous host.
+====
+
+This specific port requirement is in addition to the standard {product-title} networking requirements for installation.
+
 [id="agent-install-networking-DHCP_{context}"]
 == DHCP
 

--- a/modules/installing-ocp-agent-prereqs.adoc
+++ b/modules/installing-ocp-agent-prereqs.adoc
@@ -15,6 +15,7 @@ Before beginning your cluster installation, you must complete prerequisite tasks
 * You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
 * You read "Selecting a cluster installation method and preparing it for users".
 * If you use a firewall or proxy, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall".
+* You configured your firewall to allow TCP traffic on port `8090` from all hosts to the rendezvous host so that hosts can reach the Assisted Service API during discovery and bootstrap. For more information, see "Port requirements for the rendezvous host".
 
 endif::pxe-boot[]
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20987

Link to docs preview:
* https://116975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html
* https://116975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-basic.html
* https://116975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html

QE review:
- [ ] QE has approved this change.

Additional information:
Documents TCP port `8090` as an Agent-based Installer–specific networking requirement so non-rendezvous hosts can reach the Assisted Service API on the rendezvous host during discovery and bootstrap. This port was missing from firewall/networking guidance and caused customer confusion (case 04506402).

## Summary
- Add a "Port requirements for the rendezvous host" section documenting `8090/TCP` for Assisted Service access during install only
- Call out the requirement next to existing Machine Config Server port guidance (`22623`/`22624`)
- Add the prerequisite and Additional resources xrefs from Agent-based Installer assemblies

## Test plan
- [ ] Confirm Netlify preview shows the new rendezvous host port section in Preparing to install with the Agent-based Installer
- [ ] Confirm Additional resources xrefs resolve correctly
- [ ] Confirm wording makes clear `8090` is install-time only and not a load-balanced port