### PR TITLE
[enterprise-4.19]OSDOCS#20759: Remove duplicate --ssh-key from hcp create cluster agent example

### DIFF
--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -71,8 +71,7 @@ $ hcp create cluster agent \
   --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image>-multi \// <10>
   --node-pool-replicas=<node_pool_replica_count> \// <11>
   --render \
-  --render-sensitive \
-  --ssh-key <home_directory>/<path_to_ssh_key>/<ssh_key> > hosted-cluster-config.yaml <12>
+  --render-sensitive > hosted-cluster-config.yaml
 ----
 +
 <1> Specify the name of your hosted cluster, such as `example`.
@@ -86,7 +85,6 @@ $ hcp create cluster agent \
 <9> Specify the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 <10> Specify the supported {product-title} version that you want to use, such as `4.19.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see _Extracting the {product-title} release image digest_.
 <11> Specify the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
-<12> After the `--ssh-key` flag, specify the path to the SSH key, such as `user/.ssh/id_rsa`.
 
 . Configure the service publishing strategy. By default, hosted clusters use the `NodePort` service publishing strategy because node ports are always available without additional infrastructure. However, you can configure the service publishing strategy to use a load balancer.
 


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/116554
