### PR TITLE
CNV-84750: GA Dual Stream Support in 5.0

### DIFF
--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -91,3 +91,7 @@ Different operating systems provide varying levels of support for hot plugging C
 |Yes
 |===
 
+[NOTE]
+====
+For information on how to troubleshoot issues with offline hot plugged CPUs, see link:https://access.redhat.com/solutions/7134081[Hotplugged CPU is offline in the RHEL Guest, unable to bring online].
+====

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-edit-vms.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-hot-plugging-cpu-support_{context}"]
+= Hot plugging CPU support
+
+[role="_abstract"]
+Different operating systems provide varying levels of support for hot plugging CPUs.
+
+[cols="1a,3a,3a,3a"]
+|===
+|Operating system |Version |Architecture |Hot plug support
+
+|{op-system-base-full}
+|8.10                                     
+|x86                  
+|Yes
+
+
+|{op-system-base-full} 
+|9.0
+|x86                   
+|Yes
+
+|{op-system-base-full} 
+|9.6 and later                                    
+|x86                    
+|Yes (requires soft reboot)
+
+|{op-system-base-full} 
+|10                                       
+|x86                   
+|Yes (requires soft reboot)
+
+|Windows Server 2016
+|All
+|x86                   
+|Yes (hot unplug not supported)
+
+|Windows Server 2019   
+|All            
+|x86                   
+|Yes (hot unplug not supported)
+
+|Windows Server 2022   
+|All            
+|x86                   
+|Yes (hot unplug not supported)
+
+|Windows Server 2025   
+|All            
+|x86                   
+|Yes  (hot unplug not supported)
+
+
+|SUSE Linux Enterprise Server 12 
+|SP5                                
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 15 
+|SP3                               
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 15 
+|SP4                               
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 15
+|SP5                               
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 15 
+|SP6                               
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 15
+|SP7                               
+|x86                    
+|Yes
+
+|SUSE Linux Enterprise Server 16.0
+|                                    
+|x86                    
+|Yes
+|===

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 Different operating systems provide varying levels of support for hot plugging CPUs.
 
-[cols="1a,3a,3a,3a"]
+[cols="3a,2a,2a,3a"]
 |===
 |Operating system |Version |Architecture |Hot plug support
 
@@ -90,3 +90,4 @@ Different operating systems provide varying levels of support for hot plugging C
 |x86                    
 |Yes
 |===
+

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -95,4 +95,4 @@ Different operating systems provide varying levels of support for hot plugging C
 For information on how to troubleshoot issues with offline hot plugged CPUs, see link:https://access.redhat.com/solutions/7134081[Hotplugged CPU is offline in the RHEL Guest, unable to bring online].
 
 
-{VirtProductName} may inadverently pass nested virtualization extensions (VMX, SVM) extenstions to the guest. Nested virtualization extensions are not supported and not recommended. For more information about this issue, see link:https://redhat.atlassian.net/browse/CNV-68983[CNV-68983: Nested Virtualization may get enabled inadvertently if no default cluster cpu model set].
+{VirtProductName} may inadverently pass nested virtualization extensions (VMX, SVM) to the guest. Nested virtualization extensions are not supported and not recommended. For more information about this issue, see link:https://redhat.atlassian.net/browse/CNV-68983[CNV-68983: Nested Virtualization may get enabled inadvertently if no default cluster cpu model set].

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -27,12 +27,12 @@ Different operating systems provide varying levels of support for hot plugging C
 |{op-system-base-full} 
 |9.6 and later                                    
 |x86                    
-|Yes (requires soft reboot)
+|Yes
 
 |{op-system-base-full} 
 |10                                       
 |x86                   
-|Yes (requires soft reboot)
+|Yes
 
 |Windows Server 2016
 |All
@@ -91,7 +91,10 @@ Different operating systems provide varying levels of support for hot plugging C
 |Yes
 |===
 
-[NOTE]
-====
+
 For information on how to troubleshoot issues with offline hot plugged CPUs, see link:https://access.redhat.com/solutions/7134081[Hotplugged CPU is offline in the RHEL Guest, unable to bring online].
-====
+
+{VirtProductName} 
+
+
+OpenShift Virtualization may inadvertently pass nested virtualization (VMX, SVM) extensions to the Guest. But Nested Virtualization is not officially supported and generally not recommended, unless in specific cases. This is being tracked in CNV-68983 - Nested Virtualization may get enabled inadvertently if no default cluster cpu model set.

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -94,7 +94,5 @@ Different operating systems provide varying levels of support for hot plugging C
 
 For information on how to troubleshoot issues with offline hot plugged CPUs, see link:https://access.redhat.com/solutions/7134081[Hotplugged CPU is offline in the RHEL Guest, unable to bring online].
 
-{VirtProductName} 
 
-
-OpenShift Virtualization may inadvertently pass nested virtualization (VMX, SVM) extensions to the Guest. But Nested Virtualization is not officially supported and generally not recommended, unless in specific cases. This is being tracked in CNV-68983 - Nested Virtualization may get enabled inadvertently if no default cluster cpu model set.
+{VirtProductName} may inadverently pass nested virtualization extensions (VMX, SVM) extenstions to the guest. Nested virtualization extensions are not supported and not recommended. For more information about this issue, see link:https://redhat.atlassian.net/browse/CNV-68983[CNV-68983: Nested Virtualization may get enabled inadvertently if no default cluster cpu model set].

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -54,41 +54,6 @@ Different operating systems provide varying levels of support for hot plugging C
 |x86                   
 |Yes  (hot unplug not supported)
 
-
-|SUSE Linux Enterprise Server 12 
-|SP5                                
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 15 
-|SP3                               
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 15 
-|SP4                               
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 15
-|SP5                               
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 15 
-|SP6                               
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 15
-|SP7                               
-|x86                    
-|Yes
-
-|SUSE Linux Enterprise Server 16.0
-|                                    
-|x86                    
-|Yes
 |===
 
 

--- a/modules/virt-hot-plugging-cpu-support.adoc
+++ b/modules/virt-hot-plugging-cpu-support.adoc
@@ -95,4 +95,4 @@ Different operating systems provide varying levels of support for hot plugging C
 For information on how to troubleshoot issues with offline hot plugged CPUs, see link:https://access.redhat.com/solutions/7134081[Hotplugged CPU is offline in the RHEL Guest, unable to bring online].
 
 
-{VirtProductName} may inadverently pass nested virtualization extensions (VMX, SVM) to the guest. Nested virtualization extensions are not supported and not recommended. For more information about this issue, see link:https://redhat.atlassian.net/browse/CNV-68983[CNV-68983: Nested Virtualization may get enabled inadvertently if no default cluster cpu model set].
+{VirtProductName} may inadverently pass nested virtualization extensions (VMX, SVM) to the guest. Nested Virtualization is not officially supported and generally not recommended, except in specific cases. For more information about this issue, see link:https://redhat.atlassian.net/browse/CNV-68983[CNV-68983: Nested Virtualization may get enabled inadvertently if no default cluster cpu model set].

--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -9,13 +9,8 @@
 
 [role="_abstract"]
 
-:FeatureName: Live migration support for {op-system} 10.x
-include::snippets/technology-preview.adoc[]
-
-{VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes as a Technology Preview feature.
+{VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes.
 
 For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
 
-When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy: true`. This is a known limitation.
-
-Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster. Any VM live migration from {op-system} 10.x to {op-system} 9.x and from {op-system} 9.x to {op-system} 10.x worker nodes, is a Technology Preview feature in {product-title} 4.22.
+Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster.

--- a/virt/managing_vms/virt-edit-vms.adoc
+++ b/virt/managing_vms/virt-edit-vms.adoc
@@ -20,7 +20,7 @@ include::modules/virt-hot-plugging-memory.adoc[leveloffset=+1]
 
 include::modules/virt-hot-plugging-cpu.adoc[leveloffset=+1]
 
-include::modules/virt-hot-plugging-cpu-support[leveloffset=+2]
+include::modules/virt-hot-plugging-cpu-support.adoc[leveloffset=+2]
 
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 

--- a/virt/managing_vms/virt-edit-vms.adoc
+++ b/virt/managing_vms/virt-edit-vms.adoc
@@ -20,6 +20,8 @@ include::modules/virt-hot-plugging-memory.adoc[leveloffset=+1]
 
 include::modules/virt-hot-plugging-cpu.adoc[leveloffset=+1]
 
+include::modules/virt-hot-plugging-cpu-support[leveloffset=+2]
+
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 
 include::modules/virt-add-disk-to-vm.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Dual Stream live migration support moves from Tech Preview to GA in 5.0.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
5.0

Issue:
[CNV-84750](https://redhat.atlassian.net/browse/CNV-84750)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
