### PR TITLE
[RHDEVDCOS-7767] Release notes for Pipelines 1.22.5

### DIFF
--- a/modules/op-release-notes-1-22-5.adoc
+++ b/modules/op-release-notes-1-22-5.adoc
@@ -1,0 +1,34 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-22.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-22-5_{context}"]
+= Release notes for {pipelines-title} 1.22.5
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.22.5 is available on {OCP} 4.14, 4.16, and later supported versions.
+
+[id="fixed-issues-1-22-5_{context}"]
+== Fixed issues
+
+.User interface
+
+//SRVKP-12879
+Incorrect tab highlighting on the Overview page::
+Before this update, a PatternFly version mismatch between the {OCP} web console and the {pipelines-shortname} console plugin caused incorrect tab highlighting on the *Overview* page. In the pipelines list section, the interface highlighted the *Per Repository* tab when the *Per Pipeline* view was active, and vice versa. With this update, the console plugin PatternFly dependencies match the console version. As a result, the correct tab is highlighted.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12879[SRVKP-12879]
+
+//SRVKP-12111
+Incorrect redirect for cluster-resolver Tasks in pipeline details view::
+Before this update, navigating to a Task resolved through the cluster resolver from the *Pipeline details* view redirected users to an incorrect namespace or page. As a consequence, the console returned a 404 error despite successful Task resolution and pipeline execution. With this update, Task navigation from the *Pipeline details* view correctly resolves the namespace for cluster-resolver-based Tasks. As a result, users are redirected to the correct *Task details* page.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12111[SRVKP-12111]
+
+.Pipelines
+
+//SRVKP-12133
+Pipeline runs are stuck in ResolvingTaskRef state::
+Before this update, when a `ResolutionRequest` completion event was dropped, the associated pipeline run remained in the `ResolvingTaskRef` state indefinitely. As a consequence, pipeline runs stalled for minutes or longer, requiring manual deletion of the controller pods to recover. With this update, pipeline runs in the `ResolvingTaskRef` state are requeued after 1 second to ensure they are updated when their resolution requests complete. As a result, pipeline runs no longer stall in the `ResolvingTaskRef` state.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12133[SRVKP-12133]

--- a/release_notes/op-release-notes-1-22.adoc
+++ b/release_notes/op-release-notes-1-22.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.22
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.22.5
+include::modules/op-release-notes-1-22-5.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.22.4
 include::modules/op-release-notes-1-22-4.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7767

Link to docs preview:
- [1.22.5 Release Notes](https://117149--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-22.html#op-release-notes-1-22-5_op-release-notes-1-22)

QE/SME review:
- [x] QE/SME has approved this change.