### PR TITLE
Use oc instead of kubectl in SPO Advanced Audit Logging enable step

### DIFF
--- a/modules/spo-log-enabling.adoc
+++ b/modules/spo-log-enabling.adoc
@@ -14,7 +14,7 @@ To enable Advanced Audit Logging, configure the Audit JSON log enricher and spec
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true}}'
 ----
 Monitor the SPOD pods for correct restart and wait for all SPOD pods to show `Running` before proceeding.
 +


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Advanced Audit Logging enable command (`spo-log-enabling`)
- Aligns with OpenShift documentation conventions and the existing `oc get pods` step on the same page

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc patch` is equivalent for the `spod` CR shown in the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-enabling_spo-audit-logging


Made with [Cursor](https://cursor.com)