### PR TITLE
OSDOCS-20898: Document NetworkPolicy whitelist for health probes in ambient mode

### DIFF
--- a/modules/ossm-ambient-networkpolicy-health-probes.adoc
+++ b/modules/ossm-ambient-networkpolicy-health-probes.adoc
@@ -1,0 +1,32 @@
+////
+This module included in the following assemblies:
+* service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc
+////
+:_mod-docs-content-type: CONCEPT
+[id="ossm-ambient-networkpolicy-health-probes_{context}"]
+= Configuring network policies for health probes in ambient mode
+
+In {SMProductName} 3 ambient mode, when OVN-Kubernetes local gateway mode is enabled (`routingViaHost: true`), the ztunnel proxy performs health checks on behalf of the kubelet by using source network address translation (SNAT) with the link-local IP address `169.254.7.127`.
+
+If you apply a restrictive `NetworkPolicy` resource, such as a deny-all ingress policy, to a namespace enrolled in the ambient mesh, the ztunnel health probe traffic is blocked. This causes pod startup, readiness, or liveness probe failures.
+
+To allow health probes to function, you must add an ingress rule that permits traffic from `169.254.7.127/32` in your `NetworkPolicy` resource:
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ambient-health-probes
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - ipBlock:
+          cidr: 169.254.7.127/32
+----
+
+[NOTE]
+====
+On dual-stack or IPv6-only clusters, also allow the IPv6 address `fd16:9254:7127:1337:ffff:ffff:ffff:ffff/128`.
+====

--- a/service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc
+++ b/service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc
@@ -12,3 +12,5 @@ toc::[]
 ====
 Because {SMProductName} 3.0 releases on a different cadence from {product-title}, the {SMProductShortName} documentation is available as a separate documentation set at link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh[{SMProductName}].
 ====
+
+include::modules/ossm-ambient-networkpolicy-health-probes.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary

Fixes https://redhat.atlassian.net/browse/OSDOCS-20898

In OSSM 3 ambient mode, when OVN-Kubernetes local gateway mode is enabled
(`routingViaHost: true`), the ztunnel proxy performs health checks on behalf
of the kubelet using SNAT with the link-local IP `169.254.7.127`. If a
restrictive `NetworkPolicy` (e.g. deny-all ingress) is applied to a namespace
enrolled in the ambient mesh, health probe traffic is blocked, causing pod
startup, readiness, or liveness probe failures.

This PR adds a new module documenting the requirement to allow ingress from
`169.254.7.127/32` in `NetworkPolicy` resources.

**Versions:** OSSM 3.0+

## What changed

- New module: `modules/ossm-ambient-networkpolicy-health-probes.adoc`
- Modified assembly: `service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc`
  (added include for the new module)

## References

- Upstream: https://istio.io/latest/docs/ambient/usage/networkpolicy/
- Related issue: https://github.com/istio/istio/issues/56983

## Test plan

- [ ] Verify the new module renders correctly in the Netlify preview
- [ ] Confirm the YAML example is valid


