### PR TITLE
OBSDOCS-1772: Document RFC5424 default field mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ pull-jira-backlog.sh
 .jira-backlog/
 # Working plan files in repo root
 /*.md
+# Sensitive files
+github-pat.md
+gitlab-pat.md
+# Data files
+*.csv
+*.ods
+*.pdf

--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -147,6 +147,8 @@ include::modules/cluster-logging-collector-log-forward-logs-from-application-pod
 
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+3]
 
+include::modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc[leveloffset=+3]
+
 include::modules/cluster-logging-collector-log-forward-syslog-log-source.adoc[leveloffset=+3]
 
 include::modules/cluster-logging-collector-log-forward-cloudwatch.adoc[leveloffset=+2]

--- a/modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog-rfc5424-defaults.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * configuring/forwarding-to-third-party-systems.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cluster-logging-collector-log-forward-syslog-rfc5424-defaults_{context}"]
+= Default field mappings for RFC5424
+
+[role="_abstract"]
+When using the RFC5424 protocol, the collector automatically populates the `APP-NAME`, `PROCID`, and `MSGID` fields with default values based on the log source type. You can override these defaults by specifying `appName`, `procId`, or `msgId` in the syslog output configuration.
+
+The following table shows the default field mappings:
+
+.Default RFC5424 field values by log source
+[cols="2,3,3,3",options="header"]
+|===
+|Log source |APP-NAME |PROCID |MSGID
+
+|Infrastructure (journal logs)
+|`SYSLOG_IDENTIFIER`
+|`_PID`
+|`.log_source`
+
+|Infrastructure (container logs)
+|`namespace_pod_container`
+|`pod_id`
+|`.log_source`
+
+|Application (container logs)
+|`namespace_pod_container`
+|`pod_id`
+|`.log_source`
+
+|Audit logs
+|`.log_source`
+|`.auditID` (if available)
+|`.log_source`
+|===
+
+[NOTE]
+====
+Field values can use template syntax for dynamic per-event values. The maximum length for `APP-NAME` and `PROCID` is 48 characters, and for `MSGID` is 32 characters. The collector truncates values that exceed these limits.
+====

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -1,15 +1,15 @@
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-log-forward-syslog_{context}"]
-= Forwarding logs using the syslog protocol
+= Forwarding logs by using the syslog protocol
 
 [role="_abstract"]
 You can use the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator. You are responsible for configuring the external log aggregator, such as a syslog server, to receive the logs from {ocp-product-title}.
 
-To configure log forwarding using the syslog protocol, you must create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers, and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
+To configure log forwarding by using the syslog protocol, you must create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers, and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
 
 .Prerequisites
 
-* You must configure a logging server to receive the logging data using the specified protocol or format.
+* You must configure a logging server to receive the logging data by using the specified protocol or format.
 
 .Procedure
 
@@ -73,5 +73,4 @@ spec:
 ----
 $ oc create -f <filename>.yaml
 ----
-
 


### PR DESCRIPTION
Cherry-pick of #116468 to standalone-logging-docs-6.4

Documents RFC5424 default field mappings for syslog output and applies peer review changes (use 'by using' grammar, 'latest' in URLs, active voice).

Updates .gitignore to exclude temporary and sensitive files.