### PR TITLE
CNV-54744: KubeletConfig note

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -37,6 +37,11 @@ The `wasp-agent` component deploys an Open Container Initiative (OCI) hook to en
 . Configure the `kubelet` service to permit swap usage:
 .. Create or edit a `KubeletConfig` file with the parameters shown in the following example:
 +
+[IMPORTANT]
+====
+You must create or edit the `KubeletConfig` file with the parameters as shown in the example or the resource swap will not be properly configured.
+====
++
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add a note stressing the importance of doing the `KubeletConfg` configuration first.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
4.19
4.18
4.17

Issue:
[CNV-54744](https://redhat.atlassian.net/browse/CNV-54744)

Link to docs preview:
[Using wasp-agent to increase VM workload density](https://117869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
