### PR TITLE
OSDOCS-16997-installing-gcp-three-node# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-three-node.adoc
+++ b/installing/installing_gcp/installing-gcp-three-node.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 In {product-title} version {product-version}, you can install a three-node cluster on {gcp-first}. A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
 
-You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+You can install a three-node cluster by using either installer-provisioned or user-provisioned infrastructure.
 
 include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Installing a three-node cluster on GCP](https://117811--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-three-node.html)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
