### PR TITLE
CNV#93278: Document virtio-win ISO download from web console

### DIFF
--- a/modules/virt-adding-container-disk-as-cd.adoc
+++ b/modules/virt-adding-container-disk-as-cd.adoc
@@ -14,6 +14,8 @@ You can install VirtIO drivers from a container disk that you add to a Windows v
 [TIP]
 ====
 You do not need to download the `container-native-virtualization/virtio-win-rhel9` container disk. If the container disk is not present, the cluster downloads it from the Red Hat registry. However, to reduce the installation time, you can download the container disk in advance from the link:https://catalog.redhat.com/en/software/containers/container-native-virtualization/virtio-win-rhel9/633ffae83be061d37b2770f6[Red Hat Ecosystem Catalog].
+
+You can also download the `virtio-win` ISO file from the {product-title} web console by navigating to *Virtualization* -> *Settings* -> *Downloads*.
 ====
 
 .Prerequisites

--- a/modules/virt-downloading-virtio-win-iso.adoc
+++ b/modules/virt-downloading-virtio-win-iso.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-downloading-virtio-win-iso_{context}"]
+= Downloading the VirtIO drivers ISO from the web console
+
+[role="_abstract"]
+You can download the `virtio-win` ISO file from the {product-title} web console. The ISO file includes the VirtIO drivers and the QEMU guest agent installer for Microsoft Windows virtual machines (VMs).
+
+[NOTE]
+====
+If your cluster has Windows VMs, a notification on the *Virtualization* -> *VirtualMachines* page provides a link to the *Downloads* tab where you can download the ISO file.
+====
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Virtualization* -> *Settings*.
+. Click the *Downloads* tab.
+. In the *Windows drivers* section, click *Download ISO*.
++
+The `virtio-win` ISO file downloads to your local machine.

--- a/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
+++ b/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-VirtIO drivers are paravirtualized device drivers required for Microsoft Windows virtual machines (VMs) to run in {VirtProductName}. The drivers are shipped with the rest of the images and do not require a separate download.
+VirtIO drivers are paravirtualized device drivers required for Microsoft Windows virtual machines (VMs) to run in {VirtProductName}. The drivers are shipped with the rest of the images. You can also download the `virtio-win` ISO file from the web console to install or update drivers on Windows VMs.
 
 The `container-native-virtualization/virtio-win` container disk must be attached to the VM as a SATA CD drive to enable driver installation. You can install VirtIO drivers during Windows installation or add them to an existing Windows installation.
 
@@ -31,6 +31,8 @@ After the drivers are installed, the `container-native-virtualization/virtio-win
 |The network driver. Sometimes labeled as an *Ethernet Controller* in the *Other devices* group. Available only if a VirtIO NIC is configured.
 |===
 
+include::modules/virt-downloading-virtio-win-iso.adoc[leveloffset=+1]
+
 include::modules/virt-attaching-virtio-disk-to-windows.adoc[leveloffset=+1]
 
 include::modules/virt-attaching-virtio-disk-to-windows-existing.adoc[leveloffset=+1]
@@ -40,3 +42,8 @@ include::modules/virt-adding-container-disk-as-cd.adoc[leveloffset=+1]
 include::modules/virt-installing-virtio-drivers-installing-windows.adoc[leveloffset=+1]
 
 include::modules/virt-installing-virtio-drivers-existing-windows.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/managing_vms/virt-update-virtio-drivers.adoc#virt-update-virtio-drivers[Update VirtIO drivers]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[CNV-93278](https://redhat.atlassian.net/browse/CNV-93278)

Link to docs preview:
_Will add after preview build completes_

QE review:
- [x] QE has approved this change.

Additional information:
Document the new VirtIO drivers ISO download feature in the web console.

- Created new procedure module for downloading the virtio-win ISO from the Virtualization > Settings > Downloads tab, including a note about the VM list notification banner
- Updated the install assembly abstract to reflect the new download option (removed "do not require a separate download")
- Added the new module as the first include in the install assembly
- Added an Additional resources xref to the Update VirtIO drivers assembly
- Updated the container disk module TIP block to mention the Downloads tab as an alternative download source