### PR TITLE
Use oc instead of kubectl in Zero Trust Spire deploy rollout checks

### DIFF
--- a/modules/zero-trust-manager-deploy-spire.adoc
+++ b/modules/zero-trust-manager-deploy-spire.adoc
@@ -93,7 +93,7 @@ $ until oc get statefulset/spire-server -n "${ZTWIM_NS}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Create the `SpireAgent` CR:
@@ -131,7 +131,7 @@ $ until oc get daemonset/spire-agent -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpiffeCSIDriver` CR:
@@ -158,7 +158,7 @@ $ until oc get daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" &> /dev/null; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpireOIDCDiscoveryProvider` CR:


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in Zero Trust Workload Identity Manager Spire deploy rollout status checks (`zero-trust-manager-deploy-spire`)
- Covers Spire server, agent, and SPIFFE CSI driver `rollout status` examples
- Aligns with existing `oc apply` / `oc wait` / `oc exec` steps on the same page

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc rollout status` works for the StatefulSet/DaemonSet resources shown in the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager


Made with [Cursor](https://cursor.com)