### PR TITLE
[enterprise-4.18][OCPBUGS-83417]: Adding warning to restoring an etcd snapshot on a hosted cluster

### DIFF
--- a/modules/restoring-etcd-snapshot-hosted-cluster.adoc
+++ b/modules/restoring-etcd-snapshot-hosted-cluster.adoc
@@ -10,14 +10,14 @@ If you have a snapshot of etcd from your hosted cluster, you can restore it. Cur
 
 To restore an etcd snapshot, you modify the output from the `create cluster --render` command and define a `restoreSnapshotURL` value in the etcd section of the `HostedCluster` specification.
 
-[NOTE]
+[IMPORTANT]
 ====
-The `--render` flag in the `hcp create` command does not render the secrets. To render the secrets, you must use both the `--render` and the `--render-sensitive` flags in the `hcp create` command.
+If the snapshot that you are restoring is from a hosted cluster with `LoadBalancer` services, the load balancer IPs might no longer be valid. In that case, you must delete and re-create the `LoadBalancer` services.
 ====
 
 .Prerequisites
 
-You took an etcd snapshot on a hosted cluster.
+* You took an etcd snapshot on a hosted cluster.
 
 .Procedure
 


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/117177