### PR TITLE
OSDOCS-16997-installing-restricted-networks-gcp-installer-provisioned# CQA

### DIFF
--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -17,20 +17,30 @@ You can install an {product-title} cluster by using mirrored installation releas
 [id="prerequisites_installing-restricted-networks-gcp-installer-provisioned"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* You xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* You configured a {gcp-short} project to host the cluster.
+* You mirrored the images for a disconnected installation to your registry and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* You have an existing VPC in {gcp-short}. While installing a cluster in a restricted network that uses installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
+* You have an existing VPC in {gcp-short}. When you install a cluster in a restricted network by using installer-provisioned infrastructure, you cannot use the VPC that the installation program creates. You must use a user-provisioned VPC that satisfies one of the following requirements:
 ** Contains the mirror registry
 ** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If you are installing using a link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect (PSC) endpoint], you must configure the endpoint in the same Virtual Private Cloud (VPC) where you install the cluster, specified in the `install-config.yaml` file, as described in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC].
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. You might need to grant access to more sites, but you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If you are installing by using a Private Service Connect (PSC) endpoint, you must configure the endpoint in the same VPC where you install the cluster, as specified in the `install-config.yaml` file.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall]
+* link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect]
+* xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -91,23 +101,13 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-gcp-with-short-term-creds_installing-restricted-networks-gcp-installer-provisioned[Configuring a {gcp-short} cluster to use short-term credentials].
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -138,15 +138,16 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-[id="next-steps_installing-restricted-networks-gcp-installer-provisioned"]
-== Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configuring image streams for a disconnected cluster]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -17,20 +17,30 @@ You can install an {product-title} cluster by using mirrored installation releas
 [id="prerequisites_installing-restricted-networks-gcp-installer-provisioned"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* You xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You configured a {gcp-short} project to host the cluster. For more information, see "Configuring a {gcp-short} project".
+* You mirrored the images for a disconnected installation to your registry and obtained the `imageContentSources` data for your version of {product-title}. For more information, see "Mirroring images for a disconnected installation".
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* You have an existing VPC in {gcp-short}. While installing a cluster in a restricted network that uses installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
+* You have an existing VPC in {gcp-short}. When you install a cluster in a restricted network by using installer-provisioned infrastructure, you cannot use the VPC that the installation program creates. You must use a user-provisioned VPC that satisfies one of the following requirements:
 ** Contains the mirror registry
 ** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If you are installing using a link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect (PSC) endpoint], you must configure the endpoint in the same Virtual Private Cloud (VPC) where you install the cluster, specified in the `install-config.yaml` file, as described in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC].
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. You might need to grant access to more sites, but you must grant access to `*.googleapis.com` and `accounts.google.com`. For more information, see "Configuring your firewall for {product-title}".
+* If you are installing by using a Private Service Connect (PSC) endpoint, you must configure the endpoint in the same VPC where you install the cluster, as specified in the `install-config.yaml` file. For more information, see "Installing a cluster on {gcp-short} into an existing VPC".
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
+* link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect]
+* xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -91,23 +101,13 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-gcp-with-short-term-creds_installing-restricted-networks-gcp-installer-provisioned[Configuring a {gcp-short} cluster to use short-term credentials].
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -136,17 +136,14 @@ include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffse
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-[id="next-steps_installing-restricted-networks-gcp-installer-provisioned"]
-== Next steps
-
-* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configuring image streams for a disconnected cluster]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]

--- a/modules/cco-ccoctl-install-creating-manifests.adoc
+++ b/modules/cco-ccoctl-install-creating-manifests.adoc
@@ -67,7 +67,7 @@ endif::[]
 = Incorporating the Cloud Credential Operator utility manifests
 
 [role="_abstract"]
-To implement short-term security credentials managed outside the cluster for individual components, you must move the manifest files that the Cloud Credential Operator utility (`ccoctl`) created to the correct directories for the installation program.
+To implement short-term security credentials managed outside the cluster for individual {product-title} components, you must move the manifest files that the Cloud Credential Operator utility (`ccoctl`) created to the correct directories for the installation program.
 
 .Prerequisites
 

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -285,9 +285,7 @@ ifdef::aws[]
 +
 ... Select *AWS* as the platform to target.
 +
-... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS
-access key ID and secret access key for the user that you configured to run the
-installation program.
+... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS access key ID and secret access key for the user that you configured to run the installation program.
 +
 ... Select the AWS region to deploy the cluster to.
 +
@@ -322,17 +320,13 @@ ifdef::gcp[]
 +
 ... Select *gcp* as the platform to target.
 +
-... If you have not configured the service account key for your {gcp-short} account on
-your computer, you must obtain it from {gcp-short} and paste the contents of the file
-or enter the absolute path to the file.
+... If you have not configured the service account key for your {gcp-short} account on your computer, you must obtain it from {gcp-short} and paste the contents of the file or enter the absolute path to the file.
 +
-... Select the project ID to provision the cluster in. The default value is
-specified by the service account that you configured.
+... Select the project ID to provision the cluster in. The default value is specified by the service account that you configured.
 +
 ... Select the region to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::gcp[]
 ifdef::ibm-cloud[]
 +
@@ -340,8 +334,7 @@ ifdef::ibm-cloud[]
 +
 ... Select the region to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::ibm-cloud[]
 ifdef::ibm-power-vs[]
 +
@@ -351,8 +344,7 @@ ifdef::ibm-power-vs[]
 +
 ... Select the zone to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::ibm-power-vs[]
 ifdef::osp[]
 +
@@ -566,10 +558,7 @@ your registry:
 pullSecret: '{"auths":{"<mirror_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'
 ----
 +
-For `<mirror_host_name>`, specify the registry domain name
-that you specified in the certificate for your mirror registry, and for
-`<credentials>`, specify the base64-encoded user name and password for
-your mirror registry.
+For `<mirror_host_name>`, specify the registry domain name that you specified in the certificate for your mirror registry, and for `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 +
 .. Add the `additionalTrustBundle` parameter and value.
 +
@@ -758,8 +747,7 @@ it to install multiple clusters.
 +
 [IMPORTANT]
 ====
-The `install-config.yaml` file is consumed during the installation process. If
-you want to reuse the file, you must back it up now.
+The `install-config.yaml` file is consumed during the installation process. If you want to reuse the file, you must back it up now.
 ====
 ifdef::azure[]
 +

--- a/modules/installation-using-gcp-custom-machine-types.adoc
+++ b/modules/installation-using-gcp-custom-machine-types.adoc
@@ -29,7 +29,8 @@ endif::[]
 [id="installation-custom-machine-types_{context}"]
 = Using custom machine types
 
-Using a custom machine type to install a {product-title} cluster is supported.
+[role="_abstract"]
+If the predefined {gcp-short} machine types do not meet your workload requirements, you can configure a custom machine type in the `install-config.yaml` file during {product-title} installation.
 
 Consider the following when using a custom machine type:
 
@@ -42,11 +43,13 @@ Consider the following when using a custom machine type:
 For example, `custom-6-20480`.
 --
 
+.Procedure
+
 ifdef::ipi[]
-As part of the installation process, you specify the custom machine type in the `install-config.yaml` file.
-
-.Sample `install-config.yaml` file with a custom machine type
-
+. Specify the custom machine type in the `install-config.yaml` file.
++
+The following sample `install-config.yaml` file specifies a custom machine type:
++
 [source,yaml]
 ----
 compute:

--- a/modules/installation-using-gcp-custom-machine-types.adoc
+++ b/modules/installation-using-gcp-custom-machine-types.adoc
@@ -25,11 +25,12 @@ ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisione
 :ipi:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="installation-custom-machine-types_{context}"]
 = Using custom machine types
 
-Using a custom machine type to install a {product-title} cluster is supported.
+[role="_abstract"]
+If the predefined {gcp-short} machine types do not meet your workload requirements, you can configure a custom machine type in the `install-config.yaml` file during {product-title} installation.
 
 Consider the following when using a custom machine type:
 
@@ -46,7 +47,6 @@ ifdef::ipi[]
 As part of the installation process, you specify the custom machine type in the `install-config.yaml` file.
 
 .Sample `install-config.yaml` file with a custom machine type
-
 [source,yaml]
 ----
 compute:

--- a/modules/installing-gcp-manual-modes.adoc
+++ b/modules/installing-gcp-manual-modes.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-manual-modes_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
+
+[role="_abstract"]
+By default, {product-title} stores administrator secrets in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must configure an alternative credential management strategy by using either long-term manual credentials or short-term credentials that are managed outside the cluster.
+
+* To manage long-term cloud credentials manually, follow the procedure in "Manually creating long-term credentials".
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in "Short-term credential configuration for a {gcp-short} cluster".

--- a/modules/installing-gcp-manual-modes.adoc
+++ b/modules/installing-gcp-manual-modes.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-manual-modes_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
+
+[role="_abstract"]
+By default, {product-title} stores administrator secrets in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must configure an alternative credential management strategy by using either long-term manual credentials or short-term credentials that are managed outside the cluster.
+
+* To manage long-term cloud credentials manually, follow the procedure in "Manually creating long-term credentials".
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in "Short-term credential configuration for a {gcp-short} cluster".

--- a/modules/installing-gcp-short-term-creds.adoc
+++ b/modules/installing-gcp-short-term-creds.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-with-short-term-creds_{context}"]
+= Short-term credential configuration for a {gcp-short} cluster
+
+[role="_abstract"]
+To install an {product-title} cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster.
+
+Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.
+
+ifeval::["{context}" == "installing-gcp-shared-vpc"]
+[IMPORTANT]
+====
+When installing a cluster on a shared Virtual Private Cloud (VPC) by using short-lived credentials, you must grant the `compute.subnetworks.use` permission in the host project to Day 2 Operator service accounts.
+
+After using the `ccoctl` utility to generate the {gcp-short} credentials, manually grant this permission to the {cluster-capi-operator} and Machine API Operator service accounts.
+====
+endif::[]

--- a/modules/installing-gcp-short-term-creds.adoc
+++ b/modules/installing-gcp-short-term-creds.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-gcp-with-short-term-creds_{context}"]
+= Short-term credential configuration for a {gcp-short} cluster
+
+[role="_abstract"]
+To install an {product-title} cluster that is configured to use {gcp-short} Workload Identity, you must configure the Cloud Credential Operator (CCO) utility and create the required {gcp-short} resources for your cluster.
+
+Cluster Operators use the credentials created by the CCO. The installation program does not use these credentials.

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -152,12 +152,14 @@ endif::cco-manual-mode[]
 //For providers that support multiple modes of operation
 [role="_abstract"]
 ifdef::cco-multi-mode[]
-The Cloud Credential Operator (CCO) can be put into manual mode prior to installation in environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace.
+[role="_abstract"]
+You can put the Cloud Credential Operator (CCO) into manual mode before {product-title} installation if the cloud identity and access management (IAM) APIs are not reachable, or if you prefer not to store an administrator-level credential secret in the cluster `kube-system` namespace.
 endif::cco-multi-mode[]
 
 //For providers who only support manual mode
 ifdef::cco-manual-mode[]
-The Cloud Credential Operator (CCO) only supports your cloud provider in manual mode. As a result, you must specify the identity and access management (IAM) secrets for your cloud provider.
+[role="_abstract"]
+You must manually create and configure the identity and access management (IAM) secrets for your {product-title} cluster because the Cloud Credential Operator (CCO) only supports manual mode for your cloud provider.
 endif::cco-manual-mode[]
 
 .Procedure

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -150,14 +150,15 @@ ifdef::cco-manual-mode[]
 endif::cco-manual-mode[]
 
 //For providers that support multiple modes of operation
-[role="_abstract"]
 ifdef::cco-multi-mode[]
-The Cloud Credential Operator (CCO) can be put into manual mode prior to installation in environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace.
+[role="_abstract"]
+You can put the Cloud Credential Operator (CCO) into manual mode before {product-title} installation if the cloud identity and access management (IAM) APIs are not reachable, or if you prefer not to store an administrator-level credential secret in the cluster `kube-system` namespace.
 endif::cco-multi-mode[]
 
 //For providers who only support manual mode
 ifdef::cco-manual-mode[]
-The Cloud Credential Operator (CCO) only supports your cloud provider in manual mode. As a result, you must specify the identity and access management (IAM) secrets for your cloud provider.
+[role="_abstract"]
+You must manually create and configure the identity and access management (IAM) secrets for your {product-title} cluster because the Cloud Credential Operator (CCO) only supports manual mode for your cloud provider.
 endif::cco-manual-mode[]
 
 .Procedure

--- a/modules/nw-gcp-installing-global-access-configuration.adoc
+++ b/modules/nw-gcp-installing-global-access-configuration.adoc
@@ -7,7 +7,8 @@
 [id="nw-gcp-global-access-configuration_{context}"]
 = Create an Ingress Controller with global access on {gcp-short}
 
-You can create an Ingress Controller that has global access to a {gcp-first} cluster. Global access is only available to Ingress Controllers using internal load balancers.
+[role="_abstract"]
+You can create an Ingress Controller that has global access to a {gcp-first} cluster, which allows clients from any region to reach your cluster's internal load balancer. Global access is available only to Ingress Controllers that use internal load balancers.
 
 .Prerequisites
 
@@ -15,28 +16,25 @@ You can create an Ingress Controller that has global access to a {gcp-first} clu
 
 .Procedure
 
-Create an Ingress Controller with global access on a new {gcp-short} cluster.
-
 . Change to the directory that contains the installation program and create a manifest file:
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir <installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the name of the directory that
-contains the `install-config.yaml` file for your cluster.
++
+For `_<installation_directory>_`, specify the name of the directory that contains the `install-config.yaml` file for your cluster.
 +
 . Create a file that is named `cluster-ingress-default-ingresscontroller.yaml` in the `<installation_directory>/manifests/` directory:
 +
 [source,terminal]
 ----
-$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml <1>
+$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml
 ----
-<1> For `<installation_directory>`, specify the directory name that contains the
-`manifests/` directory for your cluster.
 +
-After creating the file, several network configuration files are in the
-`manifests/` directory, as shown:
+For `_<installation_directory>_`, specify the directory name that contains the `manifests/` directory for your cluster.
++
+After creating the file, several network configuration files are in the `manifests/` directory, as shown:
 +
 [source,terminal]
 ----
@@ -64,10 +62,11 @@ cluster-ingress-default-ingresscontroller.yaml
       loadBalancer:
         providerParameters:
           gcp:
-            clientAccess: Global <1>
+            clientAccess: Global
           type: GCP
-        scope: Internal          <2>
+        scope: Internal
       type: LoadBalancerService
 ----
-<1> Set `gcp.clientAccess` to `Global`.
-<2> Global access is only available to Ingress Controllers using internal load balancers.
++
+* `gcp.clientAccess` is set to `Global` to provide global access for the Ingress Controller.
+* `scope` is set to `Internal` because global access is available only to Ingress Controllers that use internal load balancers.

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -205,7 +205,8 @@ endif::ibm-power-vs[]
 ----
 $ ssh-add <path>/<file_name>
 ----
-Specifies the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
++
+Specifies the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`.
 +
 .Example output
 [source,terminal]

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -205,7 +205,8 @@ endif::ibm-power-vs[]
 ----
 $ ssh-add <path>/<file_name>
 ----
-Specifies the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
++
+Specify the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster on GCP in a disconnected environment](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html)
- [Generating a key pair for cluster node SSH access](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#ssh-agent-using_installing-restricted-networks-gcp-installer-provisioned)
- [Creating the installation configuration file](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installation-initializing_installing-restricted-networks-gcp-installer-provisioned)
- [Manually creating long-term credentials](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned)
- [Incorporating the Cloud Credential Operator utility manifests](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#cco-ccoctl-install-creating-manifests_installing-restricted-networks-gcp-installer-provisioned)
- [Provisioning your own DNS records](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installation-gcp-provisioning-own-dns-records_installing-restricted-networks-gcp-installer-provisioned)
- [Create an Ingress Controller with global access on GCP](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#nw-gcp-global-access-configuration_installing-restricted-networks-gcp-installer-provisioned)

- [Alternatives to storing administrator-level secrets in the kube-system project](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installing-gcp-manual-modes_installing-restricted-networks-gcp-installer-provisioned)
- [Configuring a Google Cloud cluster to use short-term credentials](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installing-gcp-with-short-term-creds_installing-restricted-networks-gcp-installer-provisioned)

- [Using custom machine types](https://117808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installation-custom-machine-types_installing-restricted-networks-gcp-installer-provisioned)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
