### PR TITLE
[enterprise-4.20] OSDOCS-17081_3#CQA updates

### DIFF
--- a/modules/support-knowledgebase-about.adoc
+++ b/modules/support-knowledgebase-about.adoc
@@ -9,7 +9,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="support-knowledgebase-about_{context}"]
-= About the Red Hat Knowledgebase
+= About the Red{nbsp}Hat Knowledgebase
 
 [role="_abstract"]
-The link:https://access.redhat.com/knowledgebase[Red{nbsp}Hat Knowledgebase] provides rich content aimed at helping you make the most of Red{nbsp}Hat's products and technologies. The Red{nbsp}Hat Knowledgebase consists of articles, product documentation, and videos outlining best practices on installing, configuring, and using Red Hat products. In addition, you can search for solutions to known issues, each providing concise root cause descriptions and remedial steps.
+The Red{nbsp}Hat Knowledgebase helps you get the most from Red{nbsp}Hat products and technologies.
+
+It includes articles, product documentation, and videos that outline best practices for installing, configuring, and using Red{nbsp}Hat products. You can also search for solutions to known issues. Each solution has a root cause description and steps to fix the problem.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/knowledgebase[Red{nbsp}Hat Knowledgebase]

--- a/modules/support-knowledgebase-search.adoc
+++ b/modules/support-knowledgebase-search.adoc
@@ -12,7 +12,7 @@
 = Searching the Red{nbsp}Hat Knowledgebase
 
 [role="_abstract"]
-You can search the Red{nbsp}Hat Knowledgebase to check whether a solution already exists for an {product-title} issue you are experiencing.
+Search the Red{nbsp}Hat Knowledgebase to find solutions to known issues and resolve problems quickly without opening a support case.
 
 .Prerequisites
 

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -11,7 +11,7 @@
 = Submitting a support case
 
 [role="_abstract"]
-You can submit a support case to Red{nbsp}Hat Support to get help resolving issues with your {product-title} cluster.
+If you cannot resolve an {product-title} issue by using the Red{nbsp}Hat Knowledgebase, submit a support case to get direct help from Red{nbsp}Hat Support.
 
 .Prerequisites
 
@@ -44,7 +44,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 . Enter the following information:
 
-.. In the *Summary* field, enter a concise but descriptive problem summary and further details about the symptoms you are experiencing and your expectations.
+.. In the *Summary* field, enter a concise but descriptive problem summary and further details about the symptoms that you experience and your expectations.
 
 .. Select *{product-title}* from the *Product* drop-down menu.
 
@@ -52,11 +52,11 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .. Select *{product-version}* from the *Version* drop-down.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-. Review the list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem you are reporting. If the suggested articles do not address the issue, click *Continue*.
+. Review the list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem that you are reporting. If the suggested articles do not address the issue, click *Continue*.
 
-. Review the updated list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem you are reporting. The list refines as you provide more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
+. Review the updated list of suggested Red{nbsp}Hat Knowledgebase solutions for a potential match against the problem that you are reporting. The list updates as you give more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
 
-. Ensure that the account information presented is as expected, and if not, change as needed.
+. Ensure that the account information presented is as expected, and if not, change it as needed.
 
 . Check that the autofilled {product-title} Cluster ID is correct. If it is not, manually obtain your cluster ID.
 ifdef::openshift-dedicated[]
@@ -71,9 +71,9 @@ endif::openshift-dedicated[]
 .. Navigate to *Home* -> *Overview*.
 .. Find the value in the *Cluster ID* field of the *Details* section.
 +
-* Alternatively, it is possible to open a new support case through the {product-title} web console and have your cluster ID autofilled.
+* Or, open a new support case from the {product-title} web console, which automatically fills in your cluster ID.
 .. From the toolbar, navigate to *(?) Help* -> *Open Support Case*.
-.. The *Cluster ID* value is autofilled.
+.. The *Cluster ID* value automatically fills in.
 +
 * To obtain your cluster ID using the OpenShift CLI (`oc`), run the following command:
 +
@@ -91,7 +91,7 @@ $ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'
 
 . Upload relevant diagnostic data files and click *Continue*.
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-Include data gathered using the `oc adm must-gather` command as a starting point, plus any issue-specific data that the command does not collect.
+Red{nbsp}Hat recommends including data gathered by using the `oc adm must-gather` command as a starting point, plus any issue-specific data that the command does not collect.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 . Input relevant case management details and click *Continue*.

--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -25,17 +25,17 @@
 = Getting support
 
 [role="_abstract"]
-If you experience difficulty with a procedure described in this documentation, or with {product-title} in general, visit the Red Hat Customer Portal.
+Red{nbsp}Hat offers several support channels to help you troubleshoot issues and get the most from {product-title}.
 
-From the Red Hat Customer Portal, you can:
+From the Red{nbsp}Hat Customer Portal, you can:
 
-* Search or browse through the Red Hat Knowledgebase of articles and solutions relating to Red Hat products.
-* Submit a support case to Red Hat Support.
+* Search or browse through the Red{nbsp}Hat Knowledgebase of articles and solutions about Red{nbsp}Hat products.
+* Submit a support case to Red{nbsp}Hat Support.
 * Access other product documentation.
 
 ifndef::microshift[]
-To identify issues with your cluster, you can use {red-hat-lightspeed} in {cluster-manager-url}. {red-hat-lightspeed} provides details about issues and, if available, information on how to solve a problem.
+To identify issues with your cluster, you can use {red-hat-lightspeed} in {cluster-manager-url}. {red-hat-lightspeed} provides details about issues and, if available, information about how to solve a problem.
 
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
-To suggest improvements or report errors, provide specific details such as the section name and {product-title} version.
+To suggest improvements or report errors, give specific details such as the section name and {product-title} version.
 endif::microshift[]


### PR DESCRIPTION
4.20 cherrypick of d840aa1802154d91f89cdffb31a91a2a40c1bc01
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/117297

Note
`support/getting-support.adoc` (the assembly short desc change) is missing from this PR because the file was already updated on 4.20, 4.21, and 4.22 by a prior cherry-pick — so when the cherry-pick applied, git saw no diff on that file and dropped it.


