### PR TITLE
OSDOCS-12589: Documented Dynamic Configuration Manager

### DIFF
--- a/modules/about-haproxy-dynamic-configuration-manager.adoc
+++ b/modules/about-haproxy-dynamic-configuration-manager.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-haproxy-dynamic-configuration-manager_{context}"]
+= HAProxy Dynamic Configuration Manager (DCM)
+
+[role="_abstract"]
+As an administrator, you can use DCM as an alternative update mechanism that configures a running HAProxy process through a domain socket.
+This approach eliminates the need to fork and reload the HAProxy process.
+
+DCM is enabled by default and requires no configuration.
+The router automatically uses DCM for supported operations and falls back to fork-and-reload for operations that DCM cannot handle.
+
+After a router reload, the default HAProxy process forks a new child process and keeps the old process running until all
+existing connections close.
+If HAProxy reloads frequently while handling long-lived connections, old processes accumulate and consume excessive memory on the node. 
+Accumulating processes can cause out-of-memory errors in environments with frequent route or endpoint changes.
+
+DCM addresses this problem by applying configuration updates directly to the running HAProxy process.
+DCM provides the following benefits over the default fork-and-reload model:
+
+* Reduced memory usage: Old HAProxy processes do not accumulate during frequent endpoint updates.
+The fork-and-reload model can cause each old process to consume hundreds of megabytes or several gigabytes of memory.
+* Improved metrics accuracy: After a fork-and-reload, the old HAProxy process cannot update metrics for its remaining connections.
+DCM preserves full metrics continuity because the process is not replaced.
+* Better load balancing: HAProxy load-balancing algorithms such as `roundrobin`, `random`, and `leastconn` track connection counts per backend server.
+After a reload, the new process has no data about connections managed by old processes. This new process causes uneven traffic distribution. DCM retains this data because the process persists.
+
+DCM handles scale-out and scale-in of a single pod endpoint per route without triggering an HAProxy reload.
+After an application scales from zero endpoints to one endpoint, or scales from one endpoint back to zero, DCM applies the update dynamically.
+
+The following operations still require a fork-and-reload:
+
+* Adding or removing routes
+* Changing TLS certificates on a route
+* Changing route annotations
+* Multiple successive scale-out events for the same route
+* Changes to the router global configuration, including the `timeout`, `maxconn`, `nbthread`, and `log` options

--- a/modules/dcm-memory-overhead.adoc
+++ b/modules/dcm-memory-overhead.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="dcm-memory-overhead_{context}"]
+= Memory overhead of DCM
+
+[role="_abstract"]
+When you use Dynamic Configuration Manager (DCM), memory usage increases slightly with the number of routes and threads you configure.
+Memory increases occur because HAProxy pre-allocates one server slot per backend in the HAProxy configuration.
+
+The following table shows the approximate memory impact of the pre-allocated server slot:
+
+[cols="3,2,2,2",options="header"]
+|===
+|Number of backends (routes) |Thread count |Memory without DCM |Memory with DCM
+
+|100
+|4 (default)
+|Negligible (MB)
+|Negligible (MB)
+
+|1,000
+|4 (default)
+|18 MB
+|23 MB
+
+|10,000
+|64
+|86 MB
+|175 MB
+
+|===
+
+For most deployments, the memory overhead is negligible. The maximum supported number of backends per router is 1,000.
+The 10,000 backend scenario is for comparison only.

--- a/modules/dcm-router-operations-reference.adoc
+++ b/modules/dcm-router-operations-reference.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="dcm-router-operations-reference_{context}"]
+= Dynamic Configuration Manager (DCM) router operations
+
+[role="_abstract"]
+DCM handles certain operations dynamically, while other operations still require a standard HAProxy fork-and-reload.
+You can plan configuration changes without causing unexpected traffic disruptions or CPU spikes.
+
+[NOTE]
+====
+When DCM encounters an operation that it cannot handle dynamically, the router falls back to the standard
+fork-and-reload mechanism.
+The fallback mechanism is automatic and does not require administrator intervention. 
+The router writes a new `haproxy.config` file and reloads HAProxy, which forks a new process to handle incoming connections.
+====
+
+DCM applies the following operations to a running HAProxy process without triggering a reload:
+
+[cols="2,3",options="header"]
+|===
+|Operation |Description
+
+|Single endpoint scale-out
+|A route scales from zero endpoints to one endpoint. DCM assigns the new endpoint to the pre-allocated server slot.
+
+|Endpoint scale-in
+|A route scales from one endpoint to zero endpoints. DCM removes the endpoint from the server slot.
+
+|Scale-out following scale-in
+|A route that previously scaled in can scale out to one endpoint again without a reload.
+
+|===
+
+The following table details operations that DCM cannot handle dynamically.
+These operations require the router to fall back to a fork-and-reload:
+
+[cols="2,3",options="header"]
+|===
+|Operation |Description
+
+|Adding or removing a route
+|HAProxy does not support adding or removing backends dynamically.
+
+|Changing TLS certificates
+|Certificate updates on a route require writing a new configuration file and reloading HAProxy.
+
+|Changing route annotations
+|Annotation changes modify the backend configuration and require a reload.
+
+|Multiple successive scale-out events
+|If a route scales from one to two or more endpoints before a reload occurs, DCM cannot assign additional server slots.
+
+|Global router configuration changes
+|Changes to the `timeout`, `maxconn`, `nbthread`, and `log` options require a pod restart.
+
+|===

--- a/modules/disabling-dcm.adoc
+++ b/modules/disabling-dcm.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="disabling-dcm_{context}"]
+= Disabling Dynamic Configuration Manager (DCM)
+
+[role="_abstract"]
+If a critical issue arises, you can disable DCM by setting the `dynamicConfigManager` field to `false` in the `IngressController` custom resource (CR).
+
+[IMPORTANT]
+====
+Using the `unsupportedConfigOverrides` section to modify the configuration of an Operator is unsupported and might block cluster updates. 
+You must remove this setting before you can update your cluster.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {oc-first}.
+
+.Procedure
+
+* Disable DCM by setting the `dynamicConfigManager` field to `false` in the `unsupportedConfigOverrides` section of the `IngressController` CR:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/default \
+--type=merge \
+--patch='{"spec":{"unsupportedConfigOverrides":{"dynamicConfigManager":"false"}}}'
+----
++
+If you need to re-enable DCM, remove the `unsupportedConfigOverrides` section from the `IngressController` CR.
+
+.Verification
+
+* Verify that the `unsupportedConfigOverrides` field is set on the `IngressController` CR by running the following
+command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator get ingresscontrollers/default -o
+jsonpath='{.spec.unsupportedConfigOverrides.dynamicConfigManager}{"\n"}'
+----
++
+The expected output is `false`.

--- a/networking/networking_operators/ingress-operator.adoc
+++ b/networking/networking_operators/ingress-operator.adoc
@@ -54,6 +54,18 @@ include::modules/nw-create-custom-ingress-controller.adoc[leveloffset=+1]
 [id="configuring-ingress-controller"]
 == Configuring the Ingress Controller
 
+// HAProxy Dynamic Configuration Manager (DCM)
+include::modules/about-haproxy-dynamic-configuration-manager.adoc[leveloffset=+2]
+
+// Memory overhead of DCM
+include::modules/dcm-memory-overhead.adoc[leveloffset=+2]
+
+// Dynamic configuration manager router operations reference
+include::modules/dcm-router-operations-reference.adoc[leveloffset=+2]
+
+// Disabling DCM
+include::modules/disabling-dcm.adoc[leveloffset=+2]
+
 include::modules/nw-ingress-setting-a-custom-default-certificate.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-custom-default-certificate-remove.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
5.0

Issue:
[OSDOCS-12589](https://redhat.atlassian.net/browse/OSDOCS-12589)

Link to docs preview:

* https://117036--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
* https://117036--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
* https://117036--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/ingress-operator.html
* https://117036--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html

- [ ] SME has approved this change (Miciah Masters/Joao Morais).
- [ ] QE has approved this change.
