### PR TITLE
OSDOCS-21024: Add 4.20.32 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-32.adoc
+++ b/modules/zstream-4-20-32.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-32_{context}"]
+= RHSA-2026:48676 - {product-title} {product-version}.32 bug fix and security update
+
+Issued: 04 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.32 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:48676[RHSA-2026:48676] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:48673[RHBA-2026:48673] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.32 --pullspecs
+----
+
+[id="zstream-4-20-32-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Cluster Ingress Operator on {product-title} 4.20 pinned Istio to v1.26.8, which was missing security fixes available in newer patch releases. As a consequence, Gateway API deployments ran an Istio control plane with known CVE vulnerabilities that had already been fixed upstream. With this release, the default Istio version is updated from v1.26.2 to v1.26.8, which includes the latest security fixes for the 1.26 stream. As a result, Gateway API deployments on {product-title} 4.20 run Istio v1.26.8 with important CVE fixes applied. (link:https://redhat.atlassian.net/browse/OCPBUGS-98968[OCPBUGS-98968])
+
+* Before this update, when telemeter-client availability flickered because of monitoring pod restarts or node disruptions, the Console Operator produced different `ConfigMap` content on each sync cycle. As a consequence, continuous console pod rollouts deleted in-memory sessions and logged users out of the {product-title} web console approximately every five minutes. With this release, the telemetry configuration always produces a stable key set regardless of telemeter-client availability. As a result, unnecessary console pod rollouts are prevented and users are no longer logged out unexpectedly. (link:https://redhat.atlassian.net/browse/OCPBUGS-98986[OCPBUGS-98986])
+
+* Before this update, when you navigated to the Cluster Dashboard Overview page and clicked the Insights window on the Status card, an underlying UI component rendered the text incorrectly. As a consequence, the icons for the four severity levels (Critical, Important, Moderate, and Low) appeared, but the actual issue counts and the links to the Insights advisor were missing. With this release, the link component inside the Insights severity message is updated to ensure that the text and links render properly. As a result, each severity level in the Insights window successfully displays its icon, the correct issue count, and a clickable link to the Insights advisor. (link:https://redhat.atlassian.net/browse/OCPBUGS-99167[OCPBUGS-99167])
+
+* Before this update, cron job objects with specified `.spec.timeZone` fields caused the kube-state-metrics (KSM) pod to fail and stop reporting all cluster metrics. With this release, the KSM pod skips cron jobs with unparseable schedules instead of failing. A new `kube_cronjob_schedule_invalid` metric identifies these specific issues. As a result, the KSM pod remains stable and continues serving metrics for all cluster resources, even when individual cron jobs have schedules or time zones that cannot be parsed. (link:https://redhat.atlassian.net/browse/OCPBUGS-99402[OCPBUGS-99402])
+
+* Before this update, Alertmanager crashed because the `tzdata` package was missing in the {product-title} base images. This issue caused the absence of the `/usr/share/zoneinfo` directory. As a consequence, Alertmanager pods failed to start, which made time-based alerts inaccessible for the time zones. With this release, the `tzdata` package has been reinstated in {product-title} images. As a result, Alertmanager does not crash on startup when location fields are present in the `active_interval` or `mute_interval` entries. (link:https://redhat.atlassian.net/browse/OCPBUGS-99449[OCPBUGS-99449])
+
+[id="zstream-4-20-32-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.32 RNs and updating
+include::modules/zstream-4-20-32.adoc[leveloffset=+2]
+
 // 4.20.31 RNs and updating
 include::modules/zstream-4-20-31.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21024

Link to docs preview:
https://117016--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-32_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/682
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:48676 / RHBA-2026:48673 (not yet published on access.redhat.com — Issued date is a placeholder)
