### PR TITLE
OSDOCS-21405: Add 4.18.52 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-52.adoc
+++ b/modules/zstream-4-18-52.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-52_{context}"]
+= RHSA-2026:51013 - {product-title} {product-version}.52 bug fix and security update
+
+Issued: 12 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.52 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:51013[RHSA-2026:51013] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:51011[RHBA-2026:51011] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.52 --pullspecs
+----
+
+[id="zstream-4-18-52-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-52-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.52 RNs and updating
+include::modules/zstream-4-18-52.adoc[leveloffset=+2]
+
 // 4.18.51 RNs and updating
 include::modules/zstream-4-18-51.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21405

Link to docs preview:
[4.18.52](https://117501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-52_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/711
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:51013 / RHBA-2026:51011 (from shipment YAML; not yet live on access.redhat.com)

### Incomplete Bug Fix RN / Invalid RN type (not documented)

| Key | Reason |
|-----|--------|
| OCPBUGS-98985 | Incomplete Bug Fix RN |
