### PR TITLE
CNV#93735: Add procedure to update VirtIO drivers and guest agent

### DIFF
--- a/modules/virt-downloading-virtio-win-iso.adoc
+++ b/modules/virt-downloading-virtio-win-iso.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
+// * virt/managing_vms/virt-update-virtio-drivers.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-downloading-virtio-win-iso_{context}"]

--- a/modules/virt-updating-virtio-drivers-guest-agent-windows.adoc
+++ b/modules/virt-updating-virtio-drivers-guest-agent-windows.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-update-virtio-drivers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-updating-virtio-drivers-guest-agent-windows_{context}"]
+= Update VirtIO drivers and the guest agent on a Windows VM
+
+[role="_abstract"]
+You can update the VirtIO drivers and the QEMU guest agent on a Windows virtual machine (VM) by using the `virtio-win` guest tools installer. This method updates both the drivers and the guest agent in one step.
+
+.Prerequisites
+
+* The `container-native-virtualization/virtio-win` container disk must be attached to the VM as a SATA CD drive. You can mount the disk from the web console by selecting the *Mount Windows drivers disk* checkbox on the *Configuration* -> *Storage* tab.
+
+.Procedure
+
+. Start the VM and connect to a graphical console.
+. Log in to the Windows guest operating system.
+. Open *File Explorer* and navigate to the `virtio-win` CD drive.
+. Double-click the `virtio-win-gt-x64` installer to launch the guest tools setup wizard.
+. Follow the prompts in the setup wizard. The default options update the VirtIO drivers and the QEMU guest agent.
+. After the update is complete, click *Finish*.
+. Reboot the VM.
+
+.Verification
+
+. On the Windows VM, navigate to *Device Manager*.
+. Select a device.
+. Select the *Driver* tab.
+. Click *Driver Details* and confirm that the `virtio` driver details displays the correct version.

--- a/virt/managing_vms/virt-update-virtio-drivers.adoc
+++ b/virt/managing_vms/virt-update-virtio-drivers.adoc
@@ -7,8 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Update VirtIO drivers in guest operating systems. Using the latest VirtIO drivers increases performance and stability.
+Update VirtIO drivers and the QEMU guest agent in guest operating systems. Using the latest VirtIO drivers increases performance and stability.
 
+include::modules/virt-downloading-virtio-win-iso.adoc[leveloffset=+1]
+include::modules/virt-updating-virtio-drivers-guest-agent-windows.adoc[leveloffset=+1]
 include::modules/virt-updating-red-hat-virtio-drivers-windows.adoc[leveloffset=+1]
 include::modules/virt-updating-virtio-drivers-windows.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[CNV-93735](https://redhat.atlassian.net/browse/CNV-93735)

Link to docs preview:

- https://117194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-update-virtio-drivers.html#virt-downloading-virtio-win-iso_virt-update-virtio-drivers
- https://117194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-update-virtio-drivers.html#virt-updating-virtio-drivers-guest-agent-windows_virt-update-virtio-drivers
- https://117194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-update-virtio-drivers.html#virt-updating-red-hat-virtio-drivers-windows_virt-update-virtio-drivers
- https://117194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-update-virtio-drivers.html#virt-updating-virtio-drivers-windows_virt-update-virtio-drivers

QE review:
- [x] QE has approved this change.

Additional information:
Document an additional method for updating VirtIO drivers that also updates the QEMU guest agent.

- Created new procedure module for updating VirtIO drivers and the QEMU guest agent by using the virtio-win guest tools installer (mount container disk, run virtio-win-gt-x64)
- Added the virtio-win ISO download procedure to the update assembly so users can also download the ISO from the web console
- Updated the assembly abstract to mention the QEMU guest agent
- Added the new modules as includes in the update assembly, before the existing WUS and GPO modules