### PR TITLE
[CNV-82154]: Add documentation for pausing guest agent ping probes

### DIFF
--- a/modules/virt-about-pausing-guest-agent-ping-probes.adoc
+++ b/modules/virt-about-pausing-guest-agent-ping-probes.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-monitoring-vm-health.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-about-pausing-guest-agent-ping-probes_{context}"]
+
+= About pausing guest agent ping probes
+
+[role="_abstract"]
+During maintenance operations such as guest OS updates, the QEMU guest agent might become temporarily unavailable. If a `GuestAgentPing` liveness probe is configured, probe failures cause the kubelet to restart the pod, which destroys the running virtual machine (VM).
+
+You can prevent unwanted pod restarts by temporarily pausing `GuestAgentPing` probes. Setting the `kubevirt.io/pause-guest-agent-probes` annotation on a `VirtualMachineInstance` (VMI) resource causes `virt-launcher` to return immediate success for `GuestAgentPing` probes without contacting the QEMU guest agent.
+
+This is a manual, temporary measure. You must set the annotation yourself before maintenance and remove it yourself when maintenance is complete. The annotation is not set or removed automatically. If the `GuestAgentPing` probe is no longer needed, update the VM spec to remove the probe instead of relying on the annotation.
+
+Consider pausing probes in the following scenarios:
+
+* Guest OS updates that require one or more reboots, such as Windows updates
+* Any planned maintenance where the guest agent will be temporarily unavailable
+
+[IMPORTANT]
+====
+* This annotation only affects `GuestAgentPing` probes. HTTP, TCP, and exec probes are not affected.
+* The annotation takes effect within seconds on the next `virt-launcher` sync cycle.
+* You must manually remove the annotation after maintenance to resume normal probe behavior. Probes remain paused indefinitely while the annotation is set.
+* If you no longer require the `GuestAgentPing` probe, remove it from the VM spec rather than keeping the annotation set permanently.
+====

--- a/modules/virt-pausing-guest-agent-ping-probes.adoc
+++ b/modules/virt-pausing-guest-agent-ping-probes.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-monitoring-vm-health.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-pausing-guest-agent-ping-probes_{context}"]
+
+= Pausing and resuming guest agent ping probes
+
+[role="_abstract"]
+You can temporarily pause `GuestAgentPing` probes on a virtual machine instance (VMI) by adding an annotation. This prevents the kubelet from restarting the pod during maintenance operations when the guest agent is temporarily unavailable.
+
+.Prerequisites
+
+* A running VMI with a `GuestAgentPing` liveness / readiness probe configured.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Pause probes by annotating the VMI:
++
+[source,terminal]
+----
+$ oc annotate vmi <vmi_name> kubevirt.io/pause-guest-agent-probes=true
+----
+
+. Verify that the annotation is set:
++
+[source,terminal]
+----
+$ oc get vmi <vmi_name> -o jsonpath='{.metadata.annotations.kubevirt\.io/pause-guest-agent-probes}'
+----
++
+.Example output
+[source,terminal]
+----
+true
+----
+
+. Optional: Verify that `virt-launcher` has picked up the annotation by checking its logs:
++
+[source,terminal]
+----
+$ oc logs -n <namespace> virt-launcher-<vmi_name>-<id> -c compute | grep "probe pause state"
+----
+
+. Perform your maintenance operations, such as guest OS updates.
+
+. Resume probes by removing the annotation:
++
+[source,terminal]
+----
+$ oc annotate vmi <vmi_name> kubevirt.io/pause-guest-agent-probes-
+----

--- a/virt/monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/monitoring/virt-monitoring-vm-health.adoc
@@ -28,6 +28,10 @@ include::modules/virt-installing-watchdog-agent.adoc[leveloffset=+2]
 // Hiding in ROSA/OSD as TP not supported
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 include::modules/virt-define-guest-agent-ping-probe.adoc[leveloffset=+1]
+
+include::modules/virt-about-pausing-guest-agent-ping-probes.adoc[leveloffset=+2]
+
+include::modules/virt-pausing-guest-agent-ping-probes.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 // Hiding in ROSA/OSD as not supported


### PR DESCRIPTION
Document the kubevirt.io/pause-guest-agent-probes VMI annotation that allows temporarily pausing GuestAgentPing liveness probes during maintenance operations such as guest OS updates.

Based on KubeVirt VEP 207 (sig-compute/207-pause-probes).

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

Version(s):
4.23

Issue:
https://redhat.atlassian.net/browse/CNV-82154

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

