### PR TITLE
[enterprise-4.20] OSDOCS-17049pr12: Fix AsciiDocDITA Vale errors in post-install content

### DIFF
--- a/modules/enabling-aws-sts-existing-cluster.adoc
+++ b/modules/enabling-aws-sts-existing-cluster.adoc
@@ -6,7 +6,8 @@
 [id="enabling-aws-sts-existing-cluster_{context}"]
 = Enabling {aws-short} {sts-first} on an existing cluster
 
-If you did not configure your {aws-first} {product-title} cluster to use {sts-first} during installation, you can enable this authentication method on an existing cluster.
+[role="_abstract"]
+Enable {aws-short} {sts-first} on an existing {product-title} cluster if you did not configure this authentication method during installation.
 
 [IMPORTANT]
 ====
@@ -49,24 +50,28 @@ $ mkdir ./output_dir
 $ oc get secret/next-bound-service-account-signing-key \
   -n openshift-kube-apiserver-operator \
   -ojsonpath='{ .data.service-account\.pub }' | base64 -d \
-  > output_dir/serviceaccount-signer.public <1>
+  > output_dir/serviceaccount-signer.public
 ----
-<1> This procedure uses a file named `serviceaccount-signer.public` as an example.
++
+This procedure uses a file named `serviceaccount-signer.public` as an example.
 
 .. Create the {aws-short} IAM identity provider and S3 bucket by running the following command:
 +
 [source,terminal]
 ----
 $ ./ccoctl aws create-identity-provider \
-  --output-dir output_dir \ <1>
-  --name <name_you_choose> \ <2>
-  --region us-east-2 \ <3>
-  --public-key-file output_dir/serviceaccount-signer.public <4>
+  --output-dir output_dir \
+  --name <name_you_choose> \
+  --region us-east-2 \
+  --public-key-file output_dir/serviceaccount-signer.public
 ----
-<1> Specify the output directory you created earlier.
-<2> Specify a globally unique name. This name functions as a prefix for AWS resources created by this command.
-<3> Specify the AWS region of the cluster.
-<4> Specify the relative path to the `serviceaccount-signer.public` file you created earlier.
++
+where:
++
+`--output-dir`:: Specify the output directory you created earlier.
+`--name`:: Specify a globally unique name. This name functions as a prefix for AWS resources created by this command.
+`--region`:: Specify the AWS region of the cluster.
+`--public-key-file`:: Specify the relative path to the `serviceaccount-signer.public` file you created earlier.
 
 .. Save or note the Amazon Resource Name (ARN) for the IAM identity provider. You can find this information in the final line of the output of the previous command.
 
@@ -163,17 +168,20 @@ $ oc adm release extract \
 [source,terminal]
 ----
 $ ./ccoctl aws create-iam-roles \
-  --output-dir ./output_dir/ \ <1>
-  --name <name_you_choose> \ <2>
-  --identity-provider-arn <identity_provider_arn> \ <3>
-  --region us-east-2 \ <4>
-  --credentials-requests-dir ./output_dir/cred-reqs/ <5>
+  --output-dir ./output_dir/ \
+  --name <name_you_choose> \
+  --identity-provider-arn <identity_provider_arn> \
+  --region us-east-2 \
+  --credentials-requests-dir ./output_dir/cred-reqs/
 ----
-<1> Specify the output directory you created earlier.
-<2> Specify a globally unique name. This name functions as a prefix for AWS resources created by this command.
-<3> Specify the ARN for the IAM identity provider.
-<4> Specify the AWS region of the cluster.
-<5> Specify the relative path to the folder where you extracted the `CredentialsRequest` files with the `oc adm release extract` command.
++
+where:
++
+`--output-dir`:: Specify the output directory you created earlier.
+`--name`:: Specify a globally unique name. This name functions as a prefix for AWS resources created by this command.
+`--identity-provider-arn`:: Specify the ARN for the IAM identity provider.
+`--region`:: Specify the AWS region of the cluster.
+`--credentials-requests-dir`:: Specify the relative path to the folder where you extracted the `CredentialsRequest` files with the `oc adm release extract` command.
 
 .. Apply the generated secrets by running the following command:
 +

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -6,7 +6,8 @@
 [id="enabling-entra-workload-id-existing-cluster_{context}"]
 = Enabling {entra-first} on an existing cluster
 
-If you did not configure your {azure-first} {product-title} cluster to use {entra-first} during installation, you can enable this authentication method on an existing cluster.
+[role="_abstract"]
+Enable {entra-first} on an existing {azure-first} {product-title} cluster. If you did not configure your cluster to use {entra-first} during installation, you can enable this authentication method post-installation.
 
 [IMPORTANT]
 ====
@@ -44,27 +45,31 @@ This procedure uses `./output_dir` as an example.
 $ oc get secret/next-bound-service-account-signing-key \
   -n openshift-kube-apiserver-operator \
   -ojsonpath='{ .data.service-account\.pub }' | base64 -d \
-  > output_dir/serviceaccount-signer.public <1>
+  > output_dir/serviceaccount-signer.public
 ----
-<1> This procedure uses a file named `serviceaccount-signer.public` as an example.
++
+This procedure uses a file named `serviceaccount-signer.public` as an example.
 
 . Use the extracted service account public signing key to create an OpenID Connect (OIDC) issuer and {azure-short} blob storage container with OIDC configuration files by running the following command:
 +
 [source,terminal]
 ----
 $ ./ccoctl azure create-oidc-issuer \
-  --name <azure_infra_name> \// <1>
+  --name <azure_infra_name> \
   --output-dir ./output_dir \
-  --region <azure_region> \// <2>
-  --subscription-id <azure_subscription_id> \// <3>
+  --region <azure_region> \
+  --subscription-id <azure_subscription_id> \
   --tenant-id <azure_tenant_id> \
-  --public-key-file ./output_dir/serviceaccount-signer.public <4>
+  --public-key-file ./output_dir/serviceaccount-signer.public
 ----
-<1> The value of the `name` parameter is used to create an Azure resource group.
++
+where:
++
+`<azure_infra_name>`:: The value of the `name` parameter is used to create an Azure resource group.
 To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
-<2> Specify the region of the existing cluster.
-<3> Specify the subscription ID of the existing cluster.
-<4> Specify the file that contains the service account public signing key for the cluster.
+`<azure_region>`:: Specify the region of the existing cluster.
+`<azure_subscription_id>`:: Specify the subscription ID of the existing cluster.
+`--public-key-file`:: Specify the file that contains the service account public signing key for the cluster.
 
 . Verify that the configuration file for the Azure pod identity webhook was created by running the following command:
 +
@@ -73,15 +78,16 @@ To use an existing Azure resource group instead of creating a new one, specify t
 $ ll ./output_dir/manifests
 ----
 +
-.Example output
+Example output:
 +
 [source,text]
 ----
 total 8
--rw-------. 1 cloud-user cloud-user 193 May 22 02:29 azure-ad-pod-identity-webhook-config.yaml <1>
+-rw-------. 1 cloud-user cloud-user 193 May 22 02:29 azure-ad-pod-identity-webhook-config.yaml
 -rw-------. 1 cloud-user cloud-user 165 May 22 02:29 cluster-authentication-02-config.yaml
 ----
-<1> The file `azure-ad-pod-identity-webhook-config.yaml` contains the Azure pod identity webhook configuration.
++
+The file `azure-ad-pod-identity-webhook-config.yaml` contains the Azure pod identity webhook configuration.
 
 . Set an `OIDC_ISSUER_URL` variable with the OIDC issuer URL from the generated manifests in the output directory by running the following command:
 +
@@ -186,12 +192,15 @@ $ ccoctl azure create-managed-identities \
   --subscription-id <azure_subscription_id> \
   --credentials-requests-dir <path_to_directory_for_credentials_requests> \
   --issuer-url "${OIDC_ISSUER_URL}" \
-  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <1>
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \
   --installation-resource-group-name "${AZURE_INSTALL_RG}" \
-  --network-resource-group-name <azure_resource_group> <2>
+  --network-resource-group-name <azure_resource_group>
 ----
-<1> Specify the name of the resource group that contains the DNS zone.
-<2> Optional: Specify the virtual network resource group if it is different from the cluster resource group.
++
+where:
++
+`<azure_dns_zone_resourcegroup_name>`:: Specify the name of the resource group that contains the DNS zone.
+`<azure_resource_group>`:: Optional: Specify the virtual network resource group if it is different from the cluster resource group.
 
 . Apply the {azure-short} pod identity webhook configuration for {entra-short} by running the following command:
 +

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -24,6 +24,6 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 Routing alerts to receivers enables you to send timely notifications to the appropriate teams when failures occur. For example, critical alerts require immediate attention and are typically paged to an individual or a critical response team. Alerts that provide non-critical warning notifications might instead be routed to a ticketing system for non-immediate review.
 
-.Checking that alerting is operational by using the watchdog alert
+**Checking that alerting is operational by using the watchdog alert**
 
 {product-title} monitoring includes a watchdog alert that fires continuously. Alertmanager repeatedly sends watchdog alert notifications to configured notification providers. The provider is usually configured to notify an administrator when it stops receiving the watchdog alert. This mechanism helps you quickly identify any communication issues between Alertmanager and the notification provider.

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -60,12 +60,12 @@ spec:
           metadata: {}
           network:
             devices:
-            - addressesFromPools: <1>
+            - addressesFromPools:
               - group: ipamcontroller.example.io
                 name: static-ci-pool
                 resource: IPPool
               nameservers:
-              - "192.168.204.1" <2>
+              - "192.168.204.1"
               networkName: qe-segment-204
           numCPUs: 4
           numCoresPerSocket: 2
@@ -80,8 +80,11 @@ spec:
             resourcePool: /IBMCdatacenter/host/IBMCcluster//Resources
             server: vcenter.ibmc.devcluster.openshift.com
 ----
-<1> Specifies an IP pool, which lists a static IP address or a range of static IP addresses. The IP Pool can either be a reference to a custom resource definition (CRD) or a resource supported by the `IPAddressClaims` resource handler. The machine controller accesses static IP addresses listed in the machine set's configuration and then allocates each address to each machine.
-<2> Lists a nameserver. You must specify a nameserver for nodes that receive static IP address, because the Dynamic Host Configuration Protocol (DHCP) network configuration does not support static IP addresses.
++
+where:
++
+`addressesFromPools`:: Specifies an IP pool, which lists a static IP address or a range of static IP addresses. The IP Pool can either be a reference to a custom resource definition (CRD) or a resource supported by the `IPAddressClaims` resource handler. The machine controller accesses static IP addresses listed in the machine set's configuration and then allocates each address to each machine.
+`nameservers`:: Lists a name server. You must specify a name server for nodes that receive static IP address, because the Dynamic Host Configuration Protocol (DHCP) network configuration does not support static IP addresses.
 
 . Scale the machine set by entering the following commands in your `oc` CLI:
 +
@@ -132,17 +135,20 @@ metadata:
   namespace: openshift-machine-api
 spec:
   address: 192.168.204.129
-  claimRef: <1>
+  claimRef:
     name: cluster-dev-9n5wg-worker-0-m7529-claim-0-0
   gateway: 192.168.204.1
-  poolRef: <2>
+  poolRef:
     apiGroup: ipamcontroller.example.io
     kind: IPPool
     name: static-ci-pool
   prefix: 23
 ----
-<1> The name of the target `IPAddressClaim` resource.
-<2> Details information about the static IP address or addresses from your nodes.
++
+where:
++
+`claimRef`:: The name of the target `IPAddressClaim` resource.
+`poolRef`:: Details information about the static IP address or addresses from your nodes.
 +
 [NOTE]
 ====

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -7,9 +7,9 @@
 = Scaling machines to use static IP addresses
 
 [role="_abstract"]
-You can add machines with pre-defined static IP addresses by creating machine resources that specify static network configuration in the machine YAML file.
+You can add machines with predefined static IP addresses by creating machine resources that specify static network configuration in the machine YAML file.
 
-You can scale additional machine sets to use pre-defined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
+You can scale additional machine sets to use predefined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
 
 .Prerequisites
 
@@ -19,7 +19,7 @@ You can scale additional machine sets to use pre-defined static IP addresses on 
 
 . Create a machine resource YAML file and define static IP address network information in the `network` parameter.
 +
-.Example of a machine resource YAML file with static IP address information defined in the `network` parameter.
+Example of a machine resource YAML file with static IP address information defined in the `network` parameter:
 +
 [source,yaml]
 ----
@@ -49,10 +49,10 @@ spec:
         creationTimestamp: null
       network:
         devices:
-        - gateway: 192.168.204.1 <1>
+        - gateway: 192.168.204.1
           ipAddrs:
-          - 192.168.204.8/24 <2>
-          nameservers: <3>
+          - 192.168.204.8/24
+          nameservers:
           - 192.168.204.1
           networkName: qe-segment-204
       numCPUs: 4
@@ -69,9 +69,12 @@ spec:
         server: <vcenter_server_ip>
 status: {}
 ----
-<1> The IP address for the default gateway for the network interface.
-<2> Lists IPv4, IPv6, or both IP addresses that installation program passes to the network interface. Both IP families must use the same network interface for the default network.
-<3> Lists a DNS nameserver. You can define up to 3 DNS nameservers. Consider defining more than one DNS nameserver to take advantage of DNS resolution if that one DNS nameserver becomes unreachable.
++
+where:
++
+`gateway`:: Specifies an IP address for the default gateway for the network interface.
+`ipAddrs`:: Specifies a list of IPv4, IPv6, or both IP addresses that installation program passes to the network interface. Both IP families must use the same network interface for the default network.
+`nameservers`:: Specifies a DNS name server. You can define up to 3 DNS name servers. Consider defining more than one DNS name server to take advantage of DNS resolution if that one DNS name server becomes unreachable.
 
 * Create a `machine` custom resource (CR) by entering the following command in your terminal:
 +

--- a/modules/refreshing-service-ids-ibm-cloud.adoc
+++ b/modules/refreshing-service-ids-ibm-cloud.adoc
@@ -22,15 +22,18 @@ You can rotate API keys for your existing service IDs and update the correspondi
 +
 [source,terminal]
 ----
-$ ccoctl <provider_name> refresh-keys \// <1>
-    --kubeconfig <openshift_kubeconfig_file> \// <2>
-    --credentials-requests-dir <path_to_credential_requests_directory> \// <3>
-    --name <name> <4>
+$ ccoctl <provider_name> refresh-keys \
+    --kubeconfig <openshift_kubeconfig_file> \
+    --credentials-requests-dir <path_to_credential_requests_directory> \
+    --name <name>
 ----
-<1> The name of the provider. For example: `ibmcloud` or `powervs`.
-<2> The `kubeconfig` file associated with the cluster. For example, `<installation_directory>/auth/kubeconfig`.
-<3> The directory where the credential requests are stored.
-<4> The name of the {product-title} cluster.
++
+where:
++
+`<provider_name>`:: The name of the provider. For example: `ibmcloud` or `powervs`.
+`<openshift_kubeconfig_file>`:: The `kubeconfig` file associated with the cluster. For example, `<installation_directory>/auth/kubeconfig`.
+`<path_to_credential_requests_directory>`:: The directory where the credential requests are stored.
+`<name>`:: The name of the {product-title} cluster.
 +
 --
 [NOTE]

--- a/modules/rotating-bound-service-keys.adoc
+++ b/modules/rotating-bound-service-keys.adoc
@@ -73,7 +73,7 @@ $ oc adm wait-for-stable-cluster --minimum-stable-period=5s
 ----
 ifdef::rotate-aws[]
 INFRA_ID=$(oc get infrastructures cluster -o jsonpath='{.status.infrastructureName}')
-CLUSTER_NAME=${INFRA_ID%-*} <1>
+CLUSTER_NAME=${INFRA_ID%-*}
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
 CURRENT_ISSUER=$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')
@@ -86,7 +86,10 @@ AZURE_STORAGE_CONTAINER=$(echo ${CURRENT_ISSUER} | cut -d "/" -f4)
 endif::rotate-azure[]
 ----
 ifdef::rotate-aws[]
-<1> This value should match the name of the cluster that was specified in the `metadata.name` field of the `install-config.yaml` file during installation.
++
+where:
++
+`CLUSTER_NAME`:: This value should match the name of the cluster that was specified in the `metadata.name` field of the `install-config.yaml` file during installation.
 endif::rotate-aws[]
 +
 [NOTE]
@@ -189,16 +192,19 @@ ifdef::rotate-aws[]
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
-  --dry-run \// <1>
+  --dry-run \
   --output-dir ${TEMPDIR} \
-  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <2>
-  --name fake \// <3>
-  --region us-east-1 <4>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \
+  --name fake \
+  --region us-east-1
 ----
-<1> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<2> Specify the path to the public key that you downloaded in the previous step.
-<3> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
-<4> Specify any valid {aws-short} region, such as `us-east-1`.
++
+where:
++
+`--dry-run`:: The dry run mode outputs files, including the new `keys.json` file, to the disk without making API calls.
+`--public-key-file`:: The path to the public key that you downloaded in the previous step.
+`--name`:: Some parameters do not require real values because the `--dry-run` option does not make any API calls.
+`--region`:: Any valid {aws-short} region, such as `us-east-1`.
 This value does not need to match the region the cluster is in.
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
@@ -206,34 +212,40 @@ ifdef::rotate-gcp[]
 [source,terminal]
 ----
 $ ccoctl gcp create-workload-identity-provider \
-  --dry-run \// <1>
+  --dry-run \
   --output-dir=${TEMPDIR} \
-  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <2>
-  --name fake \// <3>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \
+  --name fake \
   --project fake \
   --workload-identity-pool fake
 ----
-<1> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<2> Specify the path to the public key that you downloaded in the previous step.
-<3> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
++
+where:
++
+`--dry-run`:: The dry run mode outputs files, including the new `keys.json` file, to the disk without making API calls.
+`--public-key-file`:: The path to the public key that you downloaded in the previous step.
+`--name`:: Some parameters do not require real values because the `--dry-run` option does not make any API calls.
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
 +
 [source,terminal]
 ----
-$ ccoctl aws create-identity-provider \// <1>
-  --dry-run \// <2>
+$ ccoctl aws create-identity-provider \
+  --dry-run \
   --output-dir ${TEMPDIR} \
-  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <3>
-  --name fake \// <4>
-  --region us-east-1 <5>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \
+  --name fake \
+  --region us-east-1
 ----
-<1> The `ccoctl azure` command does not include a `--dry-run` option.
++
+where:
++
+`ccoctl aws`:: The command does not include a `--dry-run` option.
 To use the `--dry-run` option, you must specify `aws` for an {azure-short} cluster.
-<2> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<3> Specify the path to the public key that you downloaded in the previous step.
-<4> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
-<5> Specify any valid {aws-short} region, such as `us-east-1`.
+`--dry-run`:: The dry run mode outputs files, including the new `keys.json` file, to the disk without making API calls.
+`--public-key-file`:: The path to the public key that you downloaded in the previous step.
+`--name`:: Some parameters do not require real values because the `--dry-run` option does not make any API calls.
+`--region`:: Any valid {aws-short} region, such as `us-east-1`.
 This value does not need to match the region the cluster is in.
 endif::rotate-azure[]
 

--- a/post_installation_configuration/post-install-network-configuration.adoc
+++ b/post_installation_configuration/post-install-network-configuration.adoc
@@ -32,13 +32,13 @@ For more information, see "Cluster Network Operator in {product-title}".
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="post-install-network-configuration-default-network-policies"]
-=== Creating default network policies for a new project
+== Creating default network policies for a new project
 
 As a cluster administrator, you can modify the new project template to automatically include `NetworkPolicy` objects when you create a new project.
 
-include::modules/modifying-template-for-new-projects.adoc[leveloffset=+3]
+include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
 
-include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+3]
+include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+2]
 
 endif::[]
 


### PR DESCRIPTION
Refs https://github.com/openshift/openshift-docs/pull/117127.

Replace unsupported callouts, block titles, and nested sections for AsciiDocDITA compliance. Leaves node-tasks.adoc for a separate pass.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
