### PR TITLE
OSDOCS-17081_4: CQA updates

### DIFF
--- a/modules/cluster-resources.adoc
+++ b/modules/cluster-resources.adoc
@@ -3,7 +3,7 @@
 = Interacting with your cluster resources
 
 [role="_abstract"]
-You can use the {oc-first} tool to interact with and edit cluster resources in {product-title} to manage your cluster configuration.
+To view and edit the global configuration of your {product-title} cluster, use the {oc-first} to query and change cluster resources.
 
 .Prerequisites
 
@@ -17,7 +17,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 .Procedure
 
-. To see which configuration Operators have been applied, run the following command:
+. To check which configuration Operators apply to your cluster, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/summarizing-cluster-specifications-through-clusterversion.adoc
+++ b/modules/summarizing-cluster-specifications-through-clusterversion.adoc
@@ -7,7 +7,7 @@
 = Summarizing cluster specifications by using a cluster version object
 
 [role="_abstract"]
-You can obtain a summary of {product-title} cluster specifications by querying the `clusterversion` resource.
+To verify your cluster version, check update history, and confirm component status, query the `clusterversion` resource.
 
 .Prerequisites
 
@@ -17,7 +17,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/support/managing-cluster-resources.adoc
+++ b/support/managing-cluster-resources.adoc
@@ -11,6 +11,6 @@ endif::[]
 toc::[]
 
 [role="_abstract"]
-You can apply global configuration options in {product-title}. Operators apply these configuration settings across the cluster.
+To keep consistent behavior across your {product-title} cluster, set global configuration options that Operators apply to all nodes.
 
 include::modules/cluster-resources.adoc[leveloffset=+1]

--- a/support/summarizing-cluster-specifications.adoc
+++ b/support/summarizing-cluster-specifications.adoc
@@ -11,7 +11,7 @@ endif::[]
 toc::[]
 
 [role="_abstract"]
-You can query the `clusterversion` resource to obtain a summary of your {product-title} cluster specifications to help Red{nbsp}Hat Support troubleshoot issues.
+To verify the version, update history, and component status of your {product-title} cluster, query the `clusterversion` resource.
 
 // Summarizing cluster specifications through `clusterversion`
 include::modules/summarizing-cluster-specifications-through-clusterversion.adoc[leveloffset=+1]


### PR DESCRIPTION
Versions:
4.21+ 

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17081

Link to docs preview:

- [Interacting with your cluster resources](https://117334--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/managing-cluster-resources.html#support-cluster-resources_managing-cluster-resources)
- [Summarizing cluster specifications by using a cluster version object](https://117334--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/summarizing-cluster-specifications.html#summarizing-cluster-specifications-through-clusterversion_summarizing-cluster-specifications)
- [Managing your cluster resources](https://117334--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/managing-cluster-resources.html)
- [Summarizing cluster specifications](https://117334--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/summarizing-cluster-specifications.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
