### PR TITLE
[enterprise-4.22] OSDOCS-17081_2#CQA update

### DIFF
--- a/modules/cluster-resources.adoc
+++ b/modules/cluster-resources.adoc
@@ -3,7 +3,7 @@
 = Interacting with your cluster resources
 
 [role="_abstract"]
-You can interact with cluster resources by using the OpenShift CLI (`oc`) tool in {product-title}. The cluster resources that you see after running the `oc api-resources` command can be edited.
+You can use the {oc-first} tool to interact with and edit cluster resources in {product-title} to manage your cluster configuration.
 
 .Prerequisites
 

--- a/modules/support-knowledgebase-search.adoc
+++ b/modules/support-knowledgebase-search.adoc
@@ -9,18 +9,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="support-knowledgebase-search_{context}"]
-= Searching the Red Hat Knowledgebase
+= Searching the Red{nbsp}Hat Knowledgebase
 
 [role="_abstract"]
-In the event of an {product-title} issue, you can perform an initial search to determine if a solution already exists within the Red Hat Knowledgebase.
+You can search the Red{nbsp}Hat Knowledgebase to check whether a solution already exists for an {product-title} issue you are experiencing.
 
 .Prerequisites
 
-* You have a Red Hat Customer Portal account.
+* You have a Red{nbsp}Hat Customer Portal account.
 
 .Procedure
 
-. Log in to the link:http://access.redhat.com[Red Hat Customer Portal].
+. Log in to the link:http://access.redhat.com[Red{nbsp}Hat Customer Portal].
 
 . Click *Search*.
 

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -11,7 +11,7 @@
 = Submitting a support case
 
 [role="_abstract"]
-Submit a support case to Red Hat Support to get help with issues you encounter with {product-title}.
+You can submit a support case to Red{nbsp}Hat Support to get help resolving issues with your {product-title} cluster.
 
 .Prerequisites
 
@@ -26,13 +26,13 @@ ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * You have access to the {cluster-manager-first}.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* You have a Red Hat Customer Portal account.
-* You have a Red Hat Standard or Premium subscription.
+* You have a Red{nbsp}Hat Customer Portal account.
+* You have a Red{nbsp}Hat Standard or Premium subscription.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 .Procedure
 
-. Log in to link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.
+. Log in to link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red{nbsp}Hat Customer Portal.
 
 . Click *Get support*.
 
@@ -44,7 +44,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 . Enter the following information:
 
-.. In the *Summary* field, enter a concise but descriptive problem summary and further details about the symptoms being experienced, as well as your expectations.
+.. In the *Summary* field, enter a concise but descriptive problem summary and further details about the symptoms you are experiencing and your expectations.
 
 .. Select *{product-title}* from the *Product* drop-down menu.
 
@@ -52,11 +52,11 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .. Select *{product-version}* from the *Version* drop-down.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-. Review the list of suggested Red Hat Knowledgebase solutions for a potential match against the problem that is being reported. If the suggested articles do not address the issue, click *Continue*.
+. Review the list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem you are reporting. If the suggested articles do not address the issue, click *Continue*.
 
-. Review the updated list of suggested Red Hat Knowledgebase solutions for a potential match against the problem that is being reported. The list is refined as you provide more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
+. Review the updated list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem you are reporting. The list refines as you provide more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
 
-. Ensure that the account information presented is as expected, and if not, amend accordingly.
+. Ensure that the account information presented is as expected, and if not, change as needed.
 
 . Check that the autofilled {product-title} Cluster ID is correct. If it is not, manually obtain your cluster ID.
 ifdef::openshift-dedicated[]
@@ -91,7 +91,7 @@ $ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'
 
 . Upload relevant diagnostic data files and click *Continue*.
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-It is recommended to include data gathered using the `oc adm must-gather` command as a starting point, plus any issue specific data that is not collected by that command.
+Include data gathered using the `oc adm must-gather` command as a starting point, plus any issue-specific data that the command does not collect.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 . Input relevant case management details and click *Continue*.

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -10,23 +10,13 @@ endif::[]
 
 toc::[]
 
-[role="_abstract"]
-When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support. You can use tools such as `must-gather`, `sosreport`, and cluster node journal logs to collect diagnostic data.
-
 ifndef::openshift-origin[]
-When opening a support case, it is helpful to provide debugging
-information about your cluster to Red Hat Support.
-
-It is recommended to provide:
-
-* xref:../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Data gathered using the `oc adm must-gather` command]
-* The  xref:../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[unique cluster ID]
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* The results of a self-service xref:../support/gathering-cluster-data.adoc#about-self-service-tsr_gathering-cluster-data[Technical Supportability Review (TSR)] analysis of your `must-gather` data
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+You can gather debugging information about your {product-title} cluster to provide to Red{nbsp}Hat Support when opening a support case.
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
+[role="_abstract"]
 You can use the following tools to get debugging information about your {product-title} cluster.
 endif::openshift-origin[]
 

--- a/support/summarizing-cluster-specifications.adoc
+++ b/support/summarizing-cluster-specifications.adoc
@@ -11,7 +11,7 @@ endif::[]
 toc::[]
 
 [role="_abstract"]
-You can summarize your cluster specifications by querying the `clusterversion` resource to view cluster version information and component status.
+You can query the `clusterversion` resource to obtain a summary of your {product-title} cluster specifications to help Red{nbsp}Hat Support troubleshoot issues.
 
 // Summarizing cluster specifications through `clusterversion`
 include::modules/summarizing-cluster-specifications-through-clusterversion.adoc[leveloffset=+1]


### PR DESCRIPTION
4.22 cherrypick of https://github.com/openshift/openshift-docs/commit/fe1b327f4b8477fbfb5cd534851e93d7425b9412
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/117075

The https://github.com/openshift/openshift-docs/pull/117075 had 7 files changed. This has 5 because:
- `summarizing-cluster-specifications-through-clusterversion.adoc`: on 4.20, the PR added a [role="_abstract"] tag. On 4.22, that tag was already present, so the cherry-pick produced no diff for this file.
- `managing-cluster-resources.adoc`: same reason: the PR added [role="_abstract"] on 4.20. On 4.22, it was already there, so no diff.
