### PR TITLE
OSDOCS-21027: Add 4.17.56 z-stream release notes

### DIFF
--- a/modules/zstream-4-17-56.adoc
+++ b/modules/zstream-4-17-56.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-56-about_{context}"]
+= RHSA-2026:47728 - {product-title} {product-version}.56 bug fix and security update
+
+Issued: 06 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.56 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:47728[RHSA-2026:47728] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:47726[RHBA-2026:47726] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.56 --pullspecs
+----
+
+[id="zstream-4-17-56-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `ironic-agent` container image was missing the `iproute` package, which provides the `ip` command. As a consequence, the Ironic Python Agent (IPA) failed during network configuration and could not send heartbeats to Ironic, which caused bare-metal node cleaning to time out. With this release, the `iproute` package is available in the `ironic-agent` container image. As a result, IPA completes network configuration and heartbeats to Ironic as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-95067[OCPBUGS-95067])
+
+* Before this update, by default, the Vertical Pod Autoscaler (VPA) Operator required a primary node for running the VPA controllers, even on {hcp} (HCP) clusters where these nodes did not exist in the guest cluster. As a consequence, installation of the VPA on HCP clusters failed. With this release, the VPA controllers can run on any nodes in HCP clusters. As a result, you can install the VPA successfully on HCP clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-98866[OCPBUGS-98866])
+
+[id="zstream-4-17-56-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2949,6 +2949,9 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 // 4.17.55
+// 4.17.56 RNs and updating
+include::modules/zstream-4-17-56.adoc[leveloffset=+2]
+
 include::modules/zstream-4-17-55.adoc[leveloffset=+2]
 
 // 4.17.54


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21027

Link to docs preview:
https://117019--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-56-about_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/679
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17
- Errata: RHSA-2026:47728 / RHBA-2026:47726 (not yet published on access.redhat.com — Issued date is a placeholder)
