### PR TITLE
OSDOCS-17165-replace-unhealthy-etc CQA

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -15,12 +15,14 @@ To restore etcd quorum when a single member is unhealthy, identify the member an
 
 [NOTE]
 ====
-If you have lost the majority of your control plane hosts, follow the steps in "Restoring to an earlier cluster state" instead of this procedure..
+If you have lost the majority of your control plane hosts, follow the steps in "Restoring to an earlier cluster state" instead of this procedure.
 
 If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
 ====
+
+Take an etcd backup before replacing an unhealthy etcd member. For more information see, "Backing up etcd data".
 
 // Identifying an unhealthy etcd member
 include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
@@ -28,13 +30,15 @@ include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
 // Determining the state of the unhealthy etcd member
 include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
 
+// Determining the state of the unhealthy etcd member
+include::modules/restore-replace-unhealthy-etcd-member.adoc[leveloffset=+1]
+
 // Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node on an unhealthy cluster]
 
 // Replacing an unhealthy etcd member whose etcd pod is crashlooping
 include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]
@@ -46,4 +50,5 @@ include::modules/restore-replace-stopped-baremetal-etcd-member.adoc[leveloffset=
 .Additional resources
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] 
 * xref:../../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-etcd_deleting-machine[Quorum protection with machine lifecycle hooks]

--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -15,12 +15,14 @@ To restore etcd quorum when a single member is unhealthy, identify the member an
 
 [NOTE]
 ====
-If you have lost the majority of your control plane hosts, follow the steps in "Restoring to an earlier cluster state" instead of this procedure..
+If you have lost the majority of your control plane hosts, follow the steps in "Restoring to an earlier cluster state" instead of this procedure.
 
 If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
 ====
+
+Take an etcd backup before replacing an unhealthy etcd member. For more information see, "Backing up etcd data".
 
 // Identifying an unhealthy etcd member
 include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
@@ -28,13 +30,15 @@ include::modules/restore-identify-unhealthy-etcd-member.adoc[leveloffset=+1]
 // Determining the state of the unhealthy etcd member
 include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
 
+// Replacing an unhealthy etcd member
+include::modules/restore-replace-unhealthy-etcd-member.adoc[leveloffset=+1]
+
 // Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node on an unhealthy cluster]
 
 // Replacing an unhealthy etcd member whose etcd pod is crashlooping
 include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]
@@ -43,7 +47,9 @@ include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]
 include::modules/restore-replace-stopped-baremetal-etcd-member.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[Recovering from expired control plane certificates]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] 
 * xref:../../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-etcd_deleting-machine[Quorum protection with machine lifecycle hooks]

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -8,26 +8,27 @@
 = Determining the state of the unhealthy etcd member
 
 [role="_abstract"]
-Determine whether an unhealthy etcd member has a stopped machine or not-ready node, or a crashlooping pod, so you can follow the correct replacement procedure.
+Determine whether the unhealthy etcd member has a stopped machine, an unready node, or a crashlooping etcd pod. Knowing the failure state enables you to follow the correct replacement procedure.
 
-The steps to replace an unhealthy etcd member depend on which of the following states your etcd member is in:
+Depending on the state of your unhealthy etcd member, use one of the following procedures:
 
-* The machine is not running or the node is not ready
-* The etcd pod is crashlooping
+* Machine not running or node not ready. For more information, see "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
+* Bare-metal machine not running or node not ready on installer-provisioned bare metal. For more information, see "Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready".
+* Crashlooping etcd pod. For more information, see "Replacing an unhealthy etcd member whose etcd pod is crashlooping".
 
 [NOTE]
 ====
-If you are aware that the machine is not running or the node is not ready, but you expect it to return to a healthy state soon, then you do not need to perform a procedure to replace the etcd member. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
+If the machine is not running or the node is not ready, you might expect either to recover soon. In that case, you do not need to replace the etcd member. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 ====
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have identified an unhealthy etcd member.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You identified an unhealthy etcd member.
 
 .Procedure
 
-. Determine if the *machine is not running*:
+. Determine if the machine is not running by running the following command:
 +
 [source,terminal]
 ----
@@ -40,17 +41,13 @@ $ oc get machines -A -ojsonpath='{range .items[*]}{@.status.nodeRef.name}{"\t"}{
 ip-10-0-131-183.ec2.internal  stopped
 ----
 +
-This output lists the node and the status of the node's machine. If the status is anything other than `running`, then the *machine is not running*.
+This output lists the node and the status of the machine of the node. If the status is anything other than `running`, then the machine is not running.
+
+. Determine if the status of the node is `NotReady`.
 +
-// TODO: xref
-If the *machine is not running*, then follow the steps in "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
+If either of the following scenarios are true, then the node is not ready.
 
-
-. Determine if the *node is not ready*.
-+
-If either of the following scenarios are true, then the *node is not ready*.
-
-** If the machine is running, then check whether the node is unreachable:
+.. If the machine is running, then check whether the node has an `unreachable` taint by running the following command:
 +
 [source,terminal]
 ----
@@ -63,9 +60,9 @@ $ oc get nodes -o jsonpath='{range .items[*]}{"\n"}{.metadata.name}{"\t"}{range 
 ip-10-0-131-183.ec2.internal	node-role.kubernetes.io/master node.kubernetes.io/unreachable node.kubernetes.io/unreachable
 ----
 +
-If the node is listed with an `unreachable` taint, then the *node is not ready*.
+If the node is listed with an `unreachable` taint, then the node is not ready.
 
-** If the node is still reachable, then check whether the node is listed as `NotReady`:
+.. If the node is still reachable, then check whether the node is listed as `NotReady` by running the following command:
 +
 [source,terminal]
 ----
@@ -78,18 +75,15 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.35.4
 ----
 +
-If the node is listed as `NotReady`, then the *node is not ready*.
-
+If the node is listed as `NotReady`, then the node is not ready.
 +
-// TODO: xref
 If the *node is not ready*, then follow the "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready" procedure.
 
-
-. Determine if the *etcd pod is crashlooping*.
+. Determine if the etcd pod is crashlooping.
 +
-If the machine is running and the node is ready, then check whether the etcd pod is crashlooping.
+If the machine is running and the node status is `Ready`, check the status of the etcd pod.
 
-.. Verify that all control plane nodes are listed as `Ready`:
+.. Verify that all control plane nodes are listed as `Ready` by running the following command:
 +
 [source,terminal]
 ----
@@ -105,7 +99,7 @@ ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.35.4
 ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.35.4
 ----
 
-.. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:
+.. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff` by running the following command:
 +
 [source,terminal]
 ----
@@ -119,9 +113,6 @@ etcd-ip-10-0-131-183.ec2.internal                2/3     Error       7          
 etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          6h6m
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          6h6m
 ----
+The etcd pod crashloops because the `etcd-ip-10-0-131-183.ec2.internal` is `Error`.
 +
-Since the status of the `etcd-ip-10-0-131-183.ec2.internal` pod is `Error`, then the *etcd pod is crashlooping*.
-
-+
-// TODO: xref
 If the *etcd pod is crashlooping*, then follow the steps in "Replacing an unhealthy etcd member whose etcd pod is crashlooping".

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -8,26 +8,27 @@
 = Determining the state of the unhealthy etcd member
 
 [role="_abstract"]
-Determine whether an unhealthy etcd member has a stopped machine or not-ready node, or a crashlooping pod, so you can follow the correct replacement procedure.
+Determine whether the unhealthy etcd member has a stopped machine, an unready node, or a crashlooping etcd pod. Knowing the failure state enables you to follow the correct replacement procedure.
 
-The steps to replace an unhealthy etcd member depend on which of the following states your etcd member is in:
+Depending on the state of your unhealthy etcd member, use one of the following procedures:
 
-* The machine is not running or the node is not ready
-* The etcd pod is crashlooping
+* Machine not running or node not ready. For more information, see "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
+* Bare-metal machine not running or node not ready on installer-provisioned bare metal. For more information, see "Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready".
+* Crashlooping etcd pod. For more information, see "Replacing an unhealthy etcd member whose etcd pod is crashlooping".
 
 [NOTE]
 ====
-If you are aware that the machine is not running or the node is not ready, but you expect it to return to a healthy state soon, then you do not need to perform a procedure to replace the etcd member. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
+If the machine is not running or the node is not ready, you might expect either to recover soon. In that case, you do not need to replace the etcd member. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 ====
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have identified an unhealthy etcd member.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You identified an unhealthy etcd member.
 
 .Procedure
 
-. Determine if the *machine is not running*:
+. Determine if the machine is not running by running the following command:
 +
 [source,terminal]
 ----
@@ -40,17 +41,13 @@ $ oc get machines -A -ojsonpath='{range .items[*]}{@.status.nodeRef.name}{"\t"}{
 ip-10-0-131-183.ec2.internal  stopped
 ----
 +
-This output lists the node and the status of the node's machine. If the status is anything other than `running`, then the *machine is not running*.
+This output lists the node and the status of the machine of the node. If the status is anything other than `running`, then the machine is not running.
+
+. Determine if the status of the node is `NotReady`.
 +
-// TODO: xref
-If the *machine is not running*, then follow the steps in "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
+If either of the following scenarios are true, then the node is not ready.
 
-
-. Determine if the *node is not ready*.
-+
-If either of the following scenarios are true, then the *node is not ready*.
-
-** If the machine is running, then check whether the node is unreachable:
+.. If the machine is running, then check whether the node has an `unreachable` taint by running the following command:
 +
 [source,terminal]
 ----
@@ -63,9 +60,9 @@ $ oc get nodes -o jsonpath='{range .items[*]}{"\n"}{.metadata.name}{"\t"}{range 
 ip-10-0-131-183.ec2.internal	node-role.kubernetes.io/master node.kubernetes.io/unreachable node.kubernetes.io/unreachable
 ----
 +
-If the node is listed with an `unreachable` taint, then the *node is not ready*.
+If the node is listed with an `unreachable` taint, then the node is not ready.
 
-** If the node is still reachable, then check whether the node is listed as `NotReady`:
+.. If the node is still reachable, then check whether the node is listed as `NotReady` by running the following command:
 +
 [source,terminal]
 ----
@@ -78,18 +75,15 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.35.4
 ----
 +
-If the node is listed as `NotReady`, then the *node is not ready*.
-
+If the node is listed as `NotReady`, then the node is not ready.
 +
-// TODO: xref
 If the *node is not ready*, then follow the "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready" procedure.
 
-
-. Determine if the *etcd pod is crashlooping*.
+. Determine if the etcd pod is crashlooping.
 +
-If the machine is running and the node is ready, then check whether the etcd pod is crashlooping.
+If the machine is running and the node status is `Ready`, check the status of the etcd pod.
 
-.. Verify that all control plane nodes are listed as `Ready`:
+.. Verify that all control plane nodes are listed as `Ready` by running the following command:
 +
 [source,terminal]
 ----
@@ -105,7 +99,7 @@ ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.35.4
 ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.35.4
 ----
 
-.. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:
+.. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff` by running the following command:
 +
 [source,terminal]
 ----
@@ -119,9 +113,6 @@ etcd-ip-10-0-131-183.ec2.internal                2/3     Error       7          
 etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          6h6m
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          6h6m
 ----
+Since this status of pod `etcd-ip-10-0-131-183.ec2.internal` is `Error`, then the etcd pod is crashlooping.
 +
-Since the status of the `etcd-ip-10-0-131-183.ec2.internal` pod is `Error`, then the *etcd pod is crashlooping*.
-
-+
-// TODO: xref
 If the *etcd pod is crashlooping*, then follow the steps in "Replacing an unhealthy etcd member whose etcd pod is crashlooping".

--- a/modules/restore-identify-unhealthy-etcd-member.adoc
+++ b/modules/restore-identify-unhealthy-etcd-member.adoc
@@ -8,27 +8,25 @@
 = Identifying an unhealthy etcd member
 
 [role="_abstract"]
-Identify an unhealthy etcd member by checking the `EtcdMembersAvailable` status condition so you can proceed with the correct replacement procedure.
+You can identify an unhealthy etcd member by checking the `EtcdMembersAvailable` status condition to see how many members are available and which member is unhealthy.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup. For more information, see "Backing up etcd data".
+* You created an etcd backup.
 
 .Procedure
 
-. Check the status of the `EtcdMembersAvailable` status condition using the following command:
+* Check the status of the `EtcdMembersAvailable` status condition by running the following command:
 +
 [source,terminal]
 ----
 $ oc get etcd -o=jsonpath='{range .items[0].status.conditions[?(@.type=="EtcdMembersAvailable")]}{.message}{"\n"}{end}'
 ----
-
-. Review the output:
 +
+.Example output
 [source,terminal]
 ----
 2 of 3 members are available, ip-10-0-131-183.ec2.internal is unhealthy
 ----
-+
-This example output shows that the `ip-10-0-131-183.ec2.internal` etcd member is unhealthy.
+

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -8,14 +8,14 @@
 = Replacing an unhealthy etcd member whose etcd pod is crashlooping
 
 [role="_abstract"]
-Replace a crashlooping etcd member by removing it from the cluster and creating a healthy replacement so the control plane can regain quorum.
+Replace an unhealthy etcd member when the etcd pod is crashlooping. Restoring the member returns the control plane to a healthy state.
 
 .Prerequisites
 
-* You have identified the unhealthy etcd member.
-* You have verified that the etcd pod is crashlooping.
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup.
+* You identified the unhealthy etcd member.
+* You verified that the etcd pod is crashlooping.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You created an etcd backup before replacing the unhealthy etcd member.
 +
 [IMPORTANT]
 ====
@@ -26,9 +26,7 @@ It is important to take an etcd backup before performing this procedure so that 
 
 . Stop the crashlooping etcd pod.
 
-.. Debug the node that is crashlooping.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Debug the node that is crashlooping by running the following command:
 +
 [source,terminal]
 ----
@@ -37,26 +35,28 @@ $ oc debug node/<unhealthy_node>
 +
 Replace `<unhealthy_node>` with the name of the unhealthy etcd member.
 
-.. Change your root directory to `/host`:
+.. Change your root directory to `/host` by running the following command:
 +
 [source,terminal]
 ----
 sh-4.2# chroot /host
 ----
 
-.. Move the existing etcd pod file out of the kubelet manifest directory:
+.. Create a backup directory by running the following command:
 +
 [source,terminal]
 ----
 sh-4.2# mkdir /var/lib/etcd-backup
 ----
+
+. Move the existing etcd pod file out of the kubelet manifest directory by running the following commands:
 +
 [source,terminal]
 ----
 sh-4.2# mv /etc/kubernetes/manifests/etcd-pod.yaml /var/lib/etcd-backup/
 ----
 
-.. Move the etcd data directory to a different location:
+.. Move the etcd data directory to a different location by running the following command:
 +
 [source,terminal]
 ----
@@ -67,9 +67,7 @@ You can now exit the node shell.
 
 . Remove the unhealthy member.
 
-.. Choose a pod that is _not_ on the affected node.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Choose a pod that is _not_ on the affected node by running the following command:
 +
 [source,terminal]
 ----
@@ -84,16 +82,14 @@ etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          6h6m
 ----
 
-.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-ip-10-0-154-204.ec2.internal
 ----
 
-.. View the member list:
+.. View the member list by running the following command:
 +
 [source,terminal]
 ----
@@ -127,7 +123,7 @@ sh-4.2# etcdctl member remove 62bcf33650a7170a
 Member 62bcf33650a7170a removed from cluster ead669ce1fbfb346
 ----
 
-.. View the member list again and verify that the member was removed:
+.. View the member list again and verify that the member was removed by running the following command:
 +
 [source,terminal]
 ----
@@ -147,7 +143,7 @@ sh-4.2# etcdctl member list -w table
 +
 You can now exit the node shell.
 
-. Turn off the quorum guard by entering the following command:
+. Turn off the quorum guard by running the following command:
 +
 [source,terminal]
 ----
@@ -158,14 +154,14 @@ This command ensures that you can successfully re-create secrets and roll out th
 
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
-.. List the secrets for the unhealthy etcd member that was removed.
+.. List the secrets for the unhealthy etcd member that was removed by running the following command:
 +
 [source,terminal]
 ----
 $ oc get secrets -n openshift-etcd | grep <unhealthy_node>
 ----
 +
-Replace `<unhealthy_node>` with the name of the unhealthy etcd member.
+Replace `<unhealthy_node>` in the command with the name of the unhealthy etcd member that you noted earlier in this procedure.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
 +
@@ -177,32 +173,28 @@ etcd-serving-ip-10-0-131-183.ec2.internal           kubernetes.io/tls           
 etcd-serving-metrics-ip-10-0-131-183.ec2.internal   kubernetes.io/tls                     2      47m
 ----
 
-.. Delete the secrets for the unhealthy etcd member that was removed.
-
-... Delete the peer secret:
+.. Delete the peer secret for the unhealthy etcd member that was removed by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-peer-ip-10-0-131-183.ec2.internal
 ----
 
-... Delete the serving secret:
+.. Delete the serving secret by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-serving-ip-10-0-131-183.ec2.internal
 ----
 
-... Delete the metrics secret:
+.. Delete the metrics secret by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-serving-metrics-ip-10-0-131-183.ec2.internal
 ----
 
-. Force etcd redeployment.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Force etcd redeployment by running the following command:
 +
 [source,terminal]
 ----
@@ -213,14 +205,14 @@ The `forceRedeploymentReason` value must be unique, which is why a timestamp is 
 +
 When the etcd cluster Operator performs a redeployment, it ensures that all control plane nodes have a functioning etcd pod.
 
-. Turn the quorum guard back on by entering the following command:
+. Turn the quorum guard back on by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
-. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
+. Verify that the `unsupportedConfigOverrides` section is removed from the object by running the following command:
 +
 [source,terminal]
 ----
@@ -239,16 +231,14 @@ EtcdCertSignerControllerDegraded: [Operation cannot be fulfilled on secrets "etc
 
 * Verify that the new member is available and healthy.
 
-.. Connect to the running etcd container again.
-+
-In a terminal that has access to the cluster as a cluster-admin user, run the following command:
+** Connect to the running etcd container by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-ip-10-0-154-204.ec2.internal
 ----
 
-.. Verify that all members are healthy:
+** Verify that all members are healthy by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -8,16 +8,16 @@
 = Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready
 
 [role="_abstract"]
-Replace a bare metal etcd member whose machine is not running or whose node is not ready by removing it from the cluster and provisioning a replacement control plane machine.
+Replace an unhealthy bare metal etcd member when the machine is not running or the node is not ready. Restoring the member returns the control plane to a healthy state.
 
 If you are running installer-provisioned infrastructure or you used the Machine API to create your machines, follow these steps. Otherwise you must create the new control plane node using the same method that was used to originally create it.
 
 .Prerequisites
 
-* You have identified the unhealthy bare metal etcd member.
-* You have verified that either the machine is not running or the node is not ready.
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup.
+* You identified the unhealthy bare metal etcd member.
+* You verified that either the machine is not running or the node is not ready.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You created an etcd backup.
 +
 [IMPORTANT]
 ====
@@ -28,9 +28,7 @@ You must take an etcd backup before performing this procedure so that your clust
 
 . Verify and remove the unhealthy member.
 
-.. Choose a pod that is _not_ on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Choose a pod that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
@@ -44,16 +42,14 @@ etcd-openshift-control-plane-0   5/5   Running   11   3h56m   192.168.10.9   ope
 etcd-openshift-control-plane-1   5/5   Running   0    3h54m   192.168.10.10   openshift-control-plane-1   <none>           <none>
 etcd-openshift-control-plane-2   5/5   Running   0    3h58m   192.168.10.11   openshift-control-plane-2   <none>           <none>
 ----
-.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-openshift-control-plane-0
 ----
 
-.. View the member list:
+.. View the member list by running the following command:
 +
 [source,terminal]
 ----
@@ -72,14 +68,14 @@ sh-4.2# etcdctl member list -w table
 +------------------+---------+--------------------+---------------------------+---------------------------+---------------------+
 ----
 +
-Take note of the ID and the name of the unhealthy etcd member, because these values are required later in the procedure. The `etcdctl endpoint health` command will list the removed member until the replacement procedure is completed and the new member is added.
-
-.. Remove the unhealthy etcd member by providing the ID to the `etcdctl member remove` command:
+Take note of the ID and the name of the unhealthy etcd member, because these values are required later in the procedure. The `etcdctl endpoint health` command lists the removed member until the replacement procedure is completed and the new member is added.
 +
 [WARNING]
 ====
-Be sure to remove the correct etcd member; removing a good etcd member might lead to quorum loss.
+Be sure to remove the correct etcd member. Removing a good etcd member might lead to quorum loss.
 ====
+
+.. Remove the unhealthy etcd member by providing the ID to the `etcdctl member remove` command:
 +
 [source,terminal]
 ----
@@ -92,7 +88,7 @@ sh-4.2# etcdctl member remove 7a8197040a5126c8
 Member 7a8197040a5126c8 removed from cluster b23536c33f2cdd1b
 ----
 
-.. View the member list again and verify that the member was removed:
+.. View the member list again and verify that the member was removed by running the following command:
 +
 [source,terminal]
 ----
@@ -117,7 +113,7 @@ You can now exit the node shell.
 After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
 ====
 
-. Turn off the quorum guard by entering the following command:
+. Turn off the quorum guard by running the following command:
 +
 [source,terminal]
 ----
@@ -126,14 +122,15 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 +
 This command ensures that you can successfully re-create secrets and roll out the static pods.
 
-. Remove the old secrets for the unhealthy etcd member that was removed by running the following commands.
+. Remove the old secrets for the unhealthy etcd member that was removed.
 
-.. List the secrets for the unhealthy etcd member that was removed.
+.. List the secrets for the unhealthy etcd member that was removed by running the following command:
 +
 [source,terminal]
 ----
 $ oc get secrets -n openshift-etcd | grep openshift-control-plane-2
 ----
++
 Pass in the name of the unhealthy etcd member that you took note of earlier in this procedure.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
@@ -145,9 +142,7 @@ etcd-serving-metrics-openshift-control-plane-2  kubernetes.io/tls   2   134m
 etcd-serving-openshift-control-plane-2          kubernetes.io/tls   2   134m
 ----
 
-.. Delete the secrets for the unhealthy etcd member that was removed.
-
-... Delete the peer secret:
+..  Delete the secrets for the unhealthy etcd member by running the following command:
 +
 [source,terminal]
 ----
@@ -160,7 +155,7 @@ $ oc delete secret etcd-peer-openshift-control-plane-2 -n openshift-etcd
 secret "etcd-peer-openshift-control-plane-2" deleted
 ----
 
-... Delete the serving secret:
+.. Delete the serving secret by running the following command:
 +
 [source,terminal]
 ----
@@ -173,7 +168,7 @@ $ oc delete secret etcd-serving-metrics-openshift-control-plane-2 -n openshift-e
 secret "etcd-serving-metrics-openshift-control-plane-2" deleted
 ----
 
-... Delete the metrics secret:
+.. Delete the metrics secret by running the following command:
 +
 [source,terminal]
 ----
@@ -186,9 +181,7 @@ $ oc delete secret etcd-serving-openshift-control-plane-2 -n openshift-etcd
 secret "etcd-serving-openshift-control-plane-2" deleted
 ----
 
-. Obtain the machine for the unhealthy member.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Obtain the machine for the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
@@ -206,7 +199,7 @@ examplecluster-compute-0          Running                          165m    opens
 examplecluster-compute-1          Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 +
-`examplecluster-control-plane-0` is the control plane machine for the unhealthy node, `examplecluster-control-plane-2`.
+`examplecluster-control-plane-2` is the control plane machine for the unhealthy node `openshift-control-plane-2`.
 
 . Ensure that the Bare Metal Operator is available by running the following command:
 +
@@ -308,8 +301,7 @@ openshift-compute-0       Ready worker 176m v1.35.4
 openshift-compute-1       Ready worker 176m v1.35.4
 ----
 
-. Create the new `BareMetalHost` object and the secret to store the BMC credentials:
-
+. Create the new `BareMetalHost` object and the secret to store the Baseboard Management Controller (BMC) credentials by running the following command:
 +
 [source,terminal]
 ----
@@ -349,7 +341,7 @@ EOF
 +
 [NOTE]
 ====
-The username and password can be found from the other bare metal host's secrets. The protocol to use in `bmc:address` can be taken from other bmh objects.
+The username and password can be found from the secrets of the other bare-metal host. The protocol to use in `bmc:address` can be taken from other bmh objects.
 ====
 +
 [IMPORTANT]
@@ -361,7 +353,7 @@ Existing control plane `BareMetalHost` objects may have the `externallyProvision
 +
 After the inspection is complete, the `BareMetalHost` object is created and available to be provisioned.
 
-. Verify the creation process using available `BareMetalHost` objects:
+. Verify the creation process using available `BareMetalHost` objects by running the following command:
 +
 [source,terminal]
 ----
@@ -379,7 +371,7 @@ openshift-compute-0       provisioned            examplecluster-compute-0       
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
 
-.. Verify that a new machine has been created:
+.. Verify that a new machine has been created by running the following command:
 +
 [source,terminal]
 ----
@@ -397,10 +389,9 @@ examplecluster-compute-0               Running                          165m    
 examplecluster-compute-1               Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 +
-The new machine is being created and is ready after the phase changes from `Provisioning` to `Running`.
+The new machine is ready when the phase changes from `Provisioning` to `Running`.
 +
-It should take a few minutes for the new machine to be created. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
-
+It should take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 
 .. Verify that the bare metal host becomes provisioned and no error reported by running the following command:
 +
@@ -420,7 +411,7 @@ openshift-compute-0       provisioned            examplecluster-compute-0       
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
 
-.. Verify that the new node is added and in a ready state by running this command:
+.. Verify that the new node is added and in a ready state by running the following command:
 +
 [source,terminal]
 ----
@@ -438,14 +429,14 @@ openshift-compute-0       Ready worker 3h58m v1.35.4
 openshift-compute-1       Ready worker 3h58m v1.35.4
 ----
 
-. Turn the quorum guard back on by entering the following command:
+. Turn the quorum guard back on by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
-. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by running the following command:
 +
 [source,terminal]
 ----
@@ -462,9 +453,7 @@ EtcdCertSignerControllerDegraded: [Operation cannot be fulfilled on secrets "etc
 
 .Verification
 
-. Verify that all etcd pods are running properly.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Verify that all etcd pods are running properly by running the following command:
 +
 [source,terminal]
 ----
@@ -495,7 +484,7 @@ To verify there are exactly three etcd members, connect to the running etcd cont
 $ oc rsh -n openshift-etcd etcd-openshift-control-plane-0
 ----
 +
-. View the member list:
+. View the member list by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -8,16 +8,16 @@
 = Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready
 
 [role="_abstract"]
-Replace a bare metal etcd member whose machine is not running or whose node is not ready by removing it from the cluster and provisioning a replacement control plane machine.
+Replace an unhealthy bare metal etcd member when the machine is not running or the node is not ready. Restoring the member returns the control plane to a healthy state.
 
 If you are running installer-provisioned infrastructure or you used the Machine API to create your machines, follow these steps. Otherwise you must create the new control plane node using the same method that was used to originally create it.
 
 .Prerequisites
 
-* You have identified the unhealthy bare metal etcd member.
-* You have verified that either the machine is not running or the node is not ready.
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup.
+* You identified the unhealthy bare metal etcd member.
+* You verified that either the machine is not running or the node is not ready.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You created an etcd backup.
 +
 [IMPORTANT]
 ====
@@ -28,9 +28,7 @@ You must take an etcd backup before performing this procedure so that your clust
 
 . Verify and remove the unhealthy member.
 
-.. Choose a pod that is _not_ on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Choose a pod that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
@@ -44,16 +42,14 @@ etcd-openshift-control-plane-0   5/5   Running   11   3h56m   192.168.10.9   ope
 etcd-openshift-control-plane-1   5/5   Running   0    3h54m   192.168.10.10   openshift-control-plane-1   <none>           <none>
 etcd-openshift-control-plane-2   5/5   Running   0    3h58m   192.168.10.11   openshift-control-plane-2   <none>           <none>
 ----
-.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-openshift-control-plane-0
 ----
 
-.. View the member list:
+.. View the member list by running the following command:
 +
 [source,terminal]
 ----
@@ -72,14 +68,9 @@ sh-4.2# etcdctl member list -w table
 +------------------+---------+--------------------+---------------------------+---------------------------+---------------------+
 ----
 +
-Take note of the ID and the name of the unhealthy etcd member, because these values are required later in the procedure. The `etcdctl endpoint health` command will list the removed member until the replacement procedure is completed and the new member is added.
+Take note of the ID and the name of the unhealthy etcd member, because these values are required later in the procedure. The `etcdctl endpoint health` command lists the removed member until the replacement procedure is completed and the new member is added.
 
 .. Remove the unhealthy etcd member by providing the ID to the `etcdctl member remove` command:
-+
-[WARNING]
-====
-Be sure to remove the correct etcd member; removing a good etcd member might lead to quorum loss.
-====
 +
 [source,terminal]
 ----
@@ -91,8 +82,13 @@ sh-4.2# etcdctl member remove 7a8197040a5126c8
 ----
 Member 7a8197040a5126c8 removed from cluster b23536c33f2cdd1b
 ----
++
+[WARNING]
+====
+Be sure to remove the correct etcd member. Removing a good etcd member might lead to quorum loss.
+====
 
-.. View the member list again and verify that the member was removed:
+.. View the member list again and verify that the member was removed by running the following command:
 +
 [source,terminal]
 ----
@@ -117,7 +113,7 @@ You can now exit the node shell.
 After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
 ====
 
-. Turn off the quorum guard by entering the following command:
+. Turn off the quorum guard by running the following command:
 +
 [source,terminal]
 ----
@@ -126,14 +122,15 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 +
 This command ensures that you can successfully re-create secrets and roll out the static pods.
 
-. Remove the old secrets for the unhealthy etcd member that was removed by running the following commands.
+. Remove the old secrets for the unhealthy etcd member that was removed.
 
-.. List the secrets for the unhealthy etcd member that was removed.
+.. List the secrets for the unhealthy etcd member that was removed by running the following command.
 +
 [source,terminal]
 ----
 $ oc get secrets -n openshift-etcd | grep openshift-control-plane-2
 ----
++
 Pass in the name of the unhealthy etcd member that you took note of earlier in this procedure.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
@@ -145,9 +142,7 @@ etcd-serving-metrics-openshift-control-plane-2  kubernetes.io/tls   2   134m
 etcd-serving-openshift-control-plane-2          kubernetes.io/tls   2   134m
 ----
 
-.. Delete the secrets for the unhealthy etcd member that was removed.
-
-... Delete the peer secret:
+..  Delete the secrets for the unhealthy etcd member by running the following command:
 +
 [source,terminal]
 ----
@@ -160,7 +155,7 @@ $ oc delete secret etcd-peer-openshift-control-plane-2 -n openshift-etcd
 secret "etcd-peer-openshift-control-plane-2" deleted
 ----
 
-... Delete the serving secret:
+.. Delete the serving secret by running the following command:
 +
 [source,terminal]
 ----
@@ -173,7 +168,7 @@ $ oc delete secret etcd-serving-metrics-openshift-control-plane-2 -n openshift-e
 secret "etcd-serving-metrics-openshift-control-plane-2" deleted
 ----
 
-... Delete the metrics secret:
+.. Delete the metrics secret by running the following command:
 +
 [source,terminal]
 ----
@@ -186,9 +181,7 @@ $ oc delete secret etcd-serving-openshift-control-plane-2 -n openshift-etcd
 secret "etcd-serving-openshift-control-plane-2" deleted
 ----
 
-. Obtain the machine for the unhealthy member.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Obtain the machine for the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
@@ -206,7 +199,7 @@ examplecluster-compute-0          Running                          165m    opens
 examplecluster-compute-1          Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 +
-`examplecluster-control-plane-0` is the control plane machine for the unhealthy node, `examplecluster-control-plane-2`.
+`examplecluster-control-plane-2` is the control plane machine for the unhealthy node `openshift-control-plane-2`.
 
 . Ensure that the Bare Metal Operator is available by running the following command:
 +
@@ -308,8 +301,7 @@ openshift-compute-0       Ready worker 176m v1.35.4
 openshift-compute-1       Ready worker 176m v1.35.4
 ----
 
-. Create the new `BareMetalHost` object and the secret to store the BMC credentials:
-
+. Create the new `BareMetalHost` object and the secret to store the Baseboard Management Controller (BMC) credentials by running the following command:
 +
 [source,terminal]
 ----
@@ -349,7 +341,7 @@ EOF
 +
 [NOTE]
 ====
-The username and password can be found from the other bare metal host's secrets. The protocol to use in `bmc:address` can be taken from other bmh objects.
+The username and password can be found from the secrets of the other bare-metal host. The protocol to use in `bmc:address` can be taken from other bmh objects.
 ====
 +
 [IMPORTANT]
@@ -361,7 +353,7 @@ Existing control plane `BareMetalHost` objects may have the `externallyProvision
 +
 After the inspection is complete, the `BareMetalHost` object is created and available to be provisioned.
 
-. Verify the creation process using available `BareMetalHost` objects:
+. Verify the creation process using available `BareMetalHost` objects by running the following command:
 +
 [source,terminal]
 ----
@@ -379,7 +371,7 @@ openshift-compute-0       provisioned            examplecluster-compute-0       
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
 
-.. Verify that a new machine has been created:
+.. Verify that a new machine has been created by running the following command:
 +
 [source,terminal]
 ----
@@ -397,16 +389,15 @@ examplecluster-compute-0               Running                          165m    
 examplecluster-compute-1               Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 +
-The new machine is being created and is ready after the phase changes from `Provisioning` to `Running`.
+The new machine is ready when the phase changes from `Provisioning` to `Running`.
 +
-It should take a few minutes for the new machine to be created. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
-
+It should take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 
 .. Verify that the bare metal host becomes provisioned and no error reported by running the following command:
 +
 [source,terminal]
 ----
-$ oc get bmh -n openshift-machine-api
+$ oc get -n openshift-machine-api
 ----
 +
 .Example output
@@ -420,7 +411,7 @@ openshift-compute-0       provisioned            examplecluster-compute-0       
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
 
-.. Verify that the new node is added and in a ready state by running this command:
+.. Verify that the new node is added and in a ready state by running the following command:
 +
 [source,terminal]
 ----
@@ -438,14 +429,14 @@ openshift-compute-0       Ready worker 3h58m v1.35.4
 openshift-compute-1       Ready worker 3h58m v1.35.4
 ----
 
-. Turn the quorum guard back on by entering the following command:
+. Turn the quorum guard back on by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
-. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by running the following command:
 +
 [source,terminal]
 ----
@@ -462,9 +453,7 @@ EtcdCertSignerControllerDegraded: [Operation cannot be fulfilled on secrets "etc
 
 .Verification
 
-. Verify that all etcd pods are running properly.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Verify that all etcd pods are running properly by running the following command.
 +
 [source,terminal]
 ----
@@ -495,7 +484,7 @@ To verify there are exactly three etcd members, connect to the running etcd cont
 $ oc rsh -n openshift-etcd etcd-openshift-control-plane-0
 ----
 +
-. View the member list:
+. View the member list by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -8,7 +8,7 @@
 = Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
 
 [role="_abstract"]
-Replace an etcd member whose machine is not running or whose node is not ready by removing it from the cluster and provisioning a replacement control plane machine.
+Replace an unhealthy etcd member when the member machine is stopped or the node is not ready. Restoring the member returns the control plane to a healthy state.
 
 [NOTE]
 ====
@@ -17,29 +17,22 @@ If your cluster uses a control plane machine set, see "Recovering a degraded etc
 
 .Prerequisites
 
-* You have identified the unhealthy etcd member.
-* You have verified that either the machine is not running or the node is not ready.
+* You identified the unhealthy etcd member.
+* You verified that either the machine is not running or the node is not ready.
+* Do not power on other control plane nodes until the unhealthy etcd member replacement is complete.
+* You confirmed access to the cluster as a user with the `cluster-admin` role.
+* You created an etcd backup before replacing the unhealthy etcd member.
 +
 [IMPORTANT]
 ====
-You must wait if you power off other control plane nodes. The control plane nodes must remain powered off until the replacement of an unhealthy etcd member is complete.
-====
-+
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have taken an etcd backup.
-+
-[IMPORTANT]
-====
-Before you perform this procedure, take an etcd backup so that you can restore your cluster if you experience any issues.
+Without a recent etcd backup, you might not be able to restore the cluster if replacement fails.
 ====
 
 .Procedure
 
 . Remove the unhealthy member.
 
-.. Choose a pod that is not on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. List etcd pods and choose one that is not on the affected node by running the following command:
 +
 [source,terminal]
 ----
@@ -53,17 +46,17 @@ etcd-ip-10-0-131-183.ec2.internal                3/3     Running     0          
 etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          123m
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          124m
 ----
-
-.. Connect to the running etcd container, passing in the name of a pod that is not on the affected node:
 +
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+From the output, note a pod that is not on the affected node. In this example, the unhealthy member is `ip-10-0-131-183.ec2.internal`, so you could use `etcd-ip-10-0-154-204.ec2.internal`.
+
+.. Connect to the running etcd container on the pod you chose by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-ip-10-0-154-204.ec2.internal
 ----
 
-.. View the member list:
+.. View the member list by running the following command:
 +
 [source,terminal]
 ----
@@ -82,9 +75,9 @@ sh-4.2# etcdctl member list -w table
 +------------------+---------+------------------------------+---------------------------+---------------------------+
 ----
 +
-Take note of the ID and the name of the unhealthy etcd member because these values are needed later in the procedure. The `$ etcdctl endpoint health` command will list the removed member until the procedure of replacement is finished and a new member is added.
+Take note of the ID and the name of the unhealthy etcd member because you need these values later in the procedure. The `etcdctl endpoint health` command continues to list the removed member until replacement is complete and a new member is added.
 
-.. Remove the unhealthy etcd member by providing the ID to the `etcdctl member remove` command:
+.. Remove the unhealthy etcd member by providing the ID to the `etcdctl member remove` command by running the following command:
 +
 [source,terminal]
 ----
@@ -97,7 +90,7 @@ sh-4.2# etcdctl member remove <etcd_member_id>
 Member 6fc1e7c9db35841d removed from cluster ead669ce1fbfb346
 ----
 
-.. View the member list again and verify that the member was removed:
+.. View the member list again and verify that the member was removed by running the following command:
 +
 [source,terminal]
 ----
@@ -117,7 +110,7 @@ sh-4.2# etcdctl member list -w table
 +
 You can now exit the node shell.
 
-. Turn off the quorum guard by entering the following command:
+. Turn off the quorum guard by running the following command:
 +
 [source,terminal]
 ----
@@ -128,7 +121,7 @@ This command ensures that you can successfully re-create secrets and roll out th
 +
 [IMPORTANT]
 ====
-After you turn off the quorum guard, the cluster might be unreachable for a short time while the remaining etcd instances reboot to reflect the configuration change.
+After you turn off the quorum guard, the cluster might be unreachable for a short period of time while the remaining etcd instances reboot to reflect the configuration change.
 ====
 +
 [NOTE]
@@ -151,14 +144,14 @@ $ oc delete node ip-10-0-131-183.ec2.internal
 
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
-.. List the secrets for the unhealthy etcd member that was removed.
+.. List the secrets for the unhealthy etcd member that was removed by running the following command:
 +
 [source,terminal]
 ----
-$ oc get secrets -n openshift-etcd | grep <unhealthy_node>
+$ oc get secrets -n openshift-etcd | grep ip-10-0-131-183.ec2.internal
 ----
 +
-Replace `<unhealthy_node>` with the name of the unhealthy etcd member that you took note of earlier in this procedure. The examples throughout this procedure use `ip-10-0-131-183.ec2.interal` as the name of the unhealthy etcd member.
+Replace `ip-10-0-131-183.ec2.internal` in the command with the name of the unhealthy etcd member that you noted earlier in this procedure.
 +
 There is a peer, serving, and metrics secret as shown in the following output:
 +
@@ -170,43 +163,39 @@ etcd-serving-ip-10-0-131-183.ec2.internal           kubernetes.io/tls           
 etcd-serving-metrics-ip-10-0-131-183.ec2.internal   kubernetes.io/tls                     2      47m
 ----
 
-.. Delete the secrets for the unhealthy etcd member that was removed.
-
-... Delete the peer secret:
+.. Delete the peer secret by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-peer-ip-10-0-131-183.ec2.internal
 ----
 
-... Delete the serving secret:
+.. Delete the serving secret by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-serving-ip-10-0-131-183.ec2.internal
 ----
 
-... Delete the metrics secret:
+.. Delete the metrics secret by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-serving-metrics-ip-10-0-131-183.ec2.internal
 ----
 
-. Check whether a control plane machine set exists by entering the following command:
+. Check whether a control plane machine set exists by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-machine-api get controlplanemachineset
 ----
-
-* If the control plane machine set exists, delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically. For more information, see "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
++
+If the control plane machine set exists, delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically. For more information, see "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready".
 +
 If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new control plane by using the same method that was used to originally create it.
 
-.. Obtain the machine for the unhealthy member.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Obtain the machine for the unhealthy member by running the following command.
 +
 [source,terminal]
 ----
@@ -225,9 +214,9 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-`clustername-8qw5l-master-0` is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
+In the example output, `clustername-8qw5l-master-0` is the control plane machine for the unhealthy node `ip-10-0-131-183.ec2.internal`. Its `STATE` is `stopped`.
 
-.. Delete the machine of the unhealthy member:
+.. Delete the machine of the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
@@ -238,7 +227,7 @@ Replace `clustername-8qw5l-master-0` with the name of the control plane machine 
 +
 A new machine is automatically provisioned after deleting the machine of the unhealthy member.
 
-.. Verify that a new machine was created:
+.. Verify that a new machine was created by running the following command:
 +
 [source,terminal]
 ----
@@ -257,7 +246,7 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-The new machine, `clustername-8qw5l-master-3`, is being created and is ready once the phase changes from `Provisioning` to `Running`.
+In the example output, `clustername-8qw5l-master-3` is the new control plane machine. The machine is ready when the `PHASE` changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 +
@@ -265,14 +254,12 @@ It might take a few minutes for the new machine to be created. The etcd cluster 
 ====
 Verify the subnet IDs that you are using for your machine sets to ensure that they end up in the correct availability zone.
 ====
-
-* If the control plane machine set does not exist, delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically.
++
+If the control plane machine set does not exist, delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically.
 +
 If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new control plane by using the same method that was used to originally create it.
 
-.. Obtain the machine for the unhealthy member.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Obtain the machine for the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
@@ -291,9 +278,9 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-`clustername-8qw5l-master-0` is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
+In the example output, `clustername-8qw5l-master-0` is the control plane machine for the unhealthy node `ip-10-0-131-183.ec2.internal`. Its `STATE` is `stopped`.
 
-.. Save the machine configuration to a file on your file system:
+.. Save the machine configuration to a file on your file system by running the following command:
 +
 [source,terminal]
 ----
@@ -305,9 +292,9 @@ $ oc get machine clustername-8qw5l-master-0 \
 +
 Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the unhealthy node.
 
-.. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
+. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields:
 
-... Remove the entire `status` section:
+.. Remove the entire `status` section:
 +
 [source,yaml]
 ----
@@ -339,9 +326,7 @@ status:
     kind: AWSMachineProviderStatus
 ----
 
-... Change the `metadata.name` field to a new name.
-+
-Keep the same base name as the old machine and change the ending number to the next available number. In this example, `clustername-8qw5l-master-0` is changed to `clustername-8qw5l-master-3`.
+.. Change the `metadata.name` field to a new name.
 +
 For example:
 +
@@ -354,24 +339,26 @@ metadata:
   name: clustername-8qw5l-master-3
   ...
 ----
++
+Keep the same base name as the old machine and change the ending number to the next available number. In this example, `clustername-8qw5l-master-0` is changed to `clustername-8qw5l-master-3`
 
-... Remove the `spec.providerID` field:
+.. Remove the `spec.providerID` field:
 +
 [source,yaml]
 ----
   providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
 ----
 
-.. Delete the machine of the unhealthy member:
+. Delete the machine of the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0
 ----
 +
-Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the unhealthy node.
+In the command, replace `clustername-8qw5l-master-0` with the control plane machine name for the unhealthy node that you identified in the example output above.
 
-.. Verify that the machine was deleted:
+. Verify that the machine was deleted by running the following command:
 +
 [source,terminal]
 ----
@@ -389,14 +376,14 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 
-.. Create the new machine by using the `new-master-machine.yaml` file:
+. Create the new machine by using the `new-master-machine.yaml` file by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f new-master-machine.yaml
 ----
 
-.. Verify that the new machine was created:
+. Verify that the new machine was created by running the following command:
 +
 [source,terminal]
 ----
@@ -415,18 +402,18 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-The new machine, `clustername-8qw5l-master-3`, is being created and is ready once the phase changes from `Provisioning` to `Running`.
+In the example output, `clustername-8qw5l-master-3` is the new control plane machine. The machine is ready when the `PHASE` changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator automatically syncs when the machine or node returns to a healthy state.
 
-. Turn the quorum guard back on by entering the following command:
+. Turn the quorum guard back on by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
-. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by running the following command:
 +
 [source,terminal]
 ----
@@ -443,9 +430,7 @@ EtcdCertSignerControllerDegraded: [Operation cannot be fulfilled on secrets "etc
 
 .Verification
 
-. Verify that all etcd pods are running properly.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. Verify that all etcd pods are running properly by running the following command:
 +
 [source,terminal]
 ----
@@ -460,27 +445,25 @@ etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          124m
 ----
 +
-If the output from the previous command only lists two pods, you can manually force an etcd redeployment. In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+. If the output from the previous command lists only two pods, force an etcd redeployment by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
 ----
 +
-The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
+The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended in the example.
 
 . Verify that there are exactly three etcd members.
 
-.. Connect to the running etcd container, passing in the name of a pod that was not on the affected node:
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. Connect to the running etcd container, passing in the name of a pod that was not on the affected node by running the following command:
 +
 [source,terminal]
 ----
 $ oc rsh -n openshift-etcd etcd-ip-10-0-154-204.ec2.internal
 ----
 
-.. View the member list:
+.. View the member list by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-unhealthy-etcd-member.adoc
+++ b/modules/restore-replace-unhealthy-etcd-member.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/replacing-unhealthy-etcd-member.adoc
+// * etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
+:_mod-docs-content-type: REFERENCE
+[id="restore-replace-unhealthy-etcd-member_{context}"]
+= Replacing the unhealthy etcd member
+
+[role="_abstract"]
+You can replace an unhealthy etcd member by following one of several procedures, depending on whether the machine is not running, the node is not ready, the etcd pod is crashlooping, or the member is a stopped baremetal instance.
+
+Use one of the following procedures, based on the state of your unhealthy etcd member:
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node in an unhealthy cluster]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy stopped baremetal etcd member]

--- a/modules/restore-replace-unhealthy-etcd-member.adoc
+++ b/modules/restore-replace-unhealthy-etcd-member.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/replacing-unhealthy-etcd-member.adoc
+// * etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
+:_mod-docs-content-type: REFERENCE
+[id="restore-replace-unhealthy-etcd-member_{context}"]
+= Replacing the unhealthy etcd member
+
+[role="_abstract"]
+You can replace an unhealthy etcd member by following one of several procedures, depending on whether the machine is not running, the node is not ready, the etcd pod is crashlooping, or the member is a stopped bare-metal instance.
+
+Use one of the following procedures, based on the state of your unhealthy etcd member:
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node in an unhealthy cluster]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy stopped baremetal etcd member]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
