### PR TITLE
OSDOCS#16418_rosa_osd:CQA fixes for Building applications_rosa_osd specific

### DIFF
--- a/applications/deployments/osd-config-custom-domains-applications.adoc
+++ b/applications/deployments/osd-config-custom-domains-applications.adoc
@@ -6,12 +6,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications.
+
 [WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====
 
-You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications. 
-
 include::modules/osd-applications-config-custom-domains.adoc[leveloffset=+1]
+
 include::modules/osd-applications-renew-custom-domains.adoc[leveloffset=+1]

--- a/modules/odc-adding-health-checks.adoc
+++ b/modules/odc-adding-health-checks.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// applications/application-health
+// applications/application-health.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="odc-adding-health-checks_{context}"]
-= Adding health checks using the Developer perspective
+= Add health checks using the Developer perspective
 
 [role="_abstract"]
 You can use the *Topology* view to add health checks to your deployed application.
@@ -15,10 +15,14 @@ You can use the *Topology* view to add health checks to your deployed applicatio
 
 .Procedure
 . In the *Topology* view, click the application node to see the side panel. If the container does not have health checks added, a *Health Checks* notification is displayed with a link to add health checks.
-. In the displayed notification, click the *Add Health Checks* link.
-. Alternatively, you can also click the *Actions* list and select *Add Health Checks*. Note that if the container already has health checks, you will see the *Edit Health Checks* option instead of the add option.
+. In the displayed notification, click *Add Health Checks* by using one of following methods:
++
+* Click the *Add Health Checks* link in the notification. 
+* Click the *Actions* list and select *Add Health Checks*. 
++
+If the container already has health checks, you see the *Edit Health Checks* option instead of the add option.
 . In the *Add Health Checks* form, if you have deployed multiple containers, use the *Container* list to ensure that the appropriate container is selected.
-. Click the required health probe links to add them to the container. Default data for the health checks is pre-populated. You can add the probes with the default data or further customize the values and then add them. For example, to add a Readiness probe that checks if your container is ready to handle requests:
+. Click the required health probe links to add them to the container. Default data for the health checks is pre-populated. You can add the probes with the default data or customize the values before adding them. For example, to add a Readiness probe that checks if your container is ready to handle requests:
 .. Click *Add Readiness Probe*, to see a form containing the parameters for the probe.
 .. Click the *Type* list to select the request type you want to add. For example, in this case, select *Container Command* to select the command that will be executed inside the container.
 .. In the *Command* field, add an argument `cat`, similarly, you can add multiple arguments for the check, for example, add another argument `/tmp/healthy`.
@@ -31,6 +35,8 @@ The `Timeout` value must be lower than the `Period` value. The `Timeout` default
 .. Click the checkmark at the bottom of the form. The *Readiness Probe Added* message is displayed.
 
 . Click *Add* to add the health check. You are redirected to the *Topology* view and the container is restarted.
+
+.Verification
 . In the side panel, verify that the probes have been added by clicking on the deployed pod under the *Pods* section.
 . In the *Pod Details* page, click the listed container in the *Containers* section.
 . In the *Container Details* page, verify that the Readiness probe - *Exec Command* `cat` `/tmp/healthy` has been added to the container.

--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -4,8 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="osd-applications-config-custom-domains_{context}"]
-= Configuring custom domains for applications
+= Configure custom domains for applications
 
+[role="_abstract"]
 The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new ingress controller with a custom certificate as a second day operation. The public DNS record for this ingress controller can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.
 
 [NOTE]
@@ -43,24 +44,29 @@ kind: CustomDomain
 metadata:
   name: <company_name>
 spec:
-  domain: apps.<company_name>.io <1>
+  domain: apps.<company_name>.io
   scope: External
-  loadBalancerType: Classic <2>
+  loadBalancerType: Classic
   certificate:
-    name: <name>-tls <3>
+    name: <name>-tls
     namespace: <my_project>
-  routeSelector: <4>
+  routeSelector:
     matchLabels:
      route: acme
-  namespaceSelector: <5>
+  namespaceSelector:
     matchLabels:
      type: sharded
 ----
-<1> The custom domain.
-<2> The type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
-<3> The secret created in the previous step.
-<4> Optional: Filters the set of routes serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
-<5> Optional: Filters the set of namespaces serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
++
+--
+where:
+
+`spec.domain`:: Specifies the custom domain.
+`spec.loadBalancerType`:: Specifies the type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
+`spec.certificate.name`:: Specifies the secret created in the earlier step.
+`spec.routeSelector`:: Optional. Filters the set of routes serviced by the `CustomDomain` ingress. If no value is provided, the default is no filtering.
+`spec.namespaceSelector`:: Optional. Filters the set of namespaces serviced by the `CustomDomain` ingress. If no value is provided, the default is no filtering.
+--
 
 . Apply the CR:
 +
@@ -93,7 +99,6 @@ endif::openshift-rosa[]
 
 +
 .Example
-+
 [source,terminal]
 ----
 *.apps.<company_name>.io -> xxrywp.<company_name>.cluster-01.opln.s1.openshiftapps.com
@@ -125,4 +130,4 @@ Hello OpenShift!
 
 .Troubleshooting
 * link:https://access.redhat.com/solutions/5419501[Error creating TLS secret]
-* link:https://access.redhat.com/solutions/6546011[Troubleshooting: CustomDomain in NotReady state]
+* link:https://access.redhat.com/solutions/6546011[Troubleshooting: `CustomDomain` in `NotReady` state]

--- a/modules/osd-applications-renew-custom-domains.adoc
+++ b/modules/osd-applications-renew-custom-domains.adoc
@@ -4,34 +4,34 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="osd-applications-renew-custom-domains_{context}"]
-= Renewing a certificate for custom domains
+= Renew a certificate for custom domains
 
+[role="_abstract"]
 You can renew certificates with the Custom Domains Operator (CDO) by using the `oc` CLI tool.
 
-//s a customer of OSD/ROSA, I would like instructions on how to renew certificates with Custom Domains Operator (CDO).
 .Prerequisites
-* You have the latest version `oc` CLI tool installed.
+* You have the latest version of the `oc` CLI tool installed.
 
 .Procedure
-. Create new secret
+. Create a new secret:
 +
 [source,terminal]
 ----
-$ oc create secret tls <secret-new> --cert=fullchain.pem --key=privkey.pem -n <my_project>
+$ oc create secret tls <secret_new> --cert=fullchain.pem --key=privkey.pem -n <my_project>
 ----
 
-. Patch CustomDomain CR
+. Patch the `CustomDomain` CR:
 +
 [source,terminal]
 ----
-$ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate":{"name":"<secret-new>"}}}'
+$ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate":{"name":"<secret_new>"}}}'
 ----
 
-. Delete old secret
+. Delete the old secret:
 +
 [source,terminal]
 ----
-$ oc delete secret <secret-old> -n <my_project>
+$ oc delete secret <secret_old> -n <my_project>
 ----
 
 .Troubleshooting

--- a/modules/rosa-applications-config-custom-domains.adoc
+++ b/modules/rosa-applications-config-custom-domains.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-applications-config-custom-domains_{context}"]
-= Configuring custom domains for applications
+= Configure custom domains for applications
 
 [role="_abstract"]
 The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new ingress controller with a custom certificate as a second day operation. The public DNS record for this ingress controller can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.
@@ -64,8 +64,8 @@ where:
 `spec.domain`:: Specifies the custom domain.
 `spec.loadBalancerType`:: Specifies the type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
 `spec.certificate.name`:: Specifies the secret created in the previous step.
-`spec.routeSelector`:: Optional. Filters the set of routes serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
-`spec.namespaceSelector`:: Optional. Filters the set of namespaces serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
+`spec.routeSelector`:: Optional. Filters the set of routes serviced by the `CustomDomain` ingress. If no value is provided, the default is no filtering.
+`spec.namespaceSelector`:: Optional. Filters the set of namespaces serviced by the `CustomDomain` ingress. If no value is provided, the default is no filtering.
 --
 
 . Apply the CR:
@@ -99,7 +99,6 @@ endif::openshift-rosa[]
 
 +
 .Example
-+
 [source,terminal]
 ----
 *.apps.<company_name>.io -> xxrywp.<company_name>.cluster-01.opln.s1.openshiftapps.com
@@ -131,4 +130,4 @@ Hello OpenShift!
 
 .Troubleshooting
 * link:https://access.redhat.com/solutions/5419501[Error creating TLS secret]
-* link:https://access.redhat.com/solutions/6546011[Troubleshooting: CustomDomain in NotReady state]
+* link:https://access.redhat.com/solutions/6546011[Troubleshooting: `CustomDomain` in `NotReady` state]

--- a/modules/rosa-applications-renew-custom-domains.adoc
+++ b/modules/rosa-applications-renew-custom-domains.adoc
@@ -4,35 +4,34 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-applications-renew-custom-domains_{context}"]
-= Renewing a certificate for custom domains
+= Renew a certificate for custom domains
 
 [role="_abstract"]
 You can renew certificates with the Custom Domains Operator (CDO) by using the `oc` CLI tool.
 
-//s a customer of OSD/ROSA, I would like instructions on how to renew certificates with Custom Domains Operator (CDO).
 .Prerequisites
-* You have the latest version `oc` CLI tool installed.
+* You have the latest version of the `oc` CLI tool installed.
 
 .Procedure
-. Create new secret
+. Create a new secret:
 +
 [source,terminal]
 ----
-$ oc create secret tls <secret-new> --cert=fullchain.pem --key=privkey.pem -n <my_project>
+$ oc create secret tls <secret_new> --cert=fullchain.pem --key=privkey.pem -n <my_project>
 ----
 
-. Patch CustomDomain CR
+. Patch the `CustomDomain` CR:
 +
 [source,terminal]
 ----
-$ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate":{"name":"<secret-new>"}}}'
+$ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate":{"name":"<secret_new>"}}}'
 ----
 
-. Delete old secret
+. Delete the old secret:
 +
 [source,terminal]
 ----
-$ oc delete secret <secret-old> -n <my_project>
+$ oc delete secret <secret_old> -n <my_project>
 ----
 
 .Troubleshooting


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16418

Link to docs preview:

**ROSA HCP**
[Configure custom domains for applications](https://116999--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/applications/deployments/rosa-config-custom-domains-applications.html#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications)
[Add health checks using the Developer perspective](https://116999--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/applications/application-health.html#odc-adding-health-checks_application-health)

**Classic**
[Configure custom domains for applications](https://116999--ocpdocs-pr.netlify.app/openshift-rosa/latest/applications/deployments/rosa-config-custom-domains-applications.html#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications)
[Add health checks using the Developer perspective](https://116999--ocpdocs-pr.netlify.app/openshift-rosa/latest/applications/application-health.html#odc-adding-health-checks_application-health)

**OSD**
[Configure custom domains for applications](https://116999--ocpdocs-pr.netlify.app/openshift-dedicated/latest/applications/deployments/osd-config-custom-domains-applications.html#osd-applications-config-custom-domains_osd-config-custom-domains-applications)
[Add health checks using the Developer perspective](https://116999--ocpdocs-pr.netlify.app/openshift-dedicated/latest/applications/application-health.html#odc-adding-health-checks_application-health)

QE review:
- n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
