### PR TITLE
OSDOCS-21005: Fix broken external links in networking docs

### DIFF
--- a/modules/nv-scope-network-verification-checks.adoc
+++ b/modules/nv-scope-network-verification-checks.adoc
@@ -20,5 +20,5 @@ endif::openshift-dedicated[]
 ifdef::openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/dedicated/osd_planning/aws-ccs.html#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites]
+* link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/aws-ccs#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites]
 endif::openshift-dedicated[]

--- a/networking/networking_operators/aws-load-balancer-operator.adoc
+++ b/networking/networking_operators/aws-load-balancer-operator.adoc
@@ -51,8 +51,8 @@ include::modules/albo-installation.adoc[leveloffset=+1]
 .Additional resources
 ifndef::openshift-rosa-hcp[]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-multiple-ingress-through-single-alb[Creating many ingresses through a single AWS Load Balancer]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-multiple-ingress-through-single-alb#nw-adding-tls-termination_adding-tls-termination[Adding TLS termination]
-* link:https://docs.openshift.com/container-platform/4.13/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html[Creating an instance of AWS Load Balancer Controller]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-adding-tls-termination_adding-tls-termination[Adding TLS termination]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.13/html/networking/aws-load-balancer-operator-1#create-instance-aws-load-balancer-controller[Creating an instance of AWS Load Balancer Controller]
 endif::openshift-rosa-hcp[]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[AWS Documentation: Tag your Amazon EC2 resources]
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
@@ -24,4 +24,4 @@ include::modules/migrate-sdn-ovn-osd.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* link:https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#patching-ovnk-address-ranges_migrate-from-openshift-sdn[Patching OVN-Kubernetes address ranges]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/networking/index#patching-ovnk-address-ranges_migrate-from-openshift-sdn[Patching OVN-Kubernetes address ranges]


### PR DESCRIPTION
Version(s): 4.22+

Issue: https://redhat.atlassian.net/browse/OSDOCS-21005

Link to docs preview:

-  https://117470--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network-verification.html
- https://117470--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.html
- http://117470--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html
- https://117470--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network-verification.html
- https://117470--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/aws-load-balancer-operator.html
- https://117470--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network-verification.html

Additional information:

Summary
- Fixed malformed URL with duplicate `#` anchor in `aws-load-balancer-operator.adoc`
- Replaced deprecated `docs.openshift.com` URLs with `docs.redhat.com` in three networking files
- Corrected the OVN-Kubernetes migration link to use `html-single` format where the anchor exists

Impacted files
- `networking/networking_operators/aws-load-balancer-operator.adoc`
- `modules/nv-scope-network-verification-checks.adoc`
- `networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc`
- [x] All updated URLs verified with `curl -sI` returning HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)