### PR TITLE
[enterprise-4.14] OSDOCS-19005: Fix typos in dynamic-plugins reference pages

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -637,7 +637,7 @@ children
 
 |`name` |(optional) name of resource
 
-|`namesapce` |(optional) specific namespace for the kind resource to
+|`namespace` |(optional) specific namespace for the kind resource to
 link to
 
 |`hideIcon` |(optional) flag to hide the icon badge
@@ -732,7 +732,7 @@ const Component: React.FC = () => {
 
 == `useK8sWatchResources`
 
-Hook that retrieves the k8s resources along with their respective status for loaded and error. It returns a map where keys are as provided in initResouces and value has three properties data, loaded and error.
+Hook that retrieves the k8s resources along with their respective status for loaded and error. It returns a map where keys are as provided in initResources and value has three properties data, loaded and error.
 
 .Example
 [source,tsx]
@@ -810,7 +810,7 @@ the active cluster the user has selected
 
 == `getConsoleRequestHeaders`
 
-A function that creates impersonation and multicluster related headers for API requests using current redux state. It returns an object containing the appropriate impersonation and clustr requst headers, based on redux state.
+A function that creates impersonation and multicluster related headers for API requests using current redux state. It returns an object containing the appropriate impersonation and cluster request headers, based on redux state.
 
 [cols=",",options="header",]
 |===
@@ -822,7 +822,7 @@ targetCluster
 
 == `k8sGetResource`
 
-It fetches a resource from the cluster, based on the provided options. If the name is provided it returns one resource else it returns all the resources matching the model. It returns a promise that resolves to the response as JSON object with a resource if the name is providedelse it returns all the resources matching the
+It fetches a resource from the cluster, based on the provided options. If the name is provided it returns one resource else it returns all the resources matching the model. It returns a promise that resolves to the response as JSON object with a resource if the name is provided else it returns all the resources matching the
 model. In case of failure, the promise gets rejected with HTTP error response.
 
 [cols=",",options="header",]
@@ -870,7 +870,7 @@ URL.
 
 == `k8sUpdateResource`
 
-It updates the entire resource in the cluster, based on providedoptions. When a client needs to replace an existing resource entirely, they can use k8sUpdate. Alternatively can use k8sPatch to perform the partial update. It returns a promise that resolves to the response of the resource updated. In case of failure promise gets rejected with HTTP error response.
+It updates the entire resource in the cluster, based on provided options. When a client needs to replace an existing resource entirely, they can use k8sUpdate. Alternatively can use k8sPatch to perform the partial update. It returns a promise that resolves to the response of the resource updated. In case of failure promise gets rejected with HTTP error response.
 
 [cols=",",options="header",]
 |===
@@ -1327,12 +1327,12 @@ empty or undefined, polling is not started.
 
 |`\{number} [props.delay]` |(optional) polling delay interval (ms)
 
-|`\{number} [props.endTime]` |(optional) for QUERY_RANGE enpoint, end
+|`\{number} [props.endTime]` |(optional) for QUERY_RANGE endpoint, end
 of the query range
 
-|`\{number} [props.samples]` |(optional) for QUERY_RANGE enpoint
+|`\{number} [props.samples]` |(optional) for QUERY_RANGE endpoint
 
-|`\{number} [options.timespan]` | (optional) for QUERY_RANGE enpoint
+|`\{number} [options.timespan]` | (optional) for QUERY_RANGE endpoint
 
 |`\{string} [options.namespace]` | (optional) a search param to append
 
@@ -1342,7 +1342,7 @@ of the query range
 
 == `Timestamp`
 
-A component to render timestamp. The timestamps are synchronized between invidual instances of the Timestamp component. The provided timestamp is formatted according to user locale.
+A component to render timestamp. The timestamps are synchronized between individual instances of the Timestamp component. The provided timestamp is formatted according to user locale.
 
 [cols=",",options="header",]
 |===
@@ -1353,7 +1353,7 @@ A component to render timestamp. The timestamps are synchronized between invidua
 |`simple` |render simple version of the component omitting icon and
 tooltip.
 
-|`omitSuffix` |formats the date ommiting the suffix.
+|`omitSuffix` |formats the date omiting the suffix.
 
 |`className` |additional class name for the component.
 |===
@@ -1630,7 +1630,7 @@ Deprecated: Use `useAccessReview` from `@console/dynamic-plugin-sdk` instead. Ho
 
 == `useSafetyFirst`
 
-Deprecated: This hook is not related to console functionality. Hook that ensures a safe asynchronnous setting of React state in case a given component could be unmounted. It returns an array with a pair of state value and its set function.
+Deprecated: This hook is not related to console functionality. Hook that ensures a safe asynchronous setting of React state in case a given component could be unmounted. It returns an array with a pair of state value and its set function.
 
 [cols=",",options="header",]
 |===

--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -1404,7 +1404,7 @@ access review to control the visibility or enablement of the action.
 
 == `dev-console.add/action-group`
 
-This extension allows plugins to contibute a group in the add page of developer console. Groups can be referenced by actions, which will be grouped together in the add action page based on their extension definition. For example, a Serverless plugin can contribute a Serverless group and together with multiple add actions.
+This extension allows plugins to contribute a group in the add page of developer console. Groups can be referenced by actions, which will be grouped together in the add action page based on their extension definition. For example, a Serverless plugin can contribute a Serverless group and together with multiple add actions.
 
 [cols=",,,",options="header",]
 |===


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/117253