### PR TITLE
[OSDOCS#16980]: Kueue-CQA-2

### DIFF
--- a/ai_workloads/kueue/gangscheduling.adoc
+++ b/ai_workloads/kueue/gangscheduling.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Gang scheduling ensures that a group or _gang_ of related jobs only start when all required resources are available. {kueue-name} enables gang scheduling by suspending jobs until the {product-title} cluster can guarantee the capacity to start and execute all of the related jobs in the gang together. This is also known as _all-or-nothing_ scheduling.
+[role="_abstract"]
+You can use gang scheduling to ensure that a group, or gang, of related jobs starts only when all required resources are available.
+
+{kueue-name} enables gang scheduling by suspending jobs until the {product-title} cluster can guarantee the capacity to start and execute all of the related jobs in the _gang_ together. This is also known as _all-or-nothing_ scheduling.
 
 Gang scheduling is important if you are working with expensive, limited resources, such as GPUs. Gang scheduling can prevent jobs from claiming but not using GPUs, which can improve GPU utilization and can reduce running costs. Gang scheduling can also help to prevent issues like resource segmentation and deadlocking.
 

--- a/ai_workloads/kueue/install-kueue.adoc
+++ b/ai_workloads/kueue/install-kueue.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can install {kueue-name} by using the {kueue-op} in OperatorHub.
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]

--- a/ai_workloads/kueue/managing-workloads.adoc
+++ b/ai_workloads/kueue/managing-workloads.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{kueue-name} does not directly manipulate jobs that are created by users. Instead, Kueue manages `Workload` objects that represent the resource requirements of a job. {kueue-name} automatically creates a workload for each job, and syncs any decisions and statuses between the two objects.
+[role="_abstract"]
+When you create jobs in your cluster, {kueue-name} represents each job as a `Workload` object to track resource requirements, decisions, and statuses.
+
+{kueue-name} does not directly manipulate your jobs. Instead, {kueue-name} manages `Workload` objects that represent the resource requirements of a job, and syncs any decisions and statuses between the two objects.
 
 include::modules/kueue-label-namespaces.adoc[leveloffset=+1]
 

--- a/ai_workloads/kueue/rbac-permissions.adoc
+++ b/ai_workloads/kueue/rbac-permissions.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following procedures provide information about how you can configure role-based access control (RBAC) for your {kueue-name} deployment. These RBAC permissions determine which types of users can create which types of {kueue-name} objects.
+[role="_abstract"]
+You can configure role-based access control (RBAC) for your {kueue-name} deployment to control which users can create specific {kueue-name} objects.
 
 [id="authentication-clusterroles"]
 == Cluster roles

--- a/modules/kueue-configure-rbac-batch-admins.adoc
+++ b/modules/kueue-configure-rbac-batch-admins.adoc
@@ -6,6 +6,7 @@
 [id="configure-rbac-batch-admins_{context}"]
 = Configuring permissions for batch administrators
 
+[role="_abstract"]
 You can configure permissions for batch administrators by binding the `kueue-batch-admin-role` cluster role to a user or group of users.
 
 .Prerequisites
@@ -22,19 +23,22 @@ include::snippets/prereqs-snippet-yaml-admin.adoc[]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kueue-admins <1>
-subjects: <2>
+  name: kueue-admins
+subjects:
 - kind: User
   name: admin@example.com
   apiGroup: rbac.authorization.k8s.io
-roleRef: <3>
+roleRef:
   kind: ClusterRole
   name: kueue-batch-admin-role
   apiGroup: rbac.authorization.k8s.io
 ----
-<1> Provide a name for the `ClusterRoleBinding` object.
-<2> Add details about which user or group of users you want to provide user permissions for.
-<3> Add details about the `kueue-batch-admin-role` cluster role.
++
+where:
+
+`metadata.name`:: Specifies the name of the `ClusterRoleBinding` object.
+`subjects`:: Specifies the user or group of users you want to provide user permissions for.
+`roleRef`:: Specifies the `kueue-batch-admin-role` cluster role.
 
 . Apply the `ClusterRoleBinding` object:
 +

--- a/modules/kueue-configure-rbac-batch-users.adoc
+++ b/modules/kueue-configure-rbac-batch-users.adoc
@@ -6,6 +6,7 @@
 [id="configure-rbac-batch-users_{context}"]
 = Configuring permissions for users
 
+[role="_abstract"]
 You can configure permissions for {kueue-name} users by binding the `kueue-batch-user-role` cluster role to a user or group of users.
 
 .Prerequisites
@@ -22,22 +23,25 @@ include::snippets/prereqs-snippet-yaml-admin.adoc[]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kueue-users <1>
-  namespace: user-namespace <2>
-subjects: <3>
+  name: kueue-users
+  namespace: user-namespace
+subjects:
 - kind: Group
   name: team-a@example.com
   apiGroup: rbac.authorization.k8s.io
-roleRef: <4>
+roleRef:
   kind: ClusterRole
   name: kueue-batch-user-role
   apiGroup: rbac.authorization.k8s.io
 
 ----
-<1> Provide a name for the `RoleBinding` object.
-<2> Add details about which namespace the `RoleBinding` object applies to.
-<3> Add details about which user or group of users you want to provide user permissions for.
-<4> Add details about the `kueue-batch-user-role` cluster role.
++
+where:
+
+`metadata.name`:: Specifies the name of the `RoleBinding` object.
+`metadata.namespace`:: Specifies the namespace the `RoleBinding` object applies to.
+`subjects`:: Specifies the user or group of users you want to provide user permissions for.
+`roleRef`:: Specifies the `kueue-batch-user-role` cluster role.
 
 . Apply the `RoleBinding` object:
 +

--- a/modules/kueue-configuring-gangscheduling.adoc
+++ b/modules/kueue-configuring-gangscheduling.adoc
@@ -6,6 +6,7 @@
 [id="configuring-gangscheduling_{context}"]
 = Configuring gang scheduling
 
+[role="_abstract"]
 As a cluster administrator, you can configure gang scheduling by modifying the `gangScheduling` spec in the `Kueue` custom resource (CR).
 
 .Example `Kueue` CR with gang scheduling configured
@@ -22,22 +23,13 @@ metadata:
 spec:
   config:
     gangScheduling:
-      policy: ByWorkload # <1>
+      policy: ByWorkload
       byWorkload:
-        admission: Parallel # <2>
+        admission: Parallel
 # ...
 ----
-<1> You can set the `policy` value to enable or disable gang scheduling. The possible values are `ByWorkload`, `None`, or empty (`""`).
-+
-`ByWorkload`:: When the `policy` value is set to `ByWorkload`, each job is processed and considered for admission as a single unit. If the job does not become ready within the specified time, the entire job is evicted and retried at a later time.
-+
-`None`:: When the `policy` value is set to `None`, gang scheduling is disabled.
-+
-Empty (`""`):: When the `policy` value is empty or set to `""`, the {kueue-name} Operator determines settings for gang scheduling. Currently, gang scheduling is disabled by default.
-<2> If the `policy` value is set to `ByWorkload`, you must configure job admission settings. The possible values for the `admission` spec are `Parallel`, `Sequential`, or empty (`""`).
-+
-`Parallel`:: When the `admission` value is set to `Parallel`, pods from any job can be admitted at any time. This can cause a deadlock, where jobs are in contention for cluster capacity. When a deadlock occurs, the successful scheduling of pods from another job can prevent the scheduling of pods from the current job.
-+
-`Sequential`:: When the `admission` value is set to `Sequential`, only pods from the currently processing job are admitted. After all of the pods from the current job have been admitted and are ready, {kueue-name} processes the next job. Sequential processing can slow down admission when the cluster has sufficient capacity for multiple jobs, but provides a higher likelihood that all of the pods for a job are scheduled together successfully.
-+
-Empty (`""`):: When the `admission` value is empty or set to `""`, the {kueue-name} Operator determines job admission settings. Currently, the `admission` value is set to `Parallel` by default.
+
+`spec.config.gangScheduling.policy`:: You can set the `policy` value to enable or disable gang scheduling. The possible values are `ByWorkload`, `None`, or empty (`""`). 
+When the `policy` value is set to `ByWorkload`, each job is processed and considered for admission as a single unit. If the job does not become ready within the specified time, the entire job is evicted and retried at a later time. When the `policy` value is set to `None`, gang scheduling is disabled. When the `policy` value is empty or set to `""`, the {kueue-name} Operator determines settings for gang scheduling. Currently, gang scheduling is disabled by default.
+
+`spec.config.gangScheduling.byWorkload.admission`:: If the `policy` value is set to `ByWorkload`, you must configure job admission settings. The possible values for the `admission` spec are `Parallel`, `Sequential`, or empty (`""`). When the `admission` value is set to `Parallel`, pods from any job can be admitted at any time. This can cause a deadlock, where jobs are in contention for cluster capacity. When a deadlock occurs, the successful scheduling of pods from another job can prevent the scheduling of pods from the current job. When the `admission` value is set to `Sequential`, only pods from the currently processing job are admitted. After all of the pods from the current job have been admitted and are ready, {kueue-name} processes the next job. Sequential processing can slow down admission when the cluster has sufficient capacity for multiple jobs, but provides a higher likelihood that all of the pods for a job are scheduled together successfully. When the `admission` value is empty or set to `""`, the {kueue-name} Operator determines job admission settings. Currently, the `admission` value is set to `Parallel` by default.

--- a/modules/kueue-configuring-labelpolicy.adoc
+++ b/modules/kueue-configuring-labelpolicy.adoc
@@ -6,7 +6,10 @@
 [id="configuring-labelpolicy_{context}"]
 = Configuring label policies for jobs
 
-The `spec.config.workloadManagement.labelPolicy` spec in the `Kueue` custom resource (CR) is an optional field that controls how {kueue-name} decides whether to manage or ignore different jobs. The allowed values are `QueueName`, `None` and empty (`""`).
+[role="_abstract"]
+You can configure the `spec.config.workloadManagement.labelPolicy` field in the `Kueue` CR to control whether {kueue-name} manages or ignores specific jobs.
+
+The allowed values are `QueueName`, `None`, and empty (`""`).
 
 If the `labelPolicy` setting is omitted or empty (`""`), the default policy is that {kueue-name} manages jobs that have a `kueue.x-k8s.io/queue-name` label, and ignores jobs that do not have the `kueue.x-k8s.io/queue-name` label. This is the same workflow as if the `labelPolicy` is set to `QueueName`.
 

--- a/modules/kueue-defining-running-jobs.adoc
+++ b/modules/kueue-defining-running-jobs.adoc
@@ -6,7 +6,10 @@
 [id="defining-running-jobs_{context}"]
 = Defining a job to run with {kueue-name}
 
-When you are defining a job to run with {kueue-name}, ensure that it meets the following criteria:
+[role="_abstract"]
+When you are defining a job to run with {kueue-name}, ensure that it meets the required criteria.
+
+The job must:
 
 * Specify the local queue to submit the job to, by using the `kueue.x-k8s.io/queue-name` label.
 * Include the resource requests for each job pod.
@@ -26,12 +29,12 @@ include::snippets/prereqs-snippet-yaml-user.adoc[]
 [source,yaml]
 ----
 apiVersion: batch/v1
-kind: Job # <1>
+kind: Job
 metadata:
-  generateName: sample-job- # <2>
+  generateName: sample-job-
   namespace: my-namespace
   labels:
-    kueue.x-k8s.io/queue-name: user-queue # <3>
+    kueue.x-k8s.io/queue-name: user-queue
 spec:
   parallelism: 3
   completions: 3
@@ -41,16 +44,19 @@ spec:
       - name: dummy-job
         image: registry.k8s.io/e2e-test-images/agnhost:2.53
         args: ["entrypoint-tester", "hello", "world"]
-        resources: # <4>
+        resources:
           requests:
             cpu: 1
             memory: "200Mi"
       restartPolicy: Never
 ----
-<1> Defines the resource type as a `Job` object, which represents a batch computation task.
-<2> Provides a prefix for generating a unique name for the job.
-<3> Identifies the queue to send the job to.
-<4> Defines the resource requests for each pod.
++
+where:
+
+`kind`:: Defines the resource type as a `Job` object, which represents a batch computation task.
+`metadata.generateName`:: Provides a prefix for generating a unique name for the job.
+`metadata.labels.kueue.x-k8s.io/queue-name`:: Identifies the queue to send the job to.
+`spec.template.spec.containers[].resources`:: Defines the resource requests for each pod.
 
 . Run the job by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16980

Link to docs preview:
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/gangscheduling.html
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/install-disconnected.html
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/install-kueue.html
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/managing-workloads.html
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/rbac-permissions.html
https://117321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/release-notes.html

QE review:
N/A