### PR TITLE
OSDOCS-21406: Add 4.22.9 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-9.adoc
+++ b/modules/zstream-4-22-9.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-9_{context}"]
+= RHSA-2026:51038 - {product-title} {product-version}.9 bug fix and security update
+
+Issued: 11 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.9 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:51038[RHSA-2026:51038] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:51036[RHSA-2026:51036] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.9 --pullspecs
+----
+
+[id="zstream-4-22-9-enhancements_{context}"]
+== Enhancements
+
+* Dry-run was not generating cluster resource files before this enhancement. Now in disk-to-mirror (`d2m`) and mirror-to-mirror (`m2m`) workflows, the dry-run also generates the resource files without the need of mirroring the images. (link:https://redhat.atlassian.net/browse/OCPBUGS-93773[OCPBUGS-93773])
+
+[id="zstream-4-22-9-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-22-9-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -45,6 +45,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.9 RNs and updating
+include::modules/zstream-4-22-9.adoc[leveloffset=+2]
+
 // 4.22.8 RNs and updating
 include::modules/zstream-4-22-8.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21406

Link to docs preview:
[4.22.9](https://117497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-9_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/714
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
- Errata: RHSA-2026:51038 / RHSA-2026:51036 (from shipment YAML; not yet live on access.redhat.com)

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-33836 | Incomplete Bug Fix RN |
| OCPBUGS-76329 | Incomplete Bug Fix RN |
| OCPBUGS-76646 | Invalid RN type |
| OCPBUGS-99390 | Incomplete Bug Fix RN |
| OCPBUGS-99399 | Incomplete Bug Fix RN |
| OCPBUGS-99744 | Incomplete Bug Fix RN |
| OCPBUGS-100059 | Incomplete Bug Fix RN |
| OCPBUGS-100317 | Incomplete Bug Fix RN |
