### PR TITLE
Use oc instead of kubectl in SPO Audit JSON Log Enricher config steps

### DIFF
--- a/modules/spo-log-json-enrich.adoc
+++ b/modules/spo-log-json-enrich.adoc
@@ -22,7 +22,7 @@ Setting the audit log interval determines how often audit logs are created using
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding. By default, audit logs go to your standard output in JSON lines format. You can send them to a file instead.
@@ -55,7 +55,7 @@ $ cat patch-volume-source.json
 +
 [source,terminal]
 ----
-# kubectl patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
+# oc patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.
@@ -64,7 +64,7 @@ Wait until all SPOD pods show `Running` before proceeding.
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Audit JSON Log Enricher configuration procedure (`spo-log-json-enrich`)
- Covers the three patch examples: audit log interval, ConfigMap volume source, and audit log path

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc patch` works for the `spod` CR and `security-profiles-operator-profile` ConfigMap shown in the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-json-enrich_spo-audit-logging


Made with [Cursor](https://cursor.com)