### PR TITLE
OSDOCS-17165-quorum-rest CQA

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.adoc
@@ -8,9 +8,10 @@
 include::_attributes/common-attributes.adoc[]
 :context: dr-quorum-restoration
 
-toc::[]
+[role="_abstract"]
+You can restore etcd quorum on your {product-title} cluster by running the `quorum-restore.sh` script on a recovery host when quorum loss leaves the API read-only. After quorum is restored, the API returns to read/write mode.
 
-You can use the `quorum-restore.sh` script to restore etcd quorum on clusters that are offline due to quorum loss. When quorum is lost, the {product-title} API becomes read-only. After quorum is restored, the {product-title} API returns to read/write mode.
+toc::[]
 
 // Restoring etcd quorum for high availability clusters
 include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+1]

--- a/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
+++ b/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
@@ -18,6 +18,11 @@ To return your cluster to a working state after quorum loss, control plane failu
 Disaster recovery requires you to have at least one healthy control plane host.
 ====
 
+[id="etcd-dr-quorum"]
+== Quorum restoration
+
+You can restore etcd quorum on your {product-title} cluster by running the `quorum-restore.sh` script on a recovery host when quorum loss leaves the API read-only. After quorum is restored, the API returns to read and write mode.
+
 // Restoring etcd quorum for high availability clusters
 include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+1]
 

--- a/modules/dr-restoring-etcd-quorum-ha.adoc
+++ b/modules/dr-restoring-etcd-quorum-ha.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * disaster_recovery/quorum-restoration.adoc
+// * backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.adoc
 // * etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
 
 :_mod-docs-content-type: PROCEDURE
@@ -8,16 +8,11 @@
 = Restoring etcd quorum for high availability clusters
 
 [role="_abstract"]
-You can use the `quorum-restore.sh` script to restore etcd quorum on clusters that are offline due to quorum loss. When quorum is lost, the {product-title} API becomes read-only. After quorum is restored, the {product-title} API returns to read/write mode.
+You can restore etcd quorum on high availability (HA) clusters by running the `quorum-restore.sh` script on a recovery host. Restored quorum returns the {product-title} API to read/write mode when quorum loss takes the cluster offline.
 
-[NOTE]
-====
-If you have a majority of your control plane nodes still available and have an etcd quorum, replace a single unhealthy etcd member.
-====
+The `quorum-restore.sh` script creates a new single-member etcd cluster from the local data directory on the recovery host. No prior backup is required.
 
-The `quorum-restore.sh` script instantly brings back a new single-member etcd cluster based on its local data directory and marks all other members as invalid by retiring the previous cluster identifier. No prior backup is required to restore the control plane from.
-
-For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
+For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
 
 [WARNING]
 ====
@@ -53,12 +48,14 @@ $ oc exec -n openshift-etcd <etcd-pod> -c etcdctl -- etcdctl endpoint status -w 
 +
 Note the IP address of a member that is not a learner and has the highest Raft index.
 
-.. Run the following command and note the node name that corresponds to the IP address of the chosen etcd member:
+.. List nodes by running the following command:
 +
 [source,terminal]
 ----
 $ oc get nodes -o jsonpath='{range .items[*]}[{.metadata.name},{.status.addresses[?(@.type=="InternalIP")].address}]{end}'
 ----
++
+Note the node name that corresponds to the IP address of the chosen etcd member.
 
 . Using SSH, connect to the chosen recovery node and run the following command to restore etcd quorum:
 +
@@ -89,9 +86,7 @@ Do not delete and re-create the machine for the recovery host.
 For bare-metal installations on installer-provisioned infrastructure, control plane machines are not re-created. For more information, see "Replacing a bare-metal control plane node".
 ====
 
-.. Obtain the machine for one of the offline nodes.
-+
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+.. In a terminal that hass access to the cluster as a `cluster-admin` user, obtain the machine for one of the offline nodes by running the following command:
 +
 [source,terminal]
 ----
@@ -110,20 +105,20 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-`clustername-8qw5l-master-0` is the control plane machine for the offline node, `ip-10-0-131-183.ec2.internal`.
+In the example output, `clustername-8qw5l-master-0` is the control plane machine for the offline node, `ip-10-0-131-183.ec2.internal`.
 
-.. Delete the machine of the offline node by running:
+.. Delete the machine of the offline node by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0
 ----
 +
-Replace `clustername-8qw5l-master-0` with the name of the control plane machine for the offline node.
+Specify the name of the control plane machine for the offline node.
 +
 A new machine is automatically provisioned after deleting the machine of the offline node.
 
-. Verify that a new machine has been created by running:
+. Verify that a new machine has been created by running the following command:
 +
 [source,terminal]
 ----
@@ -142,11 +137,11 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running        m4.large    us-east-1
 clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 +
-The new machine, `clustername-8qw5l-master-3`, is being created and is ready after the phase changes from `Provisioning` to `Running`.
+In the example output, `clustername-8qw5l-master-3` is being created and is ready after the phase changes from `Provisioning` to `Running`.
 +
-It might take a few minutes for the new machine to be created. The etcd cluster Operator will automatically synchronize when the machine or node returns to a healthy state.
+It might take a few minutes for the new machine to be created. The etcd cluster Operator automatically synchronizes when the machine or node returns to a healthy state.
 
-.. Repeat these steps for each node that is offline.
+. Repeat these steps for each node that is offline.
 
 . Wait until the control plane recovers by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117093--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
