### PR TITLE
OSDOCS-21516: Fix spire server label selector in zero trust verification comm…

### DIFF
--- a/modules/zero-trust-manager-spire-server-config.adoc
+++ b/modules/zero-trust-manager-spire-server-config.adoc
@@ -111,7 +111,7 @@ $ oc apply -f SpireServer.yaml
 +
 [source,terminal]
 ----
-$ oc get statefulset -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
+$ oc get statefulset -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
 ----
 +
 .Example output
@@ -125,7 +125,7 @@ spire-server    1/1     65s
 +
 [source,terminal]
 ----
-$ oc get po -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
+$ oc get po -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
 ----
 +
 .Example output
@@ -139,7 +139,7 @@ spire-server-0     2/2     Running   1 (108s ago)    111s
 +
 [source,terminal]
 ----
-$ oc get pvc -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
+$ oc get pvc -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s): 
4.18, 4.19, 4.20, 4.21, 4.22, 5.0

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21516

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-spire-server-config_zero-trust-manager-configuration

QE review:
- [ ] QE has approved this change.

Additional information:
This PR fixes an incorrect label selector in the SPIRE server verification section (`zero-trust-manager-spire-server-config` module):

* Updated the label selector in verification commands from `app.kubernetes.io/name=server` to `app.kubernetes.io/name=spire-server`. The previous label returned `No resources found in zero-trust-workload-identity-manager namespace.` when executed.

```
Incorrect labels in current commands:

$ oc get statefulset -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
No resources found in zero-trust-workload-identity-manager namespace.
$ oc get po -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
No resources found in zero-trust-workload-identity-manager namespace.
$ oc get pvc -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager
No resources found in zero-trust-workload-identity-manager namespace.

Validated Correct Value:

$ oc get statefulset -o yaml                                                                 
apiVersion: v1
items:
- apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    creationTimestamp: "2026-08-12T08:06:01Z"
    generation: 1
    labels:
      app.kubernetes.io/component: control-plane
      app.kubernetes.io/instance: cluster-zero-trust-workload-identity-manager
      app.kubernetes.io/managed-by: zero-trust-workload-identity-manager
      app.kubernetes.io/name: spire-server

Correct commands:
 
$ oc get statefulset -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
NAME           READY   AGE
spire-server   1/1     2m41s
$ oc get po -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
NAME             READY   STATUS    RESTARTS   AGE
spire-server-0   2/2     Running   0          3m25s
$ oc get pvc -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
spire-data-spire-server-0   Bound    pvc-7422e9e2-ed7f-424b-b069-e8a22c061f2f   5Gi        RWO            gp3-csi        <unset>                 4m37s


