### PR TITLE
OSDOCS-21404: Add 4.21.28 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-28.adoc
+++ b/modules/zstream-4-21-28.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-28_{context}"]
+= RHSA-2026:51025 - {product-title} {product-version}.28 bug fix and security update
+
+Issued: 11 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.28 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:51025[RHSA-2026:51025] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:51020[RHBA-2026:51020] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.28 --pullspecs
+----
+
+[id="zstream-4-21-28-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, gateway pods used by layered products such as {rhoai-full} and Red Hat Connectivity Link did not respect the cluster-wide egress proxy configuration when attempting to pull `Wasm` plugins. As a consequence, in disconnected environments behind an enterprise HTTP proxy, the Gateway pods could not download the required `Wasm` plugins. This situation resulted in HTTP 403 role-based access control (RBAC) errors and failed inference requests. With this release, the Ingress Operator configures the Istio control plane to respect the cluster-wide egress proxy configuration (`proxies.config.openshift.io/cluster`). As a result, Gateway pods successfully pull `Wasm` plugins in proxied environments without requiring manual configuration. (link:https://redhat.atlassian.net/browse/OCPBUGS-99453[OCPBUGS-99453])
+
+[id="zstream-4-21-28-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -45,6 +45,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.28 RNs and updating
+include::modules/zstream-4-21-28.adoc[leveloffset=+2]
+
 // 4.21.27 RNs and updating
 include::modules/zstream-4-21-27.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21404

Link to docs preview:
[4.21.28](https://117498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-28_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/713
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:51025 / RHBA-2026:51020 (from shipment YAML; not yet live on access.redhat.com)

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-99747 | Incomplete Bug Fix RN |
| OCPBUGS-100390 | Incomplete Bug Fix RN |
