### PR TITLE
Use oc instead of kubectl in Zero Trust Istio deploy rollout check

### DIFF
--- a/modules/zero-trust-manager-deploy-istio.adoc
+++ b/modules/zero-trust-manager-deploy-istio.adoc
@@ -68,7 +68,7 @@ $ until oc get daemonset/istio-cni-node -n "${OSSM_CNI}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
+$ oc rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
 ----
 +
 The `until` loop waits for the {SMProductName} Operator to create the `istio-cni-node` DaemonSet. The `oc rollout status` command waits for the DaemonSet pods to become ready.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in Zero Trust Istio deploy rollout status check (`zero-trust-manager-deploy-istio`)
- Aligns with existing `oc` steps on the same page

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc rollout status` works for the DaemonSet shown in the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)