### PR TITLE
CNV-84409: VM GPU metrics

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -55,6 +55,29 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds_total[6m])
 ----
 endif::openshift-rosa,openshift-dedicated[]
 
+[id="virt-promql-vgpu-metrics_{context}"]
+== vGPU metrics
+
+You can monitor virtual machines using NVIDIA GPUs with this metric.
+
+`kubevirt_vmi_gpu_info`::
+Returns information about the GPU resources attached to the virtual machine. This metric is implemented as a Gauge with the following metadata attached:
++
+* *Node* - The associated virtual machine using the GPU resource.
+* *Namespace* -  The associated namespace using the GPU resource.
+* *Pod* - The associated pod using the GPU resource.
+* *Resource* - The `Extended Resource` type defined in the virtual machine specification.
+* *UUID* - The unique hardware identifier of the GPU resource.
++
+Implement the Data Center GPU Manager Exporter (`dcgm-exporter`) in the virtual machine with the attached GPU resources.
++
+[NOTE]
+====
+For information on implementing the `dcgm-exporter`, see link:https://docs.nvidia.com/datacenter/dcgm/latest/installation/install-dcgm-exporter.html[Install DCGM Exporter]. 
+====
++
+Expose the `dcgm-exporter` with a `Service` object. For information on configuring a `Service` object for this purpose, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/monitoring#virt-configuring-node-exporter-service_virt-exposing-custom-metrics-for-vms[Configuring the node exporter service]. This section describes how to configure a node exporter service. It is the same process to configure the `dcgm-exporter`. Substitute your `dcgm-exporter` configuration where appropriate.
+
 [id="virt-promql-network-metrics_{context}"]
 == Network metrics
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add a description of the VM GPU metrics added in Release 5.0.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
5.0

Issue:
[CNV-84409](https://redhat.atlassian.net/browse/CNV-84409)

Link to docs preview:
[vGPU metrics](https://117068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html#virt-promql-vgpu-metrics_virt-prometheus-queries)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
