### PR TITLE
OADP-8503: Migrate velero CLI references to oc oadp CLI plugin

### DIFF
--- a/modules/cleanup-a-backup-oadp-aws-sts.adoc
+++ b/modules/cleanup-a-backup-oadp-aws-sts.adoc
@@ -68,7 +68,7 @@ $ oc delete backups.velero.io hello-world
 +
 [source,terminal]
 ----
-$ velero backup delete hello-world
+$ oc oadp backup delete hello-world --confirm
 ----
 
 . If you no longer need the Custom Resource Definitions (CRD), remove them from the cluster by running the following command:

--- a/modules/cleanup-a-backup-oadp-rosa-sts.adoc
+++ b/modules/cleanup-a-backup-oadp-rosa-sts.adoc
@@ -75,7 +75,7 @@ $ oc delete backups.velero.io hello-world
 +
 [source,terminal]
 ----
-$ velero backup delete hello-world
+$ oc oadp backup delete hello-world --confirm
 ----
 
 . If you no longer need the Custom Resource Definitions (CRD), remove them from the cluster by running the following command:

--- a/modules/migration-debugging-velero-admission-webhooks-knative.adoc
+++ b/modules/migration-debugging-velero-admission-webhooks-knative.adoc
@@ -7,15 +7,15 @@
 = Restoring Knative resources
 
 [role="_abstract"]
-Resolve issues with restoring Knative resources that use admission webhooks by restoring the top-level `service.serving.knative.dev` service resource with Velero. This helps you to ensure that Knative resources are restored successfully without admission webhook errors.
+Resolve issues with restoring Knative resources that use admission webhooks by restoring the top-level `service.serving.knative.dev` service resource. This helps you to ensure that Knative resources are restored successfully without admission webhook errors.
 
 .Procedure
 
 * Restore the top level `service.serving.knative.dev Service` resource by using the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero restore <restore_name> \
-  --from-backup=<backup_name> --include-resources \
-  service.serving.knative.dev
+$ oc oadp restore create __<restore_name>__ \
+  --from-backup=__<backup_name>__ \
+  --include-resources service.serving.knative.dev
 ----

--- a/modules/oadp-backing-and-restoring-from-cluster-to-cluster.adoc
+++ b/modules/oadp-backing-and-restoring-from-cluster-to-cluster.adoc
@@ -23,9 +23,9 @@ Review the specific prerequisites and procedure differences to successfully back
 ** For best results, use OADP to create the namespace on the destination cluster.
 ** If you use the Velero `file-system-backup` option, enable the `--default-volumes-to-fs-backup` flag for use during backup by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero backup create <backup_name> --default-volumes-to-fs-backup <any_other_options>
+$ oc oadp backup create __<backup_name>__ --default-volumes-to-fs-backup
 ----
 +
 [NOTE]

--- a/modules/oadp-deleting-backups-using-velero.adoc
+++ b/modules/oadp-deleting-backups-using-velero.adoc
@@ -13,7 +13,7 @@ Delete a backup by using the {oadp-short} CLI to run the `oc oadp backup delete`
 .Prerequisites
 
 * You have run a backup of your application.
-* You have installed the {oadp-short} CLI plugin. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
+* You have installed the {oadp-short} CLI plugin.
 
 .Procedure
 

--- a/modules/oadp-deleting-backups-using-velero.adoc
+++ b/modules/oadp-deleting-backups-using-velero.adoc
@@ -5,23 +5,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-deleting-backups-using-velero_{context}"]
-= Deleting a backup by using the Velero CLI
+= Deleting a backup by using the OADP CLI
 
 [role="_abstract"]
-Delete a backup by using the Velero CLI to run the `velero backup delete` command. This helps you to quickly remove backups and their associated volume artifacts from storage.
+Delete a backup by using the {oadp-short} CLI to run the `oc oadp backup delete` command. This helps you to quickly remove backups and their associated volume artifacts from storage.
 
 .Prerequisites
 
 * You have run a backup of your application.
-* You downloaded the Velero CLI and can access the Velero binary in your cluster.
+* You have installed the {oadp-short} CLI plugin. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
 
 .Procedure
 
-* To delete the backup, run the following Velero command:
+* To delete the backup, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero backup delete <backup_name> -n openshift-adp
+$ oc oadp backup delete __<backup_name>__ --confirm
 ----
-+
-Replace `<backup_name>` with the name of the backup.

--- a/modules/oadp-review-backup-restore.adoc
+++ b/modules/oadp-review-backup-restore.adoc
@@ -16,7 +16,7 @@ Preview the backup and restore resources in advance by doing a dry run of the ba
 .Prerequisites
 
 * You have installed the OADP Operator.
-* You have installed the {oadp-short} CLI plugin. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
+* You have installed the {oadp-short} CLI plugin.
 
 .Procedure
 

--- a/modules/oadp-review-backup-restore.adoc
+++ b/modules/oadp-review-backup-restore.adoc
@@ -10,52 +10,47 @@
 [role="_abstract"]
 Preview the backup and restore resources in advance by doing a dry run of the backup and restore operations. This helps you to verify which resources will be included before committing to a full backup or restore.
 
-{oadp-short} backs up application resources based on the type, namespace, or label. This means that you can view the resources after the backup is complete. Similarly, you can view the restored objects based on the namespace, persistent volume (PV), or label after a restore operation is complete. 
+{oadp-short} backs up application resources based on the type, namespace, or label. This means that you can view the resources after the backup is complete. Similarly, you can view the restored objects based on the namespace, persistent volume (PV), or label after a restore operation is complete.
 
 
 .Prerequisites
 
 * You have installed the OADP Operator.
+* You have installed the {oadp-short} CLI plugin. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
 
 .Procedure
 
 . To preview the resources included in the backup before running the actual backup, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero backup create <backup-name> --snapshot-volumes false
+$ oc oadp backup create __<backup_name>__ --snapshot-volumes false
 ----
 +
 Specify the value of `--snapshot-volumes` parameter as `false`.
 
 . To know more details about the backup resources, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero describe backup <backup_name> --details
+$ oc oadp backup describe __<backup_name>__ --details
 ----
-+
-Replace `<backup_name>` with the name of the backup.
 
 . To preview the resources included in the restore before running the actual restore, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero restore create --from-backup <backup_name>
+$ oc oadp restore create __<restore_name>__ --from-backup __<backup_name>__
 ----
-+
-Replace `<backup_name>` with the name of the backup.
 +
 [IMPORTANT]
 ====
-The `velero restore create` command creates restore resources in the cluster. You must delete the resources created as part of the restore, after you review the resources.
+The `oc oadp restore create` command creates restore resources in the cluster. You must delete the resources created as part of the restore, after you review the resources.
 ====
 +
 . To know more details about the restore resources, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero describe restore <restore_name> --details
+$ oc oadp restore describe __<restore_name>__ --details
 ----
-+
-Replace `<restore_name>` with the name of the restore.

--- a/modules/oadp-using-ca-certificates-with-velero-command.adoc
+++ b/modules/oadp-using-ca-certificates-with-velero-command.adoc
@@ -9,10 +9,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-using-ca-certificates-with-velero-command-aliased-for-velero-deployment_{context}"]
-= Using CA certificates with the velero command aliased for Velero deployment
+= Using CA certificates with the Velero CLI
 
 [role="_abstract"]
-You might want to use the Velero CLI without installing it locally on your system by creating an alias for it.
+If your backup storage location uses a custom CA certificate, you can pass it to backup and restore commands by using the {oadp-short} CLI plugin or the `velero` CLI.
+
+[NOTE]
+====
+The {oadp-short} CLI plugin (`oc oadp`) is the recommended approach for managing backup and restore operations. For most operations, the `oc oadp` commands do not require you to pass CA certificates manually because they create Kubernetes custom resources and the CA certificate is configured in the `DataProtectionApplication` CR. Use the procedure in this section only if you need to pass a CA certificate to the `velero` CLI directly for advanced debugging.
+====
 
 .Prerequisites
 
@@ -21,63 +26,41 @@ You might want to use the Velero CLI without installing it locally on your syste
 
 .Procedure
 
-. To use an aliased Velero command, run the following command:
+. Extract the CA certificate from the `DataProtectionApplication` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ alias velero='oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero'
+$ CA_CERT=$(oc -n openshift-adp get dataprotectionapplications.oadp.openshift.io __<dpa_name>__ -o jsonpath='{.spec.backupLocations[0].velero.objectStorage.caCert}')
 ----
 
-. Check that the alias is working by running the following command:
-+
-[source,terminal]
-----
-$ velero version
-----
-+
-[source,terminal]
-----
-Client:
-	Version: v1.12.1-OADP
-	Git commit: -
-Server:
-	Version: v1.12.1-OADP
-----
-
-. To use a CA certificate with this command, you can add a certificate to the Velero deployment by running the following commands:
-+
-[source,terminal]
-----
-$ CA_CERT=$(oc -n openshift-adp get dataprotectionapplications.oadp.openshift.io <dpa-name> -o jsonpath='{.spec.backupLocations[0].velero.objectStorage.caCert}')
-----
+. Write the CA certificate to a file in the Velero pod by running the following command:
 +
 [source,terminal]
 ----
 $ [[ -n $CA_CERT ]] && echo "$CA_CERT" | base64 -d | oc exec -n openshift-adp -i deploy/velero -c velero -- bash -c "cat > /tmp/your-cacert.txt" || echo "DPA BSL has no caCert"
 ----
+
+. Run the `velero` CLI command with the `--cacert` flag by using `oc exec`:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero describe backup <backup_name> --details --cacert /tmp/<your_cacert>.txt
+$ oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero backup describe __<backup_name>__ --details --cacert /tmp/your-cacert.txt
 ----
 
-. To fetch the backup logs, run the following command:
+. To fetch the backup logs with the CA certificate, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero backup logs  <backup_name>  --cacert /tmp/<your_cacert.txt>
+$ oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero backup logs __<backup_name>__ --cacert /tmp/your-cacert.txt
 ----
 +
 You can use these logs to view failures and warnings for the resources that you cannot back up.
 
-. If the Velero pod restarts, the `/tmp/your-cacert.txt` file disappears, and you must re-create the `/tmp/your-cacert.txt` file by re-running the commands from the previous step.
+. If the Velero pod restarts, the `/tmp/your-cacert.txt` file disappears, and you must re-create the `/tmp/your-cacert.txt` file by re-running the commands from the previous steps.
 
-. You can check if the `/tmp/your-cacert.txt` file still exists, in the file location where you stored it, by running the following command:
+. You can check if the `/tmp/your-cacert.txt` file still exists by running the following command:
 +
 [source,terminal]
 ----
 $ oc exec -n openshift-adp -i deploy/velero -c velero -- bash -c "ls /tmp/your-cacert.txt"
-/tmp/your-cacert.txt
 ----
-+
-In a future release of OpenShift API for Data Protection (OADP), we plan to mount the certificate to the Velero pod so that this step is not required.

--- a/modules/resolving-oadp-operator-fails-silently-issue.adoc
+++ b/modules/resolving-oadp-operator-fails-silently-issue.adoc
@@ -14,20 +14,20 @@ To fix this issue, retrieve a list of backup storage locations (BSLs) and check 
 
 .Procedure
 
-. Retrieve a list of BSLs by using either the OpenShift or Velero command-line interface (CLI):
+. Retrieve a list of BSLs by using one of the following methods:
 
-.. Retrieve a list of BSLs by using the OpenShift CLI (`oc`):
+.. Retrieve a list of BSLs by using the {oadp-short} CLI:
++
+[source,terminal]
+----
+$ oc oadp backup-location get
+----
+
+.. Alternatively, retrieve a list of BSLs by using the OpenShift CLI (`oc`):
 +
 [source,terminal]
 ----
 $ oc get backupstoragelocations.velero.io -A
-----
-
-.. Retrieve a list of BSLs by using the `velero` CLI:
-+
-[source,terminal]
-----
-$ velero backup-location get -n <oadp_operator_namespace>
 ----
 
 . Use the list of BSLs from the previous step and run the following command to examine the manifest of each BSL for an error:

--- a/modules/troubleshooting-backup-cr-status-remains-in-progress-issue.adoc
+++ b/modules/troubleshooting-backup-cr-status-remains-in-progress-issue.adoc
@@ -14,26 +14,25 @@ Resolve the issue where an interrupted backup causes the `Backup` CR status to r
 
 . Retrieve the details of the `Backup` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
-  backup describe <backup>
+$ oc oadp backup describe __<backup_name>__ --details
 ----
 
 . Delete the `Backup` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ oc delete backups.velero.io <backup> -n openshift-adp
+$ oc delete backups.velero.io __<backup_name>__ -n openshift-adp
 ----
 +
 You do not need to clean up the backup location because an in progress `Backup` CR has not uploaded files to object storage.
 
 . Create a new `Backup` CR.
 
-. View the Velero backup details by running the following command:
+. View the backup details by running the following command:
 +
-[source,terminal, subs="+quotes"]
+[source,terminal,subs="+quotes"]
 ----
-$ velero backup describe <backup_name> --details
+$ oc oadp backup describe __<backup_name>__ --details
 ----

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -7,6 +7,6 @@
 = Velero CLI tool
 
 [role="_abstract"]
-The {oadp-short} CLI plugin (`oc oadp`) is the recommended tool for managing backup and restore operations on {product-title}. It provides the same functionality as the `velero` CLI and integrates directly with the OpenShift CLI. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
+The {oadp-short} CLI plugin (`oc oadp`) is the recommended tool for managing backup and restore operations on {product-title}. It provides the same functionality as the `velero` CLI and integrates directly with the OpenShift CLI.
 
 If you need access to the standalone `velero` CLI for advanced debugging, you can download it from {velero-cli-install}. Download the Velero version appropriate for your version of {oadp-short} and {product-title}.

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -2,21 +2,11 @@
 //
 // * backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="velero-obtaining-by-downloading_{context}"]
-= Downloading the Velero CLI tool
+= Velero CLI tool
 
 [role="_abstract"]
-Download and install the `velero` CLI tool from the Velero documentation page, which provides instructions for macOS by using Homebrew, GitHub, and Windows by using Chocolatey. This helps you to access the `velero` CLI for debugging backup and restore operations.
+The {oadp-short} CLI plugin (`oc oadp`) is the recommended tool for managing backup and restore operations on {product-title}. It provides the same functionality as the `velero` CLI and integrates directly with the OpenShift CLI. For more information, see xref:../cli-tools/oadp-cli-plugin.adoc#oadp-cli-plugin[OADP CLI plugin].
 
-
-.Prerequisites
-
-* You have access to a Kubernetes cluster, v1.16 or later, with DNS and container networking enabled.
-* You have installed `kubectl` locally.
-
-.Procedure
-
-. Open a browser and navigate to {velero-cli-install}.
-. Follow the appropriate procedure for macOS, GitHub, or Windows.
-. Download the Velero version appropriate for your version of OADP and {product-title}.
+If you need access to the standalone `velero` CLI for advanced debugging, you can download it from {velero-cli-install}. Download the Velero version appropriate for your version of {oadp-short} and {product-title}.

--- a/snippets/oadp-image-stream-tag-trigger.adoc
+++ b/snippets/oadp-image-stream-tag-trigger.adoc
@@ -14,18 +14,18 @@ The workaround for this behavior is a two-step restore process:
 
 . First, perform a restore excluding the `Deployment` resources, for example:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero restore create <RESTORE_NAME> \
-  --from-backup <BACKUP_NAME> \
+$ oc oadp restore create __<restore_name>__ \
+  --from-backup __<backup_name>__ \
   --exclude-resources=deployment.apps
 ----
 
 . After the first restore is successful, perform a second restore by including these resources, for example:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ velero restore create <RESTORE_NAME> \
-  --from-backup <BACKUP_NAME> \
+$ oc oadp restore create __<restore_name>__ \
+  --from-backup __<backup_name>__ \
   --include-resources=deployment.apps
 ----


### PR DESCRIPTION
## JIRA

* [OADP-8503](https://redhat.atlassian.net/browse/OADP-8503)

---

## Version(s):

* OCP - main
* OCP - 4.22
* OCP - 5.0

---

## Link to docs preview:

* [Backing up applications](https://<PR_NUMBER>--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html)
* [Restoring applications](https://<PR_NUMBER>--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html)

---

## QE review:
- [ ] QE has approved this change.

---

### Summary

Replaces direct `velero` CLI commands and `oc exec` alias patterns with the equivalent `oc oadp` CLI plugin commands across 11 OADP documentation modules.

With the introduction of the OADP CLI plugin (`oc oadp`) in [#116074](https://github.com/openshift/openshift-docs/pull/116074), users no longer need to download the standalone Velero binary or use the `oc exec deployment/velero` alias workaround. This PR updates the remaining OADP-owned pages to use `oc oadp` commands consistently.

Companion to [#116567](https://github.com/openshift/openshift-docs/pull/116567) which covers the `velero-cli-tool.adoc` troubleshooting page.

### Files changed

| File | Change |
|---|---|
| `velero-obtaining-by-downloading.adoc` | Replaced download instructions with redirect to `oc oadp` plugin; kept standalone CLI as fallback for advanced debugging |
| `oadp-review-backup-restore.adoc` | `velero backup/restore create/describe` → `oc oadp` equivalents |
| `oadp-deleting-backups-using-velero.adoc` | `velero backup delete` → `oc oadp backup delete`; updated title and prereqs |
| `oadp-using-ca-certificates-with-velero-command.adoc` | Removed alias pattern; added note that `oc oadp` handles CA certs via DPA; kept `oc exec` approach for advanced debugging |
| `oadp-backing-and-restoring-from-cluster-to-cluster.adoc` | `velero backup create` → `oc oadp backup create` |
| `oadp-image-stream-tag-trigger.adoc` | `velero restore create` → `oc oadp restore create` |
| `cleanup-a-backup-oadp-aws-sts.adoc` | `velero backup delete` → `oc oadp backup delete` |
| `cleanup-a-backup-oadp-rosa-sts.adoc` | `velero backup delete` → `oc oadp backup delete` |
| `migration-debugging-velero-admission-webhooks-knative.adoc` | `velero restore` → `oc oadp restore create` |
| `troubleshooting-backup-cr-status-remains-in-progress-issue.adoc` | `oc exec velero` and `velero describe` → `oc oadp backup describe` |
| `resolving-oadp-operator-fails-silently-issue.adoc` | `velero backup-location get` → `oc oadp backup-location get` |

### Not covered (cross-team, needs separate coordination)

* `hcp-dr-oadp-observe-velero.adoc` (HCP team)
* `cnf-image-based-upgrade-troubleshooting.adoc` (CNF/Edge team)
* `cloud-experts-deploy-api-data-protection-cleanup.adoc` (Cloud Experts team)

*Posted via [Claude Code](https://claude.ai/code)*