### PR TITLE
CNV-93108: Update descheduler profile docs

### DIFF
--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -59,14 +59,13 @@ endif::[]
 ... To evict pods instead of simulating the evictions, change the *Mode* field to *Automatic*.
 
 ifdef::virt[]
-... Expand the *Profiles* section and select `LongLifecycle`. The `AffinityAndTaints` profile is enabled by default.
+... Expand the *Profiles* section and select `KubeVirtRelieveAndMigrate`. The `AffinityAndTaints` profile is enabled by default.
 +
-[IMPORTANT]
+[NOTE]
 ====
-The only profile currently available for {VirtProductName} is `LongLifecycle`.
+You can also configure the profiles and settings for the descheduler later using the {oc-first}.
 ====
-+
-You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`).
+
 endif::virt[]
 ifdef::nodes[]
 ... Expand the *Profiles* section to select one or more profiles to enable. The `AffinityAndTaints` profile is enabled by default. Click *Add Profile* to select additional profiles.

--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -94,17 +94,10 @@ Do not enable `CompactAndScale` with any of the following profiles: `LifecycleAn
 
 endif::nodes[]
 ifdef::virt[]
-Use the `KubeVirtRelieveAndMigrate` or `LongLifecycle` profile to enable the descheduler on a virtual machine.
-
-[IMPORTANT]
-====
-You cannot have both `KubeVirtRelieveAndMigrate` and `LongLifeCycle` enabled at the same time.
-====
+Use the `KubeVirtRelieveAndMigrate` profile to enable the descheduler on a virtual machine.
 endif::virt[]
 
-`KubeVirtRelieveAndMigrate`:: This profile is an enhanced version of the `LongLifeCycle` profile.
-+
-The `KubeVirtRelieveAndMigrate` profile evicts pods from high-cost nodes to reduce overall resource expenses and enable workload migration. It also periodically rebalances workloads to help maintain similar spare capacity across nodes, which supports better handling of sudden workload spikes. Nodes can experience the following costs:
+`KubeVirtRelieveAndMigrate`:: The `KubeVirtRelieveAndMigrate` profile evicts pods from high-cost nodes to reduce overall resource expenses and enable workload migration. It also periodically rebalances workloads to help maintain similar spare capacity across nodes, which supports better handling of sudden workload spikes. Nodes can experience the following costs:
 +
 --
 * **Resource utilization**: Increased resource pressure raises the overhead for running applications.
@@ -125,7 +118,8 @@ The profile also exposes the following customization fields:
 * `devEnableSoftTainter`: Enables the soft-tainting component to dynamically apply or remove soft taints as scheduling hints.
 --
 +
-.Example configuration
+Example configuration:
++
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -147,7 +141,8 @@ spec:
 +
 The `KubeVirtRelieveAndMigrate` profile requires PSI metrics to be enabled on all worker nodes. You can enable this by applying the following `MachineConfig` custom resource (CR):
 +
-.Example `MachineConfig` CR
+Example `MachineConfig` CR:
++
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -168,7 +163,7 @@ The name of the `MachineConfig` object is significant because machine configs ar
 +
 You can use this profile with the `SoftTopologyAndDuplicates` profile to also rebalance pods based on soft topology constraints, which can be useful in hosted control plane environments.
 
-// Show LongLifecycle profile both for virt and nodes
+ifdef::nodes[]
 `LongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
 +
 --
@@ -178,7 +173,6 @@ You can use this profile with the `SoftTopologyAndDuplicates` profile to also re
 ** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
 --
 +
-ifdef::nodes[]
 [WARNING]
 ====
 Do not enable `LongLifecycle` with any of the following profiles: `LifecycleAndUtilization` or `CompactAndScale`. Enabling these profiles together results in a conflict.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/CNV-93108

Link to docs preview:
- https://117233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
