### PR TITLE
Use oc instead of kubectl in Service Mesh Gateway API CRD install example

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -1178,7 +1178,7 @@ The Gateway API CRDs do not come preinstalled by default on OpenShift clusters. 
 
 [source,terminal]
 ----
-$ kubectl get crd gateways.gateway.networking.k8s.io || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -; }
+$ oc get crd gateways.gateway.networking.k8s.io || { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | oc apply -f -; }
 ----
 
 ==== Enabling Kubernetes Gateway API


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Service Mesh release notes Gateway API CRD install example (`ossm-rn-new-features`)
- Leaves `kubectl.kubernetes.io` annotation references unchanged

## Test plan
- [ ] Confirm the updated command renders correctly in docs preview
- [ ] Confirm `oc get` / `oc kustomize` / `oc apply` match the install workaround

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)