### PR TITLE
OSDOCS-16948 Fix bare https links and missing AR IDs in storage assemblies

### DIFF
--- a/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
@@ -14,7 +14,7 @@ You can provision temporary, pod-specific storage by using Container Storage Int
 include::modules/ephemeral-storage-csi-inline-overview.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[{builds-v2title} 1.1]
+* link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[{builds-v2title} 1.1]
 
 include::modules/ephemeral-storage-csi-inline-overview-admin-plugin.adoc[leveloffset=+1]
 
@@ -23,4 +23,4 @@ include::modules/ephemeral-storage-csi-inline-pod.adoc[leveloffset=+1]
 [id="additional-resources_ephemeral-storage-csi-inline"]
 [role="_additional-resources"]
 == Additional resources
-* https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod Security Standards]
+* link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod Security Standards]

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -74,7 +74,7 @@ include::modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc[levelo
 
 [role="_additional-resources"]
 .Additional resources
-* https://github.com/openshift/aws-efs-csi-driver[AWS EFS CSI driver]
+* link:https://github.com/openshift/aws-efs-csi-driver[AWS EFS CSI driver]
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#storage-create-storage-class_persistent-storage-csi-aws-efs[Creating the AWS EFS storage class]
 
 // Undefine {StorageClass} attribute, so that any mistakes are easily spotted
@@ -86,9 +86,9 @@ include::modules/persistent-storage-csi-efs-security.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html[Working with access points]
+* link:https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html[Working with access points]
 
-* https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html[Encrypting data in transit]
+* link:https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html[Encrypting data in transit]
 
 include::modules/persistent-storage-csi-efs-metrics-overview.adoc[leveloffset=+1]
 
@@ -106,5 +106,6 @@ include::modules/persistent-storage-csi-efs-troubleshooting.adoc[leveloffset=+1]
 include::modules/persistent-storage-csi-olm-operator-uninstall.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]

--- a/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
@@ -45,6 +45,7 @@ include::modules/persistent-storage-csi-gcp-filestore-nfs-export-options.adoc[le
 include::modules/persistent-storage-csi-google-cloud-file-delete-instances.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
 ifndef::openshift-dedicated[]

--- a/storage/container_storage_interface/persistent-storage-csi-manila.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-manila.adoc
@@ -20,7 +20,7 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 include::modules/persistent-storage-csi-manila-limitations.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* https://access.redhat.com/articles/6667651[CephFS NFS Manila-CSI Workload Recommendations for Red Hat OpenStack Platform]
+* link:https://access.redhat.com/articles/6667651[CephFS NFS Manila-CSI Workload Recommendations for Red Hat OpenStack Platform]
 
 include::modules/persistent-storage-csi-manila-dynamic-provisioning-overview.adoc[leveloffset=+1]
 

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -41,5 +41,6 @@ include::modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc[le
 include::modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
## Summary
- Add `link:` prefix to 6 bare `https://` links across 4 storage assembly files
- Add explicit `[id="additional-resources_{context}"]` anchors to 3 assembly-level `== Additional resources` headings

## Files changed
- `storage/container_storage_interface/ephemeral-storage-csi-inline.adoc` — 2 bare links fixed
- `storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc` — 3 bare links fixed, missing AR ID added
- `storage/container_storage_interface/persistent-storage-csi-manila.adoc` — 1 bare link fixed
- `storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc` — missing AR ID added
- `storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc` — missing AR ID added