### PR TITLE
OCPBUGS#72551: Extra manifests retain original naming convention

### DIFF
--- a/modules/ztp-migrating-sno-clusterinstnce.adoc
+++ b/modules/ztp-migrating-sno-clusterinstnce.adoc
@@ -142,15 +142,13 @@ Generating ConfigMap kustomization files with name: extra-manifests-cm, namespac
 Generating extraManifests for SiteConfig: /resources/sno1.yaml
 Using absolute path for input file: /resources/sno1.yaml
 Running siteconfig-generator from directory: /resources
-Found extraManifests directory: /resources/output/extra-manifests/sno1
-Moved sno1_containerruntimeconfig_enable-crun-master.yaml to /resources/output/extra-manifests/sno1_containerruntimeconfig_enable-crun-master.yaml
-Moved sno1_containerruntimeconfig_enable-crun-worker.yaml to /resources/output/extra-manifests/sno1_containerruntimeconfig_enable-crun-worker.yaml
-Moved 2 extraManifest files from /resources/output/extra-manifests/sno1 to /resources/output/extra-manifests
-Removed directory: /resources/output/extra-manifests/sno1
+Successfully generated extra manifests in /resources/output/extra-manifests
 --- Kustomization.yaml Generator ---
 Scanning directory: /resources/output/extra-manifests
-Found and adding: extra-manifests/sno1_containerruntimeconfig_enable-crun-master.yaml
-Found and adding: extra-manifests/sno1_containerruntimeconfig_enable-crun-worker.yaml
+Found and adding: extra-manifests/06-kdump-master.yaml
+...
+Found and adding: extra-manifests/enable-crun-master.yaml
+Found and adding: extra-manifests/enable-crun-worker.yaml
 ------------------------------------
 kustomization-configMapGenerator-snippet.yaml generated successfully at: /resources/output/kustomization-configMapGenerator-snippet.yaml
 Content:
@@ -251,5 +249,5 @@ site-configs-v2/
     └── kustomization.yaml
 ----
 <1> This `ClusterInstance` CR for the `sno1` cluster.
-<2> The tool automatically generates the extra manifests referenced by the `ClusterInstance` CR. After generation, the file names might change. You can rename the files to match the original naming convention in the associated `kustomization.yaml` file.
+<2> The tool automatically generates the extra manifests referenced by the `ClusterInstance` CR.
 <3> The tool generates a `kuztomization.yaml` file snippet to create the `ConfigMap` resources that specifies the extra manifests. You can merge the generated `kustomization` snippet with your original `kuztomization.yaml` file.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
- https://redhat.atlassian.net/browse/OCPBUGS-72551
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Performing the migration from SiteConfig CR to ClusterInstance CR
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->