### PR TITLE
OSDOCS-16942: olm-cs-podsched assembly

### DIFF
--- a/modules/disabling-catalogsource-objects.adoc
+++ b/modules/disabling-catalogsource-objects.adoc
@@ -6,7 +6,8 @@
 [id="disabling-catalogsource-objects_{context}"]
 = Disabling default CatalogSource objects at a local level
 
-You can apply persistent changes to a `CatalogSource` object, such as catalog source pods, at a local level, by disabling a default `CatalogSource` object. Consider the default configuration in situations where the default `CatalogSource` object's configuration does not meet your organization's needs. By default, if you modify fields in the `spec.grpcPodConfig` section of the   `CatalogSource` object, the Marketplace Operator automatically reverts these changes.
+[role="_abstract"]
+You can make persistent local changes to a `CatalogSource` object by disabling the default `CatalogSource` object. Otherwise, the Marketplace Operator automatically reverts any manual modifications to fields in the `spec.grpcPodConfig` section.
 
 The Marketplace Operator, `openshift-marketplace`, manages the default custom resources (CRs) of the `OperatorHub`. The `OperatorHub` manages `CatalogSource` objects.
 

--- a/modules/olm-node-selector.adoc
+++ b/modules/olm-node-selector.adoc
@@ -6,6 +6,9 @@
 [id="olm-node-selector_{context}"]
 = Overriding the node selector for catalog source pods
 
+[role="_abstract"]
+To control which nodes run catalog source pods, you can override the default node selector in the `spec.grpcPodConfig` section of the `CatalogSource` object.
+
 .Prerequisites
 
 * A `CatalogSource` object of source type `grpc` with `spec.image` is defined.

--- a/modules/olm-priority-class-name.adoc
+++ b/modules/olm-priority-class-name.adoc
@@ -13,16 +13,19 @@ endif::[]
 [id="olm-priority-class-name_{context}"]
 = Overriding the priority class name for catalog source pods
 
+[role="_abstract"]
+To control the scheduling priority of catalog source pods, you can override the default priority class name in the `spec.grpcPodConfig` section of the `CatalogSource` object.
+
 .Prerequisites
 
-* A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
+* A `CatalogSource` object of source type `grpc` with a defined `spec.image`.
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* You have access to the cluster as a user with the `dedicated-admin` role.
+* Access to the cluster as a user with the `dedicated-admin` role.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 
-* Edit the `CatalogSource` object and add or modify the `spec.grpcPodConfig` section to include the following:
+* Edit the `CatalogSource` object and configure the `spec.grpcPodConfig` section, similar to the following example:
 +
 [source,yaml]
 ----
@@ -30,14 +33,16 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
     priorityClassName: <priority_class>
 ----
 +
-where `<priority_class>` is one of the following:
+where:
+
+`<priority_class>`:: Specifies one of the following priority classes:
 +
 --
-* One of the default priority classes provided by Kubernetes: `system-cluster-critical` or `system-node-critical`
-* An empty set (`""`) to assign the default priority
-* A pre-existing and custom defined priority class
+* A default Kubernetes priority class, such as `system-cluster-critical` or `system-node-critical`
+* An empty string (`""`) to assign the default priority
+* A custom, pre-existing priority class name
 --
-
++
 [NOTE]
 ====
 Previously, the only pod scheduling parameter that could be overriden was `priorityClassName`. This was done by adding the `operatorframework.io/priorityclass` annotation to the `CatalogSource` object. For example:

--- a/modules/olm-tolerations.adoc
+++ b/modules/olm-tolerations.adoc
@@ -6,6 +6,9 @@
 [id="olm-tolerations_{context}"]
 = Overriding tolerations for catalog source pods
 
+[role="_abstract"]
+To allow catalog source pods to schedule onto nodes with matching taints, you can override the default tolerations in the `spec.grpcPodConfig` section of the `CatalogSource` object.
+
 .Prerequisites
 
 * A `CatalogSource` object of source type `grpc` with `spec.image` is defined.

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -6,13 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When an Operator Lifecycle Manager (OLM) catalog source of source type `grpc` defines a `spec.image`, the Catalog Operator creates a pod that serves the defined image content. By default, this pod defines the following in its specification:
+[role="_abstract"]
+When a `grpc` type catalog source defines the `spec.image` field, the Catalog Operator creates a pod to serve that image.
 
-* Only the `kubernetes.io/os=linux` node selector.
-* The default priority class name: `system-cluster-critical`.
-* No tolerations.
+By default, the pod specification configures the following default settings:
 
-As an administrator, you can override these values by modifying fields in the `CatalogSource` object's optional `spec.grpcPodConfig` section.
+* Node selector: `kubernetes.io/os=linux`
+* Priority class name: `system-cluster-critical`
+* Tolerations: None
+
+As an administrator, you can override these defaults by configuring fields in the optional `spec.grpcPodConfig` section of the `CatalogSource` object.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16942](https://redhat.atlassian.net/browse/OSDOCS-16942)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
assemblies:
https://117667--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/admin/olm-cs-podsched.html
https://117667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html
https://117667--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/admin/olm-cs-podsched.html
https://117667--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/admin/olm-cs-podsched.html

modules:

* [modules/disabling-catalogsource-objects.adoc](https://github.com/openshift/openshift-docs/pull/117667/files#diff-2b533a86f572664c09c5d6c1c0394919b3363855761099a359f121e05836a884):
** [OpenShift Enterprise](https://117667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html#disabling-catalogsource-objects_olm-cs-podsched)
* [modules/olm-node-selector.adoc](https://github.com/openshift/openshift-docs/pull/117667/files#diff-ffa4619d0d8abb63929a9b9ef52528dcbe08d20ebd2b754cd73b828f1cd15f8e):
** [OpenShift Enterprise](https://117667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html#olm-node-selector_olm-cs-podsched)
* [modules/olm-priority-class-name.adoc](https://github.com/openshift/openshift-docs/pull/117667/files#diff-37f67f602af2395526e54084a75580640c1f9b3ad09c7af0f9ce9554d823f3bf):
** [OpenShift Enterprise](https://117667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html#olm-priority-class-name_olm-cs-podsched)
* [modules/olm-tolerations.adoc](https://github.com/openshift/openshift-docs/pull/117667/files#diff-2e0e5eee115a82808ef19df8e4c030ba5851f05b3f70c2dc77920c23a9a48430):
** [OpenShift Enterprise](https://117667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html#olm-tolerations_olm-cs-podsched)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
