### PR TITLE
OCPBUGS-99480: Harden Gateway API docs against route hijacking

### DIFF
--- a/modules/configuring-automatic-address-assignment-gateway.adoc
+++ b/modules/configuring-automatic-address-assignment-gateway.adoc
@@ -13,11 +13,11 @@ When you create a gateway resource, you must configure it for automatic address 
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {oc-first}.
-* You have an existing `GatewayClass` resource, such as `openshift-default`.
+* You have an existing `GatewayClass` custom resource, such as `openshift-default`.
 
 .Procedure
 
-. Create a YAML file, such as `hello-gateway.yaml`, that defines your `Gateway` object without the addresses field:
+. Create a YAML file, such as `hello-gateway.yaml`, that defines your `Gateway` object.
 +
 [source,yaml]
 ----
@@ -30,18 +30,21 @@ spec:
   gatewayClassName: openshift-default
   listeners:
   - name: http
-    hostname: "*.gwapi.<cluster_domain>" 
+    hostname: "*.gwapi.<cluster_domain>"
     port: 80
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            shared-gateway-access: "true"
 ----
 +
-* `metadata.name`: The name of your `Gateway` object. The name must consist of a maximum of 63 lowercase alphanumeric characters or hyphens (`-`). The name must also start and end with an alphanumeric character.
-* Replace `<cluster_domain>` with your actual cluster ingress domain (for example, `example.com`). 
-* The `spec.addresses` field is omitted from this configuration to ensure automatic assignment.
-* The `gatewayClassName` dictates which controller provisions the address and populates the `status.addresses` field.
+* `metadata.name`: Specify the name of your `Gateway` object. The name must consist of a maximum of 63 lowercase alphanumeric characters or hyphens (`-`). The name must also start and end with an alphanumeric character.
+* `spec.gatewayClassName`: Specify the `GatewayClass` object whose controller provisions the address and populates the `status.addresses` field.
+* `spec.listeners[].hostname`: Specify the listener hostname. Replace `<cluster_domain>` with your actual cluster ingress domain (for example, `example.com`). Setting a hostname limits which route hostnames can match this listener.
+* `spec.listeners[].allowedRoutes.namespaces`: Allow route attachment only from namespaces that have the `shared-gateway-access: "true"` label.
 
 . Apply the `Gateway` configuration by running the following command:
 +

--- a/modules/configuring-listener-routing-security.adoc
+++ b/modules/configuring-listener-routing-security.adoc
@@ -9,45 +9,58 @@
 [role="_abstract"]
 To ensure that your applications receive only authenticated and authorized traffic, you must specify the allowed protocols and ports for your gateway. If you are routing secure traffic, you must also configure TLS settings. You can define these parameters by configuring the `spec.listeners` field in your `Gateway` custom resource (CR).
 
+[IMPORTANT]
+====
+If your gateway is accessible from other namespaces, always configure the `spec.listeners[].allowedRoutes[].namespaces.selector` field with a selector for the permitted namespaces. By specifying a namespace selector, you prevent possible misuse or hijacking of the gateway from other namespaces.
+
+If nothing is listed in the `spec.listeners[].allowedRoutes[]` field, the gateway is accessible only from the same namespace.
+====
+
 .Procedure
 
-. Create or edit a `Gateway` YAML file to include your desired listener configuration.
+. Create or edit a `Gateway` YAML file to include your listener configuration.
 +
 --
-The following example demonstrates a `Gateway` CR with two listeners, one for HTTP and one for HTTPS. For detailed descriptions of the listener fields, see xref:gateway-listener-configuration-reference_{context}[].
+The following example demonstrates a `Gateway` CR with two listeners, one for HTTP and one for HTTPS. For detailed descriptions of the listener fields, see "Gateway listener configuration reference".
 
 [source,yaml]
 ----
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: <example_gateway>
-  namespace: openshift-ingress
+  name: <example_gateway>
+  namespace: openshift-ingress
 spec:
-  gatewayClassName: openshift-default
-  listeners:
-  - protocol: HTTP 
-    port: 80
-    name: http
-    allowedRoutes: 
-      namespaces:
-        from: Selector
-        selector:
-          matchLabels:
-            env: "dev"
-  - protocol: HTTPS 
-    port: 443
-    name: https
-    hostname: "*.<example_domain.tld>" 
-    tls: 
-      mode: Terminate
-      certificateRefs:
-        - name: <listener_cert>
-          kind: Secret
-    allowedRoutes: 
-      namespaces:
-        from: All
+  gatewayClassName: openshift-default
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http
+    hostname: "*.<example_domain.tld>"
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            env: "dev"
+  - protocol: HTTPS
+    port: 443
+    name: https
+    hostname: "*.<example_domain.tld>"
+    tls:
+      mode: Terminate
+      certificateRefs:
+        - name: <listener_cert>
+          kind: Secret
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            env: "dev"
 ----
++
+With this configuration, only `HTTPRoute` resources in namespaces that have the `env: "dev"` label can attach to these listeners.
 --
 
 . Apply the `Gateway` CR by running the following command:

--- a/modules/creating-httproute.adoc
+++ b/modules/creating-httproute.adoc
@@ -39,7 +39,8 @@ spec:
 ----
 +
 * You must include application hostnames and a `backendRef` rule that points to your backend service.
-* If your `HTTPRoute` and `Gateway` CRs are deployed in different namespaces, the `Gateway` CR listener must be configured to allow cross-namespace routes. You must set `allowedRoutes.namespaces.from: All` in the `Gateway` CR.
+* If your `HTTPRoute` and `Gateway` CRs are deployed in different namespaces, the `Gateway` CR listener must allow routes from the `HTTPRoute` namespace. You must configure the `spec.listeners.allowedRoutes.namespaces` field in the `Gateway` CR and specify a selector for trusted namespaces.
+* The listener `hostname` on the parent `Gateway` CR should cover the hostnames in your `HTTPRoute` CR. For example, a listener hostname of `*.gwapi.apps.example.com` accepts an `HTTPRoute` hostname such as `app.gwapi.apps.example.com`, but rejects hostnames outside that domain.
 
 . Apply the `HTTPRoute` CR file to your cluster:
 +

--- a/modules/gateway-api-benefits-limitations.adoc
+++ b/modules/gateway-api-benefits-limitations.adoc
@@ -9,6 +9,7 @@
 [role="_abstract"]
 To determine if Gateway API is the right routing solution for your cluster, review its benefits and limitations. The project is an effort to provide a standardized ecosystem by using a portable API with broad community support. Understanding these factors ensures your networking infrastructure aligns with your organizational needs and technical capabilities.
 
+[id="gateway-api-benefits_{context}"]
 == Benefits
 
 Gateway API provides the following benefits:
@@ -17,6 +18,7 @@ Gateway API provides the following benefits:
 * Separation of concerns: Gateway API uses a role-based approach to its resources, and more neatly fits into how a large organization structures its responsibilities and teams. Platform engineers might focus on `GatewayClass` resources, cluster administrators might focus on configuring `Gateway` resources, and application developers might focus on routing their services with `HTTPRoute` resources.
 * Extensibility: Additional functionality is developed as a standardized CRD. 
 
+[id="gateway-api-limitations_{context}"]
 == Limitations
 
 Gateway API has the following limitations:

--- a/modules/gateway-api-deployment-topologies.adoc
+++ b/modules/gateway-api-deployment-topologies.adoc
@@ -9,6 +9,7 @@
 [role="_abstract"]
 To effectively organize and secure your routing infrastructure, you must choose an appropriate deployment topology for your cluster. Gateway API is designed to accommodate two topologies: shared gateways or dedicated gateways. You can choose a topology based on its own advantages and different security implications.
 
+[id="dedicated-gateway_{context}"]
 == Dedicated gateway
 Routes and any load balancers or proxies are served from the same namespace. The `Gateway` object restricts routes to a particular application namespace. This is the default topology when deploying a Gateway API resource in {product-title}.
 
@@ -31,7 +32,7 @@ spec:
     hostname: "example.com"
 ----
 
-If you do not set `spec.listeners[].allowedRoutes` for a `Gateway` resource, the system implicitly sets the `namespaces.from` field to the value of `Same`. 
+If you do not set `spec.listeners[].allowedRoutes` for a `Gateway` resource, the system implicitly sets the `namespaces.from` field to the value of `Same`.
 
 The following example shows the associated `HTTPRoute` resource, `sales-db`, which attaches to the dedicated `Gateway` object:
 
@@ -51,11 +52,12 @@ spec:
   rules:
     - backendRefs:
         - name: sales-db
-        ¦ port: 8080
+          port: 8080
 ----
 
 The `HTTPRoute` resource must have the name of the `Gateway` object as the value for its `parentRefs` field to attach to the gateway. The system implicitly assumes that the route exists in the same namespace as the `Gateway` object.
 
+[id="shared-gateway_{context}"]
 == Shared gateway
 Routes are served from multiple namespaces or multiple hostnames. The `Gateway` object allows routes from application namespaces by using the `spec.listeners.allowedRoutes.namespaces` field.
 
@@ -80,8 +82,8 @@ spec:
       namespaces:
         from: Selector
         selector:
-        ¦ matchLabels:
-        ¦   shared-gateway-access: "true"
+          matchLabels:
+            shared-gateway-access: "true"
 ----
 
 The following examples show the allowed namespaces for the `devops-gateway` resource:
@@ -108,7 +110,7 @@ In this example, two `HTTPRoute` resources, `dev-portal` and `ops-home`, are in 
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: dev-portal
@@ -122,7 +124,7 @@ spec:
     - name: dev-portal
       port: 8080
 ---
-apiVersion: v1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ops-home

--- a/modules/gateway-listener-configuration-reference.adoc
+++ b/modules/gateway-listener-configuration-reference.adoc
@@ -18,10 +18,14 @@ Defines the list of listeners for the gateway. You can customize this field with
 Defines the network port and protocol. For example, `protocol: HTTP` accepts HTTP traffic on port `80`, and `protocol: HTTPS` accepts HTTPS traffic on port `443`.
 
 `listeners.hostname`::
-Defines the hostnames that the listener matches for incoming requests. For example, it can match only requests for hostnames ending in `<example_domain.tld>` (such as `www.<example_domain.tld>`). If no hostname is specified, the gateway routes any traffic that can attach to it.
+Defines the hostnames that the listener matches for incoming requests. For example, it can match only requests for hostnames ending in `<example_domain.tld>` (such as `www.<example_domain.tld>`). Always set a hostname on each listener, unless you are defining a catch-all route. If no hostname is specified, any route that can attach to the listener can claim arbitrary hostnames.
 
 `listeners.tls`::
 Specifies the TLS settings for secure communication, including the mode (currently, only `Terminate` is supported on {product-title}) and the Kubernetes secret containing the certificate keypair. For example, TLS is terminated at the gateway using a certificate stored in a Kubernetes `Secret` called `<listener_cert>`. You must ensure that the specified Kubernetes secret exists before you create the `Gateway` CR.
 
 `listeners.allowedRoutes`::
-Controls which `Route` resources can attach to this listener. For example, an HTTP listener might only allow `HTTPRoute` resources from namespaces that have the `env: "dev"` label (using `Selector`), while an HTTPS listener might allow `HTTPRoute` resources from any namespace to attach (using `All`). Setting `allowedRoutes.namespaces.from: Same` is not supported; routes from the same namespace as the gateway are always allowed.
+Controls which route resources can attach to this listener.
+If you omit this field, or set `namespaces.from: Same`, only routes in the same namespace as the `Gateway` can attach.
+To allow routes from other namespaces, set `namespaces.from: Selector` and a label selector for trusted namespaces.
+For example, an HTTP listener might allow `HTTPRoute` resources only from namespaces that have the `env: "dev"` label.
+Do not set `namespaces.from: All`; that setting allows routes from every namespace and can enable hostname or domain hijacking.


### PR DESCRIPTION
Replace from: All in customer-facing Gateway examples with trusted namespace selectors, require listener hostnames, and warn that unrestricted route attachment can enable traffic or hostname hijacking.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+ TBD
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:

https://redhat.atlassian.net/browse/OCPBUGS-99480

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Configuring Gateway API (landing)](https://117235--ocpdocs-pr.netlify.app/)
- [Understand Gateway API](https://117235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_gateway_api/understand-gateway-api.html)
- [Assigning network addresses to gateways](https://117235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_gateway_api/assigning-network-addresses-gateways.html)
- [Control incoming traffic with gateway listeners](https://117235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_gateway_api/controlling-incoming-traffic-gateway-listeners.html)
- [Routing HTTP requests to services](https://117235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
