### PR TITLE
OSDOCS-11246:Add Minimum network requirements: OSD on GCP.

### DIFF
--- a/modules/mos-network-prereqs-min-bandwidth.adoc
+++ b/modules/mos-network-prereqs-min-bandwidth.adoc
@@ -3,6 +3,8 @@
 // * rosa_planning/rosa-sts-aws-prereqs.adoc
 // * rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
 // * rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+// * osd_planning/aws-ccs.adoc
+// * osd_planning/gcp-ccs.adoc
 
 :_mod-docs-content-type: CONCEPT
 

--- a/osd_planning/gcp-ccs.adoc
+++ b/osd_planning/gcp-ccs.adoc
@@ -19,6 +19,7 @@ include::modules/ocm-cli-create-managed-dns-zone.adoc[leveloffset=+1]
 include::modules/ocm-cli-manage-dns-zones.adoc[leveloffset=+1]
 include::modules/ccs-gcp-iam.adoc[leveloffset=+1]
 include::modules/ccs-gcp-provisioned.adoc[leveloffset=+1]
+include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+1]
 include::modules/gcp-limits.adoc[leveloffset=+1]
 include::modules/osd-gcp-psc-firewall-prerequisites.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.22
5

Issue:
https://redhat.atlassian.net/browse/OSDOCS-11246

Link to docs preview:
[Networking prerequisites](https://117210--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#network-prereqs-osd_gcp-ccs)

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required to merge this PR. Networking prereqs for OSD on Google Cloud do not require testing. See [Slack thread](https://redhat-internal.slack.com/archives/C0AEPA2CC3U/p1776451874043889) for confirmation of this.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
