### PR TITLE
Add Gateway API version supportability matrix

### DIFF
--- a/modules/nw-ingress-gateway-api-support-matrix.adoc
+++ b/modules/nw-ingress-gateway-api-support-matrix.adoc
@@ -16,10 +16,10 @@ To plan Gateway API deployments across cluster versions, use the following suppo
 |Gateway API version
 
 |4.19
-|v1.2.1 footnote:gwapi-nominal[Nominal version. The installed custom resource definitions (CRDs) match the v1.3.0 schema.]
+|v1.2.1
 
 |4.20
-|v1.2.1 footnote:gwapi-nominal[]
+|v1.2.1
 
 |4.21
 |v1.3.0

--- a/modules/nw-ingress-gateway-api-support-matrix.adoc
+++ b/modules/nw-ingress-gateway-api-support-matrix.adoc
@@ -1,9 +1,6 @@
 // Modules included in the following assemblies:
 //
 // * networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
-//
-// Writer note: Replace the placeholder Gateway API version cell with the approved
-// supportability matrix values before requesting merge.
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-ingress-gateway-api-support-matrix_{context}"]
@@ -13,12 +10,23 @@
 To plan Gateway API deployments across cluster versions, use the following supportability matrix. The matrix lists the Gateway API version that {product-title} supports for each product version.
 
 .Gateway API supportability matrix
-[cols="1,1",options="header"]
+[cols="1,2",options="header"]
 |===
 |{product-title} version
 |Gateway API version
 
 |4.19
-|TBD
+|v1.2.1 footnote:gwapi-nominal[Nominal version. The installed custom resource definitions (CRDs) match the v1.3.0 schema.]
 
+|4.20
+|v1.2.1 footnote:gwapi-nominal[]
+
+|4.21
+|v1.3.0
+
+|4.22
+|v1.4.1
+
+|5.0
+|v1.4.1
 |===

--- a/modules/nw-ingress-gateway-api-support-matrix.adoc
+++ b/modules/nw-ingress-gateway-api-support-matrix.adoc
@@ -1,0 +1,24 @@
+// Modules included in the following assemblies:
+//
+// * networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
+//
+// Writer note: Replace the placeholder Gateway API version cell with the approved
+// supportability matrix values before requesting merge.
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ingress-gateway-api-support-matrix_{context}"]
+= Gateway API version support for {product-title}
+
+[role="_abstract"]
+To plan Gateway API deployments across cluster versions, use the following supportability matrix. The matrix lists the Gateway API version that {product-title} supports for each product version.
+
+.Gateway API supportability matrix
+[cols="1,1",options="header"]
+|===
+|{product-title} version
+|Gateway API version
+
+|4.19
+|TBD
+
+|===

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
@@ -18,6 +18,8 @@ include::modules/nw-ingress-gateway-api-overview.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-gateway-api-implementation.adoc[leveloffset=+1]
 
+include::modules/nw-ingress-gateway-api-support-matrix.adoc[leveloffset=+1]
+
 include::modules/nw-ingress-gateway-api-enable.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-gateway-api-deployment-topologies.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Adds a Gateway API version supportability matrix for OpenShift Container Platform so users can see which Gateway API version each release supports.
- Documents the mapping: 4.19 and 4.20 → v1.2.1, 4.21 → v1.3.0, 4.22 and 5.0 → v1.4.1.
- Places the new CONCEPT module in the Gateway API assembly immediately before the enable / getting-started procedure.

## Test plan
- [ ] Confirm the new section renders under Gateway API with OpenShift Container Platform networking, before Getting started with Gateway API for the Ingress Operator
- [ ] Confirm the supportability table shows the correct OpenShift ↔ Gateway API version rows
- [ ] Verify AsciiDoc builds cleanly for the `ingress-gateway-api` assembly