### PR TITLE
Use oc instead of kubectl in SPO monitor the audit logs steps

### DIFF
--- a/modules/spo-log-mon-audit.adoc
+++ b/modules/spo-log-mon-audit.adoc
@@ -17,14 +17,14 @@ The audit log file is specified in the `auditLogPath` field and is written to th
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
+# oc -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
 ----
 
 . Identify the node on which the pod is scheduled by using the following command:
 +
 [source,terminal]
 ----
-# kubectl get pod my-pod -o wide
+# oc get pod my-pod -o wide
 ----
 
 . Access the node by using the following command:


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Monitor the audit logs procedure (`spo-log-mon-audit`)
- Covers the `logs` and `get pod` examples in that section

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc logs` and `oc get pod` match the procedure steps

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-mon-audit_spo-audit-logging


Made with [Cursor](https://cursor.com)