### PR TITLE
OSDOCS-17165-graceful-shutdown CQA

### DIFF
--- a/backup_and_restore/graceful-cluster-shutdown.adoc
+++ b/backup_and_restore/graceful-cluster-shutdown.adoc
@@ -6,24 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This document describes the process to gracefully shut down your cluster. You might need to temporarily shut down your cluster for maintenance reasons, or to save on resource costs.
-
-== Prerequisites
-
-* Take an xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] prior to shutting down the cluster.
-+
-[IMPORTANT]
-====
-It is important to take an etcd backup before performing this procedure so that your cluster can be restored if you encounter any issues when restarting the cluster.
-
-For example, the following conditions can cause the restarted cluster to malfunction:
-
-* etcd data corruption during shutdown
-* Node failure due to hardware
-* Network connectivity issues
-
-If your cluster fails to recover, follow the steps to xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state].
-====
+[role="_abstract"]
+You can shut down your {product-title} cluster for planned maintenance by cordoning nodes, draining workloads, and stopping nodes in order. Graceful shutdown preserves cluster state so you can restart the cluster when maintenance is complete.
 
 // Shutting down the cluster
 include::modules/graceful-shutdown.adoc[leveloffset=+1]
@@ -32,4 +16,6 @@ include::modules/graceful-shutdown.adoc[leveloffset=+1]
 [id="additional-resources_restarting-restoring-cluster"]
 == Additional resources
 
+* xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+* xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
 * xref:../backup_and_restore/graceful-cluster-restart.adoc#graceful-restart-cluster[Restarting the cluster gracefully]

--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -6,22 +6,39 @@
 [id="graceful-shutdown_{context}"]
 = Shutting down the cluster
 
-You can shut down your cluster in a graceful manner so that it can be restarted at a later date.
+[role="_abstract"]
+You can shut down a {product-title} cluster gracefully by cordoning nodes, draining worker nodes, and stopping nodes in order. This preserves cluster data so you can restart the cluster after maintenance or a planned outage.
 
 [NOTE]
 ====
 You can shut down a cluster until a year from the installation date and expect it to restart gracefully. After a year from the installation date, the cluster certificates expire. However, you might need to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates when the cluster restarts.
 ====
 
+Take an etcd backup before shutting down the cluster so that you can restore the cluster if you encounter issues when restarting it.
+
+You might need to restore from the backup if any of the following conditions occur:
+
+* etcd data is corrupted during shutdown
+* A node fails because of hardware
+* Network connectivity is interrupted
+
+If the cluster does not recover after restart, follow the steps to restore to a previous cluster state.
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup.
+* You created an etcd backup before shutting down the cluster.
++
+[IMPORTANT]
+====
+Without a recent etcd backup, you might not be able to restore the cluster if shutdown or restart fails.
+====
+
 * If you are running a {sno} cluster, you must evacuate all workload pods off of the cluster before you shut it down.
 
 .Procedure
 
-. If you are shutting the cluster down for an extended period, determine the date on which certificates expire and run the following command:
+. If you are shutting the cluster down for an extended period, determine the date on which certificates expire by running the following command:
 +
 [source,terminal]
 ----
@@ -31,11 +48,12 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 .Example output
 [source,terminal]
 ----
-2022-08-05T14:37:50Zuser@user:~ $ <1>
+2030-08-05T14:37:50Z
 ----
-<1> To ensure that the cluster can restart gracefully, plan to restart it on or before the specified date. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
++
+Plan to restart the cluster on or before the displayed date so the cluster can restart gracefully. When the cluster restarts, you might need to manually approve pending certificate signing requests (CSRs) to recover kubelet certificates.
 
-. Mark all the nodes in the cluster as unschedulable. You can do this from your cloud provider's web console, or by running the following loop:
+. Mark all the nodes in the cluster as unschedulable by running the following command:
 +
 [source,terminal]
 ----
@@ -59,26 +77,28 @@ ci-ln-mgdnf4b-72292-n547t-worker-c-vcmtn
 node/ci-ln-mgdnf4b-72292-n547t-worker-c-vcmtn cordoned
 ----
 
-. Evacuate the pods using the following method:
+. Evacuate the pods by running the following command:
 [source,terminal]
 +
 ----
 $ for node in $(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm drain ${node} --delete-emptydir-data --ignore-daemonsets=true --timeout=15s --force ; done
 ----
++
+Draining worker nodes before shutdown allows pods to terminate gracefully, which reduces the chance of data corruption.
 
-. Shut down all of the nodes in the cluster. You can do this from the web console for your cloud provider web console, or by running the following loop. Shutting down the nodes by using one of these methods allows pods to terminate gracefully, which reduces the chance for data corruption.
+. Shut down all of the nodes in the cluster by running the following command:
++
+[source,terminal]
+----
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
+----
 +
 [NOTE]
 ====
 Ensure that the control plane node with the API VIP assigned is the last node processed in the loop. Otherwise, the shutdown command fails.
 ====
 +
-[source,terminal]
-----
-$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done <1>
-----
-+
-<1> `-h 1` indicates how long, in minutes, this process lasts before the control plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to `-h 10` or longer to make sure all the compute nodes have time to shut down first.
+The `-h 1` option indicates how long, in minutes, this process lasts before the control plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to `-h 10` or longer to ensure all the compute nodes have time to shut down first.
 +
 .Example output
 [source,terminal]
@@ -94,11 +114,11 @@ Shutdown scheduled for Mon 2021-09-13 09:36:29 UTC, use 'shutdown -c' to cancel.
 +
 [NOTE]
 ====
-It is not necessary to drain control plane nodes of the standard pods that ship with {product-title} prior to shutdown.
-Cluster administrators are responsible for ensuring a clean restart of their own workloads after the cluster is restarted. If you drained control plane nodes prior to shutdown because of custom workloads, you must mark the control plane nodes as schedulable before the cluster will be functional again after restart.
+It is not necessary to drain control plane nodes of the standard pods that ship with {product-title} before shutdown.
+Cluster administrators are responsible for ensuring a clean restart of workloads they deploy after the cluster is restarted. If you drained control plane nodes before shutdown because of custom workloads, you must mark the control plane nodes as schedulable before the cluster is functional again after restart.
 ====
 
-. Shut off any cluster dependencies that are no longer needed, such as external storage or an LDAP server. Be sure to consult your vendor's documentation before doing so.
+. Shut off any cluster dependencies that are no longer needed, such as external storage or a Lightweight Directory Access Protocol (LDAP) server. Be sure to consult documentation from the vendor before doing so.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
