### PR TITLE
[power-monitoring-docs-0.4] POWERMON-794 Power Monitoring Documentation: ceasing Kepler involement

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -9,8 +9,10 @@ toc::[]
 [role="_abstract"]
 {PM-shortname-c} uses the {PM-kepler} architecture to provide energy consumption metrics, enabling you to track and optimize the power usage of your cluster workloads.
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 include::modules/power-monitoring-overview.adoc[leveloffset=+1]
 

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -9,8 +9,10 @@ toc::[]
 [role="_abstract"]
 Configure the {PM-kepler} custom resource to manage how the Kepler exporter collects and reports power consumption metrics from your cluster nodes.
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 The `{PM-kepler}` resource is a Kubernetes custom resource definition (CRD) that enables you to configure the deployment and monitor the status of the {PM-kepler} resource.
 

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -6,11 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 [role="_abstract"]
 Install the {PM-operator} and deploy {PM-kepler} to monitor power consumption across your {ocp} cluster infrastructure.
+
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 //Installing power monitoring operator
 include::modules/power-monitoring-installing-pmo.adoc[leveloffset=+1]

--- a/release_notes/power-monitoring-release-notes-tp-0-4.adoc
+++ b/release_notes/power-monitoring-release-notes-tp-0-4.adoc
@@ -9,8 +9,10 @@ toc::[]
 [role="_abstract"]
 You can review the new features, enhancements, and fixed issues for the {PM-title} 0.4 (Technology Preview) release.
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 {product-title} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {ocp} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
 

--- a/release_notes/power-monitoring-release-notes.adoc
+++ b/release_notes/power-monitoring-release-notes.adoc
@@ -9,7 +9,9 @@ toc::[]
 [role="_abstract"]
 {product-title} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {ocp} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 These release notes track the development of {PM-title} in the {ocp}.

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -7,12 +7,12 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Uninstall {PM-shortname} by deleting the {PM-kepler} instance and removing the {PM-operator} from your {ocp} cluster.
-
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 You can uninstall {PM-shortname} by deleting the {PM-kepler} instance and then the {PM-operator} in the {ocp} web console.
+
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 // Removing kepler
 include::modules/power-monitoring-deleting-kepler.adoc[leveloffset=+1]

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -9,8 +9,10 @@ toc::[]
 [role="_abstract"]
 You can monitor energy usage across cluster resources by using power consumption dashboards in the {ocp} web console.
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
+[IMPORTANT]
+====
+{PM-shortname-c} for Red Hat OpenShift is deprecated and will have no further releases or support.
+====
 
 You can visualize {PM-shortname} metrics in the {ocp} web console by accessing {PM-shortname} dashboards or by exploring *Metrics* under the *Observe* tab.
 


### PR DESCRIPTION
Manual cherry-pick

Original PR: https://github.com/openshift/openshift-docs/pull/116878
Commit: 00b7186cd81e38a3c0b3133a61aeabe7f6192d20

Version(s):
`power-monitoring-docs-0.4`

QE review:
QE is not required for this PR.

Additional information:
* Only 7 files instead of the original 11 as 4 files that relate to release note entries for  `power-monitoring-0.5` , and reference/API docs are not applicable to the `power-monitoring-0.4` branch.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
