### PR TITLE
Mark the Jaeger UI exposed by the Tempo Query sidecar as deprecated

### DIFF
--- a/modules/distr-tracing-tempo-architecture.adoc
+++ b/modules/distr-tracing-tempo-architecture.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * service_mesh/v2x/ossm-architecture.adoc
-// * observability/distr_tracing/distr-tracing-tempo-architecture.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="distr-tracing-tempo-architecture_{context}"]
@@ -18,6 +17,11 @@
 ** *Ingester* – The Ingester batches a trace into blocks, creates bloom filters and indexes, and then flushes it all to the back end.
 
 ** *Query Frontend* – The Query Frontend shards the search space for an incoming query and sends the query to the Queriers. The Query Frontend deployment exposes the Jaeger UI through the Tempo Query sidecar.
++
+--
+:FeatureName: The Jaeger UI that the Tempo Query sidecar exposes
+include::snippets/deprecated-feature.adoc[leveloffset=+1]
+--
 
 ** *Querier* - The Querier is responsible for finding the requested trace ID in either the Ingesters or the back-end storage. Depending on parameters, it can query the Ingesters and pull Bloom indexes from the back end to search blocks in object storage.
 


### PR DESCRIPTION
## Description

Marks the Jaeger UI that the Tempo Query sidecar exposes as a deprecated feature.

- Adds the standard `snippets/deprecated-feature.adoc` admonition to the *Query Frontend* component in `modules/distr-tracing-tempo-architecture.adoc`, following the existing pattern used in `modules/nodes-pods-vertical-autoscaler-about.adoc`.
- Removes a stale entry from the module's header comment: `observability/distr_tracing/distr-tracing-tempo-architecture.adoc` no longer includes this module — it only links to the standalone Distributed Tracing Platform documentation. The only real assembly is `service_mesh/v2x/ossm-architecture.adoc`.

Rendered output:

> **IMPORTANT**
> The Jaeger UI that the Tempo Query sidecar exposes is a deprecated feature. Deprecated functionality is still included in OpenShift Container Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.

## Notes for reviewers

- **Draft:** needs a Jira ticket ID in the title and the appropriate version label(s) before review.
- Most of the `jaegerQuery` surface (the `.spec.template.queryFrontend.jaegerQuery` CR field, the monitor tab, the Jaeger UI route) lives in the standalone Distributed Tracing Platform documentation, not in this repo. This PR only covers the architecture mention that remains here.
- Deliberately **not** touched: `modules/ossm-configuring-distr-tracing-tempo.adoc` (lines 145-158), where Kiali is configured against the Jaeger Query API on port `16685`. That procedure depends on the same component, but updating it requires the replacement Kiali configuration for Tempo's native API.
- The pre-existing deprecation of the Jaeger *platform* (`snippets/distr-tracing-assembly-tip-for-jaeger-replacements.adoc`) is a separate matter and is untouched.

## Version(s)

<!-- To be filled in -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)