### PR TITLE
OSDOCS-21475, OSDOCS-21474: Docs-fix deployment name in oc logs command and sample output in Zer…

### DIFF
--- a/modules/zero-trust-manager-install-console.adoc
+++ b/modules/zero-trust-manager-install-console.adoc
@@ -65,13 +65,13 @@ $ oc get deployment -l name=zero-trust-workload-identity-manager -n zero-trust-w
 .Example output
 [source,terminal]
 ----
-NAME                                                           READY UP-TO-DATE AVAILABLE AGE
-zero-trust-workload-identity-manager-controller-manager-6c4djb 1/1   1          1         43m
+NAME                                                      READY   UP-TO-DATE   AVAILABLE   AGE
+zero-trust-workload-identity-manager-controller-manager   1/1     1            1           3h36m
 ----
 
 . To check the Operator logs, run the following command:
 +
 [source,terminal]
 ----
-$ oc logs -f deployment/zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
+$ oc logs -f deployment/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager
 ----


### PR DESCRIPTION
Version(s):
4.18, 4.19, 4.20, 4.21, 4.22, 4.23 (main/5.0)

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21475
https://redhat.atlassian.net/browse/OSDOCS-21474

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-install-console_zero-trust-manager-install

QE review:
- [ ] QE has approved this change.

Additional information:
This PR corrects two deployment-related issues in the Zero Trust Workload Identity Manager installation documentation (`zero-trust-workload-identity-manager` module):

1. **Incorrect `oc logs` Command**: The documented command referenced `deployment/zero-trust-workload-identity-manager`, which causes a `NotFound` error. Updated the command to target the actual deployment name: `deployment/zero-trust-workload-identity-manager-controller-manager`.
2. **Incorrect `oc get deployment` Sample Output**: The sample output displayed a Pod name (containing the hash suffix `-6c4djb`) instead of the Deployment name. Updated the output snippet to reflect the true Deployment name: `zero-trust-workload-identity-manager-controller-manager`.