### PR TITLE
Use oc instead of kubectl for HCP Azure private kube-apiserver port-forward

### DIFF
--- a/modules/hcp-azure-private-access.adoc
+++ b/modules/hcp-azure-private-access.adoc
@@ -29,7 +29,7 @@ $ hcp create kubeconfig \
 +
 [source,terminal]
 ----
-$ kubectl port-forward svc/kube-apiserver \
+$ oc port-forward svc/kube-apiserver \
   -n clusters-${CLUSTER_NAME} 6443:6443 &
 ----
 +


### PR DESCRIPTION
## Summary
- Replace `kubectl port-forward` with `oc port-forward` for private access to the hosted kube-apiserver on Azure

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc port-forward` matches the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)