### PR TITLE
Use oc instead of kubectl in bare metal IPI network troubleshooting steps

### DIFF
--- a/modules/ipi-install-troubleshooting-misc-issues.adoc
+++ b/modules/ipi-install-troubleshooting-misc-issues.adoc
@@ -37,7 +37,7 @@ pod/network-operator-69dfd7b577-bg89v   0/1   ContainerCreating 0          149m
 +
 [source,terminal]
 ----
-$ kubectl get network.config.openshift.io cluster -oyaml
+$ oc get network.config.openshift.io cluster -oyaml
 ----
 +
 [source,yaml]
@@ -66,14 +66,14 @@ $ openshift-install create manifests
 +
 [source,terminal]
 ----
-$ kubectl -n openshift-network-operator get pods
+$ oc -n openshift-network-operator get pods
 ----
 
 . Retrieve the logs:
 +
 [source,terminal]
 ----
-$ kubectl -n openshift-network-operator logs -l "name=network-operator"
+$ oc -n openshift-network-operator logs -l "name=network-operator"
 ----
 +
 On high availability clusters with three or more control plane nodes, the Operator will perform leader election and all other Operators will sleep. For additional details, see https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md[Troubleshooting].


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in bare metal IPI installation troubleshooting network-operator steps
- Covers `get network.config`, `get pods`, and `logs` examples that mixed with existing `oc` usage on the same page

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc get` / `oc logs` match the troubleshooting procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)