### PR TITLE
[enterprise-4.19] OSDOCS-21475, OSDOCS-21474: Docs-fix deployment name in oc logs command and sample output in Zer

### DIFF
--- a/modules/zero-trust-manager-install-console.adoc
+++ b/modules/zero-trust-manager-install-console.adoc
@@ -64,13 +64,13 @@ $ oc get deployment -l name=zero-trust-workload-identity-manager -n zero-trust-w
 .Example output
 [source,terminal]
 ----
-NAME                                                           READY UP-TO-DATE AVAILABLE AGE
-zero-trust-workload-identity-manager-controller-manager-6c4djb 1/1   1          1         43m
+NAME                                                      READY   UP-TO-DATE   AVAILABLE   AGE
+zero-trust-workload-identity-manager-controller-manager   1/1     1            1           3h36m
 ----
 
 . To check the Operator logs, run the following command:
 +
 [source,terminal]
 ----
-$ oc logs -f deployment/zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
+$ oc logs -f deployment/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager
 ----


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/117701
