### PR TITLE
Use oc instead of kubectl in Virt VNC token generation rolebinding examples

### DIFF
--- a/modules/virt-grant-token-generation-permission-VNC.adoc
+++ b/modules/virt-grant-token-generation-permission-VNC.adoc
@@ -17,12 +17,12 @@ As a cluster administrator, you can install a cluster role and bind it to a user
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --user="${USER_NAME}"
+$ oc create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --user="${USER_NAME}"
 ----
 
 ** Run the following command to bind the cluster role to a service account:
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --serviceaccount="${SERVICE_ACCOUNT_NAME}"
+$ oc create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --serviceaccount="${SERVICE_ACCOUNT_NAME}"
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in VNC token generation rolebinding examples for virtual machine consoles

## Test plan
- [ ] Confirm the updated commands render correctly in docs preview
- [ ] Confirm `oc create rolebinding` matches the procedure

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)