### PR TITLE
Replace obsolete kubectl rolling-update with oc rollout restart in secrets docs

### DIFF
--- a/modules/nodes-pods-secrets-updating.adoc
+++ b/modules/nodes-pods-secrets-updating.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 To update the values in a secret, you must re-create the pods that use that secret. Because running pods do not automatically detect changes to secret data, restarting the pods ensures they consume the updated configuration.
 
-Updating a secret follows the same workflow as deploying a new container image. You can use the `kubectl rolling-update` command.
+Updating a secret follows the same workflow as deploying a new container image. You can use the `oc rollout restart` command.
 
 The `resourceVersion` value in a secret is not specified when it is referenced. Therefore, if a secret is updated at the same time as pods are starting, the version of the secret that is used for the pod is not defined.
 


### PR DESCRIPTION
## Summary
- Replace obsolete `kubectl rolling-update` wording with `oc rollout restart` in Understanding how to update secrets
- Aligns with OpenShift CLI conventions and current Kubernetes/OpenShift CLI behavior

## Test plan
- [ ] Confirm the updated wording renders correctly in docs preview
- [ ] Confirm `oc rollout restart` is appropriate guidance for restarting workloads after secret updates

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)