### PR TITLE
OSDOCS-11871: Added documents for External DNS Operator versioning

### DIFF
--- a/modules/nw-external-dns-operator-compatability-table.adoc
+++ b/modules/nw-external-dns-operator-compatability-table.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-external-dns-operator-compatibility-table_{context}"]
+= External DNS Operator and {product-title} compatibility
+
+[role="_abstract"]
+To understand External DNS Operator and {product-title} compatibility, review the table that shows the External DNS Operator version history.
+Additionally, review the table that shows the support model for {product-title} {product-version}.
+
+.External DNS Operator version history
+[cols="2,2",options="header"]
+|===
+|External DNS Operator version |First published on {product-title}
+
+|1.3
+|4.17
+
+|1.2
+|4.14
+
+|===
+
+.External DNS Operator support model for {product-title} {product-version}
+[cols="2,2",options="header"]
+|===
+|External DNS Operator release |Support status
+
+|1.3
+|Full support
+
+|1.2
+|Full support
+
+|===

--- a/modules/nw-external-dns-operator-domain-limitations.adoc
+++ b/modules/nw-external-dns-operator-domain-limitations.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
-// * networking/understanding-external-dns-operator.adoc
+//
+// * networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-external-dns-operator-domain-limitations_{context}"]

--- a/modules/nw-external-dns-operator-logs.adoc
+++ b/modules/nw-external-dns-operator-logs.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
-// * networking/understanding-external-dns-operator.adoc
+//
+// * networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-external-dns-operator-logs_{context}"]

--- a/modules/nw-external-dns-operator-versioning.adoc
+++ b/modules/nw-external-dns-operator-versioning.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-external-dns-operator-versioning_{context}"]
+= External DNS Operator versioning and branching
+
+[role="_abstract"]
+The External DNS Operator follows semantic versioning and a branch-based release model that aligns the External DNS Operator releases with specific {product-title} versions.
+
+The External DNS Operator version uses the `X.Y.Z` format:
+
+X (major):: A set of compatible changes. A change to `X` indicates a breaking change.
+Y (minor):: A minimum feature set. A change to `Y` indicates the addition of a backwards-compatible feature.
+Z (patch):: A minimum set of bug fixes. A change to `Z` indicates a backwards-compatible change that does not add functionality.
+
+Development occurs on the `main` branch. Each minor release creates a `release-X.Y` branch that contains stable, backwards-compatible code.
+
+Operator Lifecycle Manager (OLM) provides the following two channel types for the External DNS Operator:
+
+Minor channels (`release-vX.Y`):: Contain patch releases for a specific minor version.
+Major channels (`release-vX`):: Contain all patch releases from all minor channels within a major version.

--- a/modules/nw-external-dns-operator.adoc
+++ b/modules/nw-external-dns-operator.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
-// * networking/understanding-external-dns-operator.adoc
+//
+// * networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-external-dns-operator_{context}"]

--- a/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
+++ b/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
@@ -9,6 +9,14 @@ toc::[]
 [role="_abstract"]
 The External DNS Operator deploys and manages `ExternalDNS` to provide the name resolution for services and routes from the external DNS provider to {product-title}.
 
+To view release notes for the External DNS Operator, see "External DNS Operator release notes".
+
+// External DNS Operator versioning and branching
+include::modules/nw-external-dns-operator-versioning.adoc[leveloffset=+1]
+
+// External DNS Operator and {product-title} compatibility
+include::modules/nw-external-dns-operator-compatability-table.adoc[leveloffset=+1]
+
 // External DNS Operator domain name limitations
 include::modules/nw-external-dns-operator-domain-limitations.adoc[leveloffset=+1]
 
@@ -17,3 +25,9 @@ include::modules/nw-external-dns-operator.adoc[leveloffset=+1]
 
 // Viewing External DNS Operator logs
 include::modules/nw-external-dns-operator-logs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc#external-dns-operator-release-notes[External DNS Operator release notes]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-11871](https://redhat.atlassian.net/browse/OSDOCS-11871)

Link to docs preview:

* https://117405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.html

- [ ] SME has approved this change (Andrey Lebedev).
- [ ] QE has approved this change.

