### PR TITLE
OSDOCS-18372: DITA other Vale — KMM

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -27,7 +27,7 @@ include::modules/kmm-configuring-kmmo.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-install_kernel-module-management-operator[Installing the Kernel Module Management Operator].
+* xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-install_kernel-module-management-operator[Installing the Kernel Module Management Operator]
 
 include::modules/kmm-unloading-kernel-module.adoc[leveloffset=+2]
 
@@ -36,7 +36,7 @@ include::modules/kmm-setting-kernel-firmware-search-path.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the `worker.setFirmwareClassPath` path, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-configuring-kmmo_kernel-module-management-operator[Configuring the Kernel Module Management Operator].
+* xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-configuring-kmmo_kernel-module-management-operator[Configuring the Kernel Module Management Operator]
 
 // Added for TELCODOCS-1309
 include::modules/kmm-uninstalling-kmm.adoc[leveloffset=+1]
@@ -213,7 +213,7 @@ include::modules/kmm-configuring-the-lookup-path-on-nodes.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../machine_configuration/index.adoc#machine-config-operator_machine-config-overview[Machine Config Operator].
+* xref:../machine_configuration/index.adoc#machine-config-operator_machine-config-overview[Machine Config Operator]
 
 include::modules/kmm-building-a-kmod-image.adoc[leveloffset=+2]
 

--- a/modules/kmm-hub-installing-kmm-hub-olm.adoc
+++ b/modules/kmm-hub-installing-kmm-hub-olm.adoc
@@ -8,3 +8,7 @@
 
 [role="_abstract"]
 To install KMM-Hub on {product-title} using Operator Lifecycle Manager, you can use the *Operators* section of the OpenShift web console.
+
+.Procedure
+
+* Use the *Operators* section of the OpenShift console to install KMM-Hub.

--- a/modules/kmm-hub-installing-kmm-hub.adoc
+++ b/modules/kmm-hub-installing-kmm-hub.adoc
@@ -2,7 +2,7 @@
 //
 // * hardware_enablement/kmm-kernel-module-management.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="kmm-hub-installing-kmm-hub_{context}"]
 = Installing KMM-Hub
 

--- a/modules/kmm-hub-using-the-managedclustermodule.adoc
+++ b/modules/kmm-hub-using-the-managedclustermodule.adoc
@@ -2,7 +2,7 @@
 //
 // * hardware_enablement/kmm-kernel-module-management.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="kmm-hub-using-the-managedclustermodule_{context}"]
 = Using the `ManagedClusterModule` CRD
 

--- a/modules/kmm-must-gather-tool.adoc
+++ b/modules/kmm-must-gather-tool.adoc
@@ -2,7 +2,7 @@
 //
 // * hardware_enablement/kmm-kernel-module-management.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="kmm-must-gather-tool_{context}"]
 = Using the must-gather tool
 

--- a/modules/kmm-running-depmod.adoc
+++ b/modules/kmm-running-depmod.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Run the `depmod` utlity at the end of the build process to generate `modules.dep` and `.map` files. This is especially useful if your kmod image contains several kernel modules and if one of the modules depends on another module.
 
+If you are building your image on {product-title}, consider using the Driver Toolkit (DTK). For further information, see link:https://cloud.redhat.com/blog/how-to-use-entitled-image-builds-to-build-drivercontainers-with-ubi-on-openshift[How to use entitled image builds to build DriverContainers with UBI on OpenShift].
+
 [NOTE]
 ====
 You must have a Red Hat subscription to download the `kernel-devel` package.
@@ -24,10 +26,7 @@ You must have a Red Hat subscription to download the `kernel-devel` package.
 $ depmod -b /opt ${KERNEL_FULL_VERSION}+`.
 ----
 +
-.Example Dockerfile
-If you are building your image on {product-title}, consider using the Driver Toolkit (DTK).
-+
-For further information, see link:https://cloud.redhat.com/blog/how-to-use-entitled-image-builds-to-build-drivercontainers-with-ubi-on-openshift[using an entitled build].
+The following example Dockerfile shows how to run `depmod` at the end of the build:
 +
 [source,yaml]
 ----

--- a/modules/kmm-using-signing-with-kmm.adoc
+++ b/modules/kmm-using-signing-with-kmm.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 On Secure Boot-enabled {product-title} systems, out-of-tree kernel modules must be signed with keys enrolled in the Machine Owner's Key (MOK) database. For kernel modules built out of tree, KMM supports signing kmods through the `sign` section of the kernel mapping in a `Module` custom resource.
 
-For more details on using Secure Boot, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair]
+For more details on using Secure Boot, see "Generating a public and private key pair".
 
 [id="kmm-using-signing-with-kmm-prerequisites_{context}"]
 == Prerequisites
@@ -17,3 +17,8 @@ For more details on using Secure Boot, see link:https://access.redhat.com/docume
 * A public private key pair in the correct (DER) format.
 * At least one secure-boot enabled node with the public key enrolled in its MOK database.
 * Either a pre-built driver container image, or the source code and Dockerfile needed to build one in-cluster.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair]


### PR DESCRIPTION
## Summary
Fixes remaining AsciiDocDITA issues for KMM ([OSDOCS-18372](https://redhat.atlassian.net/browse/OSDOCS-18372)): RelatedLinks prose, TaskContents (`.Procedure` / content-type corrections), BlockTitle lead-in, and ConceptLink relocation of a Secure Boot `link:`.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-18372

## Versions
4.20+

## Merge order
Independent branch from main (other-vale only). Preferred merge after #117165 (abstracts) and #117166 (callouts) if same-file conflicts; rebase if needed. Note: `kmm-hub-using-the-managedclustermodule.adoc` also appears in the callouts PR.

## Files changed
- `hardware_enablement/kmm-kernel-module-management.adoc`
- `modules/kmm-hub-installing-kmm-hub-olm.adoc`
- `modules/kmm-hub-installing-kmm-hub.adoc`
- `modules/kmm-hub-using-the-managedclustermodule.adoc`
- `modules/kmm-must-gather-tool.adoc`
- `modules/kmm-running-depmod.adoc`
- `modules/kmm-using-signing-with-kmm.adoc`

## Vale rules addressed
- AsciiDocDITA.RelatedLinks
- AsciiDocDITA.TaskContents
- AsciiDocDITA.BlockTitle
- AsciiDocDITA.ConceptLink

## Notes
- CQA 2.0 DITA pre-migration (AsciiDocDITA scope only)
- Does not include RedHat style-guide fixes unless noted
- Changed `kmm-hub-installing-kmm-hub` and `kmm-must-gather-tool` from PROCEDURE to CONCEPT (no steps); `ManagedClusterModule` CRD topic to REFERENCE

Made with [Cursor](https://cursor.com)