### PR TITLE
OSDOCS-21403: Add 4.19.42 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-42.adoc
+++ b/modules/zstream-4-19-42.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-42_{context}"]
+= RHSA-2026:51007 - {product-title} {product-version}.42 bug fix and security update
+
+Issued: 12 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.42 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:51007[RHSA-2026:51007] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:51005[RHBA-2026:51005] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.42 --pullspecs
+----
+
+[id="zstream-4-19-42-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-19-42-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.42 RNs and updating
+include::modules/zstream-4-19-42.adoc[leveloffset=+2]
+
 // 4.19.41 RNs and updating
 include::modules/zstream-4-19-41.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21403

Link to docs preview:
[4.19.42](https://117500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-42_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/710
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:51007 / RHBA-2026:51005 (from shipment YAML; not yet live on access.redhat.com)

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-99450 | Incomplete Bug Fix RN |
