### PR TITLE
OSDOCS-17081_1: CQA updates for support modules

### DIFF
--- a/modules/support-reviewing-an-access-request-from-an-email-notification.adoc
+++ b/modules/support-reviewing-an-access-request-from-an-email-notification.adoc
@@ -9,7 +9,8 @@
 [id="support-reviewing-an-access-request-from-an-email-notification_{context}"]
 = Reviewing an access request from an email notification
 
-Cluster owners will receive an email notification when Red{nbsp}Hat Site Reliability Engineering (SRE) request access to their cluster with a link to review the request in the {hybrid-console-second}.
+[role="_abstract"]
+To control when Red{nbsp}Hat Site Reliability Engineering (SRE) can access your cluster resources, you can review and respond to access requests from email notifications.
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .Prerequisites
@@ -25,7 +26,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 [NOTE]
 ====
-Denying an access request requires you to complete the *Justification* field. In this case, SRE can not directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
+Denying an access request requires you to complete the *Justification* field. In this case, SRE cannot directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
 ====
 
 . Click *Save*.

--- a/modules/support-reviewing-an-access-request-from-the-hybrid-console.adoc
+++ b/modules/support-reviewing-an-access-request-from-the-hybrid-console.adoc
@@ -7,7 +7,8 @@
 [id="support-reviewing-an-access-request-from-the-hybrid-cloud-console_{context}"]
 = Reviewing an access request from the {hybrid-console-second}
 
-Review access requests for your {product-rosa} clusters from the {hybrid-console-second}.
+[role="_abstract"]
+You can use the {hybrid-console-second} to approve or deny access requests for your {product-rosa} clusters to control when Red{nbsp}Hat Site Reliability Engineering (SRE) can access your cluster resources.
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .Prerequisites
@@ -29,7 +30,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 [NOTE]
 ====
-Denying an access request requires you to complete the *Justification* field. In this case, SRE can not directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
+Denying an access request requires you to complete the *Justification* field. In this case, SRE cannot directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
 ====
 
 . Click *Save*.

--- a/modules/support-submitting-a-case-enable-approved-access.adoc
+++ b/modules/support-submitting-a-case-enable-approved-access.adoc
@@ -7,7 +7,8 @@
 [id="support-submitting-a-case-enable-approved-access_{context}"]
 = Enabling Approved Access for ROSA clusters by submitting a support case
 
-{product-rosa} _Approved Access_ is not enabled by default. To enable _Approved Access_ for your {product-rosa} clusters, you should create a support ticket.
+[role="_abstract"]
+Enable the Approved Access feature for your {product-rosa} clusters by creating a support ticket so that you can control when Red{nbsp}Hat Site Reliability Engineering (SRE) accesses your cluster resources.
 
 .Procedure
 

--- a/support/approved-access.adoc
+++ b/support/approved-access.adoc
@@ -9,20 +9,20 @@ endif::[]
 
 toc::[]
 
-Red{nbsp}Hat Site Reliability Engineering (SRE) typically does not require elevated access to systems as part of normal operations to manage and support {product-title} clusters. Elevated access gives SRE the access levels of a cluster-admin role. See link:https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html#default-roles_using-rbac[cluster roles] for more information.
+[role="_abstract"]
+You can use the Approved Access feature to review, approve, or deny elevated access requests from Red{nbsp}Hat Site Reliability Engineering (SRE) to your {product-title} cluster resources.
 
-In the unlikely event that SRE needs elevated access to systems, you can use the _Approved Access_ interface to review and _approve_ or _deny_ access to these systems.
+Red{nbsp}Hat SRE typically does not require elevated access to systems as part of normal operations to manage and support {product-title} clusters. Elevated access gives SRE the access levels of a cluster-admin role.
 
-Elevated access requests to clusters on {product-rosa} clusters and the corresponding cloud accounts can be created by SRE either in response to a customer-initiated support ticket or in response to alerts received by SRE as part of the standard incident response process.
+SRE creates elevated access requests either in response to a customer-initiated support ticket or in response to alerts received as part of the standard incident response process.
 
-When _Approved Access_ is enabled and an SRE creates an access request, _cluster owners_ receive an email notification informing them of a new access request. The email notification contains a link allowing the cluster owner to quickly approve or deny the access request. You must respond in a timely manner otherwise there is a risk to your SLA for {product-rosa}.
+When Approved Access is enabled and an SRE creates an access request, cluster owners receive an email notification informing them of a new access request. The email notification contains a link allowing the cluster owner to quickly approve or deny the access request. You must respond in a timely manner otherwise there is a risk to your service-level agreement (SLA) for {product-rosa}.
 
-* If customers require additional users that are not the cluster owner to receive the email, they can xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#add-notification-contact_rosa-cluster-notifications[add notification cluster contacts].
 * Pending access requests are available in the {hybrid-console-second} on the clusters list or *Access Requests* tab on the cluster overview for the specific cluster.
 
 [NOTE]
 ====
-Denying an access request requires you to complete the *Justification* field. In this case, SRE can not directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
+Denying an access request requires you to complete the *Justification* field. In this case, SRE cannot directly act on the resources related to the incident. Customers can still use *Customer Support* to help investigate and resolve any issues.
 ====
 
 include::modules/support-submitting-a-case-enable-approved-access.adoc[leveloffset=+1]
@@ -30,3 +30,10 @@ include::modules/support-submitting-a-case-enable-approved-access.adoc[leveloffs
 include::modules/support-reviewing-an-access-request-from-an-email-notification.adoc[leveloffset=+1]
 
 include::modules/support-reviewing-an-access-request-from-the-hybrid-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#add-notification-contact_rosa-cluster-notifications[Adding notification cluster contacts]
+* link:https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html#default-roles_using-rbac[Cluster roles]
+* link:https://access.redhat.com/support/cases/#/case/list[Customer Support]

--- a/support/getting-support.adoc
+++ b/support/getting-support.adoc
@@ -9,6 +9,9 @@ endif::[]
 
 toc::[]
 
+[role="_abstract"]
+To resolve issues with your {product-title} cluster, you can search the Red{nbsp}Hat Knowledgebase, submit a support case, and use remote health monitoring tools.
+
 // Getting support
 
 include::modules/support.adoc[leveloffset=+1]
@@ -23,4 +26,4 @@ include::modules/support-submitting-a-case.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For details about identifying issues with your cluster, see xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using {red-hat-lightspeed} to identify issues with your cluster].
+* xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using {red-hat-lightspeed} to identify issues with your cluster]


### PR DESCRIPTION
Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17081

Link to docs preview:
[Getting support](https://117070--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/getting-support.html) 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The preview for each module apart from 'Getting support' returns a 'Page not found'. This is because they are only included in the `support/approved-access.adoc` assembly, which is only mapped in the ROSA and ROSA HCP topic maps — not in openshift-enterprise. The Netlify preview only builds the openshift-enterprise distro, so there's no page to render those modules on.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
