### PR TITLE
OCPBUGS-100116: Add fencing secret update step to TNF node replacement

### DIFF
--- a/modules/installation-replacing-control-plane-nodes.adoc
+++ b/modules/installation-replacing-control-plane-nodes.adoc
@@ -313,6 +313,63 @@ $ sudo pcs cluster node remove <node_name>
 $ sudo pcs cluster node add <node_name> addr=<node_ip> --start --enable
 ----
 
+. If the replacement node has a different BMC system UUID than the failed node, update the fencing secret so that STONITH can fence the new node.
++
+The fencing secret contains a Redfish URL in its `address` field. If the replacement node received a new BMC system UUID, the URL still points to the old UUID and STONITH cannot fence the new node.
++
+.. Verify the new BMC system UUID by querying the Redfish API:
++
+[source,terminal]
+----
+$ curl -k https://<bmc_address>/redfish/v1/Systems/ -u <username>:<password>
+----
++
+.Example output
+[source,json]
+----
+{
+  "Members": [
+    {"@odata.id": "/redfish/v1/Systems/<new_uuid>"}
+  ]
+}
+----
++
+The UUID is the last path segment of the `@odata.id` value under `Members`.
++
+.. Update the fencing secret for the replacement node:
++
+[source,terminal]
+----
+$ oc create secret generic fencing-credentials-<node_name> \
+  --namespace openshift-etcd \
+  --from-literal=address='redfish+https://<bmc_address>:<port>/redfish/v1/Systems/<new_uuid>' \
+  --from-literal=username='<username>' \
+  --from-literal=password='<password>' \
+  --from-literal=certificateVerification='<Disabled_or_Enabled>' \
+  --dry-run=client -o yaml | oc apply -f -
+----
++
+Replace `<node_name>` with the hostname of the replacement node as it appears in `oc get nodes`. Replace `<bmc_address>` and `<port>` with the BMC IP address and port, `<new_uuid>` with the new BMC system UUID, and `<username>` and `<password>` with the BMC credentials. Use `Disabled` for `certificateVerification` to skip certificate validation (matching `disableCertificateVerification: true` on the BMH object) or `Enabled` if your BMC has a valid TLS certificate.
++
+.. Verify the secret was updated:
++
+[source,terminal]
+----
+$ oc get secret fencing-credentials-<node_name> -n openshift-etcd \
+  -o jsonpath='{.data.address}' | base64 -d
+----
++
+Confirm the output contains the new BMC system UUID.
++
+[NOTE]
+====
+All four keys must be present. The cluster etcd Operator rejects secrets with missing keys.
+
+The `update-fencing-credentials.sh` script on the control plane nodes cannot be used for this step because it requires a healthy STONITH device, which does not exist until after the cluster etcd Operator completes fencing setup. Use the script for subsequent credential rotations after the cluster is fully operational.
+
+Do not update the STONITH resource directly with `pcs stonith update`. The cluster etcd Operator manages STONITH configuration and overwrites manual changes.
+====
+
 . Delete stale jobs for the failed node by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
## Summary

- Adds a step to update the fencing secret (`fencing-credentials-<node>`) when replacing a control plane node whose replacement has a different BMC system UUID
- Inserted between "Rejoin the replacement node to the pacemaker cluster" and "Delete stale jobs" so the secret is correct before the CEO creates new TNF auth/setup jobs
- Notes that `update-fencing-credentials.sh` cannot be used for this step (requires a healthy STONITH device) and should be used for subsequent credential rotations

## Bug

[OCPBUGS-100116](https://redhat.atlassian.net/browse/OCPBUGS-100116) — After node replacement, `pcs stonith status` shows the replacement node's fencing agent as FAILED because the fencing secret still references the old node's BMC UUID in `systems_uri`.

## Test plan

- [ ] Verify the new step renders correctly in the published docs preview
- [ ] Technical review: confirm the `oc create secret` command produces a valid fencing secret accepted by the CEO
- [ ] Technical review: confirm the insertion point is correct (secret must exist before CEO fencing phase runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)