### PR TITLE
OSDOCS-20883: Updated .vale for new autonode terms

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -27,3 +27,8 @@ ubxtool
 vDUs?
 VFs?
 Westport
+Karpenter
+OpenshiftEC2NodeClass
+EC2NodeClass
+NodePool
+NodeClaim


### PR DESCRIPTION
Version(s):
`enterprise-4.22+`

Issue:
**[OSDOCS-20883](https://redhat.atlassian.net/browse/OSDOCS-20883)**

Link to docs preview:
- No visible changes -

Additional information:
This PR adds some terms to Vale to prevent false positives with the new autonode features.