### PR TITLE
OSDOCS-21513: Fix spec.jwtKeyType typo in Zero Trust Manager CR parameters

### DIFF
--- a/modules/zero-trust-manager-spire-server-config.adoc
+++ b/modules/zero-trust-manager-spire-server-config.adoc
@@ -70,7 +70,7 @@ where:
 
 `spec.defaultJWTValidity`:: Specifies thedefault validity period (TTL) for JWT SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
 
-`spec.wtKeyType`:: Specifies the key type used for JWT signing. The valid options are `rsa-2048`, `rsa-4096`, `ec-p256`, and `ec-p384`. This field is optional.
+`spec.jwtKeyType`:: Specifies the key type used for JWT signing. The valid options are `rsa-2048`, `rsa-4096`, `ec-p256`, and `ec-p384`. This field is optional.
 
 `spec.caSubject.country`:: Specifies the country for the SPIRE Server certificate authority (CA). Must be an ISO 3166-1 alpha-2 country code (2 characters).
 


### PR DESCRIPTION
Version(s):
4.22, 4.21, 4.20, 4.19, 5.0

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21513

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-spire-server-config_zero-trust-manager-configuration

QE review:
- [ ] QE has approved this change.

Additional information:
This PR corrects a parameter name typo in the Zero Trust Workload Identity Manager CR configuration parameters section (`zero-trust-manager-ztwim-cr` module):

* Fixed `spec.wtKeyType` to `spec.jwtKeyType` in the configuration reference list.
