### PR TITLE
OBSDOCS-3712: Add Logging 6.0.16 z-stream release notes

### DIFF
--- a/modules/logging-release-notes-6-0-16.adoc
+++ b/modules/logging-release-notes-6-0-16.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6-0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-16_{context}"]
+= Logging 6.0.16
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:50843[RHBA-2026:50843].
+
+[id="logging-release-notes-6-0-16-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25681[CVE-2026-25681]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-27136[CVE-2026-27136]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33811[CVE-2026-33811]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39820[CVE-2026-39820]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39821[CVE-2026-39821]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42151[CVE-2026-42151]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42154[CVE-2026-42154]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42504[CVE-2026-42504]
+
+[id="logging-release-notes-6-0-16-deprecation_{context}"]
+== Deprecation
+
+Azure Monitor Data Collector API::
+The Azure Monitor Data Collector API output type is deprecated in this release and will be removed in a future release. Use the Azure Monitor Logs Ingestion API output type instead.
++
+https://redhat.atlassian.net/browse/LOG-9194[LOG-9194]

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 These release notes describe the updates in {LoggingProductName} 6.0. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-0-16.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-0-15.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-14.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Adds release notes for OpenShift Logging 6.0.16 z-stream release
- Includes 10 CVEs sorted numerically
- Includes 1 deprecation (Azure Monitor Data Collector API)
- Uses errata placeholder pending actual errata number

- Issue: https://redhat.atlassian.net/browse/OBSDOCS-3712
- Version: 6.0
- Preview: https://117363--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0.html

## Changes
- Created `modules/logging-release-notes-6-0-16.adoc` (main module with CVEs and deprecation)
- Updated `release_notes/logging-release-notes-6-0.adoc` to include new module

## CVEs Included
- CVE-2026-25681
- CVE-2026-27136
- CVE-2026-33186
- CVE-2026-33811
- CVE-2026-39820
- CVE-2026-39821
- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-42499
- CVE-2026-42504

## Deprecation
- Azure Monitor Data Collector API ([LOG-9194](https://redhat.atlassian.net/browse/LOG-9194))

## Follow-up
Errata number placeholder (`RHBA-YYYY:NNNNN`) will need to be updated once the actual errata is available.

Signed-off-by: John Wilkins <jowilkin@redhat.com>