### PR TITLE
OSDOCS-16997-uninstalling-cluster-gcp# CQA

### DIFF
--- a/installing/installing_gcp/uninstalling-cluster-gcp.adoc
+++ b/installing/installing_gcp/uninstalling-cluster-gcp.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove a cluster that you deployed to {gcp-first}.
+[role="_abstract"]
+You can remove a cluster that you deployed to {gcp-first} and delete the associated cloud provider resources when you no longer need the cluster, to free up cloud resources and stop incurring costs.
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]
 

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -32,7 +32,7 @@ endif::[]
 = Removing a cluster that uses installer-provisioned infrastructure
 
 [role="_abstract"]
-To remove an {product-title} cluster that uses installer-provisioned infrastructure, you can run the installation program destroy command. Use the installation files from your original deployment to uninstall the cluster from your cloud platform.
+To remove an {product-title} cluster that uses installer-provisioned infrastructure, you can use the installation program and the installation files from your original deployment to uninstall the cluster from your cloud platform.
 
 ifdef::aws[]
 [NOTE]


### PR DESCRIPTION
Version(s): 4.20+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16997

Link to docs preview:

[Uninstalling a cluster on GCP](https://117814--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html)
- [Removing a cluster that uses installer-provisioned infrastructure](https://117814--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html#installation-uninstall-clouds_uninstalling-cluster-gcp)

QE review: (Not needed for these superficial CQA changes)
- [ ] QE has approved this change.

Additional information:
