### PR TITLE
OSDOCS-21318: Document excludeSubnets as CIDR-only

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -56,7 +56,7 @@ The metadata `namespace` and `name` of the network attachment definition CRD whe
 |`excludeSubnets`
 |`string`
 |
-A comma-separated list of CIDRs and IP addresses. IP addresses are removed from the assignable IP address pool and are never passed to the pods.
+A comma-separated list of CIDRs. Every entry must use standard CIDR notation and must include a prefix length. The addresses covered by these CIDRs are removed from the assignable IP address pool and are never passed to the pods.
 
 |`vlanID`
 |`integer`


### PR DESCRIPTION
## Summary
- Corrects the `excludeSubnets` row in the OVN-Kubernetes network plugin JSON configuration table.
- Docs previously said bare IP addresses were accepted; the parser and CRD require standard CIDR notation with a prefix length (use `/32` or `/128` for a single address).

## Jira
https://redhat.atlassian.net/browse/OSDOCS-21318

## Versions
4.21 (cherry-picks may be needed for other enterprise branches / main)

## Test plan
- [ ] Confirm rendered Multiple networks → Secondary networks table shows CIDR-only wording for `excludeSubnets`
- [ ] Aligns with ClusterUserDefinedNetwork / primary network docs that already require CIDR notation


Made with [Cursor](https://cursor.com)