### PR TITLE
OSDOCS-20882: Autonode Release Note Update

### DIFF
--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -22,8 +22,8 @@ ifdef::openshift-rosa-hcp[]
 {autonode} based on Karpenter v1.9 is available::
 +
 With this update, you can use {autonode} to provision compute nodes based on workload demand. {autonode} is based on the open-source Karpenter project and provides dynamic node provisioning that matches workload requirements without requiring pre-configured node pools. When pods no longer require a node, {autonode} removes the node to reduce costs.
-
-//For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa_cluster_admin/autonode/rosa-autonode-about#rosa-autonode-about[About {autonode}].
++
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-autonode-about[About {autonode}].
 endif::openshift-rosa-hcp[]
 
 New version of {product-title} available::


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`enterprise-4.22+`

Issue:
**[OSDOCS-20882](https://redhat.atlassian.net/browse/OSDOCS-20882)**

Link to docs preview:
- [ROSA Release Notes](https://117164--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR simply unhides the URL to the docs from the release notes.