### PR TITLE
TELCODOCS-2934 - kdump crashkernel size inconsistency

### DIFF
--- a/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -51,6 +51,11 @@ include::modules/ztp-sno-du-setting-rcu-normal.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-enabling-kdump.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-generating-install-and-config-crs-manually_ztp-manual-install[Extracting reference and example CRs from the ztp-site-generate container]
+
 include::modules/ztp-sno-du-disabling-crio-wipe.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-configuring-crun-container-runtime.adoc[leveloffset=+2]

--- a/modules/ztp-sno-du-enabling-kdump.adoc
+++ b/modules/ztp-sno-du-enabling-kdump.adoc
@@ -7,16 +7,16 @@
 = Automatic kernel crash dumps with kdump
 
 [role="_abstract"]
-`kdump` is a Linux kernel feature that creates a kernel crash dump when the kernel crashes. `kdump` is enabled with the following `MachineConfig` CRs.
+`kdump` is a Linux kernel feature that creates a kernel crash dump when the kernel crashes.
+You can use the crash dump to debug and find the cause of the kernel crash.
+To enable kdump, you apply `MachineConfig` custom resources (CRs) that reserve memory for the crash kernel and enable the `kdump` systemd service.
+The `ztp-site-generate` container provides the following reference CRs for this configuration:
 
-.Recommended control plane node kdump configuration (`06-kdump-master.yaml`)
-[source,yaml]
-----
-include::snippets/ztp_06-kdump-master.yaml[]
-----
+* `06-kdump-master.yaml` for control plane nodes
+* `06-kdump-worker.yaml` for worker nodes
 
-.Recommended kdump worker node configuration (`06-kdump-worker.yaml`)
-[source,yaml]
-----
-include::snippets/ztp_06-kdump-worker.yaml[]
-----
+[NOTE]
+====
+Use the reference `MachineConfig` CRs from the `ztp-site-generate` container image as the source of truth for kdump configuration values.
+You can extract the CRs from the container image and find them in the `out/source-crs/extra-manifest/` folder.
+====

--- a/modules/ztp-sno-du-enabling-kdump.adoc
+++ b/modules/ztp-sno-du-enabling-kdump.adoc
@@ -7,16 +7,16 @@
 = Automatic kernel crash dumps with kdump
 
 [role="_abstract"]
-`kdump` is a Linux kernel feature that creates a kernel crash dump when the kernel crashes. `kdump` is enabled with the following `MachineConfig` CRs.
+`kdump` is a Linux kernel feature that creates a kernel crash dump when the kernel crashes.
+You can use the crash dump to debug and find the cause of the kernel crash.
+To enable `kdump`, you apply `MachineConfig` custom resources (CRs) that reserve memory for the crash kernel and enable the `kdump` systemd service.
+The `ztp-site-generate` container provides the following reference CRs for this configuration:
 
-.Recommended control plane node kdump configuration (`06-kdump-master.yaml`)
-[source,yaml]
-----
-include::snippets/ztp_06-kdump-master.yaml[]
-----
+* `06-kdump-master.yaml` for control plane nodes
+* `06-kdump-worker.yaml` for worker nodes
 
-.Recommended kdump worker node configuration (`06-kdump-worker.yaml`)
-[source,yaml]
-----
-include::snippets/ztp_06-kdump-worker.yaml[]
-----
+[NOTE]
+====
+Use the reference `MachineConfig` CRs from the `ztp-site-generate` container image as the source of truth for kdump configuration values.
+You can extract the CRs from the container image and find them in the `out/source-crs/extra-manifest/` folder.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2934
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:[Automatic kernel crash dumps with kdump](https://116998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-enabling-kdump_sno-configure-for-vdu)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
