### PR TITLE
Use oc instead of kubectl when applying ProjectHelmChartRepository

### DIFF
--- a/modules/helm-creating-credentials-and-certificates-to-add-helm-repositories.adoc
+++ b/modules/helm-creating-credentials-and-certificates-to-add-helm-repositories.adoc
@@ -53,7 +53,7 @@ The `ConfigMap` and `Secret` are consumed in the HelmChartRepository CR using th
 +
 [source,terminal]
 ----
-$ cat <<EOF | kubectl apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
## Summary
- Replace `kubectl apply` with `oc apply` in the custom Helm chart repository credentials procedure
- Aligns with existing `oc create` steps on the same page

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc apply` works for the ProjectHelmChartRepository example

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)