### PR TITLE
OCPBUGS-100169 docs: add taint removal step for bare-metal nodes on vSphere

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
@@ -40,3 +40,5 @@ To use this feature, you must explicitly disable the native {vmw-short} Containe
 include::modules/bare-metal-vsphere-iso.adoc[leveloffset=+1]
 
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]
+
+include::modules/bare-metal-vsphere-remove-uninit-taint.adoc[leveloffset=+1]

--- a/modules/bare-metal-vsphere-remove-uninit-taint.adoc
+++ b/modules/bare-metal-vsphere-remove-uninit-taint.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bare-metal-vsphere-remove-uninit-taint_{context}"]
+= Remove the cloud provider uninitialized taint from bare-metal nodes
+
+[role="_abstract"]
+After a bare-metal node joins a {vmw-first} cluster, the {vmw-short} Cloud Controller Manager (CCM) cannot remove the `node.cloudprovider.kubernetes.io/uninitialized` taint automatically. You must manually remove this taint so that workloads can be scheduled on the node.
+
+The {vmw-short} CCM attempts to initialize each node by searching vCenter for a matching virtual machine. Because a bare-metal node is physical hardware and not a VM in vCenter, the CCM cannot find a match and never removes the taint automatically.
+
+[NOTE]
+====
+The CCM logs errors similar to `No VM found` for bare-metal nodes. These errors are expected and do not indicate a problem with the node or the cluster.
+====
+
+.Prerequisites
+
+* The bare-metal node has joined the cluster and its certificate signing requests (CSRs) have been approved.
+* You have installed the {oc-first}.
+* You have cluster administrator privileges.
+
+.Procedure
+
+* Remove the `node.cloudprovider.kubernetes.io/uninitialized` taint from each bare-metal node by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc adm taint nodes <node_name> node.cloudprovider.kubernetes.io/uninitialized:NoSchedule-
+----
++
+Replace `<node_name>` with the name of the bare-metal node as shown in the output of `oc get nodes`.
+
+.Verification
+
+* Verify that the taint has been removed by running the following command and confirming that `node.cloudprovider.kubernetes.io/uninitialized` does not appear in the output:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc describe node <node_name> | grep Taint
+----
++
+Replace `<node_name>` with the name of the bare-metal node as shown in the output of `oc get nodes`.


### PR DESCRIPTION
## Summary

- Adds a new procedure module (`modules/bare-metal-vsphere-remove-uninit-taint.adoc`) documenting how to manually remove the `node.cloudprovider.kubernetes.io/uninitialized` taint from bare-metal nodes in a vSphere cluster.
- Includes a note clarifying that CCM `No VM found` log errors for bare-metal nodes are expected behavior.
- Includes the new module in the assembly (`machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc`) after the CSR approval step.

## Background

When a bare-metal node joins a vSphere cluster, the vSphere Cloud Controller Manager (CCM) attempts to initialize it by searching vCenter for a matching VM. Because the node is physical hardware (not a vCenter VM), the CCM fails repeatedly and never removes the `node.cloudprovider.kubernetes.io/uninitialized` taint. Without manually removing this taint, workloads cannot be scheduled on the node.

The current procedure does not document this requirement, causing customer confusion (support case 04506090).

## Backport target releases
-OCP 4.21 and OCP 4.22

## Related

- OCPBUGS-100169
- [SPLAT-2077](https://redhat.atlassian.net/browse/SPLAT-2077) — CCM should not attempt to initialize bare metal nodes (upstream fix)