### PR TITLE
OSDOCS-16997-installing-gcp-multiarch-support# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-multiarch-support.adoc
+++ b/installing/installing_gcp/installing-gcp-multiarch-support.adoc
@@ -6,11 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures.
+[role="_abstract"]
+You can install an {product-title} cluster on {gcp-first} with multi-architecture support to run workloads on compute machines with different CPU architectures.
 
 [NOTE]
 ====
-When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines].
+When you have nodes with different architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must verify that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information about assigning pods to nodes, see "Scheduling workloads on clusters with multi-architecture compute machines".
 ====
 
 You can install a {gcp-first} cluster with the support for configuring multi-architecture compute machines. After installing the {gcp-short} cluster, you can add multi-architecture compute machines to the cluster in the following ways:
@@ -22,11 +23,10 @@ include::snippets/about-multiarch-tuning-operator.adoc[]
 
 include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
 
-.Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installation-launching-installer_installing-gcp-customizations[Deploying the cluster]
-
-[role="_additional-resources"]
-.Additional resources
-
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines]
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a cluster with multi-architecture compute machine support on GCP](https://117810--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-multiarch-support.html)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
