### PR TITLE
[OCPBUGS-104855]: Fix PPC example to use even CPU counts for HT compatibility

### DIFF
--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -159,13 +159,19 @@ Options:
    -t                 path to a must-gather tarball
 A tool that automates creation of Performance Profiles
 
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]
+
 Usage:
   performance-profile-creator [flags]
+  performance-profile-creator [command]
 
 Flags:
       --disable-ht                        Disable Hyperthreading
+      --enable-hardware-tuning            Enable setting maximum cpu frequencies
   -h, --help                              help for performance-profile-creator
-      --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
       --mcp-name string                   MCP name corresponding to the target machines (required)
       --must-gather-dir-path string       Must gather directory path (default "must-gather")
       --offlined-cpu-count int            Number of offlined CPUs
@@ -177,7 +183,8 @@ Flags:
       --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
       --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
       --user-level-networking             Run with User level Networking(DPDK) enabled
-      --enable-hardware-tuning            Enable setting maximum CPU frequencies
+
+Use "performance-profile-creator [command] --help" for more information about a command.
 ----
 +
 [NOTE]
@@ -185,48 +192,48 @@ Flags:
 You can optionally set a path for the Node Tuning Operator image using the `-p` option. If you do not set a path, the wrapper script uses the default image: `registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version}`.
 ====
 
-. To display information about the cluster, run the PPC tool with the `log` argument by running the following command:
+. To display information about the cluster, run the PPC tool with the `info` command by running the following command:
 +
 [source,terminal]
 ----
-$ ./run-perf-profile-creator.sh -t /<path_to_must_gather_dir>/must-gather.tar.gz -- --info=log
+$ ./run-perf-profile-creator.sh -t /<path_to_must_gather_dir>/must-gather.tar.gz -- info
 ----
 * `-t /<path_to_must_gather_dir>/must-gather.tar.gz`: Specifies the path to directory containing the must-gather tarball. This is a required argument for the wrapper script.
 +
-.Example output
+The following example shows the cluster information output:
++
 [source,terminal]
 ----
-level=info msg="Cluster info:"
-level=info msg="MCP 'master' nodes:"
-level=info msg=---
-level=info msg="MCP 'worker' nodes:"
-level=info msg="Node: host.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg="Node: host1.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg=---
-level=info msg="MCP 'worker-cnf' nodes:"
-level=info msg="Node: host2.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg=---
+PPC: Cluster info:
+MCP 'master' nodes:
+---
+MCP 'worker' nodes:
+Node: host.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+Node: host1.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+---
+MCP 'worker-cnf' nodes:
+Node: host2.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+---
 ----
 
 . Create a performance profile by running the following command. The example command uses sample PPC arguments and values.
 +
 [source,terminal]
 ----
-$ ./run-perf-profile-creator.sh -t /path-to-must-gather/must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=1 --rt-kernel=true --split-reserved-cpus-across-numa=false --power-consumption-mode=ultra-low-latency --offlined-cpu-count=1 > my-performance-profile.yaml
+$ ./run-perf-profile-creator.sh -t /path-to-must-gather/must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=2 --rt-kernel=true --split-reserved-cpus-across-numa=false --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 * `--mcp-name=worker-cnf` specifies the `worker-cnf` machine config pool.
-* `--reserved-cpu-count=1` specifies one reserved CPU.
+* `--reserved-cpu-count=2` specifies two reserved CPUs.
 * `--rt-kernel=true` enables the real-time kernel.
 * `--split-reserved-cpus-across-numa=false` disables reserved CPUs splitting across NUMA nodes.
 * `--power-consumption-mode=ultra-low-latency` specifies minimal latency at the cost of increased power consumption.
-* `--offlined-cpu-count=1` specifies one offlined CPUs.
 +
 [NOTE]
 ====
@@ -240,7 +247,8 @@ The `mcp-name` argument in this example is set to `worker-cnf` based on the outp
 $ cat my-performance-profile.yaml
 ----
 +
-.Example output
+The generated YAML file should contain the following output:
++
 [source,yaml]
 ----
 apiVersion: performance.openshift.io/v2
@@ -250,8 +258,7 @@ metadata:
 spec:
   cpu:
     isolated: 2-3
-    offlined: "1"
-    reserved: "0"
+    reserved: "0-1"
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
   nodeSelector:
@@ -273,7 +280,8 @@ spec:
 $ oc apply -f my-performance-profile.yaml
 ----
 +
-.Example output
+The performance profile is successfully applied and created as shown in the following output:
++
 [source,terminal]
 ----
 performanceprofile.performance.openshift.io/performance created

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -34,7 +34,8 @@ The PPC uses the `must-gather` data from your cluster to create the performance 
 $ oc get mcp
 ----
 +
-.Example output
+The following output lists the available machine config pools:
++
 [source,terminal]
 ----
 NAME         CONFIG                                                 UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
@@ -63,7 +64,8 @@ Password: <password>
 $ podman run --rm --entrypoint performance-profile-creator registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} -h
 ----
 +
-.Example output
+The following output shows the available flags and commands for the PPC tool:
++
 [source,terminal]
 ----
 A tool that automates creation of Performance Profiles
@@ -75,7 +77,7 @@ Available Commands:
 
 Usage:
   performance-profile-creator [flags]
-performance-profile-creator [command]
+  performance-profile-creator [command]
 
 Flags:
       --disable-ht                        Disable Hyperthreading
@@ -96,7 +98,7 @@ Flags:
 Use "performance-profile-creator [command] --help" for more information about a command.
 ----
 
-. To display information about the cluster, run the PPC tool with the `log` argument by running the following command:
+. To display information about the cluster, run the PPC tool with the `info` command by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -108,62 +110,63 @@ $ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/
 ** The directory containing the `must-gather` data.
 ** An existing directory containing the `must-gather` decompressed .tar file.
 +
-.Example output
+The following output is generated from running the command:
++
 [source,terminal]
 ----
-level=info msg="Nodes names targeted by master pool are: "
-level=info msg="Nodes names targeted by worker-cnf pool are: host2.example.com "
-level=info msg="Nodes names targeted by worker pool are: host.example.com host1.example.com "
-level=info msg="Cluster info:"
-level=info msg="MCP 'master' nodes:"
-level=info msg=---
-level=info msg="MCP 'worker' nodes:"
-level=info msg="Node: host.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg="Node: host1.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg=---
-level=info msg="MCP 'worker-cnf' nodes:"
-level=info msg="Node: host2.example.com (NUMA cells: 1, HT: true)"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg=---
+PPC: Nodes names targeted by master pool are:
+PPC: Nodes names targeted by worker-cnf pool are: host2.example.com
+PPC: Nodes names targeted by worker pool are: host.example.com host1.example.com
+PPC: Cluster info:
+MCP 'master' nodes:
+---
+MCP 'worker' nodes:
+Node: host.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+Node: host1.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+---
+MCP 'worker-cnf' nodes:
+Node: host2.example.com (NUMA cells: 1, HT: true)
+NUMA cell 0 : [0 1 2 3]
+CPU(s): 4
+---
 ----
 
 . Create a performance profile by running the following command. The example uses sample PPC arguments and values:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} --mcp-name=worker-cnf --reserved-cpu-count=1 --rt-kernel=true --split-reserved-cpus-across-numa=false --must-gather-dir-path /must-gather --power-consumption-mode=ultra-low-latency --offlined-cpu-count=1 > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} --mcp-name=worker-cnf --reserved-cpu-count=2 --rt-kernel=true --split-reserved-cpus-across-numa=false --must-gather-dir-path /must-gather --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 * `-v <path_to_must_gather>` specifies the path to either of the following components:
 ** The directory containing the `must-gather` data.
 ** The directory containing the `must-gather` decompressed .tar file.
 * `--mcp-name=worker-cnf` specifies the `worker-cnf` machine config pool.
-* `--reserved-cpu-count=1` specifies one reserved CPU.
+* `--reserved-cpu-count=2` specifies two reserved CPUs.
 * `--rt-kernel=true` enables the real-time kernel.
 * `--split-reserved-cpus-across-numa=false` disables reserved CPUs splitting across NUMA nodes.
 * `--power-consumption-mode=ultra-low-latency` specifies minimal latency at the cost of increased power consumption.
-* `--offlined-cpu-count=1` specifies one offlined CPU.
 +
 [NOTE]
 ====
 The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`. For {sno} use `--mcp-name=master`.
 ====
 +
-.Example output
+The following output shows the CPU and NUMA allocation for the performance profile:
++
 [source,terminal]
 ----
-level=info msg="Nodes targeted by worker-cnf MCP are: [worker-2]"
-level=info msg="NUMA cell(s): 1"
-level=info msg="NUMA cell 0 : [0 1 2 3]"
-level=info msg="CPU(s): 4"
-level=info msg="1 reserved CPUs allocated: 0 "
-level=info msg="2 isolated CPUs allocated: 2-3"
-level=info msg="Additional Kernel Args based on configuration: []"
+PPC: Nodes targeted by worker-cnf MCP are: [worker-2]
+PPC: NUMA cell(s): 1
+PPC: NUMA cell 0 : [0 1 2 3]
+PPC: CPU(s): 4
+PPC: 2 reserved CPUs allocated: 0-1
+PPC: 2 isolated CPUs allocated: 2-3
+PPC: Additional Kernel Args based on configuration: []
 ----
 
 . Review the created YAML file by running the following command:
@@ -172,7 +175,8 @@ level=info msg="Additional Kernel Args based on configuration: []"
 ----
 $ cat my-performance-profile.yaml
 ----
-.Example output
++
+The following example shows the contents of the generated performance profile:
 +
 [source,yaml]
 ----
@@ -184,8 +188,7 @@ metadata:
 spec:
   cpu:
     isolated: 2-3
-    offlined: "1"
-    reserved: "0"
+    reserved: "0-1"
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
   net:
@@ -209,7 +212,8 @@ spec:
 $ oc apply -f my-performance-profile.yaml
 ----
 +
-.Example output
+The following output confirms that the performance profile is created:
++
 [source,terminal]
 ----
 performanceprofile.performance.openshift.io/performance created


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-104855

Link to docs preview:
<!-- Add direct link(s) to the exact page(s) with updated content from the preview build once available. -->

QE review:
- [x] QE has approved this change.

Additional information:

The Performance Profile Creator (PPC) example command used `--reserved-cpu-count=1` and `--offlined-cpu-count=1`, which fails on hyper-threading systems (the default) with:

```
Error: failed to make profile data from node handler: failed to compute the reserved and isolated CPUs: can't allocate odd number of CPUs from a NUMA Node
```

**Affected modules:**
- `modules/cnf-running-the-performance-creator-profile.adoc` (Podman procedure)
- `modules/cnf-running-the-performance-creator-profile-offline.adoc` (wrapper script procedure)

**Changes (both modules):**

1. Changes `--reserved-cpu-count` from `1` to `2` so the value is even and compatible with hyper-threading NUMA allocation.
2. Removes `--offlined-cpu-count` from the example entirely. On the existing 4-CPU example system, `--reserved-cpu-count=2` plus `--offlined-cpu-count=2` would consume all 4 CPUs, leaving zero for isolated workloads — an invalid configuration. The `--offlined-cpu-count` flag remains documented in the PPC argument reference table.
3. Updates the example output (log messages and generated PerformanceProfile YAML) to reflect the corrected CPU allocations: `reserved: "0-1"`, `isolated: 2-3`.
4. Updates example output blocks from the old `level=info msg="..."` log format to the `PPC: ...` format introduced in v4.20. Verified by testing PPC images from v4.19 (old format) through v4.22 (new format) — the cutover occurred in v4.20.
5. (Wrapper script module only) Updates help output and `--info` invocation to reflect the v4.20+ subcommand syntax (`info` instead of `--info=log`).

**Cherry-pick guidance for backports:**

The branch has 3 commits:
- `fc42ec6` — CPU count fix only (retains old `level=info msg=` format) — cherry-pick this for **4.19 and below**
- `0936dc0` — Log format update for Podman module — relevant for **4.20+ only**
- `db62046` — Same fixes for wrapper script module (CPU counts + log format + info subcommand) — relevant for **4.20+ only**; for 4.19 and below, the wrapper script module needs only the CPU count fix with old format