### PR TITLE
OSDOCS-21408: Add 4.16.68 z-stream release notes

### DIFF
--- a/modules/zstream-4-16-68.adoc
+++ b/modules/zstream-4-16-68.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-68_{context}"]
+= RHSA-2026:50758 - {product-title} {product-version}.68 bug fix and security update
+
+Issued: 13 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.68 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:50758[RHSA-2026:50758] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:50753[RHBA-2026:50753] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.68 --pullspecs
+----
+
+[id="zstream-4-16-68-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-16-68-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3391,6 +3391,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
 
+// 4.16.68 RNs and updating
+include::modules/zstream-4-16-68.adoc[leveloffset=+2]
+
 // 4.16.66 RNs and updating
 include::modules/zstream-4-16-66.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21408

Link to docs preview:
[4.16.68](https://117502--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-68_release-notes)

QE review:

- [ ] QE has approved this change.

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/701
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16
- Errata: RHSA-2026:50758 / RHBA-2026:50753 (from shipment YAML; not yet live on access.redhat.com)
