### PR TITLE
CNV#89224: Document clickable network links on VM network interfaces tab

### DIFF
--- a/modules/virt-viewing-vm-network-details.adoc
+++ b/modules/virt-viewing-vm-network-details.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-networking-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-viewing-vm-network-details_{context}"]
+= Viewing network details from the VM network interfaces tab
+
+[role="_abstract"]
+You can go directly from a virtual machine's (VM) network interface list to the detail page of the associated network resource. Use these links to quickly inspect or troubleshoot network configurations without searching for the resource manually.
+
+On the *VirtualMachine details* page, the *Configuration* -> *Network* tab lists the VM's network interfaces. Each network name is a link that opens the detail page for the associated network resource, such as a network attachment definition (NAD), user-defined network (UDN), or cluster user-defined network (CUDN).
+
+Network that use the default pod network display "Pod networking" as plain text because there is no corresponding network resource to go to.

--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -55,6 +55,8 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-nw-overview-manage-vm-nw-config.adoc[leveloffset=+1]
 
+include::modules/virt-viewing-vm-network-details.adoc[leveloffset=+1]
+
 include::modules/virt-nw-overview-vm-ssh-config.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
5.0+

Issue:
https://issues.redhat.com/browse/CNV-89224

Link to docs preview:
https://117663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-networking-overview.html#virt-viewing-vm-network-details_virt-networking-overview

QE review:
- [x] QE has approved this change.

Additional information:
Document the new clickable network name links on the VM Configuration > Network interfaces tab.

- Added new concept module (`virt-viewing-vm-network-details.adoc`) to explain that network names now link to the associated NAD, UDN, or CUDN detail page, and that Pod networking entries remain plain text
- Included the new module in the networking overview assembly (`virt-networking-overview.adoc`) between the "Manage VM network interface configuration" and "SSH access" sections