### PR TITLE
CNV-84750: Dual Stream support GA in 5.0

### DIFF
--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -9,7 +9,7 @@
 
 [role="_abstract"]
 
-{VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes as a Technology Preview feature.
+{VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes.
 
 For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
 

--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -9,13 +9,8 @@
 
 [role="_abstract"]
 
-:FeatureName: Live migration support for {op-system} 10.x
-include::snippets/technology-preview.adoc[]
-
 {VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes as a Technology Preview feature.
 
 For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
 
-When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy: true`. This is a known limitation.
-
-Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster. Any VM live migration from {op-system} 10.x to {op-system} 9.x and from {op-system} 9.x to {op-system} 10.x worker nodes, is a Technology Preview feature in {product-title} 4.22.
+Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster. 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Remove TP notations for Dual Stream support in 5.0 as it is now GA.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
5.0

Issue:
[CNV-84750](https://redhat.atlassian.net/browse/CNV-84750)

Link to docs preview:
[VM migration support for RHCOS 10.x](https://117662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration.html#virt-vm-migration-dual-stream_virt-about-live-migration)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
