### PR TITLE
OSDOCS-21025: Add 4.19.41 z-stream release notes

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -32,7 +32,7 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 
 [IMPORTANT]
 ====
-You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-8756D419-A878-4AE0-9183-C6D5A91A8FB1.html[Edit Time Configuration for a Host] in the VMware documentation.
+You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vcenter-and-host-management/host-configuration-host-management/synchronizing-clocks-on-the-vsphere-network-host-management/editing-time-configuration-for-a-host-host-management.html[Editing the Time Configuration Settings of Your ESXi Host (Broadcom documentation)].
 ====
 
 .Minimum supported vSphere version for VMware components

--- a/modules/zstream-4-19-41.adoc
+++ b/modules/zstream-4-19-41.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-41_{context}"]
+= RHSA-2026:48657 - {product-title} {product-version}.41 bug fix and security update
+
+Issued: 05 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.41 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:48657[RHSA-2026:48657] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:48655[RHBA-2026:48655] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.41 --pullspecs
+----
+
+[id="zstream-4-19-41-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when telemeter-client availability flickered because of monitoring pod restarts or node disruptions, the Console Operator produced different `ConfigMap` content on each sync cycle. As a consequence, continuous console pod rollouts deleted in-memory sessions and logged users out of the {product-title} web console approximately every five minutes. With this release, the telemetry configuration always produces a stable key set regardless of telemeter-client availability. As a result, unnecessary console pod rollouts are prevented and users are no longer logged out unexpectedly. (link:https://redhat.atlassian.net/browse/OCPBUGS-98988[OCPBUGS-98988])
+
+* Before this update, cron job objects with specified `.spec.timeZone` fields caused the kube-state-metrics (KSM) pod to fail and stop reporting all cluster metrics. With this release, the KSM pod skips cron jobs with unparseable schedules instead of failing. A new `kube_cronjob_schedule_invalid` metric identifies these specific issues. As a result, the KSM pod remains stable and continues serving metrics for all cluster resources, even when individual cron jobs have schedules or time zones that cannot be parsed. (link:https://redhat.atlassian.net/browse/OCPBUGS-99405[OCPBUGS-99405])
+
+[id="zstream-4-19-41-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,13 +2977,16 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
-// 4.19.38 RNs and updating
-// 4.19.39 RNs and updating
+// 4.19.41 RNs and updating
+include::modules/zstream-4-19-41.adoc[leveloffset=+2]
+
 // 4.19.40 RNs and updating
 include::modules/zstream-4-19-40.adoc[leveloffset=+2]
 
+// 4.19.39 RNs and updating
 include::modules/zstream-4-19-39.adoc[leveloffset=+2]
 
+// 4.19.38 RNs and updating
 include::modules/zstream-4-19-38.adoc[leveloffset=+2]
 
 // 4.19.37 z-stream RNs full document


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21025

Link to docs preview:
https://117017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-41_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/680
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:48657 / RHBA-2026:48655 (not yet published on access.redhat.com — Issued date is a placeholder)