### PR TITLE
OSDOCS-20762: Created control-plane vs. data-plane skew docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2817,6 +2817,8 @@ Topics:
   File: hcp-certificates
 - Name: Updating hosted control planes
   File: hcp-updating
+- Name: OVN-Kubernetes version skew
+  File: hcp-ovnk-version-skew
 - Name: High availability for hosted control planes
   Dir: hcp_high_availability
   Topics:

--- a/hosted_control_planes/hcp-ovnk-version-skew.adoc
+++ b/hosted_control_planes/hcp-ovnk-version-skew.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="hcp-ovnk-version-skew"]
+= OVN-Kubernetes version skew
+:context: hcp-ovnk-version-skew
+
+toc::[]
+
+[role="_abstract"]
+In {product-title}, the OVN-Kubernetes network plugin has two main component groups: the control-plane components and the data-plane agents. 
+When you upgrade your cluster, these components can temporarily run different versions, which is known as _version skew_.
+
+// Understanding OVN-Kubernetes version skew
+include::modules/nw-ovn-kubernetes-version-skew.adoc[leveloffset=+1]
+
+// Supported OVN-Kubernetes version skew matrix
+include::modules/nw-ovn-kubernetes-version-skew-matrix.adoc[leveloffset=+1]
+
+// Best-effort networking for nodes with version skew
+include::modules/nw-ovn-kubernetes-best-effort-networking.adoc[leveloffset=+1]
+
+// Skew-related alerts and status conditions
+include::modules/nw-ovn-kubernetes-skew-alerts-conditions.adoc[leveloffset=+1]
+
+// Upgrading the control plane with data-plane version skew
+include::modules/nw-ovn-kubernetes-upgrading-with-skew.adoc[leveloffset=+1]
+
+// Assessing cluster status after a skewed upgrade
+include::modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc[leveloffset=+1]

--- a/modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc
+++ b/modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-assessing-skewed-upgrade_{context}"]
+= Assessing cluster status after a skewed upgrade
+
+[role="_abstract"]
+After a control-plane upgrade, some data-plane nodes might run older OVN-Kubernetes agents.
+You can check the cluster status to identify these version-skewed nodes and verify if any networking degradation exists.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {oc-first}.
+* A control-plane upgrade has completed where one or more data-plane nodes did not upgrade.
+
+.Procedure
+
+. Check the overall cluster operator status to identify any conditions related to version skew by entering the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperators
+----
++
+Review the output for any Operators, especially the Cluster Network Operator, showing `Degraded` as `True` or `Available` as `False`.
+
+. Get the detailed status of the Cluster Network Operator by entering the following command:
++
+[source,terminal]
+----
+$ oc describe clusteroperator network
+----
++
+Review the `Status Conditions` section for any messages related to version skew, daemonset rollout, or node connectivity issues.
+
+. Inspect the OVN-Kubernetes daemonset to identify nodes running older versions by entering the following command:
++
+[source,terminal]
+----
+$ oc get daemonset -n openshift-ovn-kubernetes ovnkube-node
+----
++
+.Example output
+[source,terminal]
+----
+NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+ovnkube-node    6         6         5       4            5           kubernetes.io/os=linux   30d
+----
++
+If the `UP-TO-DATE` count is lower than the `DESIRED` count, some nodes are running an older version of the data-plane agents.
+
+. Identify which specific nodes have version skew by comparing pod images. To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node -o jsonpath='{range .items[*]}{.spec.nodeName}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
+----
++
+Compare the image versions across nodes. Nodes running an older image have data-plane version skew.
+
+. Check the status of the nodes that have version skew by entering the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+Nodes with version skew are typically in a `NotReady` or `SchedulingDisabled` state.
+This confirms that the version skew is a result of the node being unhealthy, rather than an upgrade failure.
+
+. Review monitoring and alerts for messages that distinguish intentional skew from unexpected failures.
+Check for any firing alerts related to OVN-Kubernetes by entering the following command:
++
+[source,terminal]
+----
+$ oc get prometheusrule -n openshift-ovn-kubernetes -o yaml
+----
++
+Review the alert rules for any conditions related to version skew or daemonset rollout issues.
+
+. Verify pod-to-pod connectivity across the cluster, including connections to and from nodes with version skew.
+To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -A -o wide | grep -i running
+----
++
+Check that pods on updated nodes can communicate with pods on other updated nodes.
+Connectivity to or from pods on nodes with version skew might be degraded.
+
+. Check the OVN-Kubernetes logs on a node with version skew for any version-related errors.
+To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ovn-kubernetes <ovnkube_node_pod_name> -c ovn-controller --tail=50
+----
++
+Replace `_<ovnkube_node_pod_name>_` with the name of an `ovnkube-node` pod on a node with version skew.
+Look for error messages related to version mismatches, unsupported flow configurations, or database schema incompatibilities.
+
+. Depending on the status of your nodes, choose one of the following options:
++
+* If nodes with version skew are in a `NotReady` state, investigate and resolve the underlying node issues so that the nodes can be updated.
+* If nodes with version skew are healthy but failed to update, check for issues with the machine config pool or update process.
++
+For a complete list of supported version combinations, see "Supported OVN-Kubernetes version skew matrix".

--- a/modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc
+++ b/modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc
@@ -1,0 +1,160 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-assessing-skewed-upgrade_{context}"]
+= Assessing cluster status after a skewed upgrade
+
+[role="_abstract"]
+After a control-plane upgrade, some data-plane nodes might run older OVN-Kubernetes agents.
+You can check the cluster status to identify these version-skewed nodes and verify if any networking degradation exists.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {oc-first}.
+* A control-plane upgrade has completed where one or more data-plane nodes did not upgrade.
+
+.Procedure
+
+. Set the required environment variables to target your {hcp} cluster by entering the following commands:
++
+[source,terminal]
+----
+$ export KUBECONFIG=<path_to_authentication_file>
+----
++
+[source,terminal]
+----
+$ export HC_NAME="<hosted_cluster_name>"
+----
++
+[source,terminal]
+----
+$ export HC_NAMESPACE="<hosted_cluster_namespace>"
+----
+
+. Verify that your environment targets the correct cluster by entering the following command:
++
+[source,terminal]
+----
+$ oc get hostedcluster ${HC_NAME} -n ${HC_NAMESPACE}
+----
+
+. Enter an `oc` command to verify everything is setup properly and that you are logged in by entering the following command:
++
+[source,terminal]
+----
+$ oc version
+----
++
+.Example output
+[source,terminal]
+----
+Client Version: 4.22.0-0.nightly-2026-03-15-203841
+Kustomize Version: v5.7.1
+Server Version: 4.21.7
+Kubernetes Version: v1.34.5
+----
+
+. Get the infrastructure ID of your hosted cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get hostedcluster -n clusters
+----
+
+. Check the overall cluster operator status to identify any conditions related to version skew by entering the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperators
+----
++
+Review the output for any Operators, especially the Cluster Network Operator, showing `Degraded` as `True` or `Available` as `False`.
+
+. Get the detailed status of the Cluster Network Operator by entering the following command:
++
+[source,terminal]
+----
+$ oc describe clusteroperator network
+----
++
+Review the `Status Conditions` section for any messages related to version skew, daemonset rollout, or node connectivity issues.
+
+. Inspect the OVN-Kubernetes daemonset to identify nodes running older versions by entering the following command:
++
+[source,terminal]
+----
+$ oc get daemonset -n openshift-ovn-kubernetes ovnkube-node
+----
++
+.Example output
+[source,terminal]
+----
+NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+ovnkube-node    6         6         5       4            5           kubernetes.io/os=linux   30d
+----
++
+If the `UP-TO-DATE` count is lower than the `DESIRED` count, some nodes are running an older version of the data-plane agents.
+
+. Identify which specific nodes have version skew by comparing pod images. To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node -o jsonpath='{range .items[*]}{.spec.nodeName}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
+----
++
+Compare the image versions across nodes. Nodes running an older image have data-plane version skew.
+
+. Check the status of the nodes that have version skew by entering the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+Nodes with version skew are typically in a `NotReady` or `SchedulingDisabled` state.
+This confirms that the version skew is a result of the node being unhealthy, rather than an upgrade failure.
+
+. Review monitoring and alerts for messages that distinguish intentional skew from unexpected failures.
+Check for any firing alerts related to OVN-Kubernetes by entering the following command:
++
+[source,terminal]
+----
+$ oc get prometheusrule -n openshift-ovn-kubernetes -o yaml
+----
++
+Review the alert rules for any conditions related to version skew or daemonset rollout issues.
+
+. Verify pod-to-pod connectivity across the cluster, including connections to and from nodes with version skew.
+To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -A -o wide | grep -i running
+----
++
+Check that pods on updated nodes can communicate with pods on other updated nodes.
+Connectivity to or from pods on nodes with version skew might be degraded.
+
+. Check the OVN-Kubernetes logs on a node with version skew for any version-related errors.
+To do this, enter the following command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ovn-kubernetes <ovnkube_node_pod_name> -c ovn-controller --tail=50
+----
++
+Replace `_<ovnkube_node_pod_name>_` with the name of an `ovnkube-node` pod on a node with version skew.
+Look for error messages related to version mismatches, unsupported flow configurations, or database schema incompatibilities.
+
+.Troubleshooting
+
+* Depending on the status of your nodes, choose one of the following options:
++
+* If nodes with version skew are in a `NotReady` state, investigate and resolve the underlying node issues so that the nodes can be updated.
+* If nodes with version skew are healthy but failed to update, check for issues with the machine config pool or update process.
++
+For a complete list of supported version combinations, see "Supported OVN-Kubernetes version skew matrix".

--- a/modules/nw-ovn-kubernetes-best-effort-networking.adoc
+++ b/modules/nw-ovn-kubernetes-best-effort-networking.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-kubernetes-best-effort-networking_{context}"]
+= Best-effort networking for nodes with version skew
+
+[role="_abstract"]
+If you upgrade the OVN-Kubernetes control plane while some data-plane agents remain at an older version, networking on the affected nodes operates in a best-effort mode.
+This maintains basic network connectivity, but does not guarantee full networking correctness for nodes running older data-plane agents.
+
+Understanding best-effort networking::
++
+Best-effort networking applies only to nodes where the OVN-Kubernetes data-plane agents could not be updated.
+In most cases, these nodes are already in a degraded state because they are unreachable, unhealthy, or otherwise unable to accept updates.
+The version skew does not introduce new failures on these nodes.
+Instead, the skew represents a transition from one degraded state to another, where the existing issues of the node are compounded by the version mismatch.
++
+Nodes that successfully update their data-plane agents continue to have full networking functionality, even when other nodes in the cluster are running older versions.
+Pod connectivity, service discovery, DNS, and network policies work correctly across version boundaries when both the old and new agents are functioning normally..
+
+Potential networking degradation::
++
+On nodes where data-plane agents remain at an older version, the following types of networking degradation might occur:
++
+* New networking features introduced in the control-plane version might not be available on nodes running older agents.
+* Changes to network flow programming in the newer control-plane version might not be fully compatible with older `ovn-controller` agents, potentially causing inconsistent flow rules.
+* Network policy updates that rely on new control-plane behavior might not be enforced on nodes with older agents.
+* Nodes with version skew might not correctly process updated logical flow configurations from the southbound database.
++
+[NOTE]
+====
+The specific impact depends on the extent of the version difference and what networking changes were introduced between the two versions.
+Z-stream version skew typically has lower risk of degradation than y-stream version skew, because patch releases generally contain fewer networking changes.
+====
+
+Acceptable trade-off::
++
+The best-effort networking model is designed as an acceptable trade-off for maintaining control-plane health.
+The following list describes the rationale for this approach:
++
+* Nodes that cannot update their data-plane agents are typically already experiencing issues that affect their overall functionality, not just networking.
+* Blocking a control-plane upgrade to maintain theoretical networking correctness on unhealthy nodes prevents the entire cluster from receiving critical fixes.
+* No maximum skew duration is enforced. The primary goal is to allow the control plane to move forward regardless of how long individual nodes remain at an older version.
++
+When you identify nodes with version skew, investigate and resolve the underlying issues.
+By doing this task you can prevent those nodes from updating, rather than expecting full networking correctness during the skewed state.

--- a/modules/nw-ovn-kubernetes-skew-alerts-conditions.adoc
+++ b/modules/nw-ovn-kubernetes-skew-alerts-conditions.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ovn-kubernetes-skew-alerts-conditions_{context}"]
+= Skew-related alerts and status conditions
+
+[role="_abstract"]
+When OVN-Kubernetes version skew exists in a cluster, several `ClusterOperator` conditions and Prometheus alerts can indicate the state of the skewed components. 
+Use these indicators to distinguish between intentional version skew and unexpected failures.
+
+ClusterOperator conditions::
++
+The `network` ClusterOperator reports the following conditions that are relevant to version skew:
++
+`Available`:: Indicates whether the Cluster Network Operator is functioning correctly.
+During a skewed upgrade, this condition remains `True` if the control-plane components are healthy, even if some data-plane agents are at an older version.
+`Progressing`:: Indicates whether the Cluster Network Operator is rolling out a new version.
+This condition shows `True` during the control-plane upgrade.
+After the control-plane upgrade completes, this condition might remain `True` if the operator is still attempting to update data-plane agents on remaining nodes.
++
+[NOTE]
+====
+If `Progressing` remains `True` after the control-plane upgrade is complete, check whether any nodes are unable to update their `ovnkube-node` pods. This might indicate nodes that are unreachable or unhealthy rather than an upgrade failure.
+====
+`Degraded`:: Indicates whether the Cluster Network Operator has encountered an error. This condition does not change to `True` solely because of version skew. If this condition is `True`, investigate for issues beyond version skew.
++
+To view the current conditions, run the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperator network -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
+----
+
+Daemonset status indicators::
++
+The `ovnkube-node` daemonset provides status fields that help identify version skew:
++
+`desiredNumberScheduled`:: The total number of nodes that should run the `ovnkube-node` pod.
+`updatedNumberScheduled`:: The number of nodes running the latest version of the `ovnkube-node` pod. If this number is lower than `desiredNumberScheduled`, version skew exists.
+`numberReady`:: The number of nodes where the `ovnkube-node` pod is ready. Nodes with older agents can still report as ready if the pod is functioning.
+`numberUnavailable`:: The number of nodes where the `ovnkube-node` pod is not available. This number might include nodes with version skew if those nodes are also unhealthy.
++
+To view the daemonset status, run the following command:
++
+[source,terminal]
+----
+$ oc get daemonset -n openshift-ovn-kubernetes ovnkube-node -o jsonpath='{.status}'
+----
+
+Prometheus alerts::
++
+The following alerts are relevant when monitoring clusters with OVN-Kubernetes version skew:
++
+.Alerts related to OVN-Kubernetes version skew
+[cols="1,2,1",options="header"]
+|===
+|Alert |Description |Recommended action
+
+|`KubeDaemonSetRolloutStuck`
+|Fires when a daemonset has not finished rolling out after a specified period. This alert can fire for the `ovnkube-node` daemonset if nodes with version skew prevent the rollout from completing.
+|Check which nodes have not updated. If the nodes are intentionally skewed because they are unreachable or unhealthy, this alert can be acknowledged. If the nodes are healthy, investigate the rollout failure.
+
+|`KubeDaemonSetMisScheduled`
+|Fires when a daemonset pod is running on an unexpected node. This alert is not directly related to version skew but might appear alongside it.
+|Investigate the scheduling issue independently of version skew.
+
+|`NodeNotReady`
+|Fires when a node transitions to a `NotReady` state. Nodes in this state are the most common cause of data-plane version skew.
+|Investigate the underlying node health issue. Resolving the node issue also resolves the version skew.
+|===
+
+Distinguishing intentional skew from unexpected failures::
++
+When you see indicators of version skew, determine whether the skew is intentional or unexpected by checking the following:
++
+* Intentional skew: Nodes with version skew are in a `NotReady` or `SchedulingDisabled` state, the control-plane upgrade completed successfully, and the `network` ClusterOperator shows `Available=True` and `Degraded=False`.
+* Unexpected failure: Nodes with version skew are in a `Ready` state but running older agents, or the `network` ClusterOperator shows `Degraded=True`. In this case, investigate the update process for those nodes.

--- a/modules/nw-ovn-kubernetes-upgrading-with-skew.adoc
+++ b/modules/nw-ovn-kubernetes-upgrading-with-skew.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-upgrading-with-skew_{context}"]
+= Upgrading the control plane with data-plane version skew
+
+[role="_abstract"]
+You can upgrade the OVN-Kubernetes control plane even when some worker nodes cannot update their data-plane agents.
+The Cluster Network Operator (CNO) allows the control-plane upgrade to proceed independently of the data plane.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {oc-first}.
+* The cluster is running a version of {product-title} that supports relaxed OVN-Kubernetes version skew policies.
+* You understand that nodes with older data-plane agents experience best-effort networking.
+
+.Procedure
+
+. Assess cluster health and identify nodes that might not upgrade by entering the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o wide
+----
++
+Review the output to identify any nodes in a `NotReady` or `SchedulingDisabled` state.
+These nodes might not be able to update their OVN-Kubernetes data-plane agents during the upgrade.
+
+. Check the current OVN-Kubernetes pod versions across all nodes:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -o wide
+----
++
+Note the distribution of `ovnkube-node` pods and the nodes they are running on.
+After the upgrade, you can compare this output to verify which nodes updated.
+
+. Initiate a standard z-stream or minor version upgrade for the control plane. 
+For a z-stream upgrade, enter the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade --to=<target_version>
+----
++
+Replace `_<target_version>_` with the version you are upgrading to, for example `4.y.z`.
++
+For a minor version upgrade, enter the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade --to=<target_version>
+----
++
+Replace `_<target_version>_` with the target minor version, for example `4.(y+1).0`.
+
+. Monitor the Cluster Network Operator to confirm the control-plane upgrade proceeds by entering the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperator network
+----
++
+.Example output
+[source,terminal]
+----
+NAME      VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+network   4.y.z     True        True          False      5m      ...
+----
++
+The `PROGRESSING` field shows `True` while the upgrade is in progress. The CNO allows the control-plane components to upgrade even if some `ovnkube-node` pods on worker nodes cannot be updated.
+
+. Wait for the control-plane upgrade to complete. You can monitor progress by running the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade
+----
++
+The upgrade is complete when the output shows the target version and no further updates are in progress.
+
+. Verify the new control-plane version by checking the `ovnkube-control-plane` pods:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-control-plane -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
+----
++
+Confirm that the `ovnkube-control-plane` pods are running the new version image.

--- a/modules/nw-ovn-kubernetes-upgrading-with-skew.adoc
+++ b/modules/nw-ovn-kubernetes-upgrading-with-skew.adoc
@@ -1,0 +1,144 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-upgrading-with-skew_{context}"]
+= Upgrading the control plane with data-plane version skew
+
+[role="_abstract"]
+You can upgrade the OVN-Kubernetes control plane even when some compute nodes cannot update their data-plane agents.
+The Cluster Network Operator (CNO) allows the control-plane upgrade to proceed independently of the data plane.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {oc-first}.
+* The cluster is running a version of {product-title} that supports relaxed OVN-Kubernetes version skew policies.
+* You understand that nodes with older data-plane agents experience best-effort networking.
+
+.Procedure
+
+. Verify that the cluster is healthy by confirming pod-to-pod connectivity and checking that the OVN-Kubernetes control-plane pods report no errors. To do this task, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -o wide
+----
++
+Check that all `ovnkube-control-plane` and `ovnkube-node` pods report a `Running` status and `READY` state.
+
+. Upgrade the control plane to the target version by entering the following command.
+Compute nodes remain on the current version, which creates the version skew between the control plane and the data plane.
++
+[source,terminal]
+----
+$ oc adm upgrade --to=<target_version>
+----
++
+Replace `<target_version>` with the target release version.
+
+. Verify that the OVN-Kubernetes control-plane pods are running and ready after the control-plane upgrade by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-control-plane
+----
+
+. While the cluster is running in a skewed state, validate that the data plane continues to operate correctly.
++
+.. Create a test pod and confirm that it starts successfully by entering the following command:
++
+[source,terminal]
+----
+$ oc run test-pod --image=registry.redhat.io/rhel9/support-tools -- restart=Never -- sleep 3600
+----
++
+.. Verify pod-to-pod connectivity by entering the following command:
++
+[source,terminal]
+----
+$ oc exec -i -t test-pod -- ping -c 3 <target_pod_ip>
+----
++
+.. Verify cross-node connectivity by testing both HTTP and ICMP traffic by entering the following command:
++
+[source,terminal]
+----
+$ oc exec -i -t test-pod -- curl -I http://<node_ip_or_service_ip>
+----
++
+.. Check the OVN-Kubernetes controller logs for version-incompatibility errors by entering the following command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ovn-kubernetes -l app=ovnkube-control-plane --tail=100 | grep -i error
+----
++
+.. Confirm that Geneve tunnels remain functional for cross-node traffic by entering the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-ovn-kubernetes -l app=ovnkube-node -c ovn-controller -- ovs-appctl dpif/show
+----
+
+. Verify the current state of the `NodePool` resources before upgrading the compute nodes by running the following command:
++
+[source,terminal]
+----
+$ oc get nodepool -n <hosted_cluster_namespace>
+----
++
+Confirm that each `NodePool` shows the current version and that `UPDATINGVERSION` is `False`.
+
+. Upgrade the compute nodes to match the control-plane version by patching each `NodePool` with the target release image.
+To do this task, enter the following command:
++
+[source,terminal]
+----
+$ oc patch nodepool <nodepool_name> -n <hosted_cluster_namespace> --type
+merge \
+    -p '{"spec":{"release":{"image":"<target_release_image>"}}}'
+----
++
+--
+where:
+
+`<nodepool_name>`:: Specifies the name of the `NodePool` object.
+`<hosted_cluster_namespace>`:: The namespace of the hosted cluster and `<target_release_image>` with the pull spec of the target release image.
+`<target_release_image>`:: The pull specification of the target release image.
++
+[NOTE]
+====
+The `NodePool` upgrade uses a rolling replacement strategy.
+Existing nodes are cordoned, drained, and deleted, and replacement nodes are provisioned with the target version.
+====
+--
+
+. Monitor the `NodePool` status until the upgrade completes by running the following command:
++
+[source,terminal]
+----
+$ oc get nodepool -n <hosted_cluster_namespace>
+----
++
+Confirm that each `NodePool` reports the target version, `READY` is `True`, and `UPDATING` is `False`.
+
+.Verification
+
+* Confirm that the kubelet and container runtime versions on each compute node match the target release by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o wide
+----
+
+* Confirm that the OVN-Kubernetes node pods were recreated on the new compute nodes and that all containers are ready by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node
+----
+
+* Deploy a new test pod and confirm pod-to-pod and cross-node connectivity.
+Verify that no regression exists after the control plane and data plane are fully aligned.

--- a/modules/nw-ovn-kubernetes-version-skew-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-version-skew-matrix.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ovn-kubernetes-version-skew-matrix_{context}"]
+= Supported OVN-Kubernetes version skew matrix
+
+[role="_abstract"]
+Review the tables that describe the supported combinations of OVN-Kubernetes control-plane and data-plane versions.
+The relaxed version skew policy supports both z-stream and y-stream skew scenarios.
+
+Z-stream version skew::
++
+Z-stream version skew occurs when the control-plane components are at a newer patch version within the same minor version as the data-plane agents.
++
+.Supported z-stream version skew combinations
+[cols="1,1,1",options="header"]
+|===
+|Control-plane version |Data-plane version |Support status
+
+|4.y.z (newer patch)
+|4.y.z (older patch)
+|Supported. Best-effort networking on nodes with older agents.
+
+|4.y.z
+|4.y.z (same patch)
+|Fully supported. No version skew.
+
+|4.y.z (older patch)
+|4.y.z (newer patch)
+|Not applicable. The data-plane version does not advance ahead of the control plane.
+|===
++
+In z-stream skew scenarios, the control plane and data plane share the same minor version but differ in patch version.
+This is the lowest-risk skew scenario because patch releases typically contain only bug fixes and security updates with minimal changes to networking behavior.
+
+Y-stream version skew::
++
+Y-stream version skew occurs when the control-plane components are at a newer minor version than the data-plane agents.
++
+.Supported y-stream version skew combinations
+[cols="1,1,1",options="header"]
+|===
+|Control-plane version |Data-plane version |Support status
+
+|4.(y+1).z
+|4.y.z
+|Supported. Best-effort networking on nodes with older agents.
+
+|4.(y+1).z
+|4.(y-1).z
+|Extended skew. Supported with increased risk of networking degradation.
+
+|4.(y+1).z
+|4.(y+1).z
+|Fully supported. No version skew.
+|===
++
+In y-stream skew scenarios, the control plane is at a newer minor version than the data plane.
+This scenario has a higher risk of networking degradation because minor releases can include changes to network flow programming, new features, and updated database schemas.
+
+Skew duration::
++
+No maximum skew duration is enforced.
+The OVN-Kubernetes version skew can persist indefinitely, if the underlying node issues remain unresolved.
+The primary goal of the relaxed policy is to allow the control plane to advance to a newer version regardless of the data-plane state.
++
+[IMPORTANT]
+====
+Although there is no enforced time limit, you should resolve the underlying issues that prevent nodes from updating as soon as possible.
+Extended version skew increases the risk of networking degradation and limits the availability of new networking features on affected nodes.
+====
+
+Deployment topology support::
++
+The relaxed version skew policy applies to the following deployment topologies:
++
+* Hosted control plane environments, including managed services such as {product-rosa} and {azure-first} {product-dedicated}
+* Standalone {product-title} clusters with unhealthy or unreachable worker nodes
+* Clusters with zero worker nodes, such as during scale-from-zero or hibernation scenarios

--- a/modules/nw-ovn-kubernetes-version-skew.adoc
+++ b/modules/nw-ovn-kubernetes-version-skew.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-kubernetes-version-skew_{context}"]
+= Understanding OVN-Kubernetes version skew
+
+[role="_abstract"]
+In {product-title}, the OVN-Kubernetes network plugin has two main component groups: the control-plane components and the data-plane agents. 
+When you upgrade your cluster, these components can temporarily run different versions, which is known as _version skew_.
+
+The OVN-Kubernetes control plane consists of the `ovnkube-control-plane` pods, which handle central IP address management (IPAM) allocation for the cluster.
+The data plane consists of the `ovnkube-node` daemonset pods.
+These pods run on every node and program Open vSwitch (OVS) with the network flows that implement pod networking.
+
+Previous strict version enforcement::
++
+In earlier versions of {product-title}, the Cluster Network Operator (CNO) enforced a strict version alignment policy. Data-plane agents on all nodes had to be at the same or a newer version than the control-plane components before the control plane could be upgraded. 
+This strict enforcement meant that if any worker node was unreachable, unhealthy, or unable to update its OVN-Kubernetes agents, the entire control-plane upgrade was blocked.
++
+This behavior was particularly problematic in the following scenarios:
++
+* Hosted control plane environments where management cluster components needed urgent security updates but customer-owned worker nodes were unreachable.
+* Clusters with zero worker nodes, such as during scale-from-zero or hibernation, where the absence of data-plane agents was incorrectly interpreted as an upgrade in progress.
+* Managed service environments where service providers needed to keep infrastructure compliant regardless of customer actions on the data plane.
+* Clusters where unhealthy nodes prevented the control plane from receiving critical fixes.
+
+Relaxed version skew policy::
++
+Starting with {product-title} 5.0, the CNO uses a relaxed version skew policy that allows the OVN-Kubernetes control plane to upgrade independently of the data plane.
+The control plane can advance to a newer version even when some or all data-plane agents on worker nodes remain at an older version.
++
+This relaxed policy is possible because of the OVN Interconnect (OVN-IC) architecture, which was introduced in {product-title} 4.14.
+In this architecture, the OVN northbound database, southbound database, and `ovn-northd` daemon run locally on each node rather than centrally on the control plane.
+This local-per-node design reduces the coupling between control-plane and data-plane versions.
+This happens because the OVN components on each node primarily process information local to that node.
++
+The relaxed skew policy supports the following scenarios:
++
+z-stream version skew:: The control plane can advance within the same minor version while data-plane agents remain at an older patch version.
+For example, the control plane can run version 4.y.2 while some nodes run version 4.y.1.
+y-stream version skew:: The control plane can advance to the next minor version while data-plane agents remain at the previous minor version.
+For example, the control plane can run version 4.(y+1).z while some nodes run version 4.y.z.
++
+[IMPORTANT]
+====
+Nodes that cannot update their OVN-Kubernetes agents experience best-effort networking.
+The relaxed skew policy prioritizes control-plane health and upgradeability over guaranteed full networking correctness on nodes that are already unhealthy or unreachable.
+For more information, see "Best-effort networking for nodes with version skew".
+====

--- a/modules/nw-ovn-kubernetes-version-skew.adoc
+++ b/modules/nw-ovn-kubernetes-version-skew.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-kubernetes-version-skew_{context}"]
+= Understanding OVN-Kubernetes version skew
+
+[role="_abstract"]
+The OVN-Kubernetes control plane consists of the `ovnkube-control-plane` pods, which handle central IP address management (IPAM) allocation for the cluster.
+The data plane consists of the `ovnkube-node` daemonset pods.
+These pods run on every node and program Open vSwitch (OVS) with the network flows that implement pod networking.
+
+Previous strict version enforcement::
++
+In earlier versions of {product-title}, the Cluster Network Operator (CNO) enforced a strict version alignment policy. Data-plane agents on all nodes had to be at the same or a newer version than the control-plane components before the control plane could be upgraded. 
+This strict enforcement meant that if any worker node was unreachable, unhealthy, or unable to update its OVN-Kubernetes agents, the entire control-plane upgrade was blocked.
++
+This behavior was particularly problematic in the following scenarios:
++
+* Hosted control plane environments where management cluster components needed urgent security updates but customer-owned worker nodes were unreachable.
+* Clusters with zero worker nodes, such as during scale-from-zero or hibernation, where the absence of data-plane agents was incorrectly interpreted as an upgrade in progress.
+* Managed service environments where service providers needed to keep infrastructure compliant regardless of customer actions on the data plane.
+* Clusters where unhealthy nodes prevented the control plane from receiving critical fixes.
+
+Relaxed version skew policy::
++
+Starting with {product-title} 5.0, the CNO uses a relaxed version skew policy that allows the OVN-Kubernetes control plane to upgrade independently of the data plane.
+The control plane can advance to a newer version even when some or all data-plane agents on worker nodes remain at an older version.
++
+This relaxed policy is possible because of the OVN Interconnect (OVN-IC) architecture, which was introduced in {product-title} 4.14.
+In this architecture, the OVN northbound database, southbound database, and `ovn-northd` daemon run locally on each node rather than centrally on the control plane.
+This local-per-node design reduces the coupling between control-plane and data-plane versions.
+This happens because the OVN components on each node primarily process information local to that node.
++
+The relaxed skew policy supports the following scenarios:
++
+z-stream version skew:: The control plane can advance within the same minor version while data-plane agents remain at an older patch version.
+For example, the control plane can run version 4.y.2 while some nodes run version 4.y.1.
+y-stream version skew:: The control plane can advance to the next minor version while data-plane agents remain at the previous minor version.
+For example, the control plane can run version 4.(y+1).z while some nodes run version 4.y.z.
++
+[IMPORTANT]
+====
+Nodes that cannot update their OVN-Kubernetes agents experience best-effort networking.
+The relaxed skew policy prioritizes control-plane health and upgradeability over guaranteed full networking correctness on nodes that are already unhealthy or unreachable.
+For more information, see "Best-effort networking for nodes with version skew".
+====

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -43,6 +43,24 @@ include::modules/nw-ovn-kubernetes-limitations.adoc[leveloffset=+1]
 // Session affinity
 include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 
+// Understanding OVN-Kubernetes version skew
+include::modules/nw-ovn-kubernetes-version-skew.adoc[leveloffset=+1]
+
+// Supported OVN-Kubernetes version skew matrix
+include::modules/nw-ovn-kubernetes-version-skew-matrix.adoc[leveloffset=+1]
+
+// Best-effort networking for nodes with version skew
+include::modules/nw-ovn-kubernetes-best-effort-networking.adoc[leveloffset=+1]
+
+// Skew-related alerts and status conditions
+include::modules/nw-ovn-kubernetes-skew-alerts-conditions.adoc[leveloffset=+1]
+
+// Upgrading the control plane with data-plane version skew
+include::modules/nw-ovn-kubernetes-upgrading-with-skew.adoc[leveloffset=+1]
+
+// Assessing cluster status after a skewed upgrade
+include::modules/nw-ovn-kubernetes-assessing-skewed-upgrade.adoc[leveloffset=+1]
+
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
5.0

Issue:
[OSDOCS-19471](https://redhat.atlassian.net/browse/OSDOCS-19471)

Link to docs preview:

* https://117328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-ovnk-version-skew.html

- [ ] SME has approved this change (Weibin Liang).
- [ ] QE has approved this change.
