### PR TITLE
Use oc instead of kubectl in Virt storage migration permission examples

### DIFF
--- a/modules/virt-migrating-storage-permissions.adoc
+++ b/modules/virt-migrating-storage-permissions.adoc
@@ -20,7 +20,7 @@ Cluster administrators must grant users permission to perform storage migrations
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding <role_binding_name> \
+$ oc create rolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate \
     --user=<user_name> -n <namespace>
 ----
@@ -35,7 +35,7 @@ where:
 +
 [source,terminal]
 ----
-$ kubectl create clusterrolebinding <role_binding_name> \
+$ oc create clusterrolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
     --user=<user_name>
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in OpenShift Virtualization storage migration permission examples
- Covers `create rolebinding` and `create clusterrolebinding`

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc create rolebinding` / `oc create clusterrolebinding` match the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)