### PR TITLE
OSDOCS-18372: DITA abstracts — KMM

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Learn about the Kernel Module Management (KMM) Operator and how you can use it to deploy out-of-tree kernel modules and device plugins on {product-title} clusters.
+[role="_abstract"]
+The Kernel Module Management (KMM) Operator deploys out-of-tree kernel modules and device plugins on {product-title} clusters. You can use KMM to build, load, and manage kernel modules across cluster lifecycle stages.
 
 :FeatureName: Kernel Module Management Operator
 

--- a/modules/kmm-about-kmm.adoc
+++ b/modules/kmm-about-kmm.adoc
@@ -6,9 +6,5 @@
 [id="about-kmm_{context}"]
 = About the Kernel Module Management Operator
 
-The Kernel Module Management (KMM) Operator manages, builds, signs, and deploys out-of-tree kernel modules and device plugins on {product-title} clusters.
-
-KMM adds a new `Module` CRD which describes an out-of-tree kernel module and its associated device plugin.
-You can use `Module` resources to configure how to load the module, define `ModuleLoader` images for kernel versions, and include instructions for building and signing modules for specific kernel versions.
-
-KMM is designed to accommodate multiple kernel versions at once for any kernel module, allowing for seamless node upgrades and reduced application downtime.
+[role="_abstract"]
+The Kernel Module Management (KMM) Operator on {product-title} manages the full lifecycle of out-of-tree kernel modules and device plugins, from build and signing through deployment. You can use `Module` custom resources (CRs)to define module loaders, device plugins, and version-specific build instructions across kernel upgrades.

--- a/modules/kmm-adding-the-keys-for-secureboot.adoc
+++ b/modules/kmm-adding-the-keys-for-secureboot.adoc
@@ -6,7 +6,10 @@
 [id="kmm-adding-the-keys-for-secureboot_{context}"]
 = Adding the keys for secureboot
 
-To use KMM Kernel Module Management (KMM) to sign kernel modules, a certificate and private key are required. For details on how to create these, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair].
+[role="_abstract"]
+To sign kernel modules with Kernel Module Management (KMM) on {product-title}, you can add Secure Boot certificate and private key files as Kubernetes secrets.
+
+For details on how to create these, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair].
 
 For details on how to extract the public and private key pair, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#signing-kernel-modules-with-the-private-key_signing-a-kernel-and-modules-for-secure-boot[Signing kernel modules with the private key]. Use steps 1 through 4 to extract the keys into files.
 

--- a/modules/kmm-applying-tolerations-to-kernel-module-pods.adoc
+++ b/modules/kmm-applying-tolerations-to-kernel-module-pods.adoc
@@ -6,6 +6,9 @@
 [id="kmm-applying-tolerations-to-kernel-module-pods_{context}"]
 = Applying tolerations to kernel module pods 
 
+[role="_abstract"]
+Kernel module pods in {product-title} can tolerate node taints so KMM schedules them on designated nodes. You can configure toleration parameters in the `Module` custom resource to match taint effects, keys, and values on target nodes.
+
 Taints and tolerations consist of `effect`, `key`, and `value` parameters. Tolerations include additional `operator` and `tolerationSeconds` parameters. 
 
 `effect`:: Indicates the taint effect to match. If left empty, all taint effects are matched. When you set `effect`, valid values are: `NoSchedule`, `PreferNoSchedule`, or `NoExecute`.

--- a/modules/kmm-building-a-kmod-image.adoc
+++ b/modules/kmm-building-a-kmod-image.adoc
@@ -6,6 +6,9 @@
 [id="kmm-building-a-kmod-image_{context}"]
 = Building a kmod image
 
+[role="_abstract"]
+To build a kmod image with firmware support in {product-title}, you can include the binary firmware in the builder image alongside the kernel module.
+
 .Procedure
 
 * In addition to building the kernel module itself, include the binary firmware in the builder image:

--- a/modules/kmm-building-and-signing-a-kmod-image.adoc
+++ b/modules/kmm-building-and-signing-a-kmod-image.adoc
@@ -6,7 +6,8 @@
 [id="kmm-building-and-signing-a-kmod-image_{context}"]
 = Building and signing a kmod image
 
-Use this procedure if you have source code and must build your image first.
+[role="_abstract"]
+To build and sign a kmod image from source code on {product-title}, you can apply a `Module` custom resource that builds an unsigned image and then signs it with your key and certificate secrets.
 
 The following YAML file builds a new container image using the source code from the repository. The image produced is saved back in the registry with a temporary name, and this temporary image is then signed using the parameters in the `sign` section.
 

--- a/modules/kmm-building-in-cluster.adoc
+++ b/modules/kmm-building-in-cluster.adoc
@@ -7,7 +7,8 @@
 
 = Building in the cluster
 
-KMM can build kmod images in the cluster. Follow these guidelines:
+[role="_abstract"]
+Kernel Module Management (KMM) can build kmod container images in the cluster on {product-title} when the image does not already exist in the registry. You configure in-cluster builds through the `build` section of a kernel mapping in the `Module` CR.
 
 * Provide build instructions using the `build` section of a kernel mapping.
 * Copy the Dockerfile for your container image into a `ConfigMap` resource, under the `dockerfile` key.

--- a/modules/kmm-checking-the-keys.adoc
+++ b/modules/kmm-checking-the-keys.adoc
@@ -6,7 +6,8 @@
 [id="kmm-checking-the-keys_{context}"]
 = Checking the keys
 
-After you have added the keys, you must check them to ensure they are set correctly.
+[role="_abstract"]
+To verify that your secure boot signing keys are configured correctly in {product-title}, you can inspect the public certificate and private key secrets with the OpenShift CLI.
 
 .Procedure
 

--- a/modules/kmm-configuring-kmmo.adoc
+++ b/modules/kmm-configuring-kmmo.adoc
@@ -6,7 +6,8 @@
 [id="kmm-configuring-kmmo_{context}"]
 = Configuring the Kernel Module Management Operator
 
-In most cases, the default configuration for the Kernel Module Management (KMM) Operator does not need to be modified. However, you can modify the Operator settings to suit your environment.
+[role="_abstract"]
+To adapt the Kernel Module Management (KMM) Operator to your {product-title} environment, you can create a `ConfigMap` with custom settings and restart the controller.
 
 .Procedure
 

--- a/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
+++ b/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
@@ -6,6 +6,9 @@
 [id="kmm-configuring-the-lookup-path-on-nodes_{context}"]
 = Configuring the lookup path on nodes
 
+[role="_abstract"]
+To add `/var/lib/firmware` to the kernel firmware lookup path on {product-title} nodes, you can create a `MachineConfig` custom resource that sets the `firmware_class.path` kernel argument.
+
 On {product-title} nodes, the set of default lookup paths for firmwares does not include the `/var/lib/firmware` path.
 
 .Procedure

--- a/modules/kmm-creating-kmod-image.adoc
+++ b/modules/kmm-creating-kmod-image.adoc
@@ -6,8 +6,8 @@
 [id="kmm-creating-kmod-image_{context}"]
 = Creating a kmod image
 
-Kernel Module Management (KMM) works with purpose-built kmod images, which are standard OCI images that contain `.ko` files.
-The location of the `.ko` files must match the following pattern: `<prefix>/lib/modules/[kernel-version]/`.
+[role="_abstract"]
+A kmod image is a standard OCI container image that holds `.ko` kernel module files for use with Kernel Module Management (KMM) on {product-title}. You must place `.ko` files under a path that matches `<prefix>/lib/modules/[kernel-version]/`.
 
 Keep the following in mind when working with the `.ko` files:
 

--- a/modules/kmm-creating-module-cr.adoc
+++ b/modules/kmm-creating-module-cr.adoc
@@ -7,7 +7,8 @@
 
 = The Module custom resource definition
 
-The `Module` custom resource definition (CRD) represents a kernel module that can be loaded on all or select nodes in the cluster, through a kmod image. A `Module` custom resource (CR) specifies one or more kernel versions with which it is compatible, and a node selector.
+[role="_abstract"]
+The `Module` custom resource (CR) in {product-title} represents a kernel module that can be loaded on all or select nodes in the cluster, through a kmod image. A `Module` CR specifies one or more kernel versions with which it is compatible, and a node selector.
 
 The compatible versions for a `Module` resource are listed under `.spec.moduleLoader.container.kernelMappings`. A kernel mapping can either match a `literal` version, or use `regexp` to match many of them at the same time.
 

--- a/modules/kmm-day0-day2-installation.adoc
+++ b/modules/kmm-day0-day2-installation.adoc
@@ -6,7 +6,8 @@
 [id="kmm-day0-day2-installation_{context}"]
 = Day 0 through Day 2 kmod installation
 
-You can install some kernel modules (kmods) during Day 0 through Day 2 operations without Kernel Module Management (KMM). This could assist in the transition of the kmods to KMM.
+[role="_abstract"]
+You can install some kernel modules (kmods) during Day 0 through Day 2 operations without Kernel Module Management (KMM). You can use these stages to plan kmod transitions to KMM.
 
 Use the following criteria to determine suitable kmod installations.
 

--- a/modules/kmm-day0-day2-lifecycle-management.adoc
+++ b/modules/kmm-day0-day2-lifecycle-management.adoc
@@ -6,7 +6,9 @@
 [id="kmm-day0-day2-lifecycle-management_{context}"]
 = Lifecycle management
 
-You can leverage KMM to manage the Day 0 through Day 2 lifecycle of kmods without a reboot when the driver allows it.
+[role="_abstract"]
+KMM lifecycle management on {product-title} lets you upgrade kmods from Day 0 through Day 2 without rebooting nodes when the driver supports it.
+
 
 [NOTE]
 ====

--- a/modules/kmm-day1-in-tree-module-replacement.adoc
+++ b/modules/kmm-day1-in-tree-module-replacement.adoc
@@ -6,4 +6,5 @@
 [id="kmm-day1-in-tree-module-replacement_{context}"]
 = In-tree module replacement
 
-The Day 1 functionality always tries to replace the in-tree kernel module with the OOT version. If the in-tree kernel module is not loaded, the flow is not affected; the service proceeds and loads the OOT kernel module.
+[role="_abstract"]
+Day 1 kernel module loading in {product-title} replaces in-tree kernel modules with out-of-tree (OOT) versions when present. If the in-tree module is not loaded, KMM loads the OOT module without affecting the flow.

--- a/modules/kmm-day1-kernel-module-image.adoc
+++ b/modules/kmm-day1-kernel-module-image.adoc
@@ -6,4 +6,7 @@
 [id="kmm-day1-kernel-module-image_{context}"]
 = The kernel module image
 
-The Day 1 functionality uses the same DTK based image leveraged by Day 2 KMM builds. The out-of-tree kernel module should be located under `/opt/lib/modules/${kernelVersion}`.
+[role="_abstract"]
+Day 1 kernel module loading in {product-title} uses Driver Toolkit-based container images shared with Day 2 KMM builds. These images must contain your out-of-tree kernel modules so the Machine Config Operator can pull and load them during node boot.
+
+The out-of-tree kernel module should be located under `/opt/lib/modules/${kernelVersion}`.

--- a/modules/kmm-day1-kernel-module-loading.adoc
+++ b/modules/kmm-day1-kernel-module-loading.adoc
@@ -6,4 +6,5 @@
 [id="kmm-day1-kernel-module-loading_{context}"]
 = Day 1 kernel module loading
 
-Kernel Module Management (KMM) is typically a Day 2 Operator. Kernel modules are loaded only after the complete initialization of a Linux (RHCOS) server. However, in some scenarios the kernel module must be loaded at an earlier stage. Day 1 functionality allows you to use the Machine Config Operator (MCO) to load kernel modules during the Linux `systemd` initialization stage.
+[role="_abstract"]
+Day 1 kernel module loading lets you insert kernel modules during Linux `systemd` initialization on {product-title}, before the standard KMM Day 2 loading and a complete initialization of a Linux (RHCOS) server. You can use the Machine Config Operator (MCO) when a module must load earlier than full node initialization.

--- a/modules/kmm-day1-machineconfigpool.adoc
+++ b/modules/kmm-day1-machineconfigpool.adoc
@@ -6,7 +6,8 @@
 [id="kmm-day1-machineconfigpool_{context}"]
 = The MachineConfigPool
 
-The `MachineConfigPool` identifies a collection of nodes that are affected by the applied MCO.
+[role="_abstract"]
+A `MachineConfigPool` objectidentifies a collection of {product-title} nodes affected by Machine Config Operator changes.
 
 [source,yaml]
 ----

--- a/modules/kmm-day1-mco-yaml-creation.adoc
+++ b/modules/kmm-day1-mco-yaml-creation.adoc
@@ -6,7 +6,8 @@
 [id="kmm-day1-mco-yaml-creation_{context}"]
 = MCO yaml creation
 
-KMM provides an API to create an MCO YAML manifest for the Day 1 functionality:
+[role="_abstract"]
+Kernel Module Management (KMM) exposes a `ProduceMachineConfig` API that generates Machine Config Operator (MCO) YAML for Day 1 out-of-tree kernel module loading on {product-title}. You apply the returned manifest to target nodes in a specified `MachineConfigPool` object.
 
 [source,console]
 ----

--- a/modules/kmm-day1-oot-kernel-module-loading-flow.adoc
+++ b/modules/kmm-day1-oot-kernel-module-loading-flow.adoc
@@ -6,7 +6,8 @@
 [id="kmm-day1-oot-kernel-module-loading-flow_{context}"]
 = OOT kernel module loading flow
 
-The loading of the out-of-tree (OOT) kernel module leverages the Machine Config Operator (MCO). The flow sequence is as follows:
+[role="_abstract"]
+To load an out-of-tree kernel module during {product-title} node boot, you can apply a `MachineConfig` through the Machine Config Operator (MCO). MCO reboots nodes and deploys `systemd` services that pull the kernel module image and swap in-tree modules for OOT modules.
 
 .Procedure
 

--- a/modules/kmm-day1-supported-use-cases.adoc
+++ b/modules/kmm-day1-supported-use-cases.adoc
@@ -6,7 +6,8 @@
 [id="kmm-day1-supported-use-cases_{context}"]
 = Day 1 supported use cases
 
-The Day 1 functionality supports a limited number of use cases. The main use case is to allow loading out-of-tree (OOT) kernel modules prior to NetworkManager service initialization. It does not support loading kernel module at the `initramfs` stage.
+[role="_abstract"]
+Day 1 supported use cases define when {product-title} can load out-of-tree (OOT) kernel modules before NetworkManager starts. This functionality does not support loading modules during the `initramfs` stage.
 
 The following are the conditions needed for Day 1 functionality:
 

--- a/modules/kmm-debugging-and-troubleshooting.adoc
+++ b/modules/kmm-debugging-and-troubleshooting.adoc
@@ -6,7 +6,11 @@
 [id="kmm-debugging-and-troubleshooting_{context}"]
 = Debugging and troubleshooting
 
-If the kmods in your driver container are not signed or are signed with the wrong key, then the container can enter a `PostStartHookError` or `CrashLoopBackOff` status. You can verify by running the `oc describe` command on your container, which displays the following message in this scenario:
+[role="_abstract"]
+Unsigned or incorrectly signed kmods in KMM driver containers on {product-title} can cause `PostStartHookError` or `CrashLoopBackOff` states.
+You can verify signing issues by running `oc describe` on the container and checking for a `Required key not available` error.
+
+The following message appears in this scenario:
 
 [source,terminal]
 ----

--- a/modules/kmm-deploying-modules.adoc
+++ b/modules/kmm-deploying-modules.adoc
@@ -6,7 +6,8 @@
 [id="kmm-deploy-kernel-modules_{context}"]
 = Kernel module deployment
 
-Kernel Module Management (KMM) monitors `Node` and `Module` resources in the cluster to determine if a kernel module should be loaded on or unloaded from a node.
+[role="_abstract"]
+Kernel Module Management (KMM) monitors `Node` and `Module` resources on {product-title} to load or unload kernel modules on eligible nodes. KMM creates worker pods on target nodes to reconcile the desired module state.
 
 To be eligible for a module, a node must contain the following:
 

--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -7,7 +7,8 @@
 
 = Example Module CR
 
-The following is an annotated `Module` example:
+[role="_abstract"]
+Use this annotated `Module` custom resource example as a reference when you configure kernel module loading, device plugins, builds, and signing in {product-title}.
 
 [source,yaml]
 ----

--- a/modules/kmm-firmware-support.adoc
+++ b/modules/kmm-firmware-support.adoc
@@ -6,7 +6,8 @@
 [id="kmm-firmware-support_{context}"]
 = KMM firmware support
 
-Kernel modules sometimes need to load firmware files from the file system. KMM supports copying firmware files from the kmod image to the node's file system.
+[role="_abstract"]
+KMM firmware support copying firmware files from the kmod image to a node on {product-title} before loading a kernel module.
 
 The contents of `.spec.moduleLoader.container.modprobe.firmwarePath` are copied into the `/var/lib/firmware` path on the node before running the `modprobe` command to insert the kernel module.
 

--- a/modules/kmm-gathering-data-for-kmm-hub.adoc
+++ b/modules/kmm-gathering-data-for-kmm-hub.adoc
@@ -6,6 +6,9 @@
 [id="kmm-gathering-data-for-kmm-hub_{context}"]
 = Gathering data for KMM-Hub
 
+[role="_abstract"]
+To collect diagnostic data for the KMM-Hub Operator on {product-title}, you can run the `must-gather` tool with the hub controller image and review Operator logs.
+
 .Procedure
 
 . Gather the data for the KMM Operator hub controller manager:

--- a/modules/kmm-gathering-data-for-kmm.adoc
+++ b/modules/kmm-gathering-data-for-kmm.adoc
@@ -6,6 +6,9 @@
 [id="kmm-gathering-data-for-kmm_{context}"]
 = Gathering data for KMM
 
+[role="_abstract"]
+To troubleshoot Kernel Module Management (KMM) on {product-title}, you can gather Operator data with the `must-gather` tool and review controller manager logs.
+
 .Procedure
 
 . Gather the data for the KMM Operator controller manager:

--- a/modules/kmm-hub-hub-and-spoke.adoc
+++ b/modules/kmm-hub-hub-and-spoke.adoc
@@ -6,9 +6,8 @@
 [id="kmm-hub-hub-and-spoke_{context}"]
 = KMM hub and spoke
 
-In hub and spoke scenarios, many spoke clusters are connected to a central, powerful hub cluster. Kernel Module Management (KMM) depends on Red{nbsp}Hat Advanced Cluster Management (RHACM) to operate in hub and spoke environments.
-
-KMM is compatible with hub and spoke environments through decoupling KMM features. A `ManagedClusterModule` custom resource definition (CRD) is provided to wrap the existing `Module` CRD and extend it to select Spoke clusters. Also provided is KMM-Hub, a new standalone controller that builds images and signs modules on the hub cluster.
+[role="_abstract"]
+In {rh-rhacm} hub-and-spoke deployments, the KMM-Hub controller offloads kernel module building and signing to the hub cluster. Administrators can use the `ManagedClusterModule` custom resource (CR) to load modules on spoke clusters while preserving resources on managed nodes.
 
 In hub and spoke setups, spokes are focused, resource-constrained clusters that are centrally managed by a hub cluster. Spokes run the single-cluster edition of KMM, with those resource-intensive features disabled. To adapt KMM to this environment, you should reduce the workload running on the spokes to the minimum, while the hub takes care of the expensive tasks.
 

--- a/modules/kmm-hub-installing-kmm-hub-creating-resources.adoc
+++ b/modules/kmm-hub-installing-kmm-hub-creating-resources.adoc
@@ -6,6 +6,9 @@
 [id="kmm-hub-installing-kmm-hub-creating-resources_{context}"]
 = Installing KMM-Hub by creating KMM resources
 
+[role="_abstract"]
+To install KMM-Hub programmatically on {product-title}, you can create `Namespace`, `OperatorGroup`, and `Subscription` resources.
+
 .Procedure
 
 * If you want to install KMM-Hub programmatically, you can use the following resources to create

--- a/modules/kmm-hub-installing-kmm-hub-olm.adoc
+++ b/modules/kmm-hub-installing-kmm-hub-olm.adoc
@@ -6,4 +6,5 @@
 [id="kmm-hub-installing-kmm-hub-olm_{context}"]
 = Installing KMM-Hub using the Operator Lifecycle Manager
 
-Use the *Operators* section of the OpenShift console to install KMM-Hub.
+[role="_abstract"]
+To install KMM-Hub on {product-title} using Operator Lifecycle Manager, you can use the *Operators* section of the OpenShift web console.

--- a/modules/kmm-hub-installing-kmm-hub.adoc
+++ b/modules/kmm-hub-installing-kmm-hub.adoc
@@ -6,7 +6,5 @@
 [id="kmm-hub-installing-kmm-hub_{context}"]
 = Installing KMM-Hub
 
-You can use one of the following methods to install KMM-Hub:
-
-* With the Operator Lifecycle Manager (OLM)
-* Creating KMM resources
+[role="_abstract"]
+To deploy KMM-Hub for multi-cluster kernel module management on {product-title}, you can install it with Operator Lifecycle Manager (OLM) or by creating KMM resources manually.

--- a/modules/kmm-hub-kmm-hub.adoc
+++ b/modules/kmm-hub-kmm-hub.adoc
@@ -6,9 +6,8 @@
 [id="kmm-hub-kmm-hub_{context}"]
 = KMM-Hub
 
-The KMM project provides KMM-Hub, an edition of KMM dedicated to hub clusters. KMM-Hub monitors all kernel versions running on the spokes and determines the nodes on the cluster that should receive a kernel module.
-
-KMM-Hub runs all compute-intensive tasks such as image builds and kmod signing, and prepares the trimmed-down `Module` to be transferred to the spokes through RHACM.
+[role="_abstract"]
+KMM-Hub is a hub-cluster edition of Kernel Module Management for {product-title} multi-cluster deployments. It monitors spoke kernel versions, runs image builds and kmod signing on the hub, and delivers trimmed `Module` resources to spokes through {rh-rhacm}.
 
 [NOTE]
 ====

--- a/modules/kmm-hub-running-kmm-on-the-spoke.adoc
+++ b/modules/kmm-hub-running-kmm-on-the-spoke.adoc
@@ -6,7 +6,8 @@
 [id="kmm-hub-running-kmm-on-the-spoke_{context}"]
 = Running KMM on the spoke
 
-After installing Kernel Module Management (KMM) on the spoke, no further action is required. Create a `ManagedClusterModule` object from the hub to deploy kernel modules on spoke clusters.
+[role="_abstract"]
+To run Kernel Module Management (KMM) on spoke clusters in {product-title}, you can install it with a {rh-rhacm} `Policy` object. After installation, create a `ManagedClusterModule` object from the hub to deploy kernel modules.
 
 You can install KMM on the spokes cluster through a RHACM `Policy` object. In addition to installing KMM from the software catalog and running it in a lightweight spoke mode, the `Policy` configures additional RBAC required for the RHACM agent to be able to manage `Module` resources.
 

--- a/modules/kmm-hub-using-the-managedclustermodule.adoc
+++ b/modules/kmm-hub-using-the-managedclustermodule.adoc
@@ -6,7 +6,9 @@
 [id="kmm-hub-using-the-managedclustermodule_{context}"]
 = Using the `ManagedClusterModule` CRD
 
-Use the `ManagedClusterModule` Custom Resource Definition (CRD) to configure the deployment of kernel modules on spoke clusters.
+[role="_abstract"]
+To deploy kernel modules on spoke clusters with KMM-Hub on {product-title}, you can configure a cluster-scoped `ManagedClusterModule` custom resource that wraps a `Module` spec and selects target clusters.
+
 This CRD is cluster-scoped, wraps a `Module` spec and adds the following additional fields:
 
 [source,yaml]

--- a/modules/kmm-installation.adoc
+++ b/modules/kmm-installation.adoc
@@ -6,7 +6,8 @@
 [id="kmm-install_{context}"]
 = Installing the Kernel Module Management Operator
 
-As a cluster administrator, you can install the Kernel Module Management (KMM) Operator by using the OpenShift CLI or the web console.
+[role="_abstract"]
+As a cluster administrator, you can install the Kernel Module Management (KMM) Operator on {product-title} by using the OpenShift CLI or web console.
 
 The KMM Operator is supported on {product-title} 4.12 and later.
 Installing KMM on version 4.11 does not require specific additional steps.

--- a/modules/kmm-installing-older-versions.adoc
+++ b/modules/kmm-installing-older-versions.adoc
@@ -6,9 +6,11 @@
 [id="kmm-install-older-version_{context}"]
 = Installing the Kernel Module Management Operator on earlier versions of {product-title}
 
+[role="_abstract"]
+As a cluster administrator, you can install the Kernel Module Management (KMM) Operator by using the OpenShift CLI.
+
 The KMM Operator is supported on {product-title} 4.12 and later.
 For version 4.10 and earlier, you must create a new `SecurityContextConstraint` object and bind it to the Operator's `ServiceAccount`.
-As a cluster administrator, you can install the Kernel Module Management (KMM) Operator by using the OpenShift CLI.
 
 .Prerequisites
 

--- a/modules/kmm-installing-using-cli.adoc
+++ b/modules/kmm-installing-using-cli.adoc
@@ -6,7 +6,8 @@
 [id="kmm-install-using-cli_{context}"]
 = Installing the Kernel Module Management Operator by using the CLI
 
-As a cluster administrator, you can install the Kernel Module Management (KMM) Operator by using the OpenShift CLI.
+[role="_abstract"]
+To install the Kernel Module Management (KMM) Operator on {product-title}, you can create `Namespace`, `OperatorGroup`, and `Subscription` resources by using the OpenShift CLI (`oc`).
 
 .Prerequisites
 

--- a/modules/kmm-installing-using-web-console.adoc
+++ b/modules/kmm-installing-using-web-console.adoc
@@ -6,7 +6,8 @@
 [id="kmm-install-using-web-console_{context}"]
 = Installing the Kernel Module Management Operator using the web console
 
-As a cluster administrator, you can install the Kernel Module Management (KMM) Operator using the {product-title} web console.
+[role="_abstract"]
+To install the Kernel Module Management (KMM)Operator on {product-title}, you can use the web console *Software Catalog* to deploy it into the `openshift-kmm` namespace.
 
 .Procedure
 

--- a/modules/kmm-layering-background.adoc
+++ b/modules/kmm-layering-background.adoc
@@ -6,6 +6,5 @@
 [id="kmm-layering-background_{context}"]
 = Layering background
 
-When a Day 0 kmod is installed in the cluster, layering is applied through the Machine Config Operator (MCO) and {product-title} upgrades do not trigger node upgrades.
-
-You only need to recompile the driver if you add new features to it, because the node’s operating system will remain the same.
+[role="_abstract"]
+Layering applies Day 0 kernel modules through the Machine Config Operator (MCO) on {product-title}, so cluster upgrades do not trigger node upgrades for those modules. You recompile the driver only when you add new features, because the node operating system stays the same.

--- a/modules/kmm-must-gather-tool.adoc
+++ b/modules/kmm-must-gather-tool.adoc
@@ -6,5 +6,5 @@
 [id="kmm-must-gather-tool_{context}"]
 = Using the must-gather tool
 
-The `oc adm must-gather` command is the preferred way to collect a support bundle and provide debugging information to Red Hat
-Support. Collect specific information by running the command with the appropriate arguments as described in the following sections.
+[role="_abstract"]
+To collect Kernel Module Management debugging data for Red{nbsp}Hat Support on {product-title}, you can run the `oc adm must-gather` command with KMM-specific arguments.

--- a/modules/kmm-observing-events.adoc
+++ b/modules/kmm-observing-events.adoc
@@ -6,7 +6,8 @@
 [id="kmm-observing-events_{context}"]
 = Observing events
 
-Use the following methods to view KMM events.
+[role="_abstract"]
+You can observe Kernel Module Management (KMM) events on {product-title} to monitor kmod image builds, signing, and module load or unload operations. Events attach to `Module` and `Node` objects and appear in `oc describe` output.
 
 [id="kmm-observing-events-build-and-sign_{context}"]
 == Build & sign

--- a/modules/kmm-reading-operator-logs.adoc
+++ b/modules/kmm-reading-operator-logs.adoc
@@ -6,7 +6,8 @@
 [id="kmm-reading-operator-logs_{context}"]
 = Reading Operator logs
 
-You can use the `oc logs` command to read Operator logs, as in the following examples.
+[role="_abstract"]
+KMM and KMM-Hub Operator logs on {product-title} provide diagnostic information for troubleshooting installation and runtime issues. You can read them with the `oc logs` command against the controller and webhook server deployments.
 
 Example command for KMM controller::
 +

--- a/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
+++ b/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
@@ -6,6 +6,7 @@
 [id="kmm-replacing-in-tree-modules-with-out-of-tree-modules_{context}"]
 = Replacing in-tree modules with out-of-tree modules
 
+[role="_abstract"]
 You can use Kernel Module Management (KMM) to build kernel modules that can be loaded or unloaded into the kernel on demand. These modules extend the functionality of the kernel without the need to reboot the system. Modules can be configured as built-in or dynamically loaded.
 
 Dynamically loaded modules include in-tree modules and out-of-tree (OOT) modules. In-tree modules are internal to the Linux kernel tree, that is, they are already part of the kernel. Out-of-tree modules are external to the Linux kernel tree. They are generally written for development and testing purposes, such as testing the new version of a kernel module that is shipped in-tree, or to deal with incompatibilities.

--- a/modules/kmm-running-depmod.adoc
+++ b/modules/kmm-running-depmod.adoc
@@ -7,7 +7,8 @@
 
 = Running depmod
 
-It is recommended to run `depmod` at the end of the build process to generate `modules.dep` and `.map` files. This is especially useful if your kmod image contains several kernel modules and if one of the modules depends on another module.
+[role="_abstract"]
+Run the `depmod` utlity at the end of the build process to generate `modules.dep` and `.map` files. This is especially useful if your kmod image contains several kernel modules and if one of the modules depends on another module.
 
 [NOTE]
 ====

--- a/modules/kmm-security.adoc
+++ b/modules/kmm-security.adoc
@@ -6,6 +6,9 @@
 [id="kmm-security_{context}"]
 = Security and permissions
 
+[role="_abstract"]
+KMM security and permissions govern how privileged workloads load kernel modules on {product-title} nodes. Review `ServiceAccount`, `SecurityContextConstraint`, and pod security requirements before deploying `Module` resources.
+
 [IMPORTANT]
 ====
 Loading kernel modules is a highly sensitive operation.

--- a/modules/kmm-setting-kernel-firmware-search-path.adoc
+++ b/modules/kmm-setting-kernel-firmware-search-path.adoc
@@ -6,9 +6,10 @@
 [id="kmm-setting-kernel-firmware-search-path_{context}"]
 = Setting the kernel firmware search path
 
-The Linux kernel accepts the `firmware_class.path` parameter as a search path for firmware, as explained in link:https://www.kernel.org/doc/html/latest/driver-api/firmware/fw_search_path.html[Firmware search paths].
+[role="_abstract"]
+To configure where KMM worker pods search for firmware on {product-title} nodes, you can set the `worker.setFirmwareClassPath` parameter in the Operator configuration.
 
-KMM worker pods can set this value on nodes by writing to sysfs before attempting to load kmods.
+The Linux kernel accepts the `firmware_class.path` parameter as a search path for firmware, as explained in link:https://www.kernel.org/doc/html/latest/driver-api/firmware/fw_search_path.html[Firmware search paths].
 
 .Procedure
 

--- a/modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc
+++ b/modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc
@@ -6,9 +6,10 @@
 [id="kmm-setting-soft-dependencies-between-kernel-modules_{context}"]
 = Set soft dependencies between kernel modules
 
-Some configurations require that several kernel modules be loaded in a specific order to work properly, even though the modules do not directly depend on each other through symbols. These are called soft dependencies. `depmod` is usually not aware of these dependencies, and they do not appear in the files it produces. For example, if `mod_a` has a soft dependency on `mod_b`, `modprobe mod_a` will not load `mod_b`.
+[role="_abstract"]
+Soft dependencies require kernel modules to load in a specific order even when they do not share symbols. You can declare these dependencies in the `Module` CR with the `modulesLoadingOrder` field.
 
-You can resolve these situations by declaring soft dependencies in the Module custom resource definition (CRD) using the `modulesLoadingOrder` field.
+The `depmod` utility does not recognize soft dependencies, and soft dependencies do not appear in the files it produces. For example, if `mod_a` has a soft dependency on `mod_b`, `modprobe mod_a` will not load `mod_b`.
 
 [source,yaml]
 ----

--- a/modules/kmm-signing-kmods-in-a-prebuilt-image.adoc
+++ b/modules/kmm-signing-kmods-in-a-prebuilt-image.adoc
@@ -6,7 +6,8 @@
 [id="kmm-signing-kmods-in-a-prebuilt-image_{context}"]
 = Signing kmods in a pre-built image
 
-Use this procedure if you have a pre-built image, such as an image either distributed by a hardware vendor or built elsewhere.
+[role="_abstract"]
+To sign kernel modules in a vendor-supplied or externally built image on {product-title}, you can configure a `Module` custom resource with unsigned and signed container image references and key secrets.
 
 The following YAML file adds the public/private key-pair as secrets with the required key names - `key` for the private key, `cert` for the public key. The cluster then pulls down the `unsignedImage` image, opens it, signs the kernel modules listed in `filesToSign`, adds them back, and pushes the resulting image as `containerImage`.
 

--- a/modules/kmm-symbolic-links-for-in-tree-dependencies.adoc
+++ b/modules/kmm-symbolic-links-for-in-tree-dependencies.adoc
@@ -7,7 +7,8 @@
 
 = Symbolic links for in-tree dependencies
 
-Some kernel modules depend on other kernel modules that are shipped with the node's operating system. To avoid copying those dependencies into the kmod image, Kernel Module Management (KMM) mounts `/usr/lib/modules` into both the build and the worker pod's filesystems.
+[role="_abstract"]
+Symbolic links let kmod images reference in-tree kernel module dependencies on {product-title} without copying them. KMM mounts `/usr/lib/modules` so `depmod` and `modprobe` can resolve those dependencies at build and runtime.
 
 By creating a symlink from `/opt/usr/lib/modules/<kernel_version>/<symlink_name>` to `/usr/lib/modules/<kernel_version>`, `depmod` can use the in-tree kmods on the building node's filesystem to resolve dependencies.
 

--- a/modules/kmm-troubleshooting.adoc
+++ b/modules/kmm-troubleshooting.adoc
@@ -6,5 +6,5 @@
 [id="kmm-troubleshooting_{context}"]
 = Troubleshooting KMM
 
-When troubleshooting KMM installation issues, you can monitor logs to determine at which stage issues occur.
-Then, retrieve diagnostic data relevant to that stage.
+[role="_abstract"]
+When troubleshooting KMM on {product-title}, you can monitor Operator logs to identify the failure stage and gather diagnostic data for that stage.

--- a/modules/kmm-tuning-the-module-resource.adoc
+++ b/modules/kmm-tuning-the-module-resource.adoc
@@ -6,6 +6,9 @@
 [id="kmm-tuning-the-module-resource_{context}"]
 = Tuning the Module resource
 
+[role="_abstract"]
+To configure firmware file paths for kernel modules on {product-title}, you can set `.spec.moduleLoader.container.modprobe.firmwarePath` in the `Module` CR.
+
 .Procedure
 
 * Set `.spec.moduleLoader.container.modprobe.firmwarePath` in the `Module` custom resource (CR):

--- a/modules/kmm-uninstalling-kmm.adoc
+++ b/modules/kmm-uninstalling-kmm.adoc
@@ -6,5 +6,5 @@
 [id="kmm-uninstalling-kmmo_{context}"]
 = Uninstalling the Kernel Module Management Operator
 
-Use one of the following procedures to uninstall the Kernel Module Management (KMM) Operator, depending on how
-the KMM Operator was installed.
+[role="_abstract"]
+You can uninstall the Kernel Module Management (KMM) Operator from {product-title} by using CLI or uninstalling the Operator.

--- a/modules/kmm-uninstalling-kmmo-cli.adoc
+++ b/modules/kmm-uninstalling-kmmo-cli.adoc
@@ -4,7 +4,8 @@
 [id="kmm-uninstalling-kmmo-cli_{context}"]
 = Uninstalling a CLI installation
 
-Use this command if the KMM Operator was installed using the OpenShift CLI.
+[role="_abstract"]
+To uninstall a Kernel Module Management (KMM) Operator CLI installation from {product-title}, you can run `oc delete -k` against the upstream configuration manifest.
 
 .Procedure
 

--- a/modules/kmm-uninstalling-kmmo-red-hat-catalog.adoc
+++ b/modules/kmm-uninstalling-kmmo-red-hat-catalog.adoc
@@ -4,7 +4,8 @@
 [id="kmm-uninstalling-kmmo-red-hat-catalog_{context}"]
 = Uninstalling a Red Hat catalog installation
 
-Use this procedure if KMM was installed from the Red Hat catalog.
+[role="_abstract"]
+To uninstall a Kernel Module Management (KMM) Operator installation from the Red{nbsp}Hat catalog on {product-title}, you can remove the Operator from *Installed Operators* in the web console.
 
 .Procedure
 

--- a/modules/kmm-unloading-kernel-module.adoc
+++ b/modules/kmm-unloading-kernel-module.adoc
@@ -6,6 +6,9 @@
 [id="kmm-unloading-kernel-module_{context}"]
 = Unloading the kernel module
 
+[role="_abstract"]
+To unload a kernel module deployed with KMM on {product-title}, you can delete the corresponding `Module` resource. KMM creates worker pods that run `modprobe -r` on eligible nodes.
+
 You must unload the kernel modules when moving to a newer version or if they introduce some undesirable side effect on the node.
 
 .Procedure

--- a/modules/kmm-using-driver-toolkit.adoc
+++ b/modules/kmm-using-driver-toolkit.adoc
@@ -7,10 +7,8 @@
 
 = Using the Driver Toolkit
 
-The Driver Toolkit (DTK) is a convenient base image for building build kmod loader images.
-It contains tools and libraries for the OpenShift version currently running in the cluster.
-
-Use DTK as the first stage of a multi-stage Dockerfile.
+[role="_abstract"]
+To build kernel module loader images in {product-title}, you can use the Driver Toolkit (DTK) as the first stage of a multi-stage Dockerfile. DTK provides kernel headers and build tools matched to the cluster {product-title} version.
 
 .Procedure
 

--- a/modules/kmm-using-intree-modules.adoc
+++ b/modules/kmm-using-intree-modules.adoc
@@ -7,7 +7,8 @@
 
 = Using in-tree modules with the device plugin
 
-In some cases, you might need to configure the KMM Module to avoid loading an out-of-tree kernel module and instead use the in-tree module, running only the device plugin. In such cases, you can omit the `moduleLoader` parameter from the `Module` custom resource (CR), and leave only the `devicePlugin` section, as shown in the following example.
+[role="_abstract"]
+You can configure a KMM `Module` custom resource on {product-title} to use an in-tree kernel module and run only the device plugin. Omit the `moduleLoader` section and specify only `devicePlugin` in the CR.
 
 .Example `Module` CR
 ====

--- a/modules/kmm-using-signing-with-kmm.adoc
+++ b/modules/kmm-using-signing-with-kmm.adoc
@@ -6,7 +6,8 @@
 [id="kmm-using-signing-with-kmm_{context}"]
 = Using signing with Kernel Module Management (KMM)
 
-On a Secure Boot enabled system, all kernel modules (kmods) must be signed with a public/private key-pair enrolled into the Machine Owner's Key (MOK) database. Drivers distributed as part of a distribution should already be signed by the distribution's private key, but for kernel modules build out-of-tree, KMM supports signing kernel modules using the `sign` section of the kernel mapping.
+[role="_abstract"]
+On Secure Boot-enabled {product-title} systems, out-of-tree kernel modules must be signed with keys enrolled in the Machine Owner's Key (MOK) database. For kernel modules built out of tree, KMM supports signing kmods through the `sign` section of the kernel mapping in a `Module` custom resource.
 
 For more details on using Secure Boot, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair]
 

--- a/modules/kmm-using-tolerations-for-kernel-module-scheduling.adoc
+++ b/modules/kmm-using-tolerations-for-kernel-module-scheduling.adoc
@@ -6,10 +6,7 @@
 [id="kmm-using-tolerations-for-kernel-module-scheduling_{context}"]
 = Using tolerations for kernel module scheduling
 
-There are circumstances where you need to evacuate workloads on a node before upgrading a kernel module, which you can do through taints. You can use a taint to schedule only pods that contain a matching toleration on the node.
+[role="_abstract"]
+You can configure user-defined tolerations in the ModuleSpec resource to ensure Kernel Module Management (KMM) housekeeping pods can run on cordoned or tainted nodes during driver and kernel module upgrades.
 
-However, you also need to set tolerations to allow Kernel Module Management (KMM) pods that run housekeeping operations, such as kernel module upgrades. The tolerations must match the taint that is added to the nodes.
-
-You can create user-defined tolerations to kernel modules to schedule selected KMM pods on a cordoned node. For example, during a device driver upgrade you cordon a node, at the same time, you can run housekeeping pods that perform the driver upgrades.
-
-The `ModuleSpec` field is used to carry the tolerations to the KMM pods that are used during pod creation.
+When you taint a node to evacuate workload pods prior to an upgrade, setting matching tolerations in the ModuleSpec allows KMM housekeeping pods to deploy and execute driver maintenance without being blocked by node taints.


### PR DESCRIPTION
## Summary
Rewrites `[role="_abstract"]` short descriptions for Kernel Module Management (KMM) assembly and modules from [OSDOCS-18372](https://redhat.atlassian.net/browse/OSDOCS-18372) (59 files). Addresses AsciiDocDITA.ShortDescription.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-18372

## Versions
4.20+

## Preview
https://117165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html

## Merge order
Independent branch from main (abstracts only). Preferred first among [OSDOCS-18372](https://redhat.atlassian.net/browse/OSDOCS-18372) DITA series; rebase later series if same-file conflicts.

## Files changed
See PR files list (59 KMM assembly/module files).

## Vale rules addressed
- AsciiDocDITA.ShortDescription

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted
- File list supplied from Jira ticket MODULES (attachment download blocked in agent environment)

Made with [Cursor](https://cursor.com)