### PR TITLE
OCPDOCS CQA MACH-6: CPMSO Provider Configurations and Health Checks Redux

### DIFF
--- a/machine_management/deploying-machine-health-checks.adoc
+++ b/machine_management/deploying-machine-health-checks.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure and deploy a machine health check to automatically repair damaged machines in a machine pool.
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
@@ -20,8 +21,12 @@ include::modules/machine-health-checks-about.adoc[leveloffset=+1]
 
 include::modules/machine-health-checks-resource.adoc[leveloffset=+1]
 
+include::modules/machine-health-checks-short-circuiting.adoc[leveloffset=+2]
+
 include::modules/machine-health-checks-creating.adoc[leveloffset=+1]
 
-You can configure and deploy a machine health check to detect and repair unhealthy bare metal nodes.
-
 include::modules/mgmt-power-remediation-baremetal-about.adoc[leveloffset=+1]
+
+include::modules/mgmt-power-remediation-baremetal-about-creating-mhc-baremetal.adoc[leveloffset=+2]
+
+include::modules/mgmt-power-remediation-baremetal-about-troubleshooting.adoc[leveloffset=+2]

--- a/modules/cpms-changing-openstack-flavor-type.adoc
+++ b/modules/cpms-changing-openstack-flavor-type.adoc
@@ -5,6 +5,7 @@
 [id="cpms-changing-openstack-flavor-type_{context}"]
 = Changing the {rh-openstack} compute flavor by using a control plane machine set
 
+[role="_abstract"]
 You can change the {rh-openstack-first} compute service (Nova) flavor that your control plane machines use by updating the specification in the control plane machine set custom resource.
 
 In {rh-openstack}, flavors define the compute, memory, and storage capacity of computing instances. By increasing or decreasing the flavor size, you can scale your control plane vertically.
@@ -22,10 +23,13 @@ In {rh-openstack}, flavors define the compute, memory, and storage capacity of c
 providerSpec:
   value:
 # ...
-    flavor: m1.xlarge <1>
+    flavor: m1.xlarge
 ----
-<1> Specify a {rh-openstack} flavor type that has the same base as the existing selection. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`. You can choose larger or smaller flavors depending on your vertical scaling needs.
++
+where:
+
+providerSpec.value.flavor:: Specify a {rh-openstack} flavor type that has the same base as the existing selection. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`. You can choose larger or smaller flavors depending on your vertical scaling needs.
 
 . Save your changes.
-
++
 After you save your changes, machines are replaced with ones that use the flavor you chose.

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -3,12 +3,12 @@
 // * machine_management/deploying-machine-health-checks.adoc
 // * post_installation_configuration/node-tasks.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="machine-health-checks-resource_{context}"]
-= Sample MachineHealthCheck resource
+= About the MachineHealthCheck custom resource
 
 [role="_abstract"]
-You can use the sample `MachineHealthCheck` resource to configure health criteria, remediation limits, and startup timeouts for machines in a targeted pool.
+You control how a machine health check remediates unhealthy machines by using a `MachineHealthCheck` custom resource (CR) to configure health criteria, remediation limits, and startup timeouts for machines in a targeted pool.
 
 The `MachineHealthCheck` resource for all cloud-based installation types, and other than bare metal, resembles the following YAML file:
 
@@ -17,85 +17,38 @@ The `MachineHealthCheck` resource for all cloud-based installation types, and ot
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineHealthCheck
 metadata:
-  name: example <1>
+  name: example
   namespace: openshift-machine-api
 spec:
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-machine-role: <role> <2>
-      machine.openshift.io/cluster-api-machine-type: <role> <2>
-      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone> <3>
+      machine.openshift.io/cluster-api-machine-role: <role>
+      machine.openshift.io/cluster-api-machine-type: <role>
+      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
   unhealthyConditions:
   - type:    "Ready"
-    timeout: "300s" <4>
+    timeout: "300s"
     status: "False"
   - type:    "Ready"
-    timeout: "300s" <4>
+    timeout: "300s"
     status: "Unknown"
-  maxUnhealthy: "40%" <5>
-  nodeStartupTimeout: "10m" <6>
+  maxUnhealthy: "40%"
+  nodeStartupTimeout: "10m"
 ----
-<1> Specify the name of the machine health check to deploy.
-<2> Specify a label for the machine pool that you want to check.
-<3> Specify the machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
-<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
-<5> Specify the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
-<6> Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
+where:
+
+--
+`metadata.name`:: Specifies the name of the machine health check to deploy.
+`spec.selector.matchLabels`:: Specifies the machine pool and machine set to check by adding labels:
+* `machine.openshift.io/cluster-api-machine-role`: Specifies a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machine-type`: Specifies a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machineset`: Specifies the machine set to track in the `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
+`spec.unhealthyConditions.timeout`:: Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
+`spec.maxUnhealthy`:: Specifies the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
+`spec.nodeStartupTimeout`:: Specifies the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
+--
 
 [NOTE]
 ====
 The `matchLabels` are examples only; you must map your machine groups based on your specific needs.
-====
-
-[id="machine-health-checks-short-circuiting_{context}"]
-== Short-circuiting machine health check remediation
-
-Short-circuiting ensures that machine health checks remediate machines only when the cluster is healthy.
-Short-circuiting is configured through the `maxUnhealthy` field in the `MachineHealthCheck` resource.
-
-If the user defines a value for the `maxUnhealthy` field, before remediating any machines, the `MachineHealthCheck` compares the value of `maxUnhealthy` with the number of machines within its target pool that it has determined to be unhealthy. Remediation is not performed if the number of unhealthy machines exceeds the `maxUnhealthy` limit.
-
-[IMPORTANT]
-====
-If `maxUnhealthy` is not set, the value defaults to `100%` and the machines are remediated regardless of the state of the cluster.
-====
-
-The appropriate `maxUnhealthy` value depends on the scale of the cluster you deploy and how many machines the `MachineHealthCheck` covers. For example, you can use the `maxUnhealthy` value to cover multiple compute machine sets across multiple availability zones so that if you lose an entire zone, your `maxUnhealthy` setting prevents further remediation within the cluster. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
-
-[IMPORTANT]
-====
-If you configure a `MachineHealthCheck` resource for the control plane, set the value of `maxUnhealthy` to `1`.
-
-This configuration ensures that the machine health check takes no action when multiple control plane machines appear to be unhealthy. Multiple unhealthy control plane machines can indicate that the etcd cluster is degraded or that a scaling operation to replace a failed machine is in progress.
-
-If the etcd cluster is degraded, manual intervention might be required. If a scaling operation is in progress, the machine health check should allow it to finish.
-====
-
-The `maxUnhealthy` field can be set as either an integer or percentage.
-There are different remediation implementations depending on the `maxUnhealthy` value.
-
-=== Setting maxUnhealthy by using an absolute value
-
-If `maxUnhealthy` is set to `2`:
-
-* Remediation will be performed if 2 or fewer nodes are unhealthy
-* Remediation will not be performed if 3 or more nodes are unhealthy
-
-These values are independent of how many machines are being checked by the machine health check.
-
-=== Setting maxUnhealthy by using percentages
-
-If `maxUnhealthy` is set to `40%` and there are 25 machines being checked:
-
-* Remediation will be performed if 10 or fewer nodes are unhealthy
-* Remediation will not be performed if 11 or more nodes are unhealthy
-
-If `maxUnhealthy` is set to `40%` and there are 6 machines being checked:
-
-* Remediation will be performed if 2 or fewer nodes are unhealthy
-* Remediation will not be performed if 3 or more nodes are unhealthy
-
-[NOTE]
-====
-The allowed number of machines is rounded down when the percentage of `maxUnhealthy` machines that are checked is not a whole number.
 ====

--- a/modules/machine-health-checks-short-circuiting.adoc
+++ b/modules/machine-health-checks-short-circuiting.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * machine_management/deploying-machine-health-checks.adoc
+// * post_installation_configuration/node-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="machine-health-checks-short-circuiting_{context}"]
+= About short-circuiting machine health check remediation
+
+[role="_abstract"]
+You can use machine health check short-circuiting to ensure that machine health checks remediate machines only when the cluster is healthy, by configuring the `maxUnhealthy` field in the `MachineHealthCheck` resource.
+
+If you define a value for the `maxUnhealthy` field, before remediating any machines, the `MachineHealthCheck` compares the value of `maxUnhealthy` with the number of machines within its target pool that it has determined to be unhealthy. Remediation is not performed if the number of unhealthy machines exceeds the `maxUnhealthy` limit.
+
+[IMPORTANT]
+====
+If `maxUnhealthy` is not set, the value defaults to `100%` and the machines are remediated regardless of the state of the cluster.
+====
+
+The appropriate `maxUnhealthy` value depends on the scale of the cluster you deploy and how many machines the `MachineHealthCheck` covers. For example, you can use the `maxUnhealthy` value to cover multiple compute machine sets across multiple availability zones so that if you lose an entire zone, your `maxUnhealthy` setting prevents further remediation within the cluster. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
+
+[IMPORTANT]
+====
+If you configure a `MachineHealthCheck` resource for the control plane, set the value of `maxUnhealthy` to `1`.
+
+This configuration ensures that the machine health check takes no action when multiple control plane machines appear to be unhealthy. Multiple unhealthy control plane machines can indicate that the etcd cluster is degraded or that a scaling operation to replace a failed machine is in progress.
+
+If the etcd cluster is degraded, manual intervention might be required. If a scaling operation is in progress, the machine health check should allow it to finish.
+====
+
+The `maxUnhealthy` field can be set as either an integer or percentage.
+There are different remediation implementations depending on the `maxUnhealthy` value.
+
+Setting maxUnhealthy by using an absolute value::
+If `maxUnhealthy` is set to `2`:
++
+--
+* Remediation will be performed if 2 or fewer nodes are unhealthy
+* Remediation will not be performed if 3 or more nodes are unhealthy
+--
++
+These values are independent of how many machines are being checked by the machine health check.
+
+Setting maxUnhealthy by using percentages::
+If `maxUnhealthy` is set to `40%` and there are 25 machines being checked:
++
+--
+* Remediation will be performed if 10 or fewer nodes are unhealthy
+* Remediation will not be performed if 11 or more nodes are unhealthy
+--
++
+If `maxUnhealthy` is set to `40%` and there are 6 machines being checked:
++
+--
+* Remediation will be performed if 2 or fewer nodes are unhealthy
+* Remediation will not be performed if 3 or more nodes are unhealthy
+--
++
+[NOTE]
+====
+The allowed number of machines is rounded down when the percentage of `maxUnhealthy` machines that are checked is not a whole number.
+====

--- a/modules/machineset-vsphere-multiple-nics.adoc
+++ b/modules/machineset-vsphere-multiple-nics.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * machine_management/creating_machinesets/creating-machineset-vsphere.adoc

--- a/modules/mgmt-power-remediation-baremetal-about-creating-mhc-baremetal.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about-creating-mhc-baremetal.adoc
@@ -1,0 +1,136 @@
+// Module included in the following assemblies:
+
+// * machine_management/deploying-machine-health-checks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mgmt-power-remediation-baremetal-about-creating-mhc-baremetal_{context}"]
+= Creating a MachineHealthCheck resource for bare metal
+
+[role="_abstract"]
+You control how a machine health check remediates unhealthy machines by using a `MachineHealthCheck` resource to configure health criteria, remediation limits, and startup timeouts for machines in a targeted pool.
+
+.Prerequisites
+
+* The {product-title} is installed using installer-provisioned infrastructure.
+* Access to Baseboard Management Controller (BMC) credentials or BMC access to each node.
+* Network access to the BMC interface of the unhealthy node.
+* For a metal3-based remediation, a `Metal3RemediationTemplate` resource must exist.
++
+.Sample `Metal3RemediationTemplate` resource for bare metal, metal3-based remediation
+[source,yaml]
+----
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3RemediationTemplate
+metadata:
+  name: metal3-remediation-template
+  namespace: openshift-machine-api
+spec:
+  template:
+    spec:
+      strategy:
+        type: Reboot
+        retryLimit: 1
+        timeout: 5m0s
+----
+
+.Procedure
+
+. Create a `healthcheck.yaml` file that contains the definition of your machine health check.
++
+.Sample `MachineHealthCheck` resource for bare metal, annotation-based remediation
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: example
+  namespace: openshift-machine-api
+  annotations:
+    machine.openshift.io/remediation-strategy: external-baremetal
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-machine-role: <role>
+      machine.openshift.io/cluster-api-machine-type: <role>
+      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
+  unhealthyConditions:
+  - type:    "Ready"
+    timeout: "300s"
+    status: "False"
+  - type:    "Ready"
+    timeout: "300s"
+    status: "Unknown"
+  maxUnhealthy: "40%"
+  nodeStartupTimeout: "10m"
+----
++
+where
++
+--
+`metadata.name`:: Specify the name of the machine health check to deploy.
+`metadata.annotations`:: Specify the required annotation for the annotation-based remediation process.
++
+[IMPORTANT]
+====
+You must include the `machine.openshift.io/remediation-strategy: external-baremetal` annotation in the `annotations` section to enable annotation-based remediation. With this remediation strategy, unhealthy hosts are rebooted instead of removed from the cluster.
+====
+`spec.selector.matchLabels`:: Specify the machine pool and machine set to check by adding labels:
+* `machine.openshift.io/cluster-api-machine-role`: Specify a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machine-type`: Specify a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machineset`: Specify the machine set to track in the `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
+`spec.unhealthyConditions.timeout`:: Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
+`spec.maxUnhealthy`:: Specify the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
+`spec.nodeStartupTimeout`:: Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
+--
++
+.Sample `MachineHealthCheck` resource for bare metal, metal3-based remediation
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: example
+  namespace: openshift-machine-api
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-machine-role: <role>
+      machine.openshift.io/cluster-api-machine-type: <role>
+      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
+  remediationTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: Metal3RemediationTemplate
+    name: metal3-remediation-template
+    namespace: openshift-machine-api
+  unhealthyConditions:
+  - type:    "Ready"
+    timeout: "300s"
+----
++
+where:
++
+--
+`metadata.name`:: Specify the name of the machine health check to deploy.
+`spec.selector.matchLabels`:: Specify the machine pool and machine set to check by adding labels:
+* `machine.openshift.io/cluster-api-machine-role`: Specify a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machine-type`: Specify a label for the machine pool that you want to check.
+* `machine.openshift.io/cluster-api-machineset`: Specify the machine set to track in the `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
+`spec.remediationTemplate`:: Specify the metal3 remediation template to use. Provide the following information:
+* `apiVersion`. Specify the API version as `infrastructure.cluster.x-k8s.io/v1beta1`.
+* `kind`. Specify `Metal3RemediationTemplate`.
+* `name`. Specify the name of the template.
+* `namespace`. Specify the namespace of the template.
+`spec.unhealthyConditions.timeout`:: Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
+--
++
+[NOTE]
+====
+The `matchLabels` are examples only; you must map your machine groups based on your specific needs.
+====
+
+. Apply the `healthcheck.yaml` file to your cluster using the following command:
++
+[source,terminal]
+----
+$ oc apply -f healthcheck.yaml
+----

--- a/modules/mgmt-power-remediation-baremetal-about-troubleshooting.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about-troubleshooting.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+
+// * machine_management/deploying-machine-health-checks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mgmt-power-remediation-baremetal-about-troubleshooting_{context}"]
+= Troubleshooting issues with power-based remediation
+
+[role="_abstract"]
+To troubleshoot issues you are having with power-based remediation, check the connection to the Baseboard Management Controller (BMC).
+
+.Procedure 
+
+* Verify the following conditions:
+
+** You have access to the BMC.
+** The BMC is connected to the control plane node that is responsible for running the remediation task.

--- a/modules/mgmt-power-remediation-baremetal-about.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about.adoc
@@ -2,11 +2,14 @@
 
 // * machine_management/mgmt-power-remediation-baremetal
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="mgmt-power-remediation-baremetal-about_{context}"]
 = About power-based remediation of bare metal
 
-In a bare metal cluster, remediation of nodes is critical to ensuring the overall health of the cluster. Physically remediating a cluster can be challenging and any delay in putting the machine into a safe or an operational state increases the time the cluster remains in a degraded state, and the risk that subsequent failures might bring the cluster offline. Power-based remediation helps counter such challenges.
+[role="_abstract"]
+You can configure and deploy a machine health check to detect and repair unhealthy bare-metal nodes, which is critical to ensuring the overall health of the cluster. 
+
+Physically remediating a cluster can be challenging and any delay in putting the machine into a safe or an operational state increases the time the cluster remains in a degraded state, and the risk that subsequent failures might bring the cluster offline. Power-based remediation helps counter such challenges.
 
 Instead of reprovisioning the nodes, power-based remediation uses a power controller to power off an inoperable node. This type of remediation is also called power fencing.
 
@@ -19,7 +22,7 @@ Power-based remediation provides the following capabilities:
 * Reduces the downtime associated with recovering physical machines
 
 [id="mgmt-power-remediation-baremetal-about-health-checks_{context}"]
-== MachineHealthChecks on bare metal
+== About machine health checks on bare metal
 
 Machine deletion on bare metal cluster triggers reprovisioning of a bare metal host.
 Usually bare metal reprovisioning is a lengthy process, during which the cluster
@@ -33,149 +36,36 @@ There are two ways to change the default remediation process from machine deleti
 
 After using one of these methods, unhealthy machines are power-cycled by using Baseboard Management Controller (BMC) credentials.
 
-[id="mgmt-power-remediation-baremetal-about-understanding-remediation-process_{context}"]
-== Understanding the annotation-based remediation process
-
-The remediation process operates as follows:
-
+About the annotation-based remediation process::
+The annotation-based remediation process performs the following steps:
++
+--
 . The MachineHealthCheck (MHC) controller detects that a node is unhealthy.
 . The MHC notifies the bare metal machine controller which requests to power-off the unhealthy node.
 . After the power is off, the node is deleted, which allows the cluster to reschedule the affected workload on other nodes.
 . The bare metal machine controller requests to power on the node.
 . After the node is up, the node re-registers itself with the cluster, resulting in the creation of a new node.
 . After the node is recreated, the bare metal machine controller restores the annotations and labels that existed on the unhealthy node before its deletion.
-
+--
++
 [NOTE]
 ====
 If the power operations did not complete, the bare metal machine controller triggers the reprovisioning of the unhealthy node unless this is a control plane node or a node that was provisioned externally.
 ====
 
-[id="mgmt-power-remediation-baremetal-about-understanding-metal3-remediation-process_{context}"]
-== Understanding the metal3-based remediation process
-
-The remediation process operates as follows:
-
+About the metal3-based remediation process::
+The metal3-based remediation process performs the following steps:
++
+--
 . The MachineHealthCheck (MHC) controller detects that a node is unhealthy.
 . The MHC creates a metal3 remediation custom resource for the metal3 remediation controller, which requests to power-off the unhealthy node.
 . After the power is off, the node is deleted, which allows the cluster to reschedule the affected workload on other nodes.
 . The metal3 remediation controller requests to power on the node.
 . After the node is up, the node re-registers itself with the cluster, resulting in the creation of a new node.
 . After the node is recreated, the metal3 remediation controller restores the annotations and labels that existed on the unhealthy node before its deletion.
-
+--
++
 [NOTE]
 ====
 If the power operations did not complete, the metal3 remediation controller triggers the reprovisioning of the unhealthy node unless this is a control plane node or a node that was provisioned externally.
 ====
-
-[id="mgmt-power-remediation-baremetal-about-creating-mhc-baremetal_{context}"]
-== Creating a MachineHealthCheck resource for bare metal
-
-.Prerequisites
-
-* The {product-title} is installed using installer-provisioned infrastructure (IPI).
-* Access to BMC credentials (or BMC access to each node).
-* Network access to the BMC interface of the unhealthy node.
-
-.Procedure
-
-. Create a `healthcheck.yaml` file that contains the definition of your machine health check.
-
-. Apply the `healthcheck.yaml` file to your cluster using the following command:
-+
-[source,terminal]
-----
-$ oc apply -f healthcheck.yaml
-----
-
-.Sample `MachineHealthCheck` resource for bare metal, annotation-based remediation
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: example <1>
-  namespace: openshift-machine-api
-  annotations:
-    machine.openshift.io/remediation-strategy: external-baremetal <2>
-spec:
-  selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-machine-role: <role> <3>
-      machine.openshift.io/cluster-api-machine-type: <role> <3>
-      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone> <4>
-  unhealthyConditions:
-  - type:    "Ready"
-    timeout: "300s" <5>
-    status: "False"
-  - type:    "Ready"
-    timeout: "300s" <5>
-    status: "Unknown"
-  maxUnhealthy: "40%" <6>
-  nodeStartupTimeout: "10m" <7>
-----
-<1> Specify the name of the machine health check to deploy.
-<2> For bare metal clusters, you must include the `machine.openshift.io/remediation-strategy: external-baremetal` annotation in the `annotations` section to enable power-cycle remediation. With this remediation strategy, unhealthy hosts are rebooted instead of removed from the cluster.
-<3> Specify a label for the machine pool that you want to check.
-<4> Specify the compute machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
-<5> Specify the timeout duration for the node condition. If the condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
-<6> Specify the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
-<7> Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
-
-[NOTE]
-====
-The `matchLabels` are examples only; you must map your machine groups based on your specific needs.
-====
-
-.Sample `MachineHealthCheck` resource for bare metal, metal3-based remediation
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: example
-  namespace: openshift-machine-api
-spec:
-  selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-machine-role: <role>
-      machine.openshift.io/cluster-api-machine-type: <role>
-      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
-  remediationTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3RemediationTemplate
-    name: metal3-remediation-template
-    namespace: openshift-machine-api
-  unhealthyConditions:
-  - type:    "Ready"
-    timeout: "300s"
-----
-
-.Sample `Metal3RemediationTemplate` resource for bare metal, metal3-based remediation
-[source,yaml]
-----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Metal3RemediationTemplate
-metadata:
-  name: metal3-remediation-template
-  namespace: openshift-machine-api
-spec:
-  template:
-    spec:
-      strategy:
-        type: Reboot
-        retryLimit: 1
-        timeout: 5m0s
-----
-
-[NOTE]
-====
-The `matchLabels` are examples only; you must map your machine groups based on your specific needs. The `annotations` section does not apply to metal3-based remediation. Annotation-based remediation and metal3-based remediation are mutually exclusive.
-====
-
-[id="mgmt-power-remediation-baremetal-about-troubleshooting_{context}"]
-== Troubleshooting issues with power-based remediation
-
-To troubleshoot an issue with power-based remediation, verify the following:
-
-* You have access to the BMC.
-* BMC is connected to the control plane node that is responsible for running the remediation task.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -65,6 +65,8 @@ include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 
 include::modules/machine-health-checks-resource.adoc[leveloffset=+2]
 
+include::modules/machine-health-checks-short-circuiting.adoc[leveloffset=+2]
+
 include::modules/machine-health-checks-creating.adoc[leveloffset=+2]
 
 include::modules/machineset-manually-scaling.adoc[leveloffset=+2]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-17046

Previews:
[Deploying machine health checks](https://117206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks) -- Updated entire assembly.
[Changing the RHOSP compute flavor by using a control plane machine set](https://117206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.html#cpms-changing-openstack-flavor-type_cpmso-supported-features-openstack) -- Updated module.
[Configuring multiple network interface controllers by using machine sets](https://117206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere#machineset-vsphere-multiple-nics_creating-machineset-vsphere) -- Updated module
