### PR TITLE
OSDOCS-16997-preparing-to-install-on-gcp# CQA

### DIFF
--- a/installing/installing_gcp/preparing-to-install-on-gcp.adoc
+++ b/installing/installing_gcp/preparing-to-install-on-gcp.adoc
@@ -6,54 +6,46 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Before you install {product-title} on {gcp-first}, review the requirements, supported methods, and preparation steps to plan your installation.
+
 [id="{context}-prerequisites"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
 
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 
 [id="requirements-for-installing-ocp-on-gcp"]
 == Requirements for installing {product-title} on {gcp-short}
 
-Before installing {product-title} on {gcp-first}, you must create a service account and configure a {gcp-short} project. See xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project] for details about creating a project, enabling API services, configuring DNS, {gcp-short} account limits, and supported {gcp-short} regions.
+Before installing {product-title} on {gcp-first}, you must create a service account and configure a {gcp-short} project by creating a project, enabling API services, configuring DNS, setting {gcp-short} account limits, and selecting supported {gcp-short} regions. For more information, see "Configuring a {gcp-short} project".
 
-If the cloud Identity and Access Management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials], xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}], or both for other options.
+If the cloud Identity and Access Management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can configure your cluster to use short-term credentials, manually create long-term credentials, or both. For more information, see "Configuring a {gcp-short} cluster to use short-term credentials" and "Manually creating long-term credentials".
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials]
 
 [id="choosing-an-method-to-install-ocp-on-gcp"]
 == Choosing a method to install {product-title} on {gcp-short}
 
-You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
+You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself. For more information about installer-provisioned and user-provisioned installation processes, see "Installation process".
 
-See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
+[role="_additional-resources"]
+.Additional resources
 
-[id="choosing-an-method-to-install-ocp-on-gcp-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+* xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process]
 
-You can install a cluster on {gcp-short} infrastructure that is provisioned by the {product-title} installation program, by using one of the following methods:
+include::modules/installing-gcp-ipi-methods.adoc[leveloffset=+2]
 
-* **xref:../../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[Installing a cluster quickly on {gcp-short}]**: You can install {product-title} on {gcp-short} infrastructure that is provisioned by the {product-title} installation program. You can install a cluster quickly by using the default configuration options.
-
-* **xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a customized cluster on {gcp-short}]**: You can install a customized cluster on {gcp-short} infrastructure that the installation program provisions. You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
-
-* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[Installing a cluster on {gcp-short} in a restricted network]**: You can install {product-title} on {gcp-short} on installer-provisioned infrastructure by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active internet connection to obtain the software components. While you can install {product-title} by using the mirrored content, your cluster still requires internet access to use the {gcp-short} APIs.
-
-* **xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster into an existing Virtual Private Cloud]**: You can install {product-title} on an existing {gcp-short} Virtual Private Cloud (VPC). You can use this installation method if you have constraints set by the guidelines of your company, such as limits on creating new accounts or infrastructure.
-
-* **xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing {gcp-short} VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
-
-[id="choosing-an-method-to-install-ocp-on-gcp-user-provisioned"]
-=== Installing a cluster on user-provisioned infrastructure
-
-You can install a cluster on {gcp-short} infrastructure that you provision, by using one of the following methods:
-
-* **xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[Installing a cluster on {gcp-short} with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} infrastructure that you provide. You can use the provided Infrastructure Manager templates to assist with the installation.
-
-* **xref:../../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[Installing a cluster with shared VPC on user-provisioned infrastructure in {gcp-short}]**: You can use the provided Infrastructure Manager templates to create {gcp-short} resources in a shared VPC infrastructure.
-
-* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[Installing a cluster on {gcp-short} in a restricted network with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} in a restricted network with user-provisioned infrastructure. By creating an internal mirror of the installation release content, you can install a cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.
-
-[id="preparing-to-install-on-gcp-next-steps"]
-== Next steps
-
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+include::modules/installing-gcp-upi-methods.adoc[leveloffset=+2]

--- a/installing/installing_gcp/preparing-to-install-on-gcp.adoc
+++ b/installing/installing_gcp/preparing-to-install-on-gcp.adoc
@@ -6,54 +6,52 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Before you install {product-title} on {gcp-first}, review the requirements, supported methods, and preparation steps to plan your installation.
+
 [id="{context}-prerequisites"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You reviewed details about the {product-title} installation and update processes.
 
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 
 [id="requirements-for-installing-ocp-on-gcp"]
 == Requirements for installing {product-title} on {gcp-short}
 
-Before installing {product-title} on {gcp-first}, you must create a service account and configure a {gcp-short} project. See xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project] for details about creating a project, enabling API services, configuring DNS, {gcp-short} account limits, and supported {gcp-short} regions.
+Before installing {product-title} on {gcp-first}, you must create a service account and configure a {gcp-short} project by creating a project, enabling API services, configuring DNS, setting {gcp-short} account limits, and selecting supported {gcp-short} regions.
 
-If the cloud Identity and Access Management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials], xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}], or both for other options.
+If the cloud Identity and Access Management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can configure your cluster to use short-term credentials, manually create long-term credentials, or both.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}]
 
 [id="choosing-an-method-to-install-ocp-on-gcp"]
 == Choosing a method to install {product-title} on {gcp-short}
 
 You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 
-See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
+[role="_additional-resources"]
+.Additional resources
 
-[id="choosing-an-method-to-install-ocp-on-gcp-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+* xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process]
 
-You can install a cluster on {gcp-short} infrastructure that is provisioned by the {product-title} installation program, by using one of the following methods:
+include::modules/installing-gcp-ipi-methods.adoc[leveloffset=+2]
 
-* **xref:../../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[Installing a cluster quickly on {gcp-short}]**: You can install {product-title} on {gcp-short} infrastructure that is provisioned by the {product-title} installation program. You can install a cluster quickly by using the default configuration options.
+include::modules/installing-gcp-upi-methods.adoc[leveloffset=+2]
 
-* **xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a customized cluster on {gcp-short}]**: You can install a customized cluster on {gcp-short} infrastructure that the installation program provisions. You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
-
-* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[Installing a cluster on {gcp-short} in a restricted network]**: You can install {product-title} on {gcp-short} on installer-provisioned infrastructure by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active internet connection to obtain the software components. While you can install {product-title} by using the mirrored content, your cluster still requires internet access to use the {gcp-short} APIs.
-
-* **xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster into an existing Virtual Private Cloud]**: You can install {product-title} on an existing {gcp-short} Virtual Private Cloud (VPC). You can use this installation method if you have constraints set by the guidelines of your company, such as limits on creating new accounts or infrastructure.
-
-* **xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing {gcp-short} VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
-
-[id="choosing-an-method-to-install-ocp-on-gcp-user-provisioned"]
-=== Installing a cluster on user-provisioned infrastructure
-
-You can install a cluster on {gcp-short} infrastructure that you provision, by using one of the following methods:
-
-* **xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[Installing a cluster on {gcp-short} with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} infrastructure that you provide. You can use the provided Infrastructure Manager templates to assist with the installation.
-
-* **xref:../../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[Installing a cluster with shared VPC on user-provisioned infrastructure in {gcp-short}]**: You can use the provided Infrastructure Manager templates to create {gcp-short} resources in a shared VPC infrastructure.
-
-* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[Installing a cluster on {gcp-short} in a restricted network with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} in a restricted network with user-provisioned infrastructure. By creating an internal mirror of the installation release content, you can install a cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.
-
-[id="preparing-to-install-on-gcp-next-steps"]
-== Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]

--- a/modules/installing-gcp-ipi-methods.adoc
+++ b/modules/installing-gcp-ipi-methods.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/preparing-to-install-on-gcp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installing-gcp-ipi-methods_{context}"]
+= Installer-provisioned infrastructure installation methods
+
+[role="_abstract"]
+You can choose from several methods to install a cluster on {gcp-short} by using installer-provisioned infrastructure, depending on your network requirements and environment constraints.
+
+You can install a cluster on {gcp-short} infrastructure that is provisioned by the {product-title} installation program, by using one of the following methods:
+
+* **xref:../../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[Installing a cluster quickly on {gcp-short}]**: You can install {product-title} on {gcp-short} infrastructure that is provisioned by the {product-title} installation program. You can install a cluster quickly by using the default configuration options.
+
+* **xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a customized cluster on {gcp-short}]**: You can install a customized cluster on {gcp-short} infrastructure that the installation program provisions. You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available postinstallation.
+
+* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[Installing a cluster on {gcp-short} in a restricted network]**: You can install {product-title} on installer-provisioned infrastructure in {gcp-short} by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active internet connection to obtain the software components. While you can install {product-title} by using the mirrored content, your cluster still requires internet access to use the {gcp-short} APIs.
+
+* **xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster into an existing Virtual Private Cloud]**: You can install {product-title} on an existing {gcp-short} Virtual Private Cloud (VPC). You can use this installation method if you have constraints set by the guidelines of your company, such as limits on creating new accounts or infrastructure.
+
+* **xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing {gcp-short} VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[Postinstallation configuration]

--- a/modules/installing-gcp-upi-methods.adoc
+++ b/modules/installing-gcp-upi-methods.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/preparing-to-install-on-gcp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installing-gcp-upi-methods_{context}"]
+= User-provisioned infrastructure installation methods
+
+[role="_abstract"]
+You can choose from several methods to install a cluster on {gcp-short} by using infrastructure that you provision, depending on your network requirements and environment constraints.
+
+You can install a cluster on {gcp-short} infrastructure that you provision, by using one of the following methods:
+
+* **xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[Installing a cluster on {gcp-short} with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} infrastructure that you provide. You can use the provided Infrastructure Manager templates to assist with the installation.
+
+* **xref:../../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[Installing a cluster with shared VPC on user-provisioned infrastructure in {gcp-short}]**: You can use the provided Infrastructure Manager templates to create {gcp-short} resources in a shared VPC infrastructure.
+
+* **xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[Installing a cluster on {gcp-short} in a restricted network with user-provisioned infrastructure]**: You can install {product-title} on {gcp-short} in a restricted network with user-provisioned infrastructure. By creating an internal mirror of the installation release content, you can install a cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Preparing to install on GCP](https://117813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/preparing-to-install-on-gcp.html)
- [Installing a cluster on installer-provisioned infrastructure](https://117813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/preparing-to-install-on-gcp.html#installing-gcp-ipi-methods_preparing-to-install-on-gcp)
- [Installing a cluster on user-provisioned infrastructure](https://117813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/preparing-to-install-on-gcp.html#installing-gcp-upi-methods_preparing-to-install-on-gcp)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:

Assembly requires additional review.
