### PR TITLE
Remove duplicate Additional resources link from API impersonation pages (CP to main-4.20)

### DIFF
--- a/applications/projects/creating-project-other-user.adoc
+++ b/applications/projects/creating-project-other-user.adoc
@@ -11,10 +11,6 @@ You can use impersonation to create a project on behalf of a different user acco
 
 include::modules/authentication-api-impersonation.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation[User impersonation (Kubernetes documentation)]
-
 include::modules/impersonation-project-creation.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/authentication/understanding-authentication.adoc
+++ b/authentication/understanding-authentication.adoc
@@ -26,6 +26,10 @@ include::modules/oauth-token-requests.adoc[leveloffset=+2]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/authentication-api-impersonation.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation[User impersonation (Kubernetes documentation)]
+
 include::modules/authentication-prometheus-system-metrics.adoc[leveloffset=+3]
 
 endif::[]

--- a/modules/authentication-api-impersonation.adoc
+++ b/modules/authentication-api-impersonation.adoc
@@ -10,7 +10,3 @@
 
 [role="_abstract"]
 You can configure API requests in {product-title} to act as another user. Impersonation allows you to perform actions on behalf of another account without switching credentials.
-
-[role="_additional-resources"]
-.Additional resources
-* link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation[User impersonation (Kubernetes documentation)]


### PR DESCRIPTION
This PR has been raised to remove one of the double Additional resources. The issue exists from main to 4.20.
Reference PR: https://github.com/openshift/openshift-docs/pull/117393