### PR TITLE
OSDOCS-17165-backup-etcd CQA

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
@@ -11,28 +11,31 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Back up etcd data regularly and store it in a secure location so you can restore your cluster to a previous state, using a snapshot from the same z-stream release.
+You can back up etcd data for your {product-title} cluster by creating an etcd snapshot and saving static pod resources on a control plane host. This backup preserves the cluster state so you can restore etcd after a failure or before a cluster update.
 
-As the key-value store for {product-title}, etcd persists the state of all resource objects.
+etcd is the key-value store for {product-title}, which persists the state of all resource objects.
 
-Back up the etcd data for your cluster regularly and store it in a secure location, ideally outside the {product-title} environment. Do not take an etcd backup before the first certificate rotation completes, which occurs 24 hours after installation, otherwise the backup will contain expired certificates. It is also recommended to take etcd backups during non-peak usage hours because the etcd snapshot has a high I/O cost.
+Back up etcd data for your cluster regularly. Store backups in a secure location, ideally outside the {product-title} environment.
+
+Do not take an etcd backup before the first certificate rotation completes. Certificate rotation occurs 24 hours after installation. A backup taken before rotation completes contains expired certificates.
+
+Take etcd backups during non-peak usage hours when possible. The etcd snapshot has a high I/O cost.
 
 Be sure to take an etcd backup before you update your cluster. Taking a backup before you update is important because when you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.17.5 cluster must use an etcd backup that was taken from 4.17.5.
 
 [IMPORTANT]
 ====
-Back up your cluster's etcd data by performing a single invocation of the backup script on a control plane host. Do not take a backup for each control plane host.
+Back up etcd data for your cluster by performing a single invocation of the backup script on a control plane host. Do not take a backup for each control plane host.
 ====
-
-After you have an etcd backup, you can restore to a previous cluster state.
 
 // Backing up etcd data
 include::modules/backup-etcd.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
-* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]
-* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster for {hcp}]
+[id="additional-resources_backup-etcd"]
+== Additional resources
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
 
 // Creating automated etcd backups
 include::modules/etcd-creating-automated-backups.adoc[leveloffset=+1]

--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
@@ -11,28 +11,31 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Back up etcd data regularly and store it in a secure location so you can restore your cluster to a previous state, using a snapshot from the same z-stream release.
+You can back up etcd data for your {product-title} cluster by manually creating an etcd snapshot and saving static pod resources on a control plane host, or by configuring automated single or recurring backups.
 
-As the key-value store for {product-title}, etcd persists the state of all resource objects.
+etcd is the key-value store for {product-title}, which persists the state of all resource objects.
 
-Back up the etcd data for your cluster regularly and store it in a secure location, ideally outside the {product-title} environment. Do not take an etcd backup before the first certificate rotation completes, which occurs 24 hours after installation, otherwise the backup will contain expired certificates. It is also recommended to take etcd backups during non-peak usage hours because the etcd snapshot has a high I/O cost.
+Back up etcd data for your cluster regularly. Store backups in a secure location, ideally outside the {product-title} environment.
+
+Do not take an etcd backup before the first certificate rotation completes. Certificate rotation occurs 24 hours after installation. A backup taken before rotation completes contains expired certificates.
+
+Take etcd backups during non-peak usage hours when possible. The etcd snapshot has a high I/O cost.
 
 Be sure to take an etcd backup before you update your cluster. Taking a backup before you update is important because when you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.17.5 cluster must use an etcd backup that was taken from 4.17.5.
 
 [IMPORTANT]
 ====
-Back up your cluster's etcd data by performing a single invocation of the backup script on a control plane host. Do not take a backup for each control plane host.
+Back up etcd data for your cluster by performing a single invocation of the backup script on a control plane host. Do not take a backup for each control plane host.
 ====
-
-After you have an etcd backup, you can restore to a previous cluster state.
 
 // Backing up etcd data
 include::modules/backup-etcd.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_backup-etcd"]
+== Additional resources
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]
-* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster for {hcp}]
+* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster for hosted control planes]
 
 // Creating automated etcd backups
 include::modules/etcd-creating-automated-backups.adoc[leveloffset=+1]

--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -8,7 +8,7 @@
 = Backing up etcd data
 
 [role="_abstract"]
-Follow these steps to back up etcd data by creating an etcd snapshot and backing up the resources for the static pods. This backup can be saved and used at a later time if you need to restore etcd.
+You can back up etcd data by creating an etcd snapshot and saving the static pod resources on a control plane host. This backup preserves cluster state so you can restore etcd after a failure or before a cluster update.
 
 [IMPORTANT]
 ====
@@ -20,7 +20,7 @@ For a Two-Node with Fencing (TNF) setup, follow the steps to back up etcd data o
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have checked whether the cluster-wide proxy is enabled.
+* You verified whether the cluster-wide proxy is enabled.
 +
 [TIP]
 ====
@@ -59,9 +59,8 @@ $ export HTTPS_PROXY=https://<your_proxy.example.com>:8080
 ----
 $ export NO_PROXY=<example.com>
 ----
-+
 
-. Run the `cluster-backup.sh` script in the debug shell and pass in the location to save the backup to.
+. Run the `cluster-backup.sh` script with the path to the directory where you want to save the backup:
 +
 [TIP]
 ====
@@ -96,7 +95,7 @@ snapshot db and kube resources are successfully saved to /home/core/assets/backu
 +
 In this example, two files are created in the `/home/core/assets/backup/` directory on the control plane host:
 
-* `snapshot_<datetimestamp>.db`: This file is the etcd snapshot. The `cluster-backup.sh` script confirms its validity.
+* `snapshot_<datetimestamp>.db`: This file is the etcd snapshot. The `cluster-backup.sh` script confirms the validity of the snapshot.
 * `static_kuberesources_<datetimestamp>.tar.gz`: This file contains the resources for the static pods. If etcd encryption is enabled, it also contains the encryption keys for the etcd snapshot.
 +
 [NOTE]

--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -8,7 +8,7 @@
 = Backing up etcd data
 
 [role="_abstract"]
-Follow these steps to back up etcd data by creating an etcd snapshot and backing up the resources for the static pods. This backup can be saved and used at a later time if you need to restore etcd.
+You can back up etcd data by creating an etcd snapshot and saving the static pod resources on a control plane host. This backup preserves the cluster state and provides the resources required to restore etcd at a later time.
 
 [IMPORTANT]
 ====
@@ -20,7 +20,7 @@ For a Two-Node with Fencing (TNF) setup, follow the steps to back up etcd data o
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have checked whether the cluster-wide proxy is enabled.
+* You have verified whether the cluster-wide proxy is enabled.
 +
 [TIP]
 ====
@@ -59,9 +59,8 @@ $ export HTTPS_PROXY=https://<your_proxy.example.com>:8080
 ----
 $ export NO_PROXY=<example.com>
 ----
-+
 
-. Run the `cluster-backup.sh` script in the debug shell and pass in the location to save the backup to.
+. Run the `cluster-backup.sh` script with the path to the directory where you want to save the backup:
 +
 [TIP]
 ====
@@ -96,7 +95,7 @@ snapshot db and kube resources are successfully saved to /home/core/assets/backu
 +
 In this example, two files are created in the `/home/core/assets/backup/` directory on the control plane host:
 
-* `snapshot_<datetimestamp>.db`: This file is the etcd snapshot. The `cluster-backup.sh` script confirms its validity.
+* `snapshot_<datetimestamp>.db`: This file is the etcd snapshot. The `cluster-backup.sh` script confirms the validity of the snapshot.
 * `static_kuberesources_<datetimestamp>.tar.gz`: This file contains the resources for the static pods. If etcd encryption is enabled, it also contains the encryption keys for the etcd snapshot.
 +
 [NOTE]

--- a/modules/creating-recurring-etcd-backups.adoc
+++ b/modules/creating-recurring-etcd-backups.adoc
@@ -1,5 +1,6 @@
-//Module included in the following assemblies:
+// Module included in the following assemblies:
 //
+// * backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
 // * etcd/etcd-backup-restore/etcd-backup.adoc
 
 :_mod-docs-content-type: PROCEDURE
@@ -7,14 +8,14 @@
 = Creating recurring automated etcd backups
 
 [role="_abstract"]
-Create a scheduled `Backup` custom resource with a persistent volume claim to automate recurring etcd backups and retain them by count or size for disaster recovery.
+You can create recurring automated etcd backups by applying a custom resource (CR). Configure a schedule and retention policy to create snapshots automatically and retain backup data according to your requirements.
 
 Use dynamically-provisioned storage to keep the created etcd backup data in a safe, external location if possible. If dynamically-provisioned storage is not available, consider storing the backup data on an NFS share to make backup recovery more accessible.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
@@ -38,12 +39,14 @@ spec:
   volumeMode: Filesystem
   storageClassName: etcd-backup-local-storage
 ----
-+
-The `spec.resources.requests.storage` field defines the amount of storage available to the PVC. Adjust this value for your requirements.
++ 
+where:
+
+`spec.resources.requests.storage`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements.
 +
 [NOTE]
 ====
-Each of the following providers require changes to the `accessModes` and `storageClassName` keys:
+Each of the following providers requires changes to the `accessModes` and `storageClassName` keys:
 
 [cols="1,1,1"]
 |===
@@ -70,7 +73,7 @@ Each of the following providers require changes to the `accessModes` and `storag
 $ oc apply -f etcd-backup-pvc.yaml
 ----
 
-.. Verify the creation of the PVC by running the following command:
+.. Verify that the PVC was created by running the following command:
 +
 [source,terminal]
 ----
@@ -140,15 +143,17 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          - <example_master_node>
+          - <example_control_plane_node>
 ----
 +
-** The `spec.capacity.storage` field defines the amount of storage available to the PV. Adjust this value for your requirements.
-** Replace `<example_master_node>` with the master node to attach this PV to.
+where:
+
+`spec.capacity.storage`:: Specifies the amount of storage available to the PV. Adjust this value for your requirements.
+`spec.nodeAffinity.required.nodeSelectorTerms.matchExpressions.values`:: Specifies the control plane node to attach this PV to. Replace with the actual node name.
 +
 [TIP]
 ====
-Run the following command to list the available nodes:
+List the available nodes by running the following command:
 
 [source,terminal]
 ----
@@ -156,7 +161,7 @@ $ oc get nodes
 ----
 ====
 
-.. Verify the creation of the PV by running the following command:
+.. Verify that the PV was created by running the following command:
 +
 [source,terminal]
 ----
@@ -188,7 +193,9 @@ spec:
   storageClassName: etcd-backup-local-storage
 ----
 +
-The `spec.resources.requests.storage` field defines the amount of storage available to the PVC. Adjust this value for your requirements.
+where:
+
+`spec.resources.requests.storage`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements.
 
 .. Apply the PVC by running the following command:
 +
@@ -197,7 +204,7 @@ The `spec.resources.requests.storage` field defines the amount of storage availa
 $ oc apply -f etcd-backup-pvc.yaml
 ----
 
-. Create a custom resource definition (CRD) file named `etcd-recurring-backups.yaml`. The contents of the created CRD define the schedule and retention type of automated backups.
+. Create a CR file named `etcd-recurring-backups.yaml`. The contents of the CR define the schedule and retention type of automated backups.
 +
 ** For the default retention type of `RetentionNumber` with 15 retained backups, use contents such as the following example:
 +
@@ -214,9 +221,11 @@ spec:
     pvcName: etcd-backup-pvc
 ----
 +
-The `spec.etcd.schedule` field is a `CronTab` schedule for recurring backups. Adjust this value for your needs.
+where:
+
+`spec.etcd.schedule`:: Specifies the `CronTab` schedule for recurring backups. Adjust this value for your needs.
 +
-** To use retention based on the maximum number of backups, add the following key-value pairs to the `etcd` key:
+.. To use retention based on the maximum number of backups, add the following key-value pairs to the `etcd` key:
 +
 [source,yaml]
 ----
@@ -228,15 +237,17 @@ spec:
         maxNumberOfBackups: 5
 ----
 +
-*** The `spec.etcd.retentionPolicy.retentionType` field defines the retention type. Defaults to `RetentionNumber` if unspecified.
-*** The `spec.etcd.retentionNumber.maxNumberOfBackups` field defines the maximum number of backups to retain. Adjust this value for your needs. Defaults to 15 backups if unspecified.
+where:
+
+`spec.etcd.retentionPolicy.retentionType`:: Specifies the retention type. Defaults to `RetentionNumber` if unspecified.
+`spec.etcd.retentionPolicy.retentionNumber.maxNumberOfBackups`:: Specifies the maximum number of backups to retain. Adjust this value for your needs. Defaults to 15 backups if unspecified.
 +
 [WARNING]
 ====
 A known issue causes the number of retained backups to be one greater than the configured value.
 ====
 +
-** For retention based on the file size of backups, use the following:
+.. For retention based on the file size of backups, use the following:
 +
 [source,yaml]
 ----
@@ -248,7 +259,9 @@ spec:
         maxSizeOfBackupsGb: 20
 ----
 +
-The `spec.etcd.retentionPolicy.retentionSize.maxSizeOfBackupsGb` field defines the maximum file size of the retained backups in gigabytes. Adjust this value for your needs. Defaults to 10 GB if unspecified.
+where:
+
+`spec.etcd.retentionPolicy.retentionSize.maxSizeOfBackupsGb`:: Specifies the maximum file size of the retained backups in gigabytes. Adjust this value for your needs. Defaults to 10 GB if unspecified.
 +
 [WARNING]
 ====

--- a/modules/creating-recurring-etcd-backups.adoc
+++ b/modules/creating-recurring-etcd-backups.adoc
@@ -1,5 +1,6 @@
-//Module included in the following assemblies:
+// Module included in the following assemblies:
 //
+// * backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
 // * etcd/etcd-backup-restore/etcd-backup.adoc
 
 :_mod-docs-content-type: PROCEDURE
@@ -7,14 +8,14 @@
 = Creating recurring automated etcd backups
 
 [role="_abstract"]
-Create a scheduled `Backup` custom resource with a persistent volume claim to automate recurring etcd backups and retain them by count or size for disaster recovery.
+You can create recurring automated etcd backups by applying a custom resource (CR) that defines a backup schedule and retention policy. Backup data is stored on either dynamically-provisioned or local storage.
 
 Use dynamically-provisioned storage to keep the created etcd backup data in a safe, external location if possible. If dynamically-provisioned storage is not available, consider storing the backup data on an NFS share to make backup recovery more accessible.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
@@ -38,12 +39,14 @@ spec:
   volumeMode: Filesystem
   storageClassName: etcd-backup-local-storage
 ----
-+
-The `spec.resources.requests.storage` field defines the amount of storage available to the PVC. Adjust this value for your requirements.
++ 
+where:
+
+`spec.resources.requests.storage`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements.
 +
 [NOTE]
 ====
-Each of the following providers require changes to the `accessModes` and `storageClassName` keys:
+Each of the following providers requires changes to the `accessModes` and `storageClassName` keys:
 
 [cols="1,1,1"]
 |===
@@ -70,7 +73,7 @@ Each of the following providers require changes to the `accessModes` and `storag
 $ oc apply -f etcd-backup-pvc.yaml
 ----
 
-.. Verify the creation of the PVC by running the following command:
+.. Verify that the PVC was created by running the following command:
 +
 [source,terminal]
 ----
@@ -140,15 +143,17 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          - <example_master_node>
+          - <example_control_plane_node>
 ----
 +
-** The `spec.capacity.storage` field defines the amount of storage available to the PV. Adjust this value for your requirements.
-** Replace `<example_master_node>` with the master node to attach this PV to.
+where:
+
+`spec.capacity.storage`:: Specifies the amount of storage available to the PV. Adjust this value for your requirements.
+`spec.nodeAffinity.required.nodeSelectorTerms.matchExpressions.values`:: Specifies the control plane node to attach this PV to. Replace with the actual node name.
 +
 [TIP]
 ====
-Run the following command to list the available nodes:
+List the available nodes by running the following command:
 
 [source,terminal]
 ----
@@ -156,7 +161,7 @@ $ oc get nodes
 ----
 ====
 
-.. Verify the creation of the PV by running the following command:
+.. Verify that the PV was created by running the following command:
 +
 [source,terminal]
 ----
@@ -188,7 +193,9 @@ spec:
   storageClassName: etcd-backup-local-storage
 ----
 +
-The `spec.resources.requests.storage` field defines the amount of storage available to the PVC. Adjust this value for your requirements.
+where:
+
+`spec.resources.requests.storage`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements.
 
 .. Apply the PVC by running the following command:
 +
@@ -197,7 +204,7 @@ The `spec.resources.requests.storage` field defines the amount of storage availa
 $ oc apply -f etcd-backup-pvc.yaml
 ----
 
-. Create a custom resource definition (CRD) file named `etcd-recurring-backups.yaml`. The contents of the created CRD define the schedule and retention type of automated backups.
+. Create a CR file named `etcd-recurring-backups.yaml`. The contents of the CR define the schedule and retention type of automated backups.
 +
 ** For the default retention type of `RetentionNumber` with 15 retained backups, use contents such as the following example:
 +
@@ -214,9 +221,11 @@ spec:
     pvcName: etcd-backup-pvc
 ----
 +
-The `spec.etcd.schedule` field is a `CronTab` schedule for recurring backups. Adjust this value for your needs.
+where:
+
+`spec.etcd.schedule`:: Specifies the `CronTab` schedule for recurring backups. Adjust this value for your needs.
 +
-** To use retention based on the maximum number of backups, add the following key-value pairs to the `etcd` key:
+.. To use retention based on the maximum number of backups, add the following key-value pairs to the `etcd` key:
 +
 [source,yaml]
 ----
@@ -228,15 +237,17 @@ spec:
         maxNumberOfBackups: 5
 ----
 +
-*** The `spec.etcd.retentionPolicy.retentionType` field defines the retention type. Defaults to `RetentionNumber` if unspecified.
-*** The `spec.etcd.retentionNumber.maxNumberOfBackups` field defines the maximum number of backups to retain. Adjust this value for your needs. Defaults to 15 backups if unspecified.
+where:
+
+`spec.etcd.retentionPolicy.retentionType`:: Specifies the retention type. Defaults to `RetentionNumber` if unspecified.
+`spec.etcd.retentionPolicy.retentionNumber.maxNumberOfBackups`:: Specifies the maximum number of backups to retain. Adjust this value for your needs. Defaults to 15 backups if unspecified.
 +
 [WARNING]
 ====
 A known issue causes the number of retained backups to be one greater than the configured value.
 ====
 +
-** For retention based on the file size of backups, use the following:
+.. For retention based on the file size of backups, use the following:
 +
 [source,yaml]
 ----
@@ -248,7 +259,9 @@ spec:
         maxSizeOfBackupsGb: 20
 ----
 +
-The `spec.etcd.retentionPolicy.retentionSize.maxSizeOfBackupsGb` field defines the maximum file size of the retained backups in gigabytes. Adjust this value for your needs. Defaults to 10 GB if unspecified.
+where:
+
+`spec.etcd.retentionPolicy.retentionSize.maxSizeOfBackupsGb`:: Specifies the maximum file size of the retained backups in gigabytes. Adjust this value for your needs. Defaults to 10 GB if unspecified.
 +
 [WARNING]
 ====

--- a/modules/creating-single-etcd-backup.adoc
+++ b/modules/creating-single-etcd-backup.adoc
@@ -8,16 +8,16 @@
 = Creating a single automated etcd backup
 
 [role="_abstract"]
-Follow these steps to create a single etcd backup by creating and applying a custom resource (CR).
+You can create a single automated etcd backup by applying an `EtcdBackup` custom resource (CR) that specifies the PVC name for the snapshot. Apply the CR in the `openshift-etcd` namespace to start the backup.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
-* If dynamically-provisioned storage is available, complete the following steps to create a single automated etcd backup:
+. If dynamically-provisioned storage is available, complete the following steps to create a single automated etcd backup:
 +
 .. Create a persistent volume claim (PVC) named `etcd-backup-pvc.yaml` with contents such as the following example:
 +
@@ -38,17 +38,17 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements, such as `200Gi`.
-+
+
 .. Apply the PVC by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-backup-pvc.yaml
 ----
-+
-.. Verify the creation of the PVC by running the following command:
+
+.. Verify that the PVC ws created by running the following command:
 +
 [source,terminal]
 ----
@@ -66,7 +66,7 @@ etcd-backup-pvc   Bound                                                       51
 ====
 Dynamic PVCs stay in the `Pending` state until they are mounted.
 ====
-+
+
 .. Create a CR file named `etcd-single-backup.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -81,18 +81,18 @@ spec:
 ----
 +
 where:
-+
+
 `<pvc_name>`:: Specifies the name of the PVC to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
-+
-.. Apply the CR to start a single backup:
+
+.. Apply the CR to start a single backup by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-single-backup.yaml
 ----
 
-* If dynamically-provisioned storage is not available, complete the following steps to create a single automated etcd backup:
-+
+. If dynamically-provisioned storage is not available, complete the following steps to create a single automated etcd backup:
+
 .. Create a `StorageClass` CR file named `etcd-backup-local-storage.yaml` with the following contents:
 +
 [source,yaml]
@@ -104,14 +104,14 @@ metadata:
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: Immediate
 ----
-+
+
 .. Apply the `StorageClass` CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-backup-local-storage.yaml
 ----
-+
+
 .. Create a PV named `etcd-backup-pv-fs.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -141,11 +141,11 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PV. Adjust this value for your requirements, such as `100Gi`.
-`<node_name>`:: Specifies the node to attach this PV to. Replace with the actual node name, such as `master-0`.
-+
-.. Verify the creation of the PV by running the following command:
+`<node_name>`:: Specifies the control plane node to attach this PV to. Replace with the actual node name.
+
+.. Verify that the PV was created by running the following command:
 +
 [source,terminal]
 ----
@@ -178,7 +178,7 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements, such as `10Gi`.
 +
 .. Apply the PVC by running the following command:
@@ -187,7 +187,7 @@ where:
 ----
 $ oc apply -f etcd-backup-pvc.yaml
 ----
-+
+
 .. Create a CR file named `etcd-single-backup.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -202,10 +202,10 @@ spec:
 ----
 +
 where:
+
+`<pvc_name>`:: Specifies the name of the PVC to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
 +
-`<pvc_name>`:: Specifies the name of the persistent volume claim (PVC) to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
-+
-.. Apply the CR to start a single backup:
+.. Apply the CR to start a single backup by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/creating-single-etcd-backup.adoc
+++ b/modules/creating-single-etcd-backup.adoc
@@ -8,16 +8,16 @@
 = Creating a single automated etcd backup
 
 [role="_abstract"]
-Follow these steps to create a single etcd backup by creating and applying a custom resource (CR).
+You can create a single automated etcd backup by applying an `EtcdBackup` custom resource (CR). Backup data is stored on either dynamically-provisioned or local storage.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
-* If dynamically-provisioned storage is available, complete the following steps to create a single automated etcd backup:
+. If dynamically-provisioned storage is available, complete the following steps to create a single automated etcd backup:
 +
 .. Create a persistent volume claim (PVC) named `etcd-backup-pvc.yaml` with contents such as the following example:
 +
@@ -38,17 +38,17 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements, such as `200Gi`.
-+
+
 .. Apply the PVC by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-backup-pvc.yaml
 ----
-+
-.. Verify the creation of the PVC by running the following command:
+
+.. Verify that the PVC was created by running the following command:
 +
 [source,terminal]
 ----
@@ -66,7 +66,7 @@ etcd-backup-pvc   Bound                                                       51
 ====
 Dynamic PVCs stay in the `Pending` state until they are mounted.
 ====
-+
+
 .. Create a CR file named `etcd-single-backup.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -81,18 +81,18 @@ spec:
 ----
 +
 where:
-+
+
 `<pvc_name>`:: Specifies the name of the PVC to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
-+
-.. Apply the CR to start a single backup:
+
+.. Apply the CR to start a single backup by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-single-backup.yaml
 ----
 
-* If dynamically-provisioned storage is not available, complete the following steps to create a single automated etcd backup:
-+
+. If dynamically-provisioned storage is not available, complete the following steps to create a single automated etcd backup:
+
 .. Create a `StorageClass` CR file named `etcd-backup-local-storage.yaml` with the following contents:
 +
 [source,yaml]
@@ -104,14 +104,14 @@ metadata:
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: Immediate
 ----
-+
+
 .. Apply the `StorageClass` CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f etcd-backup-local-storage.yaml
 ----
-+
+
 .. Create a PV named `etcd-backup-pv-fs.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -141,11 +141,11 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PV. Adjust this value for your requirements, such as `100Gi`.
-`<node_name>`:: Specifies the node to attach this PV to. Replace with the actual node name, such as `master-0`.
-+
-.. Verify the creation of the PV by running the following command:
+`<node_name>`:: Specifies the control plane node to attach this PV to. Replace with the actual node name.
+
+.. Verify that the PV was created by running the following command:
 +
 [source,terminal]
 ----
@@ -178,7 +178,7 @@ spec:
 ----
 +
 where:
-+
+
 `<storage_amount>`:: Specifies the amount of storage available to the PVC. Adjust this value for your requirements, such as `10Gi`.
 +
 .. Apply the PVC by running the following command:
@@ -187,7 +187,7 @@ where:
 ----
 $ oc apply -f etcd-backup-pvc.yaml
 ----
-+
+
 .. Create a CR file named `etcd-single-backup.yaml` with contents such as the following example:
 +
 [source,yaml]
@@ -202,10 +202,10 @@ spec:
 ----
 +
 where:
+
+`<pvc_name>`:: Specifies the name of the PVC to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
 +
-`<pvc_name>`:: Specifies the name of the persistent volume claim (PVC) to save the backup to. Adjust this value according to your environment, such as `etcd-backup-pvc`.
-+
-.. Apply the CR to start a single backup:
+.. Apply the CR to start a single backup by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/etcd-creating-automated-backups.adoc
+++ b/modules/etcd-creating-automated-backups.adoc
@@ -7,9 +7,7 @@
 = Creating automated etcd backups
 
 [role="_abstract"]
-Enable automated etcd backups so your cluster can create single and recurring backups through the Backup API.
-
-The automated backup feature for etcd supports both recurring and single backups. Recurring backups create a cron job that starts a single backup each time the job triggers.
+You can enable automated etcd backups for your cluster by applying a `FeatureGate` and backup custom resources (CRs).
 
 :FeatureName: Automating etcd backups
 include::snippets/technology-preview.adoc[]
@@ -22,7 +20,7 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster prevents minor v
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
@@ -38,14 +36,16 @@ spec:
   featureSet: TechPreviewNoUpgrade
 ----
 
-. Apply the CR and enable automated backups:
+. Apply the CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f enable-tech-preview-no-upgrade.yaml
 ----
++
+Applying the `FeatureGate` enables the automated backup APIs. It takes time for the related APIs to become available.
 
-. It takes time to enable the related APIs. Verify the creation of the custom resource definition (CRD) by running the following command:
+. Verify that the custom resource definition (CRD) was created by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/etcd-creating-automated-backups.adoc
+++ b/modules/etcd-creating-automated-backups.adoc
@@ -7,9 +7,7 @@
 = Creating automated etcd backups
 
 [role="_abstract"]
-Enable automated etcd backups so your cluster can create single and recurring backups through the Backup API.
-
-The automated backup feature for etcd supports both recurring and single backups. Recurring backups create a cron job that starts a single backup each time the job triggers.
+You can enable automated etcd backups for your cluster by applying a `FeatureGate` and backup custom resources (CRs). You can then apply backup CRs for on-demand snapshots or define a recurring schedule that creates a cron job.
 
 :FeatureName: Automating etcd backups
 include::snippets/technology-preview.adoc[]
@@ -22,7 +20,7 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster prevents minor v
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 
 .Procedure
 
@@ -38,14 +36,16 @@ spec:
   featureSet: TechPreviewNoUpgrade
 ----
 
-. Apply the CR and enable automated backups:
+. Apply the CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f enable-tech-preview-no-upgrade.yaml
 ----
++
+Applying the `FeatureGate` enables the automated backup APIs. It takes time for the related APIs to become available.
 
-. It takes time to enable the related APIs. Verify the creation of the custom resource definition (CRD) by running the following command:
+. Verify that the custom resource definition (CRD) was created by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117074--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
