### PR TITLE
OSDOCS-21049: Update WIF permission docs for Milestone-2 least-privilege changes

### DIFF
--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -34,7 +34,7 @@ The following roles are attached to the service account:
 
 |DNS Administrator
 |`roles/dns.admin`
-|Provides read-write access to all Cloud DNS resources.
+|Provides read/write access to all Cloud DNS resources.
 
 |Security Admin
 |`roles/iam.securityAdmin`
@@ -71,7 +71,7 @@ The `sd-sre-platform-gcp-access` Google group is granted access to the {gcp-shor
 
 [NOTE]
 ====
-* For information regarding the roles within the `sd-sre-platform-gcp-access`  group that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
+* For information regarding the roles within the `sd-sre-platform-gcp-access` group that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.22/vanilla.yaml[managed-cluster-config].
 * For information about creating a cluster using the Workload Identity Federation authentication type, see _Additional resources_.
 ====
 The following roles are attached to the group:
@@ -118,6 +118,6 @@ The following roles are attached to the group:
 
 |Tech Support Editor
 |`roles/cloudsupport.techSupportEditor`
-|Provides full read-write access to technical support cases.
+|Provides full read/write access to technical support cases.
 
 |===

--- a/modules/create-wif-configuration.adoc
+++ b/modules/create-wif-configuration.adoc
@@ -7,11 +7,11 @@
 = Creating a Workload Identity Federation configuration
 
 [role="_abstract"]
-You can create a WIF configuration using the `auto` mode or the `manual` mode in the `ocm` CLI.
+You can create a Workload Identity Federation (WIF) configuration using the `auto` mode or the `manual` mode in the `ocm` CLI.
 
-The `auto` mode enables you to automatically create the service accounts for {product-title} components as well as other IAM resources.
+In `auto` mode, the service accounts for {product-title} components and other IAM resources are created automatically.
 
-Alternatively, you can use the `manual` mode. In `manual` mode, you are provided with commands within a `script.sh` file which you use to manually create the service accounts for {product-title} components as well as other IAM resources.
+Alternatively, you can use the `manual` mode. In `manual` mode, a `script.sh` file provides commands that you use to manually create the service accounts for {product-title} components and other IAM resources.
 
 .Procedure
 
@@ -21,15 +21,21 @@ Alternatively, you can use the `manual` mode. In `manual` mode, you are provided
 +
 [source,terminal]
 ----
-$ ocm gcp create wif-config --name <wif_name> \ <1>
-  --project <gcp_project_id> \ <2>
-  --version <osd_version> <3>
-  --federated-project <gcp_project_id> <4>
+$ ocm gcp create wif-config --name <wif_name> \
+  --project <gcp_project_id> \
+  --version <osd_version> \
+  --federated-project <gcp_project_id>
 ----
-<1> Replace `<wif_name>` with the name of your WIF configuration.
-<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
-<3> Optional: Replace `<osd_version>` with the desired {product-title} version the wif-config will need to support. If you do not specify a version, the wif-config will support the latest {product-title} y-stream version as well as the last three supported {product-title} y-stream versions (beginning with version 4.17).
-<4> Optional: Replace `<gcp_project_id>` with the ID of the dedicated project where the workload identity pools and providers will be created and managed. If the `--federated-project` flag is not specified, the workload identity pools and providers will be created and managed in the project specified by the `--project` flag.
++
+where:
+
+`--wif_name`:: Specifies the name of the WIF configuration. The name must be unique within your {GCP} project.
+
+`--project`:: Specifies the ID of the {GCP} project where the WIF configuration will be implemented.
+
+`--version`:: Optional. Specifies the desired {product-title} version the wif-config will need to support. If you do not specify a version, the wif-config will support the latest {product-title} y-stream version as well as the last three supported {product-title} y-stream versions (beginning with version 4.17).
+
+`--federated-project`:: Optional. Specifies the ID of the dedicated project where the workload identity pools and providers will be created and managed. If this flag is not specified, the workload identity pools and providers will be created and managed in the project specified by the `--project` flag.
 +
 [IMPORTANT]
 =====
@@ -45,20 +51,20 @@ For more information, see link:https://cloud.google.com/iam/docs/best-practices-
 **Example output**
 [source,terminal]
 ----
-2024/09/26 13:05:41 Creating workload identity configuration...
-2024/09/26 13:05:47 Workload identity pool created with name 2e1kcps6jtgla8818vqs8tbjjls4oeub
-2024/09/26 13:05:47 workload identity provider created with name oidc
-2024/09/26 13:05:48 IAM service account osd-worker-oeub created
-2024/09/26 13:05:49 IAM service account osd-control-plane-oeub created
-2024/09/26 13:05:49 IAM service account openshift-gcp-ccm-oeub created
-2024/09/26 13:05:50 IAM service account openshift-gcp-pd-csi-driv-oeub created
-2024/09/26 13:05:50 IAM service account openshift-image-registry-oeub created
-2024/09/26 13:05:51 IAM service account openshift-machine-api-gcp-oeub created
-2024/09/26 13:05:51 IAM service account osd-deployer-oeub created
-2024/09/26 13:05:52 IAM service account cloud-credential-operator-oeub created
-2024/09/26 13:05:52 IAM service account openshift-cloud-network-c-oeub created
-2024/09/26 13:05:53 IAM service account openshift-ingress-gcp-oeub created
-2024/09/26 13:05:55 Role "osd_deployer_v4.19" updated
+2026/09/26 13:05:41 Creating workload identity configuration...
+2026/09/26 13:05:47 Workload identity pool created with name 2e1kcps6jtgla8818vqs8tbjjls4oeub
+2026/09/26 13:05:47 workload identity provider created with name oidc
+2026/09/26 13:05:48 IAM service account osd-worker-oeub created
+2026/09/26 13:05:49 IAM service account osd-control-plane-oeub created
+2026/09/26 13:05:49 IAM service account openshift-gcp-ccm-oeub created
+2026/09/26 13:05:50 IAM service account openshift-gcp-pd-csi-driv-oeub created
+2026/09/26 13:05:50 IAM service account openshift-image-registry-oeub created
+2026/09/26 13:05:51 IAM service account openshift-machine-api-gcp-oeub created
+2026/09/26 13:05:51 IAM service account osd-deployer-oeub created
+2026/09/26 13:05:52 IAM service account cloud-credential-operator-oeub created
+2026/09/26 13:05:52 IAM service account openshift-cloud-network-c-oeub created
+2026/09/26 13:05:53 IAM service account openshift-ingress-gcp-oeub created
+2026/09/26 13:05:55 Role "osd_deployer_v4.22" updated
 ----
 --
 +
@@ -66,26 +72,32 @@ For more information, see link:https://cloud.google.com/iam/docs/best-practices-
 +
 [source,terminal]
 ----
-$ ocm gcp create wif-config --name <wif_name> \ <1>
-  --project <gcp_project_id> \ <2>
+$ ocm gcp create wif-config --name <wif_name> \
+  --project <gcp_project_id> \
   --mode=manual
 ----
-<1> Replace `<wif_name>` with the name of your WIF configuration.
-<2> Replace `<gcp_project_id>` with the ID  of the {GCP} project where the WIF configuration will be implemented.
++
+where:
+
+`--wif_name`:: Specifies the name of the WIF configuration. The name must be unique within your {GCP} project.
+
+`--project`:: Specifies the ID of the {GCP} project where the WIF configuration will be implemented.
+
+`--mode=manual`:: Specifies that the WIF configuration is created in manual mode. In this mode, a `script.sh` file is generated that contains commands to manually create the service accounts for {product-title} components and other IAM resources.
 +
 Once the WIF is configured, the following service accounts, roles, and groups are created.
 +
 [NOTE]
 ====
-Red{nbsp}Hat custom roles are versioned with every OpenShift y-stream release, for example 4.19.
+Red{nbsp}Hat custom roles are versioned with every OpenShift y-stream release, for example 4.22.
 ====
 +
-.WIF configuration service accounts, group and roles
+.WIF configuration service accounts, group, and roles
 [cols="2a,3a",options="header"]
 |===
 
 |Service Account/Group
-|{gcp-short} pre-defined roles and Red Hat custom roles
+|{gcp-short} predefined roles and Red{nbsp}Hat custom roles
 
 
 |osd-deployer
@@ -112,7 +124,6 @@ Red{nbsp}Hat custom roles are versioned with every OpenShift y-stream release, f
 
 |openshift-gcp-pd-csi-driver-operator
 |- compute.storageAdmin
-- iam.serviceAccountUser
 - resourcemanager.tagUser
 - openshift_gcp_pd_csi_driver_operator_v<y-stream-version>
 
@@ -123,12 +134,13 @@ Red{nbsp}Hat custom roles are versioned with every OpenShift y-stream release, f
 |openshift_ingress_gcp_v<y-stream-version>
 
 |openshift-machine-api-gcp
-|openshift_machine_api_gcp_v<y-stream-version>
+|- iam.serviceAccountUser (scoped to `osd-worker` and `osd-control-plane` service accounts)
+- openshift_machine_api_gcp_v<y-stream-version>
 
 |Access via SRE group:sd-sre-platform-gcp-access
 |sre_managed_support
 |===
 +
-For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
+For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.22/vanilla.yaml[managed-cluster-config].
 
 

--- a/modules/create-wif-configuration.adoc
+++ b/modules/create-wif-configuration.adoc
@@ -11,7 +11,7 @@ You can create a Workload Identity Federation (WIF) configuration using the `aut
 
 In `auto` mode, the service accounts for {product-title} components and other IAM resources are created automatically.
 
-Alternatively, you can use the `manual` mode. In `manual` mode, a `script.sh` file provides commands that you use to manually create the service accounts for {product-title} components and other IAM resources.
+You can also use the `manual` mode, where a `script.sh` file has commands that you use to manually create the service accounts for {product-title} components and other IAM resources.
 
 .Procedure
 

--- a/modules/persistent-storage-csi-gcp-pd-reduce-permissions.adoc
+++ b/modules/persistent-storage-csi-gcp-pd-reduce-permissions.adoc
@@ -7,7 +7,8 @@
 = Reducing permissions while using the GCP PD CSI Driver Operator
 
 [role="_abstract"]
-By default, the Google Cloud Platform (GCP) persistent disk (PD) Container Storage Interface (CSI) Driver can impersonate any service account in the Google Cloud project. You can reduce the scope of permissions to only the required node service accounts.
+By default, the Google Cloud Platform (GCP) persistent disk (PD) Container Storage Interface (CSI) Driver can impersonate any service account in the Google Cloud project.
+You can reduce the scope of permissions to only the required node service accounts.
 
 To reduce permissions, grant the `iam.serviceAccountUser` role to the control plane and compute node service accounts, and then remove the `iam.serviceAccountUser` role from the project-wide service account, thus reducing the scope of the permission.
 
@@ -17,17 +18,26 @@ Reducing permissions only applies to GCP clusters using Workload Identity Federa
 ====
 
 .Procedure
+
+. Verify that your cluster is running a version earlier than {product-title} 4.21.
+If your cluster is running {product-title} 4.21 or later, this procedure is not necessary.
++
+[source,terminal]
+----
+$ oc get clusterversion
+----
+
 . Grant scoped `iam.serviceAccountUser` role for node service accounts by running the following Bash commands:
 +
 [source,terminal]
 ----
-gcloud iam service-accounts add-iam-policy-binding "${MASTER_NODE_SA}" --project="${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
-gcloud iam service-accounts add-iam-policy-binding "${WORKER_NODE_SA}" --project="${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
+$ gcloud iam service-accounts add-iam-policy-binding "${MASTER_NODE_SA}" --project="${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
+$ gcloud iam service-accounts add-iam-policy-binding "${WORKER_NODE_SA}" --project="${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
 ----
 +
 * `GOOGLE_PROJECT_ID`: The unique ID of your Google Cloud project.
 
-* `SERVICE_ACCOUNT_EMAIL`: The email address of the "Member" (the person or service account) who is being granted the new permissions. To find the service account, on WIF clusters, there is a default service account on GCP for the CSI driver based on the cluster name, for example: `${CLUSTER_NAME}-openshift-gcp-pd-csi-*`. 
+* `SERVICE_ACCOUNT_EMAIL`: The email address of the "Member" (the person or service account) who is being granted the new permissions. To find the service account, on WIF clusters, there is a default service account on GCP for the CSI driver based on the cluster name, for example: `${CLUSTER_NAME}-openshift-gcp-pd-csi-*`.
 
 * `MASTER_NODE_SA`: The email address of the service account used by your cluster's master node.
 
@@ -37,10 +47,10 @@ gcloud iam service-accounts add-iam-policy-binding "${WORKER_NODE_SA}" --project
 +
 [source,terminal]
 ----
-gcloud projects remove-iam-policy-binding "${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
+$ gcloud projects remove-iam-policy-binding "${GOOGLE_PROJECT_ID}" --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountUser" --condition=None
 ----
 +
 
-* `SERVICE_ACCOUNT_EMAIL`: The email address of the account losing the permission. For example, `my-app-sa@my-project.iam.gserviceaccount.com`. To find the service account, on WIF clusters, there is a default service account on GCP for the CSI driver based on the cluster name, for example: `${CLUSTER_NAME}-openshift-gcp-pd-csi-*`. 
+* `SERVICE_ACCOUNT_EMAIL`: The email address of the account losing the permission. For example, `my-app-sa@my-project.iam.gserviceaccount.com`. To find the service account, on WIF clusters, there is a default service account on GCP for the CSI driver based on the cluster name, for example: `${CLUSTER_NAME}-openshift-gcp-pd-csi-*`.
 
 * `GOOGLE_PROJECT_ID`: The unique ID of the Google Cloud project where this is occurring. For example, `prod-data-789`.

--- a/modules/persistent-storage-csi-gcp-pd-reduce-permissions.adoc
+++ b/modules/persistent-storage-csi-gcp-pd-reduce-permissions.adoc
@@ -14,18 +14,10 @@ To reduce permissions, grant the `iam.serviceAccountUser` role to the control pl
 
 [NOTE]
 ====
-Reducing permissions only applies to GCP clusters using Workload Identity Federation (WIF).
+Reducing permissions only applies to {GCP} clusters using Workload Identity Federation (WIF).
 ====
 
 .Procedure
-
-. Verify that your cluster is running a version earlier than {product-title} 4.21.
-If your cluster is running {product-title} 4.21 or later, this procedure is not necessary.
-+
-[source,terminal]
-----
-$ oc get clusterversion
-----
 
 . Grant scoped `iam.serviceAccountUser` role for node service accounts by running the following Bash commands:
 +

--- a/modules/private-service-connect-prereqs.adoc
+++ b/modules/private-service-connect-prereqs.adoc
@@ -22,7 +22,7 @@ The subnet mask for the PSC service attachment must be /29 or larger and must be
 +
 For information about how to create a VPC on {GCP}, see link:https://cloud.google.com/vpc/docs/create-modify-vpc-networks[Create and manage VPC networks] in the {gcp-full} documentation.
 
-* Provide a path from the OpenShift Dedicated cluster to the internet for the domains and ports listed in the _{gcp-short} firewall prerequisites_ in the _Additional resources_ section.
+* Provide a path from the OpenShift Dedicated cluster to the internet for the domains and ports listed in the _{gcp-short} firewall prerequisites_ in the _Next steps_ section.
 
 * Enabled link:https://console.cloud.google.com/marketplace/product/google/iap.googleapis.com?q=search&referrer=search&hl=en&project=openshift-gce-devel[Cloud Identity-Aware Proxy API] at the {GCP} project level.
 

--- a/modules/wif-configuration-update.adoc
+++ b/modules/wif-configuration-update.adoc
@@ -18,7 +18,7 @@ Before upgrading a WIF-enabled {product-title} cluster to a newer version, you m
 
 As part of Red{nbsp}Hat's ongoing commitment to the principle of least privilege, certain permissions previously assigned to the `osd-deployer` service account in WIF configurations have been removed. These changes help enhance the security of your clusters by ensuring that service accounts have only the permissions they need to perform their functions.
 
-For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
+For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.22/vanilla.yaml[managed-cluster-config].
 
 To align your existing WIF configurations with these updated permissions, you can run the `ocm gcp update wif-config` command. This command updates the WIF configuration to include the latest permissions and roles required for optimal operation.
 
@@ -30,9 +30,9 @@ When you update a wif-config or create a new one, ensure your {cluster-manager} 
 Error: failed to create wif-config: failed to create wif-config: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-10-06T15:18:37Z' and operation identifier is 'f9551d63-a58a-4e3c-b847-5f99ba1b0b74': Client version is out of date for WIF operations. Please update from vOCM-CLI/1.0.7 to v1.0.8 and try again.
 ----
 
-You can also update an existing {product-title} cluster that is already using WIF by adding a dedicated project to manage workload identity pools and providers using the `--federated-project` flag. This best-practice model separates the workload identity pools and providers into a dedicated, centralized {GCP} project.
+You can also update an existing {product-title} cluster that is already using WIF by adding a dedicated project to manage workload identity pools and providers by using the `--federated-project` flag. This best-practice model separates the workload identity pools and providers into a dedicated, centralized {GCP} project.
 
-When you update the configuration using the `--federated-project` flag, any associated workload identity pools move to the new federated project you specify, while the existing IAM service accounts and custom roles remain in the original cluster-associated project.
+When you update the configuration by using the `--federated-project` flag, any associated workload identity pools move to the new federated project you specify, while the existing IAM service accounts and custom roles remain in the original cluster-associated project.
 
 .Procedure
 . To check the version of your `ocm`, run the following command:
@@ -48,22 +48,24 @@ $ ocm version
 +
 [source,terminal]
 ----
-ocm gcp update wif-config <wif_name> \
---version <version>
---federated-project <gcp_project_id>
+$ ocm gcp update wif-config <wif_name> \
+  --version <version> \
+  --federated-project <gcp_project_id>
 ----
 +
 where:
 
 `<wif_name>`:: The name of the WIF configuration you want to update.
 
-`<version>`:: Optional: The {product-title} y-stream version you plan to update the cluster to. If you do not specify a version, the wif-config will be updated to support the latest {product-title} y-stream version as well as the last three {product-title} supported y-stream versions (beginning with version 4.17).
+`<version>`:: Optional: The {product-title} y-stream version you plan to update the cluster to. If you do not specify a version, the wif-config is updated to support the latest {product-title} y-stream version and the last three {product-title} supported y-stream versions (beginning with version 4.17).
 
 `--federated-project <gcp_project_id>`:: Optional: A flag to specify a new dedicated project where the workload identity pools and providers will be created and managed. If this flag is not included, the workload identity pools and providers will remain in the project associated with the cluster.
 
 .Next steps
 
-The stale set of permissions previously assigned to the `osd-deployer` service account will remain on the account after updating the wif-config. You need to manually access the roles and remove these stale permissions from them.
+If you are upgrading a cluster across multiple y-stream versions, update the WIF configuration to each intermediate version before upgrading the cluster to that version. For example, to upgrade from 4.20 to 4.22, update the WIF configuration to 4.21 first, upgrade the cluster to 4.21, then update the WIF configuration to 4.22 and upgrade the cluster to 4.22.
+
+The stale set of permissions previously assigned to the `osd-deployer` service account will remain on the account after updating the `wif-config`. You need to manually access the roles and remove these stale permissions from them.
 
 Follow the instructions in the "Removing stale deployer permissions from service accounts managed by a WIF configuration" and "Removing stale support permissions from service accounts managed by a WIF configuration" guides to remove these stale permissions.
 

--- a/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
+++ b/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
@@ -8,12 +8,12 @@
 = Remove stale CSI driver and Machine API permissions from service accounts managed by a WIF configuration
 
 [role="_abstract"]
-The `wif-config` permission set has had two separate reductions in permissions:
+The `wif-config` permission set enables Workload Identity Federation (WIF) authentication for {product-title} service accounts to securely interact with {gcp-full} services. You can remove stale permissions from the CSI driver and Machine API service accounts to reduce the scope of permissions to only those required for the cluster's operation.
 
-* The Container Storage Interface (CSI) driver service account no longer uses the predefined `iam.serviceAccountUser` role.
-* The custom role used by the Machine API service account no longer requires the `iam.serviceAccounts.actAs` permission.
-
-To update your environment to remove these extra permissions, run the following commands on a terminal with access to the {gcp-full} project hosting the service accounts.
+[NOTE]
+====
+This procedure is applicable to clusters using WIF with versions `4.20`, `4.21`, and `4.22`.
+====
 
 .Prerequisites
 
@@ -94,7 +94,7 @@ $ gcloud iam roles update machine_api_gcp_${VERSION} \
   --file=/tmp/updated_role.yaml
 ----
 
-. After completing the earlier steps for all applicable versions, update the `wif-config` to ensure it is current:
+. Update the `wif-config` to ensure it is current:
 +
 [source,terminal]
 ----

--- a/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
+++ b/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="wif-remove-stale-csi-driver-machine-api-permissions_{context}"]
+= Remove stale CSI driver and Machine API permissions from service accounts managed by a WIF configuration
+
+[role="_abstract"]
+The `wif-config` permission set has had two separate reductions in permissions:
+
+* The Container Storage Interface (CSI) driver service account no longer uses the predefined `iam.serviceAccountUser` role.
+* The custom role used by the Machine API service account no longer requires the `iam.serviceAccounts.actAs` permission.
+
+To update your environment to remove these extra permissions, run the following commands on a terminal with access to the {gcp-full} project hosting the service accounts.
+
+.Prerequisites
+
+* You have set the `PROJECT_ID` environment variable to your {gcp-full} project ID:
++
+[source,terminal]
+----
+$ export PROJECT_ID=<your_gcp_project_id>
+----
+
+* You have set the `WIF_SUFFIX` environment variable to the last four characters of the `wif-config` ID:
++
+[source,terminal]
+----
+$ export WIF_SUFFIX=<last_four_characters_of_wif_config_id>
+----
+
+* You have pruned the `wif-config` to only include version `4.20` and later versions.
++
+[source,terminal]
+----
+$ ocm gcp update wif-config ${WIF_ID} --versions v4.20,v4.21,v4.22 --mode manual --output-dir /tmp/scripts/
+----
+
+.Procedure
+
+. Remove the CSI driver service account's redundant project-level `iam.serviceAccountUser` role binding:
++
+[source,terminal]
+----
+$ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:gcp-pd-csi-driver-op-${WIF_SUFFIX}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None
+----
+
+. Remove the `iam.serviceAccounts.actAs` permission from the Machine API service account custom role. Repeat the following sub-steps for each applicable version (`v4.20`, `v4.21`, `v4.22`):
+
+.. Set the `VERSION` environment variable to the target version:
++
+[source,terminal]
+----
+$ export VERSION=<version>
+----
++
+Replace `<version>` with `v4.20`, `v4.21`, or `v4.22`.
+
+.. Retrieve the existing role definition:
++
+[source,terminal]
+----
+$ gcloud iam roles describe machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID \
+  --format=yaml > /tmp/role.yaml
+----
++
+.. Remove the unwanted permission. You can do this by filtering out the unwanted permission from the role definition file and saving the updated definition to a new file:
++
+[source,terminal]
+----
+$ cat /tmp/role.yaml | grep -v "iam.serviceAccounts.actAs" > /tmp/updated_role.yaml
+----
++
+.. Review the changes in the output between the original and updated role definitions to ensure only the intended permission line was removed.
+Verify that no comments, descriptions, or other metadata lines were unintentionally filtered:
++
+[source,terminal]
+----
+$ diff /tmp/role.yaml /tmp/updated_role.yaml
+----
++
+.. Update the role in {gcp-full} with the updated role definition file:
++
+[source,terminal]
+----
+$ gcloud iam roles update machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID \
+  --file=/tmp/updated_role.yaml
+----
+
+. After completing the earlier steps for all applicable versions, update the `wif-config` to ensure it is current:
++
+[source,terminal]
+----
+$ ocm gcp update wif-config <wif_config_id> --versions v4.20,v4.21,v4.22
+----
++
+Replace `<wif_config_id>` with the ID of your WIF configuration.
+
+.Verification
+
+* Verify that the `iam.serviceAccounts.actAs` permission is no longer listed in the Machine API role for each applicable version:
++
+[source,terminal]
+----
+$ gcloud iam roles describe machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID
+----
++
+Confirm that `iam.serviceAccounts.actAs` is no longer present in the `includedPermissions` list.

--- a/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
+++ b/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="wif-remove-stale-csi-driver-machine-api-permissions_{context}"]
+= Remove stale CSI driver and Machine API permissions from service accounts managed by a WIF configuration
+
+[role="_abstract"]
+The `wif-config` permission set has had two separate reductions in permissions:
+
+* The Container Storage Interface (CSI) driver service account no longer uses the predefined `iam.serviceAccountUser` role.
+* The custom role used by the Machine API service account no longer requires the `iam.serviceAccounts.actAs` permission.
+
+To update your environment to remove these extra permissions, run the following commands on a terminal with access to the {gcp-full} project hosting the service accounts.
+
+.Prerequisites
+
+* You have set the `PROJECT_ID` environment variable to your {gcp-full} project ID:
++
+[source,terminal]
+----
+$ export PROJECT_ID=<your_gcp_project_id>
+----
+
+* You have set the `WIF_SUFFIX` environment variable to the last four characters of the `wif-config` ID:
++
+[source,terminal]
+----
+$ export WIF_SUFFIX=<last_four_characters_of_wif_config_id>
+----
+
+.Procedure
+
+. Remove the CSI driver service account's redundant project-level `iam.serviceAccountUser` role binding:
++
+[source,terminal]
+----
+$ gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:gcp-pd-csi-driver-op-${WIF_SUFFIX}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None
+----
+
+. Remove the `iam.serviceAccounts.actAs` permission from the Machine API service account custom role. Repeat the following sub-steps for each applicable version (`v4.20`, `v4.21`, `v4.22`):
+
+.. Set the `VERSION` environment variable to the target version:
++
+[source,terminal]
+----
+$ export VERSION=<version>
+----
++
+Replace `<version>` with `v4.20`, `v4.21`, or `v4.22`.
+
+.. Retrieve the existing role definition:
++
+[source,terminal]
+----
+$ gcloud iam roles describe machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID \
+  --format=yaml > /tmp/role.yaml
+----
++
+.. Remove the unwanted permission. You can do this by filtering out the unwanted permission from the role definition file and saving the updated definition to a new file:
++
+[source,terminal]
+----
+$ cat /tmp/role.yaml | grep -v "iam.serviceAccounts.actAs" > /tmp/updated_role.yaml
+----
++
+.. Review the changes in the output between the original and updated role definitions to ensure only the intended permission line was removed.
+Verify that no comments, descriptions, or other metadata lines were unintentionally filtered:
++
+[source,terminal]
+----
+$ diff /tmp/role.yaml /tmp/updated_role.yaml
+----
++
+.. Update the role in {gcp-full} with the updated role definition file:
++
+[source,terminal]
+----
+$ gcloud iam roles update machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID \
+  --file=/tmp/updated_role.yaml
+----
+
+. After completing the earlier steps for all applicable versions, update the `wif-config` to ensure it is current:
++
+[source,terminal]
+----
+$ ocm gcp update wif-config <wif_config_id>
+----
++
+Replace `<wif_config_id>` with the ID of your WIF configuration.
+
+.Verification
+
+* Verify that the `iam.serviceAccounts.actAs` permission is no longer listed in the Machine API role for each applicable version:
++
+[source,terminal]
+----
+$ gcloud iam roles describe machine_api_gcp_${VERSION} \
+  --project $PROJECT_ID
+----
++
+Confirm that `iam.serviceAccounts.actAs` is no longer present in the `includedPermissions` list.

--- a/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
+++ b/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
@@ -31,11 +31,19 @@ $ export PROJECT_ID=<your_gcp_project_id>
 $ export WIF_SUFFIX=<last_four_characters_of_wif_config_id>
 ----
 
-* You have pruned the `wif-config` to only include version `4.20` and later versions.
+* You have pruned the `wif-config` to only include version `4.20` and later versions. Only manual mode is supported for pruning operations.
 +
 [source,terminal]
 ----
 $ ocm gcp update wif-config ${WIF_ID} --versions v4.20,v4.21,v4.22 --mode manual --output-dir /tmp/scripts/
+----
++
+After running this command, execute the generated scripts to apply the changes:
++
+[source,terminal]
+----
+$ /tmp/scripts/apply.sh
+$ /tmp/scripts/prune.sh
 ----
 
 .Procedure

--- a/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
+++ b/modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc
@@ -31,22 +31,29 @@ $ export PROJECT_ID=<your_gcp_project_id>
 $ export WIF_SUFFIX=<last_four_characters_of_wif_config_id>
 ----
 
-* You have pruned the `wif-config` to only include version `4.20` and later versions. Only manual mode is supported for pruning operations.
+* You have set the `WIF_ID` environment variable to your WIF configuration ID:
++
+[source,terminal]
+----
+$ export WIF_ID=<your_wif_config_id>
+----
+
+.Procedure
+
+. Prune the `wif-config` to only include version `4.20` and later versions. Only manual mode is supported for pruning operations:
 +
 [source,terminal]
 ----
 $ ocm gcp update wif-config ${WIF_ID} --versions v4.20,v4.21,v4.22 --mode manual --output-dir /tmp/scripts/
 ----
-+
-After running this command, execute the generated scripts to apply the changes:
+
+. Execute the generated scripts to apply the changes:
 +
 [source,terminal]
 ----
 $ /tmp/scripts/apply.sh
 $ /tmp/scripts/prune.sh
 ----
-
-.Procedure
 
 . Remove the CSI driver service account's redundant project-level `iam.serviceAccountUser` role binding:
 +
@@ -101,15 +108,6 @@ $ gcloud iam roles update machine_api_gcp_${VERSION} \
   --project $PROJECT_ID \
   --file=/tmp/updated_role.yaml
 ----
-
-. Update the `wif-config` to ensure it is current:
-+
-[source,terminal]
-----
-$ ocm gcp update wif-config <wif_config_id> --versions v4.20,v4.21,v4.22
-----
-+
-Replace `<wif_config_id>` with the ID of your WIF configuration.
 
 .Verification
 

--- a/modules/wif-removing-stale-deployer-permissions.adoc
+++ b/modules/wif-removing-stale-deployer-permissions.adoc
@@ -10,41 +10,66 @@
 [role="_abstract"]
 To remove the stale deployer permissions from service accounts managed by a WIF configuration, run the following commands on a terminal with access to the {gcp-full} project hosting the service accounts.
 
+.Prerequisites
+
+* You have set the `PROJECT_ID` environment variable to your {gcp-full} project ID:
++
+[source,terminal]
+----
+$ export PROJECT_ID=<your_gcp_project_id>
+----
+
 .Procedure
 
-. Retrieve the existing role definition, ensuring the `PROJECT_ID` environment variable points to your {gcp-full} project:
+. Retrieve the existing role definition:
 +
 [source,terminal]
 ----
 $ gcloud iam roles describe \
-  osd_deployer_v4.18 \
+  osd_deployer_v4.22 \
   --project $PROJECT_ID \
-  --format=yaml > /tmp/role.yaml
+  --format=yaml > /tmp/deployer_role.yaml
 ----
 +
 . Remove the unwanted permissions. You can do this by filtering out the unwanted permissions from the role definition file and saving the updated definition to a new file:
 +
 [source,terminal]
 ----
-$ cat /tmp/role.yaml | \
+$ cat /tmp/deployer_role.yaml | \
 grep -v "resourcemanager.projects.setIamPolicy" | \
 grep -v "iam.serviceAccounts.signBlob" | \
-grep -v "iam.serviceAccounts.actAs" > /tmp/updated_role.yaml
+grep -v "iam.serviceAccounts.actAs" > /tmp/updated_deployer_role.yaml
 ----
 +
-. Review the changes in the output between the original and updated role definitions to ensure only the unwanted permissions have been removed:
+. Review the changes in the output between the original and updated role definitions to ensure only the intended permission lines were removed.
+Verify that no comments, descriptions, or other metadata lines were unintentionally filtered:
 +
 [source,terminal]
 ----
-$ diff /tmp/role.yaml /tmp/updated_role.yaml
+$ diff /tmp/deployer_role.yaml /tmp/updated_deployer_role.yaml
 ----
 +
-. Update the role in {gcp-full} with the updated role definition file, ensuring the `PROJECT_ID` environment variable points to your {gcp-full} project:
+. Update the role in {gcp-full} with the updated role definition file:
 +
 [source,terminal]
 ----
 $ gcloud iam roles update \
-  osd_deployer_v4.18 \
+  osd_deployer_v4.22 \
   --project=$PROJECT_ID \
-  --file=/tmp/updated_role.yaml
+  --file=/tmp/updated_deployer_role.yaml
 ----
+
+.Verification
+
+* Verify that the stale permissions are no longer listed in the role:
++
+[source,terminal]
+----
+$ gcloud iam roles describe \
+  osd_deployer_v4.22 \
+  --project=$PROJECT_ID
+----
++
+Confirm that `resourcemanager.projects.setIamPolicy`, `iam.serviceAccounts.signBlob`, and `iam.serviceAccounts.actAs` are no longer present in the `includedPermissions` list.
++
+Confirm that `compute.firewalls.create` is no longer present in the `includedPermissions` list.

--- a/modules/wif-removing-stale-support-permissions.adoc
+++ b/modules/wif-removing-stale-support-permissions.adoc
@@ -10,32 +10,53 @@
 [role="_abstract"]
 To remove stale support permissions, run the following commands on a terminal with access to the {gcp-full} project hosting the service accounts.
 
-.Procedure
+.Prerequisites
 
-. Retrieve the existing role definition, ensuring the `PROJECT_ID` environment variable points to your {gcp-full} project:
+* You have set the `PROJECT_ID` environment variable to your {gcp-full} project ID:
 +
 [source,terminal]
 ----
-$ gcloud iam roles describe sre_managed_support --project $PROJECT_ID --format=yaml > /tmp/role.yaml
+$ export PROJECT_ID=<your_gcp_project_id>
+----
+
+.Procedure
+
+. Retrieve the existing role definition:
++
+[source,terminal]
+----
+$ gcloud iam roles describe sre_managed_support --project $PROJECT_ID --format=yaml > /tmp/support_role.yaml
 ----
 +
 . Remove the unwanted permissions. You can do this by filtering out the unwanted permissions from the role definition file and saving the updated definition to a new file:
 +
 [source,terminal]
 ----
-$ cat /tmp/role.yaml | grep -v "compute.firewalls.create"  > /tmp/updated_role.yaml
+$ cat /tmp/support_role.yaml | grep -v "compute.firewalls.create"  > /tmp/updated_support_role.yaml
 ----
 +
-. Review the changes in the output between the original and updated role definitions to ensure only the unwanted permissions have been removed:
-+
-[source,terminal]
-----
-$ diff /tmp/role.yaml /tmp/updated_role.yaml
-----
-+
-. Update the role in {gcp-full} with the updated role definition file, ensuring the `PROJECT_ID` environment variable points to your {gcp-full} project:
+. Review the changes in the output between the original and updated role definitions to ensure only the intended permission lines were removed.
+Verify that no comments, descriptions, or other metadata lines were unintentionally filtered:
 +
 [source,terminal]
 ----
-$ gcloud iam roles update sre_managed_support --project $PROJECT_ID --file=/tmp/updated_role.yaml
+$ diff /tmp/support_role.yaml /tmp/updated_support_role.yaml
 ----
++
+. Update the role in {gcp-full} with the updated role definition file:
++
+[source,terminal]
+----
+$ gcloud iam roles update sre_managed_support --project $PROJECT_ID --file=/tmp/updated_support_role.yaml
+----
+
+.Verification
+
+* Verify that the stale permissions are no longer listed in the role:
++
+[source,terminal]
+----
+$ gcloud iam roles describe sre_managed_support --project $PROJECT_ID
+----
++
+Confirm that `compute.firewalls.create` is no longer present in the `includedPermissions` list.

--- a/modules/wif-troubleshoot-permissions.adoc
+++ b/modules/wif-troubleshoot-permissions.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="wif-troubleshoot-permissions_{context}"]
+= Troubleshoot Workload Identity Federation permission issues
+
+[role="_abstract"]
+Discover how to troubleshoot common permission issues that can occur when using a Workload Identity Federation (WIF) configuration in {product-title} clusters on {gcp}. The following table lists common symptoms, their causes, and recommended resolutions.
+
+[cols="2a,2a,3a",options="header"]
+|===
+|Symptom
+|Cause
+|Resolution
+
+|Cluster version upgrade fails with a WIF configuration version mismatch error.
+|The WIF configuration was not updated to match the target {product-title} version before the cluster upgrade was initiated.
+|Update the WIF configuration to the target version by running `ocm gcp update wif-config <wif_name> --version <version>`, then retry the cluster upgrade.
+
+|Machine API pods report `Permission iam.serviceAccounts.actAs denied` or similar errors when provisioning nodes.
+|The scoped `iam.serviceAccountUser` binding to the `osd-worker` and `osd-control-plane` service accounts is missing or incorrect.
+|Verify that the `openshift-machine-api-gcp` service account has the `iam.serviceAccountUser` role scoped to the `osd-worker` and `osd-control-plane` service accounts. Check the IAM bindings on those service accounts in the {gcp-full} console or by using `gcloud iam service-accounts get-iam-policy`.
+
+|GCP PD CSI Driver pods fail to attach or mount persistent volumes with `iam.serviceAccountUser` errors.
+|The project-level `iam.serviceAccountUser` role was removed from the CSI driver service account, but the scoped binding to node service accounts was not applied.
+|For clusters running {product-title} 4.21 or later, update the WIF configuration, which applies the scoped binding automatically. For clusters running earlier versions, follow the procedure in "Reducing permissions while using the GCP PD CSI Driver Operator" to manually grant the scoped binding before removing the project-level role.
+
+|The `ocm gcp create wif-config` or `ocm gcp update wif-config` command fails with a client version error.
+|The installed version of the {cluster-manager} CLI (`ocm`) is older than the minimum version required for the WIF operation.
+|Download and install the latest version of the `ocm` CLI from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
+
+
+|After removing stale permissions, the `gcloud iam roles describe` output still shows removed permissions.
+|IAM role changes can take up to 60 seconds to propagate across {gcp-full}.
+|Wait 60 seconds and run the `gcloud iam roles describe` command again to verify the updated role definition.
+|===
+
+To restore a permission that was removed by mistake, retrieve the current role definition, add the permission back to the `includedPermissions` list, and update the role:
+
+[source,terminal]
+----
+$ gcloud iam roles describe <role_name> \
+ --project $PROJECT_ID \
+ --format=yaml > /tmp/role_restore.yaml
+----
+
+Edit `/tmp/role_restore.yaml` to add the permission back under `includedPermissions`, then apply the change:
+
+[source,terminal]
+----
+$ gcloud iam roles update <role_name> \
+ --project=$PROJECT_ID \
+ --file=/tmp/role_restore.yaml
+----
+
+

--- a/modules/wif-troubleshoot-permissions.adoc
+++ b/modules/wif-troubleshoot-permissions.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="wif-troubleshoot-permissions_{context}"]
+= Troubleshoot Workload Identity Federation permission issues
+
+[role="_abstract"]
+Discover how to troubleshoot common permission issues that can occur when using a Workload Identity Federation (WIF) configuration in {product-title} clusters on {gcp}. The following table lists common symptoms, their causes, and recommended resolutions.
+
+[cols="2a,2a,3a",options="header"]
+|===
+|Symptom
+|Cause
+|Resolution
+
+|Cluster version upgrade fails with a WIF configuration version mismatch error.
+|The WIF configuration was not updated to match the target {product-title} version before the cluster upgrade was initiated.
+|Update the WIF configuration to the target version by running `ocm gcp update wif-config <wif_name> --version <version>`, then retry the cluster upgrade.
+
+|Machine API pods report `Permission iam.serviceAccounts.actAs denied` or similar errors when provisioning nodes.
+|The scoped `iam.serviceAccountUser` binding to the `osd-worker` and `osd-control-plane` service accounts is missing or incorrect.
+|Verify that the `openshift-machine-api-gcp` service account has the `iam.serviceAccountUser` role scoped to the `osd-worker` and `osd-control-plane` service accounts. Check the IAM bindings on those service accounts in the {gcp-full} console or by using `gcloud iam service-accounts get-iam-policy`. |Update the WIF configuration to the target version by running `ocm gcp update wif-config <wif_name> --version <version>`.
+
+|GCP PD CSI Driver pods fail to attach or mount persistent volumes with `iam.serviceAccountUser` errors.
+|The project-level `iam.serviceAccountUser` role was removed from the CSI driver service account, but the scoped binding to node service accounts was not applied.
+|For clusters running {product-title} 4.21 or later, update the WIF configuration, which applies the scoped binding automatically. For clusters running earlier versions, follow the procedure in "Reducing permissions while using the GCP PD CSI Driver Operator" to manually grant the scoped binding before removing the project-level role.
+
+|The `ocm gcp create wif-config` or `ocm gcp update wif-config` command fails with a client version error.
+|The installed version of the {cluster-manager} CLI (`ocm`) is older than the minimum version required for the WIF operation.
+|Download and install the latest version of the `ocm` CLI from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
+
+
+|After removing stale permissions, the `gcloud iam roles describe` output still shows removed permissions.
+|IAM role changes can take up to 60 seconds to propagate across {gcp-full}.
+|Wait 60 seconds and run the `gcloud iam roles describe` command again to verify the updated role definition.
+|===
+
+To restore a permission that was removed by mistake, retrieve the current role definition, add the permission back to the `includedPermissions` list, and update the role:
+
+[source,terminal]
+----
+$ gcloud iam roles describe <role_name> \
+ --project $PROJECT_ID \
+ --format=yaml > /tmp/role_restore.yaml
+----
+
+Edit `/tmp/role_restore.yaml` to add the permission back under `includedPermissions`, then apply the change:
+
+[source,terminal]
+----
+$ gcloud iam roles update <role_name> \
+ --project=$PROJECT_ID \
+ --file=/tmp/role_restore.yaml
+----
+
+

--- a/modules/wif-troubleshoot-permissions.adoc
+++ b/modules/wif-troubleshoot-permissions.adoc
@@ -38,22 +38,13 @@ Discover how to troubleshoot common permission issues that can occur when using 
 |Wait 60 seconds and run the `gcloud iam roles describe` command again to verify the updated role definition.
 |===
 
-To restore a permission that was removed by mistake, retrieve the current role definition, add the permission back to the `includedPermissions` list, and update the role:
+To restore permissions that were removed by mistake, run the following command:
 
 [source,terminal]
 ----
-$ gcloud iam roles describe <role_name> \
- --project $PROJECT_ID \
- --format=yaml > /tmp/role_restore.yaml
+$ ocm gcp update wif-config <wif_config_id>
 ----
 
-Edit `/tmp/role_restore.yaml` to add the permission back under `includedPermissions`, then apply the change:
-
-[source,terminal]
-----
-$ gcloud iam roles update <role_name> \
- --project=$PROJECT_ID \
- --file=/tmp/role_restore.yaml
-----
+This command automatically detects and restores missing permissions to the custom roles within the specified WIF configuration.
 
 

--- a/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc
@@ -47,6 +47,8 @@ include::modules/ocm-cli-list-wif-commands.adoc[leveloffset=+1]
 include::modules/wif-configuration-update.adoc[leveloffset=+1]
 include::modules/wif-removing-stale-deployer-permissions.adoc[leveloffset=+2]
 include::modules/wif-removing-stale-support-permissions.adoc[leveloffset=+2]
+include::modules/wif-remove-stale-csi-driver-machine-api-permissions.adoc[leveloffset=+2]
+include::modules/wif-troubleshoot-permissions.adoc[leveloffset=+2]
 include::modules/ocm-cli-verify-wif-commands.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
Version(s):
4.22
5

Issue:
[OSDOCS-21049](https://redhat.atlassian.net/browse/OSDOCS-21049)

Link to docs preview:

- [Updating a Workload Identity Federation configuration](https://117548--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation)
- [Private Service Connect overview](https://117548--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster)
- [IAM service account and roles](https://117548--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs#ccs-gcp-iam-service-account-roles_gcp-ccs)
- [GCP PD CSI Driver Operator](https://117548--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/container_storage_interface/persistent-storage-csi-gcp-pd)

Summary:

This PR is part of a collection of updates encompassing the new features launched with [OSDGCP-37](https://redhat.atlassian.net/browse/OSDGCP-37) and OSDGCP-76. The other linked PRs are:

https://github.com/openshift/openshift-docs/pull/118053
https://github.com/openshift/openshift-docs/pull/118155
https://github.com/openshift/openshift-docs/pull/118378

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
