### PR TITLE
CNV#92962: Add tip for checking VirtIO driver versions

### DIFF
--- a/modules/virt-updating-virtio-drivers-windows.adoc
+++ b/modules/virt-updating-virtio-drivers-windows.adoc
@@ -31,3 +31,8 @@ If you restrict the WUS to only allow drivers explicitly signed and published by
 . Select a device.
 . Select the *Driver* tab.
 . Click *Driver Details* and confirm that the `virtio` driver details displays the correct version.
+
+[TIP]
+====
+To view the individual driver versions included in the `virtio-win` container disk, open the `release-drivers-versions.txt` file at the root of the `virtio-win` CD drive.
+====


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/CNV-92962

Link to docs preview:
https://117198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-update-virtio-drivers.html#virt-updating-virtio-drivers-windows_virt-update-virtio-drivers

QE review:
- [x] QE has approved this change.

Additional information:
Adds a tip pointing users to the release-drivers-versions.txt file for checking individual VirtIO driver versions.

- Added a tip to the VirtIO driver update verification section because there was no public documentation telling users where to find the package-to-driver-version mapping (the file ships at the root of the virtio-win ISO)