### PR TITLE
OADP-8505: Add OADP 1.3.10 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -42,7 +42,7 @@ endif::[]
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
 :oadp-version: 1.4.10
-:oadp-version-1-3: 1.3.9
+:oadp-version-1-3: 1.3.10
 :oadp-version-1-4: 1.4.10
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 The release notes for {oadp-first} 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-10.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-9.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-3-8.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-3-10.adoc
+++ b/modules/oadp-release-notes-1-3-10.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-3-10-release-notes_{context}"]
+= {oadp-short} 1.3.10 release notes
+
+[role="_abstract"]
+{oadp-first} 1.3.10 release notes list new features and resolved issues.
+
+The following Red Hat Security Advisory (RHSA) is available for {oadp-short} 1.3.10:
+
+* link:https://access.redhat.com/errata/RHSA-2026:51033[RHSA-2026:51033 - New version of Red{nbsp}Hat OpenShift API for Data Protection]
+
+[id="new-features-1-3-10_{context}"]
+== New features
+
+{oadp-short} CLI plugin::
+{oadp-short} includes a `kubectl` command-line interface (CLI) plugin that provides a `kubectl` native interface for managing backups and restores. Before this update, you aliased to the Velero CLI to perform backup operations. With the CLI plugin, you can run `kubectl oadp` or `oc oadp` commands to manage cluster-wide Velero operations directly through a single command-line interface.
++
+link:https://redhat.atlassian.net/browse/OADP-8077[OADP-8077]
+
+
+[id="resolved-issues-1-3-10_{context}"]
+== Resolved issues
+
+{oadp-short} workload pods use dedicated service accounts::
+Before this update, the `oadp-cli-server` workload pods in the `openshift-adp` namespace used the default service account instead of dedicated, workload-specific service accounts. As a consequence, access control validation checks failed during deployment verification. With this release, dedicated and valid service accounts are properly assigned to these workload pods. As a result, all {oadp-short} workload pods comply with access control verification and adhere to cluster security standards.
++
+link:https://redhat.atlassian.net/browse/OADP-8450[OADP-8450]
+
+{oadp-short} containers include liveness, readiness, and startup probes::
+Before this update, the {oadp-short} command-line interface (CLI) containers did not have configured Kubernetes health probes (liveness, readiness, and startup probes). As a consequence, workloads could not automatically recover from common failures, such as pod, host, or network issues. With this release, liveness, readiness, and startup probes were added to the deployed containers. As a result, workloads can use native Kubernetes health-checking mechanisms to self-recover from failures and ensure reliable application traffic routing.
++
+link:https://redhat.atlassian.net/browse/OADP-8484[OADP-8484]
+
+{gcp-full} backups no longer fail with a 404 error on existence check when BSL remains available::
+Before this update, the {gcp-full} object store plugin treated a missing `velero-backup.json` file as a `404 Not Found` error during existence checks rather than handling it as a normal `does not exist` state. As a consequence, creating any new Velero backup on {gcp-full} failed immediately during the pre-backup check, even when the `BackupStorageLocation` (BSL) was healthy and active. With this release, the {gcp-full} plugin correctly interprets `ErrObjectNotExist` as a non-existent object instead of a critical failure. As a result, pre-creation existence checks for new backups succeed, and backup operations proceed as expected on {gcp-full}.
++
+link:https://redhat.atlassian.net/browse/OADP-8509[OADP-8509]


### PR DESCRIPTION
Summary of changes: Add OADP 1.3.10 release notes and update attributes accordingly.

Version(s):
OCP 4.12-4.15

Issue:
[OADP-8505](https://redhat.atlassian.net/browse/OADP-8505)

Link to docs preview:
[OADP 1.3.10 release notes](https://117209--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#oadp-1-3-10-release-notes_oadp-release-notes)

QE review:
- [x] QE has approved this change.