### PR TITLE
OSDOCS-16919: CQA fixes for developer perspective/catalog customizati…

### DIFF
--- a/modules/odc-customizing-a-perspective-using-YAML-view.adoc
+++ b/modules/odc-customizing-a-perspective-using-YAML-view.adoc
@@ -7,7 +7,7 @@
 = Customizing a perspective using YAML view
 
 [role="_abstract"]
-You can customize the visibility of a perspective in the web console by using the YAML view.
+You can customize a perspective by editing the console resource YAML content.
 
 .Prerequisites
 * You must have administrator privileges.

--- a/modules/odc-customizing-a-perspective-using-form-view.adoc
+++ b/modules/odc-customizing-a-perspective-using-form-view.adoc
@@ -7,7 +7,7 @@
 = Customizing a perspective using form view
 
 [role="_abstract"]
-You can customize the visibility of a perspective in the web console by using the form view.
+You can customize a perspective by using the form view of the console resource.
 
 .Prerequisites
 * You must have administrator privileges.

--- a/modules/odc-customizing-user-perspectives.adoc
+++ b/modules/odc-customizing-user-perspectives.adoc
@@ -7,9 +7,7 @@
 = Customizing user perspectives
 
 [role="_abstract"]
-As a cluster administrator, you can show or hide {product-title} web console perspectives, such as *Administrator* and *Developer*, for all users or for a specific user role. This lets you limit each user's view to only the perspectives and cluster resources that are relevant to their role.
-
-By default, the web console provides the *Administrator* and *Developer* perspectives, though more might be available depending on installed console plugins. For example, you can hide the *Administrator* perspective from unprivileged users so that they cannot manage cluster resources, users, and projects, or show the *Developer* perspective to users with the developer role so that they can create, deploy, and monitor applications.
+As a cluster administrator, you can show or hide web console perspectives for all users or for a specific user role, ensuring users see only the perspectives relevant to their role and tasks. For example, you can hide the *Administrator* perspective from users without administrative access.
 
 You can also customize the perspective visibility for users based on role-based access control (RBAC). For example, if you customize a perspective for monitoring purposes, which requires specific permissions, you can define that the perspective is visible only to users with required permissions.
 

--- a/modules/odc_con_example-yaml-file-changes.adoc
+++ b/modules/odc_con_example-yaml-file-changes.adoc
@@ -8,7 +8,7 @@
 = Example YAML file changes
 
 [role="_abstract"]
-You can dynamically add the following snippets in the YAML editor for customizing a developer catalog.
+You can customize a developer catalog by dynamically editing YAML content in the YAML editor.
 
 Use the following snippet to display all the sub-catalogs by setting the _state_ type to *Enabled*.
 [source,yaml]

--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -71,10 +71,10 @@ include::modules/odc_con_customizing-a-developer-catalog-or-its-sub-catalogs.ado
 // Hiding in ROSA/OSD, as Hive overwrites changes to console config
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-yaml-view.adoc[leveloffset=+2]
 
-// Hiding in ROSA/OSD, as dedicated-admins do not have sufficient permissions to read any cluster configuration
-include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc[leveloffset=+2]
-
 // Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "consoles"
 include::modules/odc_con_example-yaml-file-changes.adoc[leveloffset=+3]
+
+// Hiding in ROSA/OSD, as dedicated-admins do not have sufficient permissions to read any cluster configuration
+include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc[leveloffset=+2]
 
 endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
…on docs

Split out of PR #115956 (too large for review, per skopacz1's request) into a single-purpose subset: content-type/abstract and Vale fixes for the developer-perspective and developer-catalog customization modules.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+ (CQA)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
