### PR TITLE
[OSDOCS#21528] overriding operand-arguments

### DIFF
--- a/modules/external-secrets-operator-overriding-operand-arguments.adoc
+++ b/modules/external-secrets-operator-overriding-operand-arguments.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-overriding-operand-arguments_{context}"]
+= Overriding operand container arguments for the {external-secrets-operator}
+
+[role="_abstract"]
+You can override container arguments for the `external-secrets` operand deployments by setting environment variables on the {external-secrets-operator} subscription. Use this method when you need to pass additional or replacement `--key=value` flags to operand containers.
+
+[NOTE]
+====
+This is a temporary feature available only in the {external-secrets-operator} 1.1 and 1.2 z-streams. {external-secrets-operator} 1.3.0 adds support in the `ExternalSecretsConfig` API to configure the same behavior. Consider migrating to the `ExternalSecretsConfig` API when upgrading to {external-secrets-operator-short} 1.3.0. This subscription-based method is scheduled to be deprecated and removed in {external-secrets-operator} 1.4.0.
+====
+
+.Prerequisites
+
+* Your installed {external-secrets-operator} version is 1.1 or 1.2.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Update the Subscription for the {external-secrets-operator-short} to set the operand argument overrides by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERAND_EXTERNAL_SECRETS_ARGS","value":"<controller_args>"},{"name":"OPERAND_WEBHOOK_ARGS","value":"<webhook_args>"},{"name":"OPERAND_CERT_CONTROLLER_ARGS","value":"<cert_controller_args>"},{"name":"OPERAND_BITWARDEN_SDK_SERVER_ARGS","value":"<bitwarden_args>"}]}}}'
+----
++
+where:
+
+`<external_secrets_operator_namespace>`:: Specifies the namespace where the Operator is installed.
+`<controller_args>`:: Specifies a comma-separated list of `--key` or `--key=value` flags for the `external-secrets` core controller. For example, `--concurrent=2,--loglevel=debug`.
+`<webhook_args>`:: Specifies a comma-separated list of flags for the webhook. Commas inside a flag value are preserved when the next flag begins with `--`. For example, `--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,--loglevel=debug`.
+`<cert_controller_args>`:: Specifies a comma-separated list of flags for the `cert-controller`. For example, `--crd-requeue-interval=10m,--loglevel=debug`.
+`<bitwarden_args>`:: Specifies a comma-separated list of flags for the `bitwarden-sdk-server`. For example, `--key-file=/certs/key.pem,--cert-file=/certs/cert.pem`.
++
+Set only the environment variables you need. Omit any unused entries from the `env` list.
+
+.Verification
+
+. Verify that the environment variables are set on the Operator by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n <external_secrets_operator_namespace> --list | grep -e OPERAND_ -e container
+----
++
+.Example output
+[source,terminal]
+----
+$ deployments/external-secrets-operator-controller-manager, container manager
+OPERAND_EXTERNAL_SECRETS_ARGS=--concurrent=2,--loglevel=debug
+OPERAND_WEBHOOK_ARGS=--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,--loglevel=debug
+----
+
+. Verify that the operand `Deployment` container arguments were updated by running the following command:
++
+[source,terminal]
+----
+$ oc get deploy/external-secrets-webhook -n <operand_namespace> -o jsonpath='{.spec.template.spec.containers[0].args}'
+----
++
+.Example output
+[source,terminal]
+----
+$ ["webhook","--dns-name=external-secrets-webhook.external-secrets.svc","--port=10250","--cert-dir=/tmp/certs","--check-interval=15m0s","--metrics-addr=:8080","--healthz-addr=:8081","--loglevel=debug","--zap-time-encoding=epoch","--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"]
+----

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -54,6 +54,10 @@ include::modules/external-secrets-operator-set-custom-variables.adoc[leveloffset
 
 // Set custom environment variables
 include::modules/external-secrets-operator-enable-optional-features.adoc[leveloffset=+1]
+
 // mounting a custom trustBundle
 include::modules/external-secrets-operator-mounting-bundle.adoc[leveloffset=+1]
+
+// overriding operand arguments
+include::modules/external-secrets-operator-overriding-operand-arguments.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21528

Link to docs preview:
https://117847--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html#external-secrets-operator-overriding-operand-arguments_external-secrets-log-levels


QE review:
- [x] QE has approved this change.


Additional information:

