### PR TITLE
[enterprise-5.0] OSDOCS-17081_2#CQA update

### DIFF
--- a/modules/cluster-resources.adoc
+++ b/modules/cluster-resources.adoc
@@ -3,7 +3,7 @@
 = Interacting with your cluster resources
 
 [role="_abstract"]
-You can interact with cluster resources by using the OpenShift CLI (`oc`) tool in {product-title}. The cluster resources that you see after running the `oc api-resources` command can be edited.
+You can use the {oc-first} tool to interact with and edit cluster resources in {product-title} to manage your cluster configuration.
 
 .Prerequisites
 

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -10,23 +10,13 @@ endif::[]
 
 toc::[]
 
-[role="_abstract"]
-When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support. You can use tools such as `must-gather`, `sosreport`, and cluster node journal logs to collect diagnostic data.
-
 ifndef::openshift-origin[]
-When opening a support case, it is helpful to provide debugging
-information about your cluster to Red Hat Support.
-
-It is recommended to provide:
-
-* xref:../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Data gathered using the `oc adm must-gather` command]
-* The  xref:../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[unique cluster ID]
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* The results of a self-service xref:../support/gathering-cluster-data.adoc#about-self-service-tsr_gathering-cluster-data[Technical Supportability Review (TSR)] analysis of your `must-gather` data
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+You can gather debugging information about your {product-title} cluster to provide to Red{nbsp}Hat Support when opening a support case.
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
+[role="_abstract"]
 You can use the following tools to get debugging information about your {product-title} cluster.
 endif::openshift-origin[]
 

--- a/support/summarizing-cluster-specifications.adoc
+++ b/support/summarizing-cluster-specifications.adoc
@@ -11,7 +11,7 @@ endif::[]
 toc::[]
 
 [role="_abstract"]
-You can summarize your cluster specifications by querying the `clusterversion` resource to view cluster version information and component status.
+You can query the `clusterversion` resource to obtain a summary of your {product-title} cluster specifications to help Red{nbsp}Hat Support troubleshoot issues.
 
 // Summarizing cluster specifications through `clusterversion`
 include::modules/summarizing-cluster-specifications-through-clusterversion.adoc[leveloffset=+1]


### PR DESCRIPTION
5.0 cherrypick of https://github.com/openshift/openshift-docs/commit/fe1b327f4b8477fbfb5cd534851e93d7425b9412
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/117075

Note:
https://github.com/openshift/openshift-docs/pull/117075 had 7 files changed. This has 3 because:
 - `modules/support-knowledgebase-search.adoc:` already fixed by PR #117297
 - `modules/support-submitting-a-case.adoc`: already fixed by PR #117297
- `modules/summarizing-cluster-specifications-through-clusterversion.adoc`: abstract already present 
- `support/managing-cluster-resources.ado`c: abstract already present

