### PR TITLE
OSDOCS-20768: Add missing --render and --render-sensitive flag descriptions

### DIFF
--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -93,6 +93,8 @@ where:
 * `--node-pool-replicas` specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
 * `--disable-cluster-capabilities` specifies that you want to disable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
 * `--enable-cluster-capabilities` specifies that you want to enable optional capabilities in the hosted cluster. This flag is optional. For more information, see "Capabilities for hosted clusters".
+* `--render` renders the output as YAML to stdout instead of applying the resources to the cluster. By default, secrets are not included in the rendered output.
+* `--render-sensitive` includes secrets in the rendered output when used with the `--render` flag.
 
 . Configure the service publishing strategy. By default, hosted clusters use the `NodePort` service publishing strategy because node ports are always available without additional infrastructure. However, you can configure the service publishing strategy to use a load balancer.
 


### PR DESCRIPTION
## Summary

Fixes https://redhat.atlassian.net/browse/OSDOCS-20768

In the "Creating a hosted cluster by using the CLI" procedure (`modules/hcp-bm-hc.adoc`), the `hcp create cluster agent` command includes the `--render` and `--render-sensitive` flags, but their descriptions were missing from the "where:" parameter list that follows the command block. This PR adds the two missing entries.

**Versions:** 4.18+

## What changed

Added descriptions for:
- `--render`: Renders output as YAML to stdout instead of applying the resources to the cluster. By default, secrets are not included in the rendered output.
- `--render-sensitive`: Includes secrets in the rendered output when used with the `--render` flag.

Descriptions are based on the HyperShift CLI source:
https://github.com/openshift/hypershift/blob/main/cmd/cluster/core/create.go

## Test plan

- [ ] Verify the two new bullet points render correctly in the Netlify preview
- [ ] Confirm the descriptions are accurate against the HyperShift CLI `--help` output
- [ ] Ensure cherry-pick applies cleanly to `enterprise-4.18` through `enterprise-4.22`

