### PR TITLE
Use oc instead of kubectl when retrieving HCP custom admin kubeconfig secret

### DIFF
--- a/modules/hcp-kube-api-server-cert.adoc
+++ b/modules/hcp-kube-api-server-cert.adoc
@@ -75,7 +75,7 @@ After the configuration is applied, the HyperShift Operator generates a new `kub
 +
 [source,terminal]
 ----
-$ kubectl get secret <hosted_cluster_name>-custom-admin-kubeconfig \
+$ oc get secret <hosted_cluster_name>-custom-admin-kubeconfig \
   -n <cluster_namespace> \
   -o jsonpath='{.data.kubeconfig}' | base64 -d
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` when retrieving the hosted cluster custom admin kubeconfig secret
- Aligns with existing `oc` usage in the hosted control planes certificates docs

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc get secret` matches the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)