### PR TITLE
OSDOCS-21327: Document WIF Config Version Pruning.

### DIFF
--- a/modules/wif-prune-configuration.adoc
+++ b/modules/wif-prune-configuration.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="wif-prune-configuration_{context}"]
+= Prune unused versions from a Workload Identity Federation configuration
+
+[role="_abstract"]
+You can remove unused {product-title} versions from an existing Workload Identity Federation (WIF) configuration by using the `ocm gcp prune wif-config` command. Pruning removes the roles and permissions associated with the specified version from the WIF configuration.
+
+Pruning is useful when older versions carry broader permissions that override the security improvements in newer versions. For example, if your WIF configuration includes version 4.19, the broader permissions from that version remain in effect. These broader permissions persist even after you update the configuration to include versions with reduced permissions, such as 4.20 or later. Removing the older version allows your configuration to benefit from the reduced permission set.
+
+[NOTE]
+====
+You cannot prune a version that is in use by an active cluster. The backend validates that no running clusters depend on the version before allowing removal.
+====
+
+By default, the `prune` command runs in dry-run mode and displays the changes that the command would make without applying them. You must pass the `--confirm` flag to apply the changes.
+
+.Prerequisites
+
+* You have downloaded the latest version of the {cluster-manager} CLI (`ocm`) from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
+* You have an existing WIF configuration that includes the version you want to remove.
+* No active clusters use the version that you want to remove.
+
+.Procedure
+
+. Preview the changes by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp prune wif-config <wif_name> \
+ --version=<version>
+----
++
+where:
+
+`<wif_name>`:: The name of the WIF configuration to prune.
+
+`<version>`:: The {product-title} y-stream version to remove, for example `4.19`. To remove multiple versions, add the versions separated by commas, for example `4.19,4.20`.
++
+Review the output to confirm which roles and permissions the command will remove.
++
+. After reviewing the dry-run output, apply the changes by running the command with the `--confirm` flag:
++
+[source,terminal]
+----
+$ ocm gcp prune wif-config <wif_name> \
+ --version=<version> \
+ --confirm
+----
+
+.Verification
+
+* Verify that the pruned version and its associated roles are no longer listed in the WIF configuration by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp describe wif-config <wif_name>
+----

--- a/modules/wif-prune-configuration.adoc
+++ b/modules/wif-prune-configuration.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="wif-prune-configuration_{context}"]
+= Prune unused versions from a Workload Identity Federation configuration
+
+[role="_abstract"]
+You can remove unused {product-title} versions from an existing Workload Identity Federation (WIF) configuration by using the `ocm gcp prune wif-config` command. Pruning removes the roles and permissions associated with the specified version from the WIF configuration.
+
+Pruning is useful when older versions carry broader permissions that override the security improvements in newer versions. For example, if your WIF configuration includes version 4.19, the broader permissions from that version remain in effect. These broader permissions persist even after you update the configuration to include versions with reduced permissions, such as 4.20 or later. Removing the older version allows your configuration to benefit from the reduced permission set.
+
+[NOTE]
+====
+You can only run the `prune` command in manual mode and you cannot prune a version that is in use by an active cluster.
+====
+
+.Prerequisites
+
+* You have downloaded the latest version of the {cluster-manager} CLI (`ocm`) from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
+* You have an existing WIF configuration that includes the version you want to remove.
+
+.Procedure
+
+. Preview the changes by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp prune wif-config <wif_name> \
+ --version=<version> \
+ --mode=manual
+----
++
+where:
+
+`<wif_name>`:: The name of the WIF configuration to prune.
+
+`<version>`:: The {product-title} y-stream version to remove, for example `4.19`. To remove multiple versions, add the versions separated by commas, for example `4.19,4.20`.
++
+Review the output to confirm which roles and permissions the command will remove.
++
+. After reviewing the output, apply the changes by running the command with the `--confirm` flag:
++
+[source,terminal]
+----
+$ ocm gcp prune wif-config <wif_name> \
+ --version=<version> \
+ --confirm
+----
+
+.Verification
+
+* Verify that the pruned version and its associated roles are no longer listed in the WIF configuration by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp describe wif-config <wif_name>
+----

--- a/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc
@@ -47,6 +47,7 @@ include::modules/ocm-cli-list-wif-commands.adoc[leveloffset=+1]
 include::modules/wif-configuration-update.adoc[leveloffset=+1]
 include::modules/wif-removing-stale-deployer-permissions.adoc[leveloffset=+2]
 include::modules/wif-removing-stale-support-permissions.adoc[leveloffset=+2]
+include::modules/wif-prune-configuration.adoc[leveloffset=+1]
 include::modules/ocm-cli-verify-wif-commands.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
Version(s):
4.22
5

Issue:
[OSDOCS-21327](https://redhat.atlassian.net/browse/OSDOCS-21327)

This PR is part of a collection of updates encompassing the new features launched with [OSDGCP-37](https://redhat.atlassian.net/browse/OSDGCP-37) and OSDGCP-76. The other linked PRs are:

https://github.com/openshift/openshift-docs/pull/118053
https://github.com/openshift/openshift-docs/pull/118155
https://github.com/openshift/openshift-docs/pull/117548
https://github.com/openshift/openshift-docs/pull/118378

Link to docs preview:
[Prune unused versions from a Workload Identity Federation configuration](https://117606--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#wif-prune-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation)

SME review:
- [ ] SME has approved this change.

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- [ ] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
