### PR TITLE
Use oc instead of kubectl when creating Pipelines as Code Repository CR

### DIFF
--- a/modules/op-using-repository-crd-with-pipelines-as-code.adoc
+++ b/modules/op-using-repository-crd-with-pipelines-as-code.adoc
@@ -18,7 +18,7 @@ You can use the `tkn pac` CLI or other alternative methods to create a `Reposito
 
 [source,terminal]
 ----
-cat <<EOF|kubectl create -n my-pipeline-ci -f- <1>
+cat <<EOF|oc create -n my-pipeline-ci -f- <1>
 
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository


### PR DESCRIPTION
## Summary
- Replace `kubectl create` with `oc create` in the Pipelines as Code Repository CR example

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc create` works for the Repository CR example

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)