### PR TITLE
OSDOCS#21066: MicroShift: Add 2 bugs  to 4.22.7 that were initially labeled security 

### DIFF
--- a/modules/microshift-4-22-7-async.adoc
+++ b/modules/microshift-4-22-7-async.adoc
@@ -19,9 +19,11 @@ See the latest images included with {microshift-short} by using the following in
 [id="microshift-4-22-7-fixed-issues_{context}"]
 == Fixed issues
 
-There are no notable fixed issues in this release.
+* Before this release, {microshift-short} did not support Cluster to Cluster Communication (C2CC), limiting the ability to establish direct connectivity between {microshift-short} clusters at the edge. With this release, the C2CC feature is available as a Technology Preview in {microshift-short} 4.22, enabling cluster-to-cluster networking for edge deployments. This backport includes the full feature implementation with code and tests. (link:https://issues.redhat.com/browse/OCPBUGS-99419[OCPBUGS-99419])
+
+* Before this release, {microshift-short} did not support custom DNS configuration, which required users to rely on the default DNS settings without the ability to tailor name resolution to their specific edge environment. With this release, custom DNS configuration is available in {microshift-short} 4.22, and allows administrators to customize DNS behavior to meet site-specific requirements. This backport includes the full feature implementation with code and tests. (link:https://issues.redhat.com/browse/OCPBUGS-99406[OCPBUGS-99406])
 
 [id="microshift-4-22-7-known-issues_{context}"]
 == Known issues
 
-* {microshift-short} 4.22.7 images have a prioritizer compatibility issue with unsupported paths that lead to an incomplete fixed issue in the release notes. There is no workaround for OCPBUGS-98603. As a result, users should apply a system update to resolve the issue.
+* {microshift-short} 4.22.7 images have a prioritizer compatibility issue with unsupported paths that lead to an incomplete fixed issue in the release notes. There is no workaround for OCPBUGS-98603. As a result, users should apply a system update to resolve the issue. (link:https://issues.redhat.com/browse/OCPBUGS-99904[OCPBUGS-99904])


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-21066](https://redhat.atlassian.net/browse/OSDOCS-21066)

Link to docs preview:
[4.22.7](https://117220--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-22-release-notes.html#microshift-4-22-7-async_release-notes)

QE review:
- [ x] QE has approved this change.
QE/SME review to verify bug text accuracy

Additional information:

- ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22?page=2)
- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/671)
