### PR TITLE
OCPBUGS-100432: Exclude SriovFecClusterConfig from seed image on 4.18

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -110,6 +110,9 @@ The following table lists the components, resources, and configurations that you
 
 |`StorageLVMCluster.yaml`
 |No
+
+|`SriovFecClusterConfig.yaml`
+|No
 |====
 
 ifdef::ibu[]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OCPBUGS-100432](https://issues.redhat.com/browse/OCPBUGS-100432)

Link to docs preview:
- https://117442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-preparing-for-image-based-install.html
- https://117442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed.html#ztp-image-based-upgrade-seed-image-config-ran_generate-seed

QE review:
- [x] QE has approved this change.

Additional information:
Backports only the `SriovFecClusterConfig.yaml` seed-image exclusion guidance from [PR #109599](https://github.com/openshift/openshift-docs/pull/109599) / OCPBUGS-74682 to `enterprise-4.18`.

Does **not** backport `SriovVrbClusterConfig.yaml` (unsupported until 4.19).

Change: In the RAN DU seed image configuration table, add `SriovFecClusterConfig.yaml` with Include in seed image: No. Extra-manifest listings are left unchanged.