### PR TITLE
OSDOCS-21026: Add 4.18.51 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-51.adoc
+++ b/modules/zstream-4-18-51.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-51_{context}"]
+= RHSA-2026:48699 - {product-title} {product-version}.51 bug fix and security update
+
+Issued: 05 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.51 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:48699[RHSA-2026:48699] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:48696[RHBA-2026:48696] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.51 --pullspecs
+----
+
+[id="zstream-4-18-51-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when a machine config attempted to install an extension package, the installation could silently fail. As a consequence, the Machine Config Pool (MCP) would incorrectly report `Update=True` even though the packages were not actually installed on the nodes. With this release, the Machine Config Operator (MCO) verifies that the expected packages are successfully installed on the nodes. As a result, the Operator degrades the MCP appropriately if the installation is not successful, preventing a false successful update status. (link:https://redhat.atlassian.net/browse/OCPBUGS-91747[OCPBUGS-91747])
+
+* Before this update, binary data such as `JAR` or `JCEKS` keystores, was incorrectly decoded as UTF-8 text when `Secret` objects were edited through the {product-title} web console. This corrupted the binary values with replacement characters and rendered the files unusable. With this release, the web console now preserves base64-encoded binary data and passes it directly to the file input component without text conversion. Binary secret data remains intact when editing other fields in the same secret. (link:https://issues.redhat.com/browse/OCPBUGS-91944[OCPBUGS-91944])
+
+[id="zstream-4-18-51-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.51 RNs and updating
+include::modules/zstream-4-18-51.adoc[leveloffset=+2]
+
 // 4.18.50 RNs and updating
 include::modules/zstream-4-18-50.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21026

Link to docs preview:
https://117018--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-51_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/684
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:48699 / RHBA-2026:48696 (not yet published on access.redhat.com — Issued date is a placeholder)
