### PR TITLE
OCPBUGS-103097: Clarify HTTPRoute routing docs for 4.22

### DIFF
--- a/modules/applying-processing-filters-http-requests.adoc
+++ b/modules/applying-processing-filters-http-requests.adoc
@@ -11,7 +11,6 @@ To modify how HTTP requests are processed before they reach your backend service
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/comparing-openshift-routes-and-httproutes.adoc
+++ b/modules/comparing-openshift-routes-and-httproutes.adoc
@@ -23,7 +23,6 @@ The following features are exclusive to {product-title} routes:
 * IP allow lists
 * Rate limiting (connection-based)
 * Subdomain indication
-* Re-encrypt TLS termination
 * Passthrough TLS termination
 
 The following table outlines the features that are shared between both resources and how their specific implementations differ:

--- a/modules/comparing-openshift-routes-and-httproutes.adoc
+++ b/modules/comparing-openshift-routes-and-httproutes.adoc
@@ -4,7 +4,7 @@
 //
 :_mod-docs-content-type: REFERENCE
 [id="comparing-openshift-routes-and-httproutes_{context}"]
-= {product-title} routes and HTTPRoutes Comparison
+= {product-title} routes and HTTPRoutes comparison
 
 [role="_abstract"]
 When you migrate from standard networking to the Gateway API, you can compare {product-title} routes with `HTTPRoute` custom resources (CRs) to understand which features are supported and how your configuration must change. While both resources handle ingress traffic, they have distinct feature sets and implementation differences.

--- a/modules/configuring-http-request-matching-conditions.adoc
+++ b/modules/configuring-http-request-matching-conditions.adoc
@@ -4,14 +4,13 @@
 //
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-http-request-matching-conditions_{context}"]
-= Configure HTTP request matching conditions
+= Configure path-based routing
 
 [role="_abstract"]
 To ensure traffic is routed to the correct application when multiple services share a gateway, you can define request matching conditions within your `HTTPRoute` custom resource (CR). You can match HTTP requests based on paths, headers, query parameters, or methods.
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/configuring-routing-destinations-weights.adoc
+++ b/modules/configuring-routing-destinations-weights.adoc
@@ -11,7 +11,6 @@ To route traffic to your backends, you must define service destinations and traf
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/setting-timeouts-http-requests.adoc
+++ b/modules/setting-timeouts-http-requests.adoc
@@ -11,7 +11,6 @@ To prevent hanging connections and ensure your application remains responsive, y
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/supported-httproute-match-types.adoc
+++ b/modules/supported-httproute-match-types.adoc
@@ -23,11 +23,6 @@ Each consists of type, name, and value. QueryParameters match type indicates how
 `method`::
 A value in upper case that should match on the HTTP request method. Must be one of: GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, or PATCH.
 
-[NOTE]
-====
-According to Gateway API conventions, the `RegularExpression` match type is classified as an implementation-specific feature (`Support: Implementation-specific`). While {SMProductName} fully supports regular expression matching, this feature might not be available or behave identically across other Gateway API implementations.
-====
-
 == Example: path match
 
 The following example demonstrates a complete `HTTPRoute` custom resource (CR) configured with path-based matching to route requests for `/<example_app>` to a backend service:

--- a/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services.adoc
+++ b/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 When you expose your applications through a gateway, you must configure an `HTTPRoute` custom resource (CR) to accurately direct incoming HTTP requests from your network listener to the appropriate backend services. A Gateway API `HTTPRoute` CR specifies the exact routing behavior for these requests by evaluating a set of rules.
 
-The core configuration element of an `HTTPRoute` CR is a rule. You can configure up to 16 rules for a single route. Within each rule, you can establish the following routing behaviors:
+Traffic delivery can be configured for an `HTTPRoute` using rules. You can configure up to 16 rules for a single route. Within each rule, you can establish the following routing behaviors:
 
 * `Matches`: Define the conditions an HTTP request must meet based on paths, headers, query parameters, or methods.
 * `Filters`: Apply processing directions to the request, such as header modifications, mirrors, or redirects.


### PR DESCRIPTION
Align assembly intro and path-based routing title with user tasks, drop an incorrect cluster-admin prerequisite, remove the RegularExpression implementation note, and stop listing re-encrypt TLS as routes-only.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:

https://redhat.atlassian.net/browse/OCPBUGS-103097
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

[Routing HTTP requests to services](https://117250--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
