### PR TITLE
OSDOCS-21022-1:Add 4.22.8 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-8.adoc
+++ b/modules/zstream-4-22-8.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-8_{context}"]
+= RHSA-2026:48693 - {product-title} {product-version}.8 bug fix and security update
+
+Issued: 04 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.8 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:48693[RHSA-2026:48693] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:48694[RHBA-2026:48694] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.8 --pullspecs
+----
+
+[id="zstream-4-22-8-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, setting the `.spec.timeZone` parameter in a cron job might have crashed the kube-state-metrics (KSM) pod. This issue removed the cluster metrics and monitoring alerts. With this release, kube-state-metrics (KSM) gracefully skip cron job objects with unparseable schedules instead of crashing. As a result, the KSM pod remains stable and continues to serve metrics for all cluster resources, even when individual cron job objects have schedules or time zones that cannot be parsed. (link:https://redhat.atlassian.net/browse/OCPBUGS-87957[OCPBUGS-87957])
+
+* Before this update, KubeVirt-based `NodePool` resources incorrectly reported `ClusterNetworkCIDRConflict` errors because the controller flagged OVN-Kubernetes internal overlay IP addresses as conflicting with the cluster network. With this release, Classless Inter-Domain Routing (CIDR) conflict detection is triggered only when all the non-link local addresses for the machine fall within the cluster network. As a result, when external addresses exist, in-network addresses are correctly treated as expected container network interface (CNI) internal IP addresses, which prevents false positive conflict reports. (link:https://redhat.atlassian.net/browse/OCPBUGS-97921[OCPBUGS-97921])
+
+* Before this update, on hosted control plane (HCP) clusters where the management cluster required a proxy for outbound internet access, the `Konnectivity` proxy sidecar containers did not receive the management cluster proxy environment variables such as `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. As a consequence, cloud API calls to {aws-first}, {azure-first}, or {ibm-cloud-name} endpoints made through the direct cloud API bypass path failed with TLS handshake timeouts. With this release, management cluster proxy environment variables are propagated to the `Konnectivity` sidecar containers when the direct cloud API connection feature is enabled. As a result, cloud API calls succeed through the proxy. (link:https://redhat.atlassian.net/browse/OCPBUGS-99299[OCPBUGS-99299])
+
+* Before this update, Alertmanager crashed because the `tzdata` package was missing in the {product-title} base images, This issue caused the absence of the `/usr/share/zoneinfo` directory. As a consequence, Alertmanager pods failed to start, which made time-based alerts inaccessible for the time zones. With this release, the `tzdata` package has been reinstated in {product-title} images. As a result, Alertmanager does not crash on startup when location fields are present in the `active_interval` or `mute_interval` entries. (link:https://redhat.atlassian.net/browse/OCPBUGS-99442[OCPBUGS-99442])
+
+* Before this update, the web console storage unit parser treated a `findIndex` result of `0` for the largest unit, `Ei` or `EiB`, as not found, and the binary byte unit list omitted `EiB`. As a consequence, creating a persistent volume claim (PVC) with an exbibyte-sized request, for example `1Ei` or `1EiB`, displayed the requested capacity as `0 B` on the PVC details page, even though the API stored the correct value. With this release, the unit lookup logic recognizes index `0` as valid and includes `EiB` in the binary byte units used for humanization. As a result, the PVC details page displays the correct capacity, for example `1 EiB`, when storage is requested in exbibyte units. (link:https://redhat.atlassian.net/browse/OCPBUGS-99545[OCPBUGS-99545])
+
+* Before this update, locale files under `locales/{xx}/olm.json` translated the Kubernetes custom resource kind names `CatalogSource` and `OperatorGroup` into local languages. As a consequence, in non-English UI locales, Operator Lifecycle Manager (OLM) pages displayed localized labels for these resource kinds that did not match the API, the CLI (`oc`), or YAML, which caused inconsistency and confusion. With this release, the canonical English kind names `CatalogSource` and `OperatorGroup` are restored in the affected OLM locale files so that they are not translated. As a result, `CatalogSource` and `OperatorGroup` labels are in English across all locales and stay consistent with the API and CLI. (link:https://redhat.atlassian.net/browse/OCPBUGS-99548[OCPBUGS-99548])
+
+* Before this update, the Cluster Monitoring Operator (CMO) checked only the `openshift-config/pull-secret` for the `cloud.openshift.com` authentication token used by the telemeter client. As a consequence, on platforms where this secret did not contain the token, such as the Microsoft Azure Red Hat OpenShift hosted control plane, the telemeter client was not deployed, which prevented cluster registration in {cluster-manager-first}. With this release, the CMO falls back to `kube-system/global-pull-secret` if the token is not found in the primary secret. As a result, the telemeter client is deployed correctly. (link:https://redhat.atlassian.net/browse/OCPBUGS-99748[OCPBUGS-99748])
+
+[id="zstream-4-22-8-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -45,6 +45,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.8 RNs and updating
+include::modules/zstream-4-22-8.adoc[leveloffset=+2]
+
 // 4.22.7 RNs and updating
 include::modules/zstream-4-22-7.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21022

Link to docs preview:
https://117318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-8_release-notes

QE review:
N/A

Additional information:

    Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/683
    ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
    Errata: RHSA-2026:48693 / RHBA-2026:48694 (not yet published on access.redhat.com — Issued date is a placeholder)


NOTE: This PR incorporates the suggested edits from https://github.com/openshift/openshift-docs/pull/117013.
