### PR TITLE
ROX-36077: Removes Mandatory ScannerV2 Notices

### DIFF
--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -17,4 +17,4 @@ Central services contain the following components:
 
 * Central
 * Scanner V4
-* StackRox Scanner: Although the StackRox Scanner is deprecated, you still must enable it on the cluster where you install Central due to software dependencies.
+* StackRox Scanner (Deprecated)

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -79,7 +79,7 @@ where:
 |Use this parameter to configure additional hostnames to resolve in the pod's hosts file.
 
 |===
-* *Scanner Component Settings*: Settings for the StackRox Scanner. See the "Scanner" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}". Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
+* *Scanner Component Settings*: Settings for the StackRox Scanner. See the "Scanner" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}". The StackRox Scanner is deprecated and will be removed in a future version.
 * *Scanner V4 Component Settings*: Settings for Scanner V4 scanner, the default scanner. See the "Scanner V4" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".
 +
 You can configure the following options for Scanner V4:

--- a/modules/scanner-overview.adoc
+++ b/modules/scanner-overview.adoc
@@ -9,6 +9,4 @@
 [role="_abstract"]
 Scanner is responsible for scanning images, nodes, and the platform for vulnerabilities.
 
-Scanner is responsible for scanning images, nodes, and the platform for vulnerabilities.
-
 {product-title-short} includes two image vulnerability scanners: StackRox Scanner and Scanner V4. The StackRox Scanner is deprecated. Scanner V4 became available in release 4.4 and as of release 4.8 is the default image scanner.

--- a/modules/stackrox-scanner-public-config.adoc
+++ b/modules/stackrox-scanner-public-config.adoc
@@ -7,7 +7,7 @@
 = StackRox Scanner
 
 [role="_abstract"]
-The following table lists the configurable parameters for the StackRox Scanner. Although the StackRox Scanner is deprecated, you must still enable it on the cluster where you install Central due to software dependencies.
+The following table lists the configurable parameters for the StackRox Scanner. The StackRox Scanner is deprecated and will be removed in a future version.
 
 |===
 | Parameter | Description


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
5.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[ROX-36077](https://redhat.atlassian.net/browse/ROX-36077)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
ScannerV2 is no longer mandatory for a successful installation of Central within RHACS. This PR updates the documentation to reflect that, as well as ensure that it is clear that the StackRox Scanner will be removed entirely in the future.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
  
PR Currently in Draft, as I'm awaiting the last of the functionality changes to merge to the StackRox repo.
