### PR TITLE
OSDOCS-16942: CQA crd-crds assemblies

### DIFF
--- a/modules/crd-creating-aggregated-cluster-roles.adoc
+++ b/modules/crd-creating-aggregated-cluster-roles.adoc
@@ -6,6 +6,7 @@
 [id="crd-creating-aggregated-cluster-role_{context}"]
 = Creating cluster roles for custom resource definitions
 
+[role="_abstract"]
 Cluster administrators can grant permissions to existing cluster-scoped custom resource definitions (CRDs). If you use the `admin`, `edit`, and `view` default cluster roles, you can take advantage of cluster role aggregation for their rules.
 
 [IMPORTANT]
@@ -27,39 +28,42 @@ endif::[]
 [source,yaml]
 ----
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1 <1>
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aggregate-cron-tabs-admin-edit <2>
+  name: aggregate-cron-tabs-admin-edit
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true" <3>
-    rbac.authorization.k8s.io/aggregate-to-edit: "true" <4>
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
-- apiGroups: ["stable.example.com"] <5>
-  resources: ["crontabs"] <6>
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"] <7>
+- apiGroups: ["stable.example.com"]
+  resources: ["crontabs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aggregate-cron-tabs-view <2>
+  name: aggregate-cron-tabs-view
   labels:
     # Add these permissions to the "view" default role.
-    rbac.authorization.k8s.io/aggregate-to-view: "true" <8>
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true" <9>
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
-- apiGroups: ["stable.example.com"] <5>
-  resources: ["crontabs"] <6>
-  verbs: ["get", "list", "watch"] <7>
+- apiGroups: ["stable.example.com"]
+  resources: ["crontabs"]
+  verbs: ["get", "list", "watch"]
 ----
-<1> Use the `rbac.authorization.k8s.io/v1` API.
-<2> Specify a name for the definition.
-<3> Specify this label to grant permissions to the admin default role.
-<4> Specify this label to grant permissions to the edit default role.
-<5> Specify the group name of the CRD.
-<6> Specify the plural name of the CRD that these rules apply to.
-<7> Specify the verbs that represent the permissions that are granted to the role. For example, apply read and write permissions to the `admin` and `edit` roles and only read permission to the `view` role.
-<8> Specify this label to grant permissions to the `view` default role.
-<9> Specify this label to grant permissions to the `cluster-reader` default role.
++
+where:
++
+`apiVersion`:: Specifies the `rbac.authorization.k8s.io/v1` API.
+`metadata.name`:: Specifies a name for the definition.
+`metadata.labels.rbac.authorization.k8s.io/aggregate-to-admin`:: Specifies `"true"` to enable cluster role aggregation to the admin role.
+`metadata.labels.rbac.authorization.k8s.io/aggregate-to-edit`:: Specifies `"true"` to grant permissions to the edit default role.
+`rules.apiGroups`:: Specifies the group name of the CRD.
+`rules.resources`:: Specifies the plural name of the CRD that these rules apply to.
+`rules.verbs`:: Specifies the verbs that represent the permissions that are granted to the role. For example, apply read and write permissions to the `admin` and `edit` roles and only read permission to the `view` role.
+`metadata.labels.rbac.authorization.k8s.io/aggregate-to-view`:: Specifies `"true"` to grant permissions to the `view` default role.
+`metadata.labels."rbac.authorization.k8s.io/aggregate-to-cluster-reader"`:: Specifies `"true"` to grant permissions to the `cluster-reader` default role.
 
 . Create the cluster role:
 +

--- a/modules/crd-creating-crds.adoc
+++ b/modules/crd-creating-crds.adoc
@@ -6,6 +6,7 @@
 [id="crd-creating-custom-resources-definition_{context}"]
 = Creating a custom resource definition
 
+[role="_abstract"]
 To create custom resource (CR) objects, cluster administrators must first create a custom resource definition (CRD).
 
 .Prerequisites
@@ -14,21 +15,19 @@ To create custom resource (CR) objects, cluster administrators must first create
 
 .Procedure
 
-To create a CRD:
-
 . Create a YAML file that contains the following field types:
 +
 .Example YAML file for a CRD
 [source,yaml]
 ----
-apiVersion: apiextensions.k8s.io/v1 <1>
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crontabs.stable.example.com <2>
+  name: crontabs.stable.example.com
 spec:
-  group: stable.example.com <3>
+  group: stable.example.com
   versions:
-    - name: v1 <4>
+    - name: v1
       served: true
       storage: true
       schema:
@@ -44,23 +43,26 @@ spec:
                   type: string
                 replicas:
                   type: integer
-  scope: Namespaced <5>
+  scope: Namespaced
   names:
-    plural: crontabs <6>
-    singular: crontab <7>
-    kind: CronTab <8>
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
     shortNames:
-    - ct <9>
+    - ct
 ----
-<1> Use the `apiextensions.k8s.io/v1` API.
-<2> Specify a name for the definition. This must be in the `<plural-name>.<group>` format using the values from the `group` and `plural` fields.
-<3> Specify a group name for the API. An API group is a collection of objects that are logically related. For example, all batch objects like `Job` or `ScheduledJob` could be in the batch API group (such as `batch.api.example.com`). A good practice is to use a fully-qualified-domain name (FQDN) of your organization.
-<4> Specify a version name to be used in the URL. Each API group can exist in multiple versions, for example `v1alpha`, `v1beta`, `v1`.
-<5> Specify whether the custom objects are available to a project (`Namespaced`) or all projects in the cluster (`Cluster`).
-<6> Specify the plural name to use in the URL. The `plural` field is the same as a resource in an API URL.
-<7> Specify a singular name to use as an alias on the CLI and for display.
-<8> Specify the kind of objects that can be created. The type can be in CamelCase.
-<9> Specify a shorter string to match your resource on the CLI.
++
+where:
++
+`apiVersion`:: Specifies the `apiextensions.k8s.io/v1` API parameter.
+`metadata.name`:: Specifies a name for the definition. This must be in the `<plural-name>.<group>` format using the values from the `group` and `plural` fields.
+`spec.group`:: Specifies a group name for the API. An API group is a collection of objects that are logically related. For example, all batch objects like `Job` or `ScheduledJob` could be in the batch API group (such as `batch.api.example.com`). A good practice is to use a fully-qualified-domain name (FQDN) of your organization.
+`spec.versions.name`:: Specifies a version name to be used in the URL. Each API group can exist in multiple versions, for example `v1alpha`, `v1beta`, `v1`.
+`spec.scope`:: Specifies whether the custom objects are available to a project (`Namespaced`) or all projects in the cluster (`Cluster`).
+`spec.names.plural`:: Specifies the plural name to use in the URL. The `plural` field is the same as a resource in an API URL.
+`spec.names.singular`:: Specifies a singular name to use as an alias on the CLI and for display.
+`spec.names.kind`:: Specifies the kind of objects that can be created. The type can be in camel case.
+`spec.names.shortNames`:: Specifies a shorter string to match your resource on the CLI.
 +
 [NOTE]
 ====

--- a/modules/crd-creating-custom-resources-from-file.adoc
+++ b/modules/crd-creating-custom-resources-from-file.adoc
@@ -9,7 +9,8 @@
 [id="crd-creating-custom-resources-from-file_{context}"]
 = Creating custom resources from a file
 
-After a custom resource definition (CRD) has been added to the cluster, custom resources (CRs) can be created with the CLI from a file using the CR specification.
+[role="_abstract"]
+After you add a custom resource definition (CRD) to the cluster, you can create custom resources (CRs) from a file by using the CLI.
 
 .Prerequisites
 
@@ -24,22 +25,24 @@ endif::[]
 .Example YAML file for a CR
 [source,yaml]
 ----
-apiVersion: "stable.example.com/v1" <1>
-kind: CronTab <2>
+apiVersion: "stable.example.com/v1"
+kind: CronTab
 metadata:
-  name: my-new-cron-object <3>
-  finalizers: <4>
+  name: my-new-cron-object
+  finalizers:
   - finalizer.stable.example.com
-spec: <5>
+spec:
   cronSpec: "* * * * /5"
   image: my-awesome-cron-image
 ----
 +
-<1> Specify the group name and API version (name/version) from the CRD.
-<2> Specify the type in the CRD.
-<3> Specify a name for the object.
-<4> Specify the link:https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#finalizers[finalizers] for the object, if any. Finalizers allow controllers to implement conditions that must be completed before the object can be deleted.
-<5> Specify conditions specific to the type of object.
+where:
++
+`apiVersion`:: Specifies the group name and API version (name/version) from the CRD.
+`kind`:: Specifies the type in the CRD.
+`metadata.name`:: Specifies a name for the object.
+`metadata.finalizers`:: Specifies the finalizers for the object, if any. Finalizers allow controllers to implement conditions that must be completed before the object can be deleted.
+`spec`:: Specifies conditions specific to the type of object.
 
 . After you create the file, create the object:
 +

--- a/modules/crd-custom-resource-definitions.adoc
+++ b/modules/crd-custom-resource-definitions.adoc
@@ -7,6 +7,7 @@
 [id="crd-custom-resource-definitions_{context}"]
 = Custom resource definitions
 
+[role="_abstract"]
 In the Kubernetes API, a _resource_ is an endpoint that stores a collection of API objects of a certain kind. For example, the built-in `Pods` resource contains a collection of `Pod` objects.
 
 A _custom resource definition_ (CRD) object defines a new, unique object type, called a _kind_, in the cluster and lets the Kubernetes API server handle its entire lifecycle.

--- a/modules/crd-inspecting-custom-resources.adoc
+++ b/modules/crd-inspecting-custom-resources.adoc
@@ -9,6 +9,7 @@
 [id="crd-inspecting-custom-resources_{context}"]
 = Inspecting custom resources
 
+[role="_abstract"]
 You can inspect custom resource (CR) objects that exist in your cluster using the CLI.
 
 .Prerequisites
@@ -87,7 +88,8 @@ items:
     selfLink: /apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object
     uid: 9423255b-4600-11e7-af6a-28d2447dc82b
   spec:
-    cronSpec: '* * * * /5' <1>
-    image: my-awesome-cron-image <1>
+    cronSpec: '* * * * /5'
+    image: my-awesome-cron-image
 ----
-<1> Custom data from the YAML that you used to create the object displays.
++
+The `spec` section in the output displays the custom configuration settings, such as `cronSpec` and `image`, that you defined when creating the object.

--- a/operators/understanding/crds/crd-extending-api-with-crds.adoc
+++ b/operators/understanding/crds/crd-extending-api-with-crds.adoc
@@ -7,7 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Operators use the Kubernetes extension mechanism, custom resource definitions (CRDs), so that custom objects managed by the Operator look and act just like the built-in, native Kubernetes objects. This guide describes how cluster administrators can extend their {product-title} cluster by creating and managing CRDs.
+[role="_abstract"]
+To extend the Kubernetes API with custom object types that behave like built-in Kubernetes objects, cluster administrators can create and manage custom resource definitions (CRDs) on their {product-title} cluster.
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 

--- a/operators/understanding/crds/crd-managing-resources-from-crds.adoc
+++ b/operators/understanding/crds/crd-managing-resources-from-crds.adoc
@@ -7,7 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide describes how developers can manage custom resources (CRs) that come from custom resource definitions (CRDs).
+[role="_abstract"]
+As a developer, you can manage custom resources (CRs) that come from custom resource definitions (CRDs) to work with the custom object types available in your cluster.
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16942](https://redhat.atlassian.net/browse/OSDOCS-16942)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
assemblies:
https://117669--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/understanding/crds/crd-managing-resources-from-crds.html
https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html
https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-managing-resources-from-crds.html
https://117669--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/understanding/crds/crd-managing-resources-from-crds.html
https://117669--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/understanding/crds/crd-managing-resources-from-crds.html

modules: 

* [modules/crd-creating-aggregated-cluster-roles.adoc](https://github.com/openshift/openshift-docs/pull/117669/files#diff-91862f2d3b94140a66c688aaf92ef0175e1626d8c1c511f401ece2ffa1fb61bd):
** [OpenShift Enterprise — crd-extending-api-with-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-creating-aggregated-cluster-role_crd-extending-api-with-crds)
* [modules/crd-creating-crds.adoc](https://github.com/openshift/openshift-docs/pull/117669/files#diff-7ddc0a682fe2c5e55c86cd502c63bb313c7509f8dbb35b318a5ffd3a96a9ad8f):
** [OpenShift Enterprise — crd-extending-api-with-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-creating-custom-resources-definition_crd-extending-api-with-crds)
* [modules/crd-creating-custom-resources-from-file.adoc](https://github.com/openshift/openshift-docs/pull/117669/files#diff-5c925b09cc81d1657b036d629e702263a4168e8c20d8493e10cbe0259a383e80):
** [OpenShift Enterprise — crd-extending-api-with-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-creating-custom-resources-from-file_crd-extending-api-with-crds)
** [OpenShift Enterprise — crd-managing-resources-from-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-managing-resources-from-crds.html#crd-creating-custom-resources-from-file_crd-managing-resources-from-crds)
* [modules/crd-custom-resource-definitions.adoc](https://github.com/openshift/openshift-docs/pull/117669/files#diff-a936ffe9d2271b80c12f3706b568144aa31aff29c6be10e97d472f41cbb04cb6):
** [OpenShift Enterprise — crd-extending-api-with-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-custom-resource-definitions_crd-extending-api-with-crds)
** [OpenShift Enterprise — crd-managing-resources-from-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-managing-resources-from-crds.html#crd-custom-resource-definitions_crd-managing-resources-from-crds)
* [modules/crd-inspecting-custom-resources.adoc](https://github.com/openshift/openshift-docs/pull/117669/files#diff-36e8f9bde61ca0b64b8842cb33e8874f10c83986ae1d2bbd3443334432433eca):
** [OpenShift Enterprise — crd-extending-api-with-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-inspecting-custom-resources_crd-extending-api-with-crds)
** [OpenShift Enterprise — crd-managing-resources-from-crds](https://117669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/crds/crd-managing-resources-from-crds.html#crd-inspecting-custom-resources_crd-managing-resources-from-crds)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
