### PR TITLE
OSDOCS-21407: Add 4.20.33 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-33.adoc
+++ b/modules/zstream-4-20-33.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-33_{context}"]
+= RHSA-2026:51022 - {product-title} {product-version}.33 bug fix and security update
+
+Issued: 11 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.33 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:51022[RHSA-2026:51022] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:51018[RHBA-2026:51018] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.33 --pullspecs
+----
+
+[id="zstream-4-20-33-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-20-33-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.33 RNs and updating
+include::modules/zstream-4-20-33.adoc[leveloffset=+2]
+
 // 4.20.32 RNs and updating
 include::modules/zstream-4-20-32.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21407

Link to docs preview:
[4.20.33](https://117499--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-33_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/712
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:51022 / RHBA-2026:51018 (from shipment YAML; not yet live on access.redhat.com)

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-99650 | Incomplete Bug Fix RN |
| OCPBUGS-99749 | Incomplete Bug Fix RN |
| OCPBUGS-99764 | Incomplete Bug Fix RN |
