### PR TITLE
OSDOCS-17165-dr-scenario-3 CQA

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc
@@ -8,6 +8,9 @@
 include::_attributes/common-attributes.adoc[]
 :context: dr-recovering-expired-certs
 
+[role="_abstract"]
+You can restore kubelet certificates on your {product-title} cluster by approving pending certificate signing requests (CSRs) after control plane certificates expire. Approved CSRs return nodes to a healthy state.
+
 toc::[]
 
 // Recovering from expired control plane certificates

--- a/modules/dr-recover-expired-control-plane-certs.adoc
+++ b/modules/dr-recover-expired-control-plane-certs.adoc
@@ -1,21 +1,23 @@
 // Module included in the following assemblies:
 //
-// * disaster_recovery/scenario-3-expired-certs.adoc
+// * backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc
 // * etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-scenario-3-recovering-expired-certs_{context}"]
 = Recovering from expired control plane certificates
 
-The cluster can automatically recover from expired control plane certificates.
+[role="_abstract"]
+You can restore kubelet certificates by manually approving pending `node-bootstrapper` certificate signing requests (CSRs) and, on user-provisioned installations, kubelet serving CSRs. Approved CSRs return nodes to a healthy state after control plane certificates expire.
 
-However, you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. For user-provisioned installations, you might also need to approve pending kubelet serving CSRs.
+.Prerequisites
 
-Use the following steps to approve the pending CSRs:
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the {oc-first}.
 
 .Procedure
 
-. Get the list of current CSRs:
+. Get the list of current CSRs by running the following command:
 +
 [source,terminal]
 ----
@@ -23,33 +25,37 @@ $ oc get csr
 ----
 +
 .Example output
+[source,terminal]
 ----
 NAME        AGE    SIGNERNAME                                    REQUESTOR                                                                   CONDITION
-csr-2s94x   8m3s   kubernetes.io/kubelet-serving                 system:node:<node_name>                                                     Pending <1>
+csr-2s94x   8m3s   kubernetes.io/kubelet-serving                 system:node:<node_name>                                                     Pending
 csr-4bd6t   8m3s   kubernetes.io/kubelet-serving                 system:node:<node_name>                                                     Pending
-csr-4hl85   13m    kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending <2>
+csr-4hl85   13m    kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending
 csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending
 ...
 ----
-<1> A pending kubelet service CSR (for user-provisioned installations).
-<2> A pending `node-bootstrapper` CSR.
++
+In the example output, CSRs with a `SIGNERNAME` of `kubernetes.io/kubelet-serving` are kubelet serving CSRs. You see this CSR type on user-provisioned installations. CSRs with a `SIGNERNAME` of `kubernetes.io/kube-apiserver-client-kubelet` and a `node-bootstrapper` requestor are `node-bootstrapper` CSRs that you must approve to restore kubelet certificates.
 
-. Review the details of a CSR to verify that it is valid:
+. Review the details of a CSR to verify that it is valid by running the following command:
 +
 [source,terminal]
 ----
-$ oc describe csr <csr_name> <1>
+$ oc describe csr <csr_name>
 ----
-<1> `<csr_name>` is the name of a CSR from the list of current CSRs.
++
+where:
 
-. Approve each valid `node-bootstrapper` CSR:
+`<csr_name>`:: Specifies the name of a CSR from the list of current CSRs.
+
+. Approve each valid `node-bootstrapper` CSR by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm certificate approve <csr_name>
 ----
 
-. For user-provisioned installations, approve each valid kubelet serving CSR:
+. For user-provisioned installations, approve each valid kubelet serving CSR by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
