### PR TITLE
Add Network Policies documentation for OpenShift Builds 1.8

### DIFF
--- a/about/overview-openshift-builds.adoc
+++ b/about/overview-openshift-builds.adoc
@@ -20,6 +20,8 @@ include::modules/ob-about-buildrun.adoc[leveloffset=+2]
 
 include::modules/ob-about-build-controller.adoc[leveloffset=+2]
 
+include::modules/ob-network-policies.adoc[leveloffset=+2]
+
 include::modules/ob-build-validation.adoc[leveloffset=+2]
 
 

--- a/modules/ob-network-policies.adoc
+++ b/modules/ob-network-policies.adoc
@@ -1,0 +1,34 @@
+// This module is included in the following assembly:
+//
+// * about/overview-openshift-builds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-policies_{context}"]
+= Network policies
+
+[role="_abstract"]
+The Operator enforces a zero-trust network model in the `openshift-builds` namespace by automatically creating and managing NetworkPolicy resources.
+These policies control ingress traffic to pods, ensuring that only authorized connections are allowed.
+
+Starting with {builds-shortname} 1.8, the Operator enforces a zero-trust network model in the `openshift-builds` namespace.
+Five NetworkPolicy resources are automatically created and managed by the Operator.
+The following network policies are enforced:
+
+Default deny:: All ingress traffic to pods in the `openshift-builds` namespace is denied unless explicitly allowed by one of the following policies.
+
+Webhook ingress:: Admission webhook ports (TCP 8443) on the Shipwright and Shared Resource CSI Driver webhook pods accept traffic only from the `openshift-kube-apiserver` namespace.
+
+Metrics ingress:: Metrics and health ports accept traffic only from namespaces labeled `network.openshift.io/policy-group: monitoring`:
++
+* Shared Resource CSI Driver: ports 6000 (provisioner metrics) and 9898 (health)
+* Shipwright Build controller: port 8383 (metrics)
+
+These policies are fully managed by the Operator and require no user configuration.
+You must not edit them manually.
+
+[IMPORTANT]
+====
+If you use a custom monitoring stack, ensure the namespace running your Prometheus or scraper has the label `network.openshift.io/policy-group: monitoring`.
+Otherwise, metrics collection from the `openshift-builds` namespace will be blocked.
+The built-in {ocp-product-title} monitoring stack already has this label.
+====


### PR DESCRIPTION
## Summary
- Added new concept module documenting the zero-trust network model enforced by the operator in the `openshift-builds` namespace
- Documents the five automatically managed NetworkPolicy resources (Default deny, Webhook ingress, Metrics ingress)
- Includes important guidance for users with custom monitoring stacks

## Changes
- **New module**: `modules/ob-network-policies.adoc` - CONCEPT module explaining network policies
- **Modified**: `about/overview-openshift-builds.adoc` - Added include for the new module after Build controller section

## Test plan
- [ ] Verify module follows Red Hat modular documentation standards
- [ ] Check that the module renders correctly in the documentation build
- [ ] Validate that custom monitoring stack guidance is clear and actionable
- [ ] Ensure version references use correct attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)