### PR TITLE
OSDOCS-17165-scenario-2 CQA

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -4,25 +4,27 @@
 
 :_mod-docs-content-type: ASSEMBLY
 [id="dr-restoring-cluster-state"]
-= Restoring to a previous cluster state
+= Restoring to an earlier cluster state
 include::_attributes/common-attributes.adoc[]
 :context: dr-restoring-cluster-state
 
+[role="_abstract"]
+To return your {product-title} cluster to a known good state, restore from a saved etcd snapshot after quorum loss or critical resource deletion. Understanding restore impact helps you decide whether rollback is appropriate before you begin.
+
 toc::[]
 
-To restore the cluster to a previous state, you must have previously backed up the `etcd` data by creating a snapshot. You will use this snapshot to restore the cluster state. For more information, see "Backing up etcd data".
-
-// About restoring to a previous cluster state
+// About restoring to an earlier cluster state
 include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
 
-// Restoring to a previous cluster state for a single node
+// Restoring to an earlier cluster state for a single node
 include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+1]
 
-// Restoring to a previous cluster state
+// Restoring to an earlier cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
+
+include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
-
-include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
+* xref:../../../storage/persistent_storage_local/persistent-storage-local.adoc#local-storage-deleting-resources-overview_persistent-storage-local[Deleting the Local Storage Operator resources]

--- a/modules/dr-restoring-cluster-state-about.adoc
+++ b/modules/dr-restoring-cluster-state-about.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * backup_and_recovery/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+// * backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
 // * etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -8,21 +8,21 @@
 = About restoring to an earlier cluster state
 
 [role="_abstract"]
-To restore the cluster to an earlier state, you must have already backed up the `etcd` data by creating a snapshot. You can use this snapshot to restore the cluster state. For more information, see "Backing up etcd data".
+To assess restore risks before you choose rollback as a last resort, review how an etcd snapshot restore affects your {product-title} cluster, including Operators, workloads, and persistent storage.
 
 You can use an etcd backup to restore your cluster to an earlier state. This can be used to recover from the following situations:
 
-* The cluster has lost the majority of control plane hosts (quorum loss).
+* The cluster has lost the majority of control plane hosts and quorum.
 * An administrator has deleted something critical and must restore to recover the cluster.
 
 [WARNING]
 ====
-Restoring to an earlier cluster state is a destructive and destablizing action to take on a running cluster. This should only be used as a last resort.
+Restoring to an earlier cluster state is a destructive and destabilizing action to take on a running cluster. This should only be used as a last resort.
 
 If you cannot retrieve data using the Kubernetes API server, then etcd is available and you should not restore using an etcd backup.
 ====
 
-Restoring etcd effectively takes a cluster back in time and all clients will experience a conflicting, parallel history. This can impact the behavior of watching components like kubelets, Kubernetes controller managers, persistent volume controllers, and {product-title} Operators, including the network Operator.
+Restoring etcd effectively takes a cluster back in time and all clients experience a conflicting, parallel history. This can impact the behavior of watching components like kubelets, Kubernetes controller managers, persistent volume controllers, and {product-title} Operators, including the network Operator.
 
 It can cause Operator churn when the content in etcd does not match the actual content on disk, causing Operators for the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, and etcd to get stuck when files on disk conflict with content in etcd. This can require manual actions to resolve the issues.
 

--- a/modules/dr-restoring-cluster-state-sno.adoc
+++ b/modules/dr-restoring-cluster-state-sno.adoc
@@ -8,7 +8,7 @@
 = Restoring to an earlier cluster state for a single node
 
 [role="_abstract"]
-You can use a saved etcd backup to restore an earlier cluster state on a single node.
+To restore your {product-title} cluster on a single node, use a saved etcd snapshot to roll back to an earlier state after quorum loss or critical data deletion.
 
 [IMPORTANT]
 ====
@@ -17,9 +17,9 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
+* You have access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file.
 * You have SSH access to control plane hosts.
-* A backup directory containing both the etcd snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
+* You have a backup directory containing both the `etcd` snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
 
 .Procedure
 
@@ -30,7 +30,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 $ cp <etcd_backup_directory> /home/core
 ----
 
-. To restore the cluster from an earlier backup, run the following command on the single node::
+. To restore the cluster from an earlier backup on the single node, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -18,25 +18,20 @@
 = Restoring to an earlier cluster state for more than one node
 
 [role="_abstract"]
-You can use a saved etcd backup to restore an earlier cluster state or restore a cluster that has lost the majority of control plane hosts.
+To restore your {product-title} cluster with more than one control plane node to an earlier state, use a saved etcd snapshot after quorum loss or critical data deletion.
 
-For a Two-Node with Fencing (TNF) setup, a single surviving node can continue to operate in degraded mode. Use a saved etcd backup to restore an earlier cluster state if only one node is operational, or when both nodes have failed and you need to restart the cluster from a known safe state. In both cases, perform the restore procedure on a single node. The peer node automatically synchronizes its data with the restored node when it rejoins the cluster.
+For a Two-Node with Fencing (TNF) setup, a single surviving node can continue to operate in degraded mode. Use a saved etcd backup to restore an earlier cluster state if only one node is operational, or when both nodes have failed and you need to restart the cluster from a known safe state. In both cases, perform the restore procedure on a single node. The peer node automatically synchronizes data with the restored node when it rejoins the cluster.
 
-For a 3-node HA cluster, shut down etcd on the following number of hosts:
+Before you restore from backup on the recovery host, shut down etcd on enough control plane nodes so the remaining members cannot form a quorum:
 
-- For 3-node clusters: Shut down etcd on 2 hosts.
-- For 4-node and 5-node clusters: Shut down etcd on 3 hosts.
+* Shut down etcd on 2 hosts in a 3-node cluster.
+* Shut down etcd on 3 hosts in a 4-node or 5-node cluster.
 
-Quorum requires a simple majority of nodes. The minimum number of nodes required for a quorum is as follows:
-
-- For 3-node HA cluster: 2.
-- For 4-node and 5-node HA clusters: 3.
-
-If you start a new cluster from backup on your recovery host, the other etcd members might still form a quorum and continue service.
+If too few hosts are shut down, the other etcd members might still form a quorum and continue service while you restore.
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to an earlier cluster state for a single node".
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in the control plane machine set troubleshooting topic for an etcd recovery procedure. For {product-title} on a single node, follow the procedure to restore to an earlier cluster state for a single node.
 ====
 
 [IMPORTANT]
@@ -46,11 +41,11 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
-* A healthy control plane host to use as the recovery host.
+* You have access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
+* You have a healthy control plane host to use as the recovery host.
 * You have SSH access to control plane hosts.
-* A backup directory containing both the `etcd` snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
-* Nodes must be accessible or bootable.
+* You have a backup directory containing both the `etcd` snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
+* Control plane nodes are accessible or bootable.
 
 [IMPORTANT]
 ====
@@ -63,14 +58,14 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 
 . Establish SSH connectivity to each of the control plane nodes, including the recovery host.
 +
-`kube-apiserver` becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to each control plane host in a separate terminal.
+`kube-apiserver` becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. Establish SSH connectivity to each control plane host in a separate terminal.
 +
 [IMPORTANT]
 ====
 If you do not complete this step, you cannot access the control plane hosts to complete the restore procedure, and you cannot recover your cluster from this state.
 ====
 
-. Using SSH, connect to each control plane node and run the following command to disable etcd:
+. Using SSH, connect to each control plane node to disbale etcd by running the following command:
 +
 [source,terminal]
 ----
@@ -81,7 +76,7 @@ $ sudo -E /usr/local/bin/disable-etcd.sh
 +
 This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
 
-. Use SSH to connect to the recovery host. To restore the cluster from an earlier backup, run the following command:
+. Use SSH to connect to the recovery host. Restore the cluster from an earlier backup by running the following command:
 +
 [source,terminal]
 ----
@@ -90,7 +85,12 @@ $ sudo -E /usr/local/bin/cluster-restore.sh /home/core/<etcd-backup-directory>
 
 . Exit the SSH session.
 
-. When the API responds, to turn off the etcd Operator quorum guard, run the following command:
+. When the API responds, turn off the etcd Operator quorum guard by running the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
+----
 +
 [IMPORTANT]
 ====
@@ -100,13 +100,8 @@ For a TNF setup, do not:
 
   * Turn the etcd Operator quorum off.
 
-  * Turn the etcd Operator quorum on back.
+  * Turn the etcd Operator quorum back on.
 ====
-+
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
-----
 
 . Monitor the recovery progress of the control plane by running the following command:
 +

--- a/modules/dr-scenario-cluster-state-issues.adoc
+++ b/modules/dr-scenario-cluster-state-issues.adoc
@@ -9,7 +9,7 @@
 = Issues and workarounds for restoring a persistent storage state
 
 [role="_abstract"]
-After restoring a cluster from an etcd snapshot, persistent storage resources might no longer match the current storage provider state. Identify and resolve outdated volume, credential, attachment, or device references to restore workloads safely.
+To restore workloads safely after an etcd snapshot restore, identify and resolve outdated persistent storage references, including volumes, credentials, attachments, and devices on your {product-title} cluster.
 
 If your {product-title} cluster uses persistent storage of any form, a state of the cluster is typically stored outside etcd. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
 
@@ -24,7 +24,7 @@ The following are some example scenarios that produce an out-of-date status:
 
 * Pod P1 is using volume A, which is attached to node X. If the etcd snapshot is taken while another pod uses the same volume on node Y, then when the etcd restore is performed, pod P1 might not be able to start correctly due to the volume still being attached to node Y. {product-title} is not aware of the attachment, and does not automatically detach it. When this occurs, the volume must be manually detached from node Y so that the volume can attach on node X, and then pod P1 can start.
 
-* Cloud provider or storage provider credentials were updated after the etcd snapshot was taken. This causes any CSI drivers or Operators that depend on the those credentials to not work. You might have to manually update the credentials required by those drivers or Operators.
+* Cloud provider or storage provider credentials were updated after the etcd snapshot was taken. This causes any CSI drivers or Operators that depend on those credentials to not work. You might have to manually update the credentials required by those drivers or Operators.
 
 * A device is removed or renamed from {product-title} nodes after the etcd snapshot is taken. The Local Storage Operator creates symlinks for each PV that it manages from `/dev/disk/by-id` or `/dev` directories. This situation might cause the local PVs to refer to devices that no longer exist.
 +
@@ -32,4 +32,4 @@ To fix this problem, an administrator must:
 
 . Manually remove the PVs with invalid devices.
 . Remove symlinks from respective nodes.
-. Delete `LocalVolume` or `LocalVolumeSet` objects (see _Storage_ -> _Configuring persistent storage_ -> _Persistent storage using local volumes_ -> _Deleting the Local Storage Operator Resources_).
+. Delete `LocalVolume` or `LocalVolumeSet` objects. For more information, see "Deleting the Local Storage Operator resources".


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17165

Link to docs preview:
https://117133--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
