### PR TITLE
OSDOCS: Note that changing cgroupMode reboots nodes

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -46,6 +46,11 @@ include::snippets/deprecated-feature.adoc[]
 * You have a running {product-title} cluster that uses version 4.12 or later.
 * You are logged in to the cluster as a user with administrative privileges.
 
+[IMPORTANT]
+====
+Changing the cgroup version by editing the `node.config` object updates the machine config with new kernel arguments. The Machine Config Operator (MCO) drains and reboots each node, one at a time per machine config pool, for the changes to take effect. Plan a maintenance window accordingly.
+====
+
 .Procedure
 
 . Configure the wanted cgroup version on your nodes:
@@ -196,7 +201,7 @@ spec:
 <1> Disables cgroup v2.
 <2> Enables cgroup v1 in systemd.
 
-. Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
+. Check the nodes to see that scheduling on the nodes is disabled. This indicates that the MCO is draining the node before rebooting it into the new configuration:
 +
 [source,terminal]
 ----
@@ -215,7 +220,7 @@ ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   4
 ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.31.3
 ----
 
-. After a node returns to the `Ready` state, start a debug session for that node:
+. After a node reboots and returns to the `Ready` state, start a debug session for that node:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Changing nodes.config spec.cgroupMode updates MachineConfig kernel arguments; the MCO drains and reboots nodes. The procedure only described SchedulingDisabled → Ready, which omitted the reboot.

Jira: 
- [OSDOCS-21295](https://redhat.atlassian.net/browse/OSDOCS-21295)

Description:
- Document that changing `spec.cgroupMode` on `nodes.config/cluster` causes the Machine Config Operator (MCO) to drain and reboot nodes.
- Previously, the "Configuring Linux cgroup" procedure only showed nodes entering `Ready,SchedulingDisabled` and returning to `Ready`, which can be read as a non-disruptive config apply. In practice, this change updates MachineConfig `kernelArguments`, so nodes must reboot for the new cgroup configuration to take effect.


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 
- 4.14, 4.15, 4.16, 4.17, 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> 
- The procedure "Configuring Linux cgroup" (nodes-clusters-cgroups-2) does not state that changing `spec.cgroupMode` on `nodes.config/cluster` causes the Machine Config Operator to drain and reboot nodes.

- Changing `cgroupMode` renders new MachineConfigs with updated `kernelArguments` (`systemd.unified_cgroup_hierarchy`, `cgroup_no_v1`, etc.). Kernel-argument changes only take effect after a full node reboot (standard MCO cordon → drain → reboot → uncordon behavior). The published Verification steps only mention `Ready,SchedulingDisabled` and return to `Ready`, which customers read as a non-disruptive config apply.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
-  https://117208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html
- https://117208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.---> 
- Doc URL: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-clusters#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2
- File: `modules/nodes-clusters-cgroups-2.adoc`
- Please cherry-pick to: enterprise-4.14, enterprise-4.15, enterprise-4.16, enterprise-4.17, enterprise-4.18

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
