### PR TITLE
[DRAFT - NO MERGE] Add installation docs for OpenShift on Google Cloud Dedicated

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -295,6 +295,8 @@ endif::[]
 :gcp-first: Google Cloud
 :gcp-full: Google Cloud
 :gcp-short: Google Cloud
+// Google Cloud Dedicated (sovereign cloud)
+:gcp-dedicated: Google Cloud Dedicated
 // IBM general
 :ibm-name: IBM(R)
 :ibm-title: IBM

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -335,6 +335,8 @@ Topics:
     File: installing-gcp-shared-vpc
   - Name: Installing a private cluster on Google Cloud
     File: installing-gcp-private
+  - Name: Installing a cluster on Google Cloud into a sovereign cloud region
+    File: installing-gcp-sovereign-cloud
   - Name: Installing a cluster on Google Cloud using Infrastructure Manager templates
     File: installing-gcp-user-infra
   - Name: Installing a cluster into a shared VPC on Google Cloud using Infrastructure Manager templates

--- a/installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+++ b/installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
@@ -1,0 +1,82 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-gcp-sovereign-cloud"]
+= Installing a cluster on {gcp-short} into a sovereign cloud region
+include::_attributes/common-attributes.adoc[]
+:context: installing-gcp-sovereign-cloud
+
+toc::[]
+
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on a Google Cloud Dedicated (GCD) sovereign cloud region. GCD is a fully isolated cloud environment that provides Google Cloud technology with strict data and operational sovereignty guarantees.
+
+To configure the sovereign cloud region, you modify parameters in the `install-config.yaml` file before you install the cluster.
+
+:FeatureName: Installing a cluster on {gcp-short} into a sovereign cloud region
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-about-sovereign-cloud.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-sovereign-cloud-limitations.adoc[leveloffset=+1]
+
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
+* You have a GCD service account credential file that includes the `universe_domain` field for your sovereign cloud region.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to, including the GCD API endpoints for your region.
+
+include::modules/installation-gcp-sovereign-cloud-prerequisites.adoc[leveloffset=+1]
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-config-parameters-gcp[Installation configuration parameters for {gcp-short}]
+
+include::modules/installation-gcp-sovereign-cloud-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
+include::modules/installation-gcp-sovereign-cloud-machine-types.adoc[leveloffset=+2]
+
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+[id="installing-gcp-sovereign-cloud-manual-modes_{context}"]
+== Alternatives to storing administrator-level secrets in the kube-system project
+
+By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
+
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-sovereign-cloud.adoc#manually-create-iam_installing-gcp-sovereign-cloud[Manually creating long-term credentials].
+
+//Manually creating long-term credentials
+include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
+
+[id="next-steps_{context}"]
+== Next steps
+
+* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation].
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_gcp/preparing-to-install-on-gcp.adoc
+++ b/installing/installing_gcp/preparing-to-install-on-gcp.adoc
@@ -42,6 +42,8 @@ You can install a cluster on {gcp-short} infrastructure that is provisioned by t
 
 * **xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing {gcp-short} VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
 
+* **xref:../../installing/installing_gcp/installing-gcp-sovereign-cloud.adoc#installing-gcp-sovereign-cloud[Installing a cluster on {gcp-short} into a sovereign cloud region]**: You can install {product-title} on a Google Cloud Dedicated (GCD) sovereign cloud region. GCD is a fully isolated cloud environment with strict data and operational sovereignty guarantees. This feature is a Technology Preview feature.
+
 [id="choosing-an-method-to-install-ocp-on-gcp-user-provisioned"]
 === Installing a cluster on user-provisioned infrastructure
 

--- a/modules/installation-gcp-about-sovereign-cloud.adoc
+++ b/modules/installation-gcp-about-sovereign-cloud.adoc
@@ -45,7 +45,7 @@ The following constraints apply when you install {product-title} on a GCD sovere
 
 * Only the `hyperdisk-balanced` disk type is available. Other disk types such as `pd-ssd`, Persistent Disk, and Local SSD are not available.
 
-* The {op-system-first} image is not pre-published in GCD regions. The installer automatically downloads and uploads the {op-system} image during installation. Internet access is required for this process.
+* The {op-system-first} image is not pre-published in GCD regions. You must upload a custom {op-system} image to your GCD project and specify it in the `install-config.yaml` file.
 
 * Only private DNS zones are supported. You must set the `publish` parameter to `Internal` in the `install-config.yaml` file.
 

--- a/modules/installation-gcp-about-sovereign-cloud.adoc
+++ b/modules/installation-gcp-about-sovereign-cloud.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-about-sovereign-cloud_{context}"]
+= {gcp-short} sovereign cloud regions
+
+Google Cloud Dedicated (GCD) is a sovereign cloud platform that provides Google Cloud technology and services in a fully isolated environment with strict data and operational sovereignty guarantees. GCD operates as a separate universe from public Google Cloud, with its own networking, API endpoints, and management infrastructure completely disconnected from public Google Cloud.
+
+{product-title} supports deploying clusters to GCD sovereign cloud regions by using installer-provisioned infrastructure.
+
+[NOTE]
+====
+The GCD sovereign cloud region cannot be selected by using the guided terminal prompts from the installation program. You must define the region and other GCD-specific parameters manually in the `install-config.yaml` file.
+====
+
+[id="gcp-sovereign-cloud-key-differences_{context}"]
+== Key differences from public {gcp-short}
+
+GCD regions differ from public {gcp-short} in several ways that affect {product-title} installation and operation:
+
+Single region per universe:: Each GCD deployment operates as a single region. Multi-region features such as cross-region load balancing and multi-region storage are not available. You must use multiple zones within the single region for high availability.
+
+Different API endpoints:: GCD uses API endpoints in the format `<service>.apis-<region-host>.goog` instead of `<service>.googleapis.com`. For example, the Berlin region uses `compute.apis-berlin-build0.goog` instead of `compute.googleapis.com`.
+
+Domain-scoped project IDs:: All GCD project IDs carry a mandatory prefix, such as `eu0:`. For example, a project named `my-project` has the project ID `eu0:my-project`. You must include this prefix in all commands and configuration.
+
+Different service account email format:: Service account email addresses use GCD-specific domains. User-managed service accounts use the format `<name>@<project-name>.<prefix>.iam.gserviceaccount.com`. For example, `my-sa@my-project.eu0.iam.gserviceaccount.com`.
+
+Limited service availability:: Only a subset of Google Cloud services is available. Older Compute Engine machine types, ARM-based instances, TPUs, and several other services are not available.
+
+No Cloud Identity:: GCD does not support Google Accounts or Google Groups for identity management. Authentication must use Workforce Identity Federation with an external identity provider (IdP) or service accounts.
+
+No default VPC:: A default VPC network is not automatically created for new projects. You must create or configure a VPC explicitly.
+
+[id="gcp-sovereign-cloud-openshift-constraints_{context}"]
+== {product-title} constraints on GCD
+
+The following constraints apply when you install {product-title} on a GCD sovereign cloud region:
+
+* This feature is a Technology Preview feature. You must set the `featureSet` parameter to `TechPreviewNoUpgrade` in the `install-config.yaml` file.
+
+* Only the C3, M3, and A3 Edge machine series are available. The default instance type is `c3-standard-4`. Other series such as N2, E2, and T2A are not available.
+
+* Only the `hyperdisk-balanced` disk type is available. Other disk types such as `pd-ssd`, Persistent Disk, and Local SSD are not available.
+
+* The {op-system-first} image is not pre-published in GCD regions. The installer automatically downloads and uploads the {op-system} image during installation. Internet access is required for this process.
+
+* Only private DNS zones are supported. You must set the `publish` parameter to `Internal` in the `install-config.yaml` file.
+
+* Private Service Connect (PSC) endpoint overrides are not supported. Do not set the `platform.gcp.endpoint` field in the `install-config.yaml` file.
+
+* The universe domain from the GCD credentials is exposed on the `Infrastructure` custom resource (CR) at `status.platformStatus.gcp.universeDomain`. Cluster components use this value to determine the correct API endpoints.
+
+[id="gcp-sovereign-cloud-supported-regions_{context}"]
+== Supported GCD regions
+
+The following GCD sovereign cloud regions are supported for {product-title} installation:
+
+.GCD regions
+[cols="1,1,1",options="header"]
+|====
+|Region |Identifier |Zones
+
+|Berlin, Germany
+|`u-germany-northeast1`
+|`u-germany-northeast1-a`, `u-germany-northeast1-b`, `u-germany-northeast1-c`
+|====
+
+[NOTE]
+====
+Additional GCD regions may be supported in future releases. The architectural constraints described in this document, such as the single-region design, limited machine types, and different API endpoints, apply to all GCD regions.
+====

--- a/modules/installation-gcp-sovereign-cloud-config-yaml.adoc
+++ b/modules/installation-gcp-sovereign-cloud-config-yaml.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-gcp-sovereign-cloud-config-yaml_{context}"]
+= Sample install-config.yaml file for a GCD sovereign cloud region
+
+The following `install-config.yaml` file demonstrates the required configuration for installing {product-title} on a Google Cloud Dedicated (GCD) sovereign cloud region.
+
+[IMPORTANT]
+====
+This sample YAML file is provided for reference only. You must obtain your `install-config.yaml` file by using the installation program and modify it to include the GCD-specific parameters.
+====
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com <1>
+featureSet: TechPreviewNoUpgrade <2>
+controlPlane:
+  name: master
+  replicas: 3
+  platform:
+    gcp:
+      type: c3-standard-4 <3>
+      osDisk:
+        diskType: hyperdisk-balanced <4>
+        diskSizeGB: 128
+compute:
+- name: worker
+  replicas: 3
+  platform:
+    gcp:
+      type: c3-standard-4 <3>
+      osDisk:
+        diskType: hyperdisk-balanced <4>
+        diskSizeGB: 128
+metadata:
+  name: my-gcd-cluster
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  gcp:
+    projectID: eu0:my-project <5>
+    region: u-germany-northeast1 <6>
+publish: Internal <7>
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+----
+<1> The base domain of the cluster. This must correspond to a private DNS zone configured in your GCD project.
+<2> Required. GCD sovereign cloud support requires the `TechPreviewNoUpgrade` feature set.
+<3> A machine type from the C3, M3, or A3 Edge series. The default is `c3-standard-4`. Other series such as N2, E2, and T2A are not available in GCD.
+<4> The disk type. Only `hyperdisk-balanced` is available in GCD. If not specified, the installer defaults to `hyperdisk-balanced` for sovereign cloud installations.
+<5> The domain-scoped project ID for your GCD project. The project ID must include the prefix, such as `eu0:`.
+<6> The GCD region identifier. For the Berlin region, use `u-germany-northeast1`.
+<7> Required. GCD supports only private DNS zones. Set to `Internal` to use private API endpoints and application routes.

--- a/modules/installation-gcp-sovereign-cloud-config-yaml.adoc
+++ b/modules/installation-gcp-sovereign-cloud-config-yaml.adoc
@@ -50,7 +50,11 @@ platform:
   gcp:
     projectID: eu0:my-project <5>
     region: u-germany-northeast1 <6>
-publish: Internal <7>
+    defaultMachinePlatform:
+      osImage:
+        name: my-custom-rhcos <7>
+        project: eu0:my-image-project <8>
+publish: Internal <9>
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ----
@@ -60,4 +64,6 @@ sshKey: ssh-ed25519 AAAA...
 <4> The disk type. Only `hyperdisk-balanced` is available in GCD. If not specified, the installer defaults to `hyperdisk-balanced` for sovereign cloud installations.
 <5> The domain-scoped project ID for your GCD project. The project ID must include the prefix, such as `eu0:`.
 <6> The GCD region identifier. For the Berlin region, use `u-germany-northeast1`.
-<7> Required. GCD supports only private DNS zones. Set to `Internal` to use private API endpoints and application routes.
+<7> Required. The name of a custom {op-system} image that you uploaded to your GCD project. The {op-system} image is not pre-published in GCD regions.
+<8> Required. The GCD project that contains the custom {op-system} image.
+<9> Required. GCD supports only private DNS zones. Set to `Internal` to use private API endpoints and application routes.

--- a/modules/installation-gcp-sovereign-cloud-limitations.adoc
+++ b/modules/installation-gcp-sovereign-cloud-limitations.adoc
@@ -31,12 +31,10 @@ The following limitations apply to {product-title} clusters installed on Google 
 [id="gcp-sovereign-cloud-limitations-os-image_{context}"]
 == Operating system image
 
-The {op-system-first} image is not pre-published in GCD regions. The installer handles the image in one of the following ways:
+The {op-system-first} image is not pre-published in GCD regions. You must provide a custom OS image that has been uploaded to your GCD project.
 
-* **Automatic upload (default):** If you do not specify a custom OS image, the installer automatically downloads the {op-system} image from the internet and uploads it to your GCD project during installation. This process creates a temporary Cloud Storage bucket for staging and cleans up the staging resources after the image is created. Internet access is required for this process.
+Specify the OS image by using the `platform.gcp.defaultMachinePlatform.osImage` field or per-machine-pool `osImage` fields. You must provide both the `name` and `project` fields. The installation fails if these fields are not set.
 
-* **Custom image:** If you specify a custom OS image by using the `platform.gcp.defaultMachinePlatform.osImage` field or per-machine-pool `osImage` fields, you must provide both the `name` and `project` fields. The `project` field is required for sovereign cloud installations.
-+
 .Example custom OS image configuration
 [source,yaml]
 ----

--- a/modules/installation-gcp-sovereign-cloud-limitations.adoc
+++ b/modules/installation-gcp-sovereign-cloud-limitations.adoc
@@ -19,6 +19,15 @@ The following limitations apply to {product-title} clusters installed on Google 
 
 * ARM-based (aarch64) machine types and images are not available.
 
+[id="gcp-sovereign-cloud-limitations-storage_{context}"]
+== Storage
+
+* Because only the `hyperdisk-balanced` disk type is available in GCD, you must change the default storage class to use `hyperdisk-balanced` after installation. The default storage class provisioned by the installer uses `pd-ssd`, which is not available in GCD regions. For instructions on modifying storage classes, see the "GCE PersistentDisk (gcePD) object definition" section in _Dynamic provisioning_ in _Storage_.
+
+* Cloud Storage is available but limited to single-region buckets only. Dual-region, multi-region, and bucket relocation are not available.
+
+* Cloud Storage bucket locations must be set explicitly. There is no default bucket location in GCD.
+
 [id="gcp-sovereign-cloud-limitations-os-image_{context}"]
 == Operating system image
 

--- a/modules/installation-gcp-sovereign-cloud-limitations.adoc
+++ b/modules/installation-gcp-sovereign-cloud-limitations.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-gcp-sovereign-cloud-limitations_{context}"]
+= Limitations for {product-title} on GCD sovereign cloud regions
+
+The following limitations apply to {product-title} clusters installed on Google Cloud Dedicated (GCD) sovereign cloud regions.
+
+[id="gcp-sovereign-cloud-limitations-machine-disk_{context}"]
+== Machine types and disk types
+
+* Only the C3, M3, and A3 Edge machine series are available. The installer defaults to `c3-standard-4` for all machine pools. If you specify a machine type from an unavailable series, the installation fails.
+
+* Only the `hyperdisk-balanced` disk type is available. The installer defaults to `hyperdisk-balanced` for sovereign cloud installations. Other disk types such as `pd-ssd`, `pd-standard`, and Local SSD are not available.
+
+* The installer validates disk type availability against the GCD API on a per-zone basis. If a disk type is not available in the specified zones, the installation fails with an error indicating the unavailable zones.
+
+* ARM-based (aarch64) machine types and images are not available.
+
+[id="gcp-sovereign-cloud-limitations-os-image_{context}"]
+== Operating system image
+
+The {op-system-first} image is not pre-published in GCD regions. The installer handles the image in one of the following ways:
+
+* **Automatic upload (default):** If you do not specify a custom OS image, the installer automatically downloads the {op-system} image from the internet and uploads it to your GCD project during installation. This process creates a temporary Cloud Storage bucket for staging and cleans up the staging resources after the image is created. Internet access is required for this process.
+
+* **Custom image:** If you specify a custom OS image by using the `platform.gcp.defaultMachinePlatform.osImage` field or per-machine-pool `osImage` fields, you must provide both the `name` and `project` fields. The `project` field is required for sovereign cloud installations.
++
+.Example custom OS image configuration
+[source,yaml]
+----
+platform:
+  gcp:
+    defaultMachinePlatform:
+      osImage:
+        name: my-custom-rhcos
+        project: eu0:my-image-project
+----
+
+[id="gcp-sovereign-cloud-limitations-networking_{context}"]
+== Networking
+
+* Only private DNS zones are supported. Public DNS zones are not available in GCD. You must set the `publish` parameter to `Internal` in the `install-config.yaml` file.
+
+* Private Service Connect (PSC) endpoint overrides are not supported. Do not set the `platform.gcp.endpoint` field in the `install-config.yaml` file. PSC endpoint overrides generate URLs targeting the `googleapis.com` domain, which is not compatible with GCD sovereign cloud environments.
+
+* A default VPC network is not automatically created for new GCD projects. You must create or specify a VPC network before installation.
+
+[id="gcp-sovereign-cloud-limitations-identity_{context}"]
+== Identity and service accounts
+
+* Service account email addresses use a different domain format in GCD. For domain-scoped project IDs (for example, `eu0:my-project`), the installer generates service account emails in the format `<name>@<project-name>.<prefix>.iam.gserviceaccount.com` instead of the standard `<name>@<project-id>.iam.gserviceaccount.com`.
+
+* Google Accounts and Google Groups are not supported for IAM bindings. Use Workforce Identity Federation or service accounts.
+
+* The GCD credential file does not populate the `project_id` field. The installer reads the project ID from the `platform.gcp.projectID` field in the `install-config.yaml` file instead.
+
+[id="gcp-sovereign-cloud-limitations-other_{context}"]
+== Other limitations
+
+* GCD sovereign cloud support is a Technology Preview feature. You must set `featureSet: TechPreviewNoUpgrade` in the `install-config.yaml` file. Clusters installed with this feature set cannot be upgraded to a later version.
+
+* The installer automatically detects a GCD sovereign cloud environment based on the domain-scoped project ID prefix (for example, `eu0:`) and the universe domain in the credential file.
+
+* The universe domain from the GCD credentials is recorded on the cluster's `Infrastructure` custom resource at `status.platformStatus.gcp.universeDomain`. Cluster components use this value to route API requests to the correct GCD endpoints.

--- a/modules/installation-gcp-sovereign-cloud-machine-types.adoc
+++ b/modules/installation-gcp-sovereign-cloud-machine-types.adoc
@@ -12,7 +12,7 @@ The following instance types have been tested with {product-title} on Google Clo
 ====
 ARM-based machine types are not available in GCD. All architectures use x86_64 instance types.
 
-All instance types require the `hyperdisk-balanced` disk type. Other disk types such as `pd-ssd` and Persistent Disk are not available in GCD.
+All instance types require the `hyperdisk-balanced` disk type. Other disk types such as `pd-ssd` and Persistent Disk are not available in GCD. You must also change the default storage class to use `hyperdisk-balanced` after installation. For instructions on modifying storage classes, see the "GCE PersistentDisk (gcePD) object definition" section in _Dynamic provisioning_ in _Storage_.
 ====
 
 .C3 machine series (general-purpose)

--- a/modules/installation-gcp-sovereign-cloud-machine-types.adoc
+++ b/modules/installation-gcp-sovereign-cloud-machine-types.adoc
@@ -1,0 +1,136 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-gcp-sovereign-cloud-machine-types_{context}"]
+= Tested instance types for GCD sovereign cloud regions
+
+The following instance types have been tested with {product-title} on Google Cloud Dedicated (GCD) sovereign cloud regions. Only the C3, M3, and A3 Edge machine series are available. Other series such as N2, E2, and T2A are not available in GCD.
+
+[NOTE]
+====
+ARM-based machine types are not available in GCD. All architectures use x86_64 instance types.
+
+All instance types require the `hyperdisk-balanced` disk type. Other disk types such as `pd-ssd` and Persistent Disk are not available in GCD.
+====
+
+.C3 machine series (general-purpose)
+[cols="1,1,1",options="header"]
+|====
+|Instance type |vCPUs |Memory (GB)
+
+|`c3-standard-4` (default)
+|4
+|16
+
+|`c3-standard-8`
+|8
+|32
+
+|`c3-standard-22`
+|22
+|88
+
+|`c3-standard-44`
+|44
+|176
+
+|`c3-standard-88`
+|88
+|352
+
+|`c3-standard-176`
+|176
+|704
+
+|`c3-highcpu-4`
+|4
+|8
+
+|`c3-highcpu-8`
+|8
+|16
+
+|`c3-highcpu-22`
+|22
+|44
+
+|`c3-highcpu-44`
+|44
+|88
+
+|`c3-highcpu-88`
+|88
+|176
+
+|`c3-highcpu-176`
+|176
+|352
+
+|`c3-highmem-4`
+|4
+|32
+
+|`c3-highmem-8`
+|8
+|64
+
+|`c3-highmem-22`
+|22
+|176
+
+|`c3-highmem-44`
+|44
+|352
+
+|`c3-highmem-88`
+|88
+|704
+
+|`c3-highmem-176`
+|176
+|1408
+|====
+
+.M3 machine series (memory-optimized)
+[cols="1,1,1",options="header"]
+|====
+|Instance type |vCPUs |Memory (GB)
+
+|`m3-ultramem-32`
+|32
+|976
+
+|`m3-ultramem-64`
+|64
+|1952
+
+|`m3-ultramem-128`
+|128
+|3904
+
+|`m3-megamem-64`
+|64
+|896
+
+|`m3-megamem-128`
+|128
+|1792
+|====
+
+.A3 Edge machine series (GPU-accelerated)
+[cols="1,1,1,1",options="header"]
+|====
+|Instance type |vCPUs |Memory (GB) |GPUs
+
+|`a3-edgegpu-8g-nolssd`
+|208
+|1872
+|8x NVIDIA H100
+|====
+
+[IMPORTANT]
+====
+The A3 Edge machine series is intended for GPU workloads and is not recommended for control plane or general-purpose compute nodes. Bare metal instances are not available in GCD.
+====

--- a/modules/installation-gcp-sovereign-cloud-prerequisites.adoc
+++ b/modules/installation-gcp-sovereign-cloud-prerequisites.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-sovereign-cloud.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-gcp-sovereign-cloud-prerequisites_{context}"]
+= Configuring a GCD project for {product-title}
+
+Before you install {product-title} on a Google Cloud Dedicated (GCD) sovereign cloud region, you must configure your GCD project and credentials to work with the sovereign cloud environment.
+
+In addition to the standard {gcp-short} project configuration described in xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project], GCD requires the following additional configuration.
+
+.Prerequisites
+
+* You have a GCD project with a domain-scoped project ID, such as `eu0:my-project`.
+* You have configured an identity provider through Workforce Identity Federation.
+* You have a service account with the required permissions for {product-title} installation.
+
+.Procedure
+
+. Obtain the GCD credential configuration file for your service account. The credential file must include the `universe_domain` field that corresponds to your GCD region. For example, the Berlin region uses `apis-berlin-build0.goog`.
++
+Verify that your credential file contains the `universe_domain` field:
++
+[source,terminal]
+----
+$ cat <path_to_credentials>/credentials.json | grep universe_domain
+----
++
+.Example output
+[source,terminal]
+----
+  "universe_domain": "apis-berlin-build0.goog"
+----
+
+. Set the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable to the universe domain for your GCD region:
++
+[source,terminal]
+----
+$ export GOOGLE_CLOUD_UNIVERSE_DOMAIN=<universe_domain> <1>
+----
+<1> Replace `<universe_domain>` with the universe domain for your GCD region. For the Berlin region, use `apis-berlin-build0.goog`.
+
+. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of your GCD credential file:
++
+[source,terminal]
+----
+$ export GOOGLE_APPLICATION_CREDENTIALS=<path_to_credentials>/credentials.json <1>
+----
+<1> Replace `<path_to_credentials>` with the path to the directory that contains your GCD credential file.
+
+. Verify that the required APIs are enabled in your GCD project. The following APIs are required:
++
+--
+* Compute Engine API (`compute.googleapis.com`)
+* Cloud DNS API (`dns.googleapis.com`)
+* Cloud Storage API (`storage.googleapis.com`)
+* IAM API (`iam.googleapis.com`)
+* Service Usage API (`serviceusage.googleapis.com`)
+* Cloud Resource Manager API (`cloudresourcemanager.googleapis.com`)
+--
++
+[NOTE]
+====
+GCD uses the same API service names as public {gcp-short} for enabling and disabling APIs. The service endpoints, however, use the GCD-specific domain.
+====
+
+. Create a VPC network if one does not already exist. GCD does not create a default VPC network for new projects.
++
+[source,terminal]
+----
+$ gcloud compute networks create <network_name> --subnet-mode=custom
+----
+
+. Configure a private DNS zone for your cluster's base domain. GCD supports only private DNS zones.
++
+[source,terminal]
+----
+$ gcloud dns managed-zones create <zone_name> \
+    --dns-name=<base_domain> \
+    --description="Private DNS zone for OpenShift" \
+    --visibility=private \
+    --networks=<network_name>
+----


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is a draft only, not intended to be merged
> A follow up PR can use this as reference, feel free to close after.


## Summary

- Add user-facing installation documentation for deploying OpenShift on Google Cloud Dedicated (GCD) sovereign cloud regions
- Follow the same pattern as existing Azure government-region and AWS specialized-region docs
- GCD support is gated behind the `GCPSovereignCloudInstall` TechPreview feature gate

## New files

- `installing/installing_gcp/installing-gcp-sovereign-cloud.adoc` - Main assembly page
- `modules/installation-gcp-about-sovereign-cloud.adoc` - Concept module covering GCD overview, key differences from public Google Cloud, and OpenShift-specific constraints
- `modules/installation-gcp-sovereign-cloud-prerequisites.adoc` - Procedure module for GCD credential/project setup
- `modules/installation-gcp-sovereign-cloud-config-yaml.adoc` - Annotated sample install-config.yaml for GCD
- `modules/installation-gcp-sovereign-cloud-machine-types.adoc` - Supported C3/M3/A3 Edge machine types reference
- `modules/installation-gcp-sovereign-cloud-limitations.adoc` - GCD-specific limitations (disk types, networking, identity, OS images)

## Modified files

- `_topic_maps/_topic_map.yml` - Added sovereign cloud entry to the Google Cloud section
- `installing/installing_gcp/preparing-to-install-on-gcp.adoc` - Added sovereign cloud to the IPI methods list
- `_attributes/common-attributes.adoc` - Added `:gcp-dedicated:` attribute

## Related installer PRs

- https://github.com/openshift/installer/pull/10630 - Add Support for GCD on the installer
- ~https://github.com/openshift/installer/pull/10686 - Auto upload RHCOS image for sovereign cloud~
- https://github.com/openshift/installer/pull/10709 - Add OS Image validation for sovereign clouds
- https://github.com/openshift/installer/pull/10708 - Reject PSC endpoint overrides for sovereign cloud
- https://github.com/openshift/installer/pull/10706 - Set machine types
- https://github.com/openshift/installer/pull/10691 - Email format
- https://github.com/openshift/installer/pull/10688 - Use project ID metadata
- https://github.com/openshift/installer/pull/10687 - Disk type validation
- https://github.com/openshift/api/pull/2963 - Add UniverseDomain (API)
- https://github.com/openshift/release/pull/81238 - Add CI job for GCD

## Test plan

- [ ] Verify AsciiDoc syntax parses without errors
- [ ] Verify all include paths resolve correctly
- [ ] Verify all xref cross-references point to existing files
- [ ] Verify topic map YAML is valid
- [ ] Review content accuracy against installer PR implementations
- [ ] SME review from GCD engineering team

Generated with [Claude Code](https://claude.com/claude-code)