### PR TITLE
OSDOCS-21440: adds post-release QE doc enhancements

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -33,9 +33,9 @@
 :ossm-v: 3.4
 
 :cert-manager: cert-manager Operator for Red Hat OpenShift
-:cert-manager-version: 1.18
+:cert-manager-version: 1.19
 :keycloak: Red Hat build of Keycloak
-:keycloak-version: 26.4
+:keycloak-version: 26.6
 
 :TempoName: Red{nbsp}Hat OpenShift Distributed Tracing Platform
 :TempoShortName: Distributed Tracing Platform

--- a/modules/con-install-getting-ready.adoc
+++ b/modules/con-install-getting-ready.adoc
@@ -36,13 +36,13 @@ Before using a {prodname} `TLSPolicy` custom resource (CR), you must set up a ce
 ====
 
 [id="rhcl-optional-components_{context}"]
-== Optional components
+== Prerequisites for other components
 
 The following components are optional with {prodname}. You can decide what you want to use and plan for those configurations before beginning your installation.
 
 DNSPolicy::
 
-For a `DNSPolicy` CR, you must have an account for one of the supported cloud DNS providers and have set up a hosted zone for {prodname}. For more details, see your cloud DNS provider documentation:
+For a `DNSPolicy` CR, you can use a cloud DNS provider or coreDNS. If you are using a cloud provider, you must have an account for one of the supported DNS providers and have set up a hosted zone for {prodname}. For more details, see your cloud DNS provider documentation:
 
 * link:https://docs.aws.amazon.com/route53/?icmpid=docs_homepage_networking[Amazon Route 53 documentation]
 * link:https://cloud.google.com/dns/docs[Google Cloud DNS documentation]
@@ -50,7 +50,7 @@ For a `DNSPolicy` CR, you must have an account for one of the supported cloud DN
 
 RateLimitPolicy::
 
-For `RateLimitPolicy` CRs, you must have a shared accessible Redis-based datastore for rate-limit counters in a multicluster environment. For details on how to install and configure a secure and highly available datastore, see the documentation for your Redis-compatible datastore:
+For `RateLimitPolicy` CRs, if you require a shared counter in multicluster environment, you can use a Redis-based datastore. For details on how to install and configure a secure and highly available datastore, see the documentation for your Redis-compatible datastore:
 
 * link:https://redis.io/docs/latest/[Redis documentation]
 * link:https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html[AWS ElastiCache (Redis OSS) User Guide]

--- a/modules/con-supported-configs.adoc
+++ b/modules/con-supported-configs.adoc
@@ -7,7 +7,7 @@
 = Supported configurations with {prodname}
 
 [role="_abstract"]
-{prodname} must run on a supported combination of {ocp} and use the {cert-manager}.
+{prodname} must run on a supported version of {ocp}. If you want to use TLS policies, {cert-manager} must be also be installed. {prodname} is supported on x86_64a and AArch64 (ARM) architectures.
 
 To configure observability, use {rh} {service-mesh}.
 
@@ -30,7 +30,7 @@ include::snippets/snippet-rhcl-with-ocp-418-ossm.adoc[]
 |4.22, 4.21, 4.20, 4.19
 |4.22, 4.21, 4.20, 4.19
 |4.22, 4.21, 4.20, 4.19
-|4.19
+|4.19, 4.20
 
 |1.3
 |4.21, 4.20, 4.19, 4.18
@@ -60,7 +60,7 @@ See also link:https://access.redhat.com/support/policy/updates/openshift_operato
 
 |Version 1.4
 |3.3, 3.4
-|1.19, 1.20
+|1.19
 
 |Version 1.3
 |3.2
@@ -96,31 +96,35 @@ For more information, see the documentation for your chosen cloud DNS provider.
 [id="rhcl-supported-on-premise-dns-providers_{context}"]
 == Supported on-premise DNS providers
 
-You can use CoreDNS can to configure an on-cluster DNS zone. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/latest/html/deploying_red_hat_connectivity_link/rhcl-using-on-prem-dns-coredns#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[Using on-premise DNS with CoreDNS].
+You can use CoreDNS can to configure an on-cluster DNS zone. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.4/html/deploy_red_hat_connectivity_link/rhcl-using-on-prem-dns-coredns#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[Using on-premise DNS with CoreDNS].
 
 [id="rhcl-supported-data-stores-for-rate-limiting_{context}"]
 == Supported data stores for rate limiting
 
 For rate limiting policies, {prodname} supports the following Redis-based data stores for rate limit counters in multicluster environments:
 
-[%header,cols="3",cols="3,1,1,1"]
+[%header,cols="5",cols="3,1,1,1,1"]
 |===
 |*{product-title}*
 |*Redis Enterprise or Cloud*
 |*Amazon ElastiCache*
 |*Dragonfly Community or Cloud*
+|*Valkey*
 
 |1.4
 |8.6.2
 |latest
 |1.39.0
+|9.x.x
 
 |1.3
 |latest
 |latest
 |latest
+|latest
 
 |1.2
+|latest
 |latest
 |latest
 |latest
@@ -139,7 +143,7 @@ For authentication policies, {prodname} supports API keys and the following prod
 |*{keycloak}*
 
 |1.4
-|26.7
+|26.6
 
 |1.3
 |26.4

--- a/modules/proc-install-on-openshift-cli-cio.adoc
+++ b/modules/proc-install-on-openshift-cli-cio.adoc
@@ -118,15 +118,14 @@ spec: {}
 +
 Replace `_<kuadrant_system>_` with the namespace you used.
 
-. Optional. If you have a {rhdh} subscription, enable the {rhdh} plugin enabled by using the following example:
+. Optional. If you have a {rhdh} subscription, enable the {rhdh} plugin by using the following example:
 +
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
-  name: kuadrant
-  namespace: <kuadrant_system>
+#...
 spec:
   components:
     developerPortal:


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.5 

Issue:
[OSDOCS-21440](https://redhat.atlassian.net/browse/OSDOCS-21440)

Link to docs preview:
https://117675--ocpdocs-pr.netlify.app/rhcl/latest/install_rhcl/install-guide#rhcl-getting-ready-to-install_install-on-ocp
https://117675--ocpdocs-pr.netlify.app/rhcl/latest/install_rhcl/install-guide.html#proc-install-on-ocp-cmd-cio_install-on-ocp (step 8)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
