### PR TITLE
ROX-35915: Release notes for 4.10.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ include/
 # Claude Code workspace and tool files
 .agent_workspace/
 .claude/
+CLAUD.md

--- a/modules/bug-fixes-in-version-4106.adoc
+++ b/modules/bug-fixes-in-version-4106.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * release_notes/410-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="bug-fixes_4106_{context}"]
+= Bug fixes in version 4.10.6
+
+[role="_abstract"]
+This release addresses the following security vulnerabilities:
+
+* Go and golang.org:
+//ROX-35995
+** go-git: Unescaped single quotation marks in repository paths during SSH transport command construction allow shell command breakout and execution (link:https://access.redhat.com/security/cve/CVE-2026-45570[CVE-2026-45570])
+//ROX-36001
+** oras-go: Information disclosure and arbitrary file access via crafted tarball hard links (link:https://access.redhat.com/security/cve/CVE-2026-50163[CVE-2026-50163])
+//ROX-35467
+* Brace-expansion: Denial of service due to exponential-time complexity (link:https://access.redhat.com/security/cve/CVE-2026-13149[CVE-2026-13149])
+//ROX-35798
+* DOMPurify: Cross-site scripting vulnerability allows code execution (link:https://access.redhat.com/security/cve/CVE-2026-49978[CVE-2026-49978])
+//ROX-35557
+* containerd: Security bypass via Container Device Interface (CDI) annotation smuggling during checkpoint restoration (link:https://access.redhat.com/security/cve/CVE-2026-53492[CVE-2026-53492])
+//ROX-35693
+* js-yaml: Denial of service via crafted YAML documents (link:https://access.redhat.com/security/cve/CVE-2026-59869[CVE-2026-59869])
+//ROX-35997 
+* `github.com/jackc/pgx`: SQL injection via specific SQL query conditions (link:https://access.redhat.com/security/cve/CVE-2026-41889[CVE-2026-41889])
+//ROX-35999
+* `github.com/sigstore/fulcio`: Server-side request forgery (SSRF) and Kubernetes ServiceAccount token leakage (link:https://access.redhat.com/security/cve/CVE-2026-49478[CVE-2026-49478])

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -65,13 +65,14 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.10.5
+:rhacs-version: 4.10.6
 :ga-date-410: 3 March 2026
 :ga-date-4101: 8 April 2026
 :ga-date-4102: 4 May 2026
 :ga-date-4103: 2 June 2026
 :ga-date-4104: 18 June 2026
 :ga-date-4105: 7 July 2026
+:ga-date-4106: 30 July 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/release-dates-410.adoc
+++ b/modules/release-dates-410.adoc
@@ -21,5 +21,7 @@ Review the official release dates and update schedule for {product-title-short} 
 |`4.10.3` | {ga-date-4103}
 |`4.10.4` | {ga-date-4104}
 |`4.10.5` | {ga-date-4105}
+|`4.10.6` | {ga-date-4106}
+
 
 |====

--- a/release_notes/410-release-notes.adoc
+++ b/release_notes/410-release-notes.adoc
@@ -89,6 +89,8 @@ include::modules/bug-fixes-in-version-4104.adoc[leveloffset=+1]
 
 include::modules/bug-fixes-in-version-4105.adoc[leveloffset=+1]
 
+include::modules/bug-fixes-in-version-4106.adoc[leveloffset=+1]
+
 include::modules/known-issues-in-version-4101.adoc[leveloffset=+1]
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.10.6

Issue: [ROX-35915](https://redhat.atlassian.net/browse/ROX-35915)

Link to docs preview:

- release date table: https://117080--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes
- 4.10.6 content: https://117080--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes#bug-fixes_4106_release-notes-410

QE review: **RHACS has no formal QE process, approved by SME**
- [x] QE has approved this change.


Additional information:

