### PR TITLE
Use oc instead of kubectl in SPO advanced audit logs for a specific pod

### DIFF
--- a/modules/spo-log-adv-pod.adoc
+++ b/modules/spo-log-adv-pod.adoc
@@ -40,7 +40,7 @@ This profile allows all normal actions (`defaultAction: SCMP_ACT_ALLOW`). It spe
 +
 [source,terminal]
 ----
-# kubectl apply -f profile1.yaml
+# oc apply -f profile1.yaml
 ----
 +
 [NOTE]
@@ -68,14 +68,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl apply -f image_sec_comp.yaml
+# oc apply -f image_sec_comp.yaml
 ----
 
 . Label the namespace to activate the binding by running the following command:
 +
 [source,terminal]
 ----
-# kubectl label ns default spo.x-k8s.io/enable-binding=true
+# oc label ns default spo.x-k8s.io/enable-binding=true
 ----
 
 . Create a file such as `my-pod.yaml` that contains the following pod definition:
@@ -105,14 +105,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl apply -f my-pod.yaml
+# oc apply -f my-pod.yaml
 ----
 
 . Open a shell in the pod by running the following command:
 +
 [source,terminal]
 ----
-# kubectl exec -it my-pod -- /bin/sh
+# oc exec -it my-pod -- /bin/sh
 ----
 
 . Create an empty file in the pod by running the following command:
@@ -126,14 +126,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
+# oc -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
 ----
 
 . Identify the node where the pod runs by running the following command:
 +
 [source,terminal]
 ----
-# kubectl get pod my-pod -o wide
+# oc get pod my-pod -o wide
 ----
 +
 The audit log file specified in the `auditLogPath` field is written to the file system on the node where the pod is running. To inspect the audit logs, access the node and open the file at the configured path, such as `/tmp/logs/audit1.log`.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Advanced audit logs for a specific pod procedure (`spo-log-adv-pod`)
- Covers `apply`, `label`, `exec`, `logs`, and `get` examples in that section

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc apply` / `oc label` / `oc exec` / `oc logs` / `oc get` match the procedure steps

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-adv-pod_spo-audit-logging


Made with [Cursor](https://cursor.com)