### PR TITLE
ROX-35916: Release notes for 4.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ include/
 .claude/
 .agent_workspace/
 agent_workspace/
+CLAUDE.md

--- a/modules/bug-fixes-in-version-4112.adoc
+++ b/modules/bug-fixes-in-version-4112.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/412-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="bug-fixes-in-version-4112_{context}"]
+= Bug fixes and security updates in version 4.11.2
+
+[role="_abstract"]
+{product-title-short} includes fixes for the following security vulnerabilities:
+
+* Go and golang.org:
+//ROX-35462, ROX-35464
+** Golang MIME: Denial of Service via maliciously-crafted MIME header (link:https://access.redhat.com/security/cve/CVE-2026-42504[CVE-2026-42504])
+//ROX-35673
+** Go os.Root: Symlink following vulnerability allows directory traversal (link:https://access.redhat.com/security/cve/CVE-2026-39822[CVE-2026-39822])
+//ROX-35468
+* Brace-expansion: Denial of service due to exponential-time complexity (link:https://access.redhat.com/security/cve/CVE-2026-13149[CVE-2026-13149])
+//ROX-35692
+* js-yaml: Denial of service via crafted YAML documents (link:https://access.redhat.com/security/cve/CVE-2026-59869[CVE-2026-59869])
+//ROX-35799
+* DOMPurify: Cross-site scripting vulnerability allows code execution (link:https://access.redhat.com/security/cve/CVE-2026-49978[CVE-2026-49978])

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -65,9 +65,10 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.11.1
+:rhacs-version: 4.11.2
 :ga-date-411: 15 June 2026
 :ga-date-4111: 7 July 2026
+:ga-date-4112: 30 July 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/release-dates-411.adoc
+++ b/modules/release-dates-411.adoc
@@ -19,4 +19,6 @@ Review the official release dates and update schedule for {product-title-short} 
 
 |`4.11.1` | {ga-date-4111}
 
+|`4.11.2` | {ga-date-4112}
+
 |====

--- a/release_notes/411-release-notes.adoc
+++ b/release_notes/411-release-notes.adoc
@@ -111,4 +111,6 @@ include::modules/bug-fixes-in-version-411.adoc[leveloffset=+1]
 
 include::modules/bug-fixes-in-version-4111.adoc[leveloffset=+1]
 
+include::modules/bug-fixes-in-version-4112.adoc[leveloffset=+1]
+
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.11.2

Issue: [ROX-35916](https://redhat.atlassian.net/browse/ROX-35916)

Link to docs preview:

- release date table: https://117101--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/411-release-notes
- 4.11.2 content: https://117101--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/411-release-notes#bug-fixes-in-version-4112_release-notes-411

QE review: **RHACS has no formal QE process, approved by SME**
- [x] QE has approved this change.

Additional information:
