### PR TITLE
OCPBUGS-104855: Fix PPC example CPU counts for HT compatibility (4.19)

### DIFF
--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -218,15 +218,14 @@ level=info msg=---
 +
 [source,terminal]
 ----
-$ ./run-perf-profile-creator.sh -t /path-to-must-gather/must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=1 --rt-kernel=true --split-reserved-cpus-across-numa=false --power-consumption-mode=ultra-low-latency --offlined-cpu-count=1 > my-performance-profile.yaml
+$ ./run-perf-profile-creator.sh -t /path-to-must-gather/must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=2 --rt-kernel=true --split-reserved-cpus-across-numa=false --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 * `--mcp-name=worker-cnf` specifies the `worker-cnf` machine config pool.
-* `--reserved-cpu-count=1` specifies one reserved CPU.
+* `--reserved-cpu-count=2` specifies two reserved CPUs.
 * `--rt-kernel=true` enables the real-time kernel.
 * `--split-reserved-cpus-across-numa=false` disables reserved CPUs splitting across NUMA nodes.
 * `--power-consumption-mode=ultra-low-latency` specifies minimal latency at the cost of increased power consumption.
-* `--offlined-cpu-count=1` specifies one offlined CPUs.
 +
 [NOTE]
 ====
@@ -250,8 +249,7 @@ metadata:
 spec:
   cpu:
     isolated: 2-3
-    offlined: "1"
-    reserved: "0"
+    reserved: "0-1"
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
   nodeSelector:

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -136,18 +136,17 @@ level=info msg=---
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} --mcp-name=worker-cnf --reserved-cpu-count=1 --rt-kernel=true --split-reserved-cpus-across-numa=false --must-gather-dir-path /must-gather --power-consumption-mode=ultra-low-latency --offlined-cpu-count=1 > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} --mcp-name=worker-cnf --reserved-cpu-count=2 --rt-kernel=true --split-reserved-cpus-across-numa=false --must-gather-dir-path /must-gather --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 * `-v <path_to_must_gather>` specifies the path to either of the following components:
 ** The directory containing the `must-gather` data.
 ** The directory containing the `must-gather` decompressed .tar file.
 * `--mcp-name=worker-cnf` specifies the `worker-cnf` machine config pool.
-* `--reserved-cpu-count=1` specifies one reserved CPU.
+* `--reserved-cpu-count=2` specifies two reserved CPUs.
 * `--rt-kernel=true` enables the real-time kernel.
 * `--split-reserved-cpus-across-numa=false` disables reserved CPUs splitting across NUMA nodes.
 * `--power-consumption-mode=ultra-low-latency` specifies minimal latency at the cost of increased power consumption.
-* `--offlined-cpu-count=1` specifies one offlined CPU.
 +
 [NOTE]
 ====
@@ -161,7 +160,7 @@ level=info msg="Nodes targeted by worker-cnf MCP are: [worker-2]"
 level=info msg="NUMA cell(s): 1"
 level=info msg="NUMA cell 0 : [0 1 2 3]"
 level=info msg="CPU(s): 4"
-level=info msg="1 reserved CPUs allocated: 0 "
+level=info msg="2 reserved CPUs allocated: 0-1 "
 level=info msg="2 isolated CPUs allocated: 2-3"
 level=info msg="Additional Kernel Args based on configuration: []"
 ----
@@ -184,8 +183,7 @@ metadata:
 spec:
   cpu:
     isolated: 2-3
-    offlined: "1"
-    reserved: "0"
+    reserved: "0-1"
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
   net:


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-104855

Link to docs preview:
<!-- Add direct link(s) to the exact page(s) with updated content from the preview build once available. -->

QE review:
- [x] QE has approved this change.

Additional information:

Cherry-pick of fc42ec6 from PR #117426 (main branch).

The PPC example command used `--reserved-cpu-count=1` and `--offlined-cpu-count=1`, which fails on hyper-threading systems (the default) with:

```
Error: failed to make profile data from node handler: failed to compute the reserved and isolated CPUs: can't allocate odd number of CPUs from a NUMA Node
```

Changes:
1. Changes `--reserved-cpu-count` from `1` to `2` for HT NUMA compatibility.
2. Removes `--offlined-cpu-count` from the example (on a 4-CPU system, 2 reserved + 2 offlined = 0 isolated, which is invalid).
3. Updates example output to reflect corrected CPU allocations.

Note: This backport retains the `level=info msg="..."` log format used by PPC in 4.19. The v4.20+ `PPC: ...` format update is in PR #117426 (main) only.