### PR TITLE
Use oc instead of kubectl when listing API resources for quotas

### DIFF
--- a/modules/admin-quota-overview.adoc
+++ b/modules/admin-quota-overview.adoc
@@ -116,4 +116,4 @@ where:
 
 `<resource>`:: Specifies the name of the resource. 
 
-`<group>`:: Specifies the API group, if applicable. You can use the `kubectl api-resources` command for a list of resources and their associated API groups.
+`<group>`:: Specifies the API group, if applicable. You can use the `oc api-resources` command for a list of resources and their associated API groups.


### PR DESCRIPTION
## Summary
- Replace `kubectl api-resources` with `oc api-resources` in the resource quota overview

## Test plan
- [ ] Confirm the updated wording renders correctly in docs preview
- [ ] Confirm `oc api-resources` lists API groups as described

Version(s): OpenShift Container Platform 4.22 (`enterprise-4.22`)

Made with [Cursor](https://cursor.com)