### PR TITLE
OSDOCS-18373 HE-3 CQA B2: CQA editorial improvements for NFD

### DIFF
--- a/hardware_enablement/psap-node-feature-discovery-operator.adoc
+++ b/hardware_enablement/psap-node-feature-discovery-operator.adoc
@@ -7,13 +7,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Learn about the Node Feature Discovery (NFD) Operator and how you can use it to expose node-level information by orchestrating Node Feature Discovery, a Kubernetes add-on for detecting hardware features and system configuration.
+You can use the Node Feature Discovery (NFD) Operator to detect and expose hardware features and system configuration as node-level information.
 
 include::modules/psap-node-feature-discovery-operator.adoc[leveloffset=+1]
 
 include::modules/psap-installing-node-feature-discovery-operator.adoc[leveloffset=+1]
 
-include::modules/psap-using-node-feature-discovery-operator.adoc[leveloffset=+1]
+include::modules/nfd-using-operator-overview.adoc[leveloffset=+1]
 
 include::modules/creating-nfd-cr-cli.adoc[leveloffset=+2]
 

--- a/modules/nfd-rules-about.adoc
+++ b/modules/nfd-rules-about.adoc
@@ -6,6 +6,5 @@
 [id="nfd-rules-about_{context}"]
 = About the NodeFeatureRule custom resource
 
-`NodeFeatureRule` objects are a `NodeFeatureDiscovery` custom resource designed for rule-based custom labeling of nodes. Some use cases include application-specific labeling or distribution by hardware vendors to create specific labels for their devices.
-
-`NodeFeatureRule` objects provide a method to create vendor- or application-specific labels and taints. It uses a flexible rule-based mechanism for creating labels and optionally taints based on node features.
+[role="_abstract"]
+A `NodeFeatureRule` custom resource provides a flexible, rule-based method to create vendor- or application-specific labels and optionally taints on nodes based on detected hardware features and system configuration.

--- a/modules/nfd-rules-using.adoc
+++ b/modules/nfd-rules-using.adoc
@@ -6,7 +6,8 @@
 [id="nfd-rules-using_{context}"]
 = Using the NodeFeatureRule custom resource
 
-Create a `NodeFeatureRule` object to label nodes if a set of rules match the conditions.
+[role="_abstract"]
+Create a `NodeFeatureRule` object to apply custom labels to nodes based on detected features, enabling targeted workload scheduling and hardware-specific configuration.
 
 .Procedure
 
@@ -35,7 +36,7 @@ spec:
             vendor: {op: In, value: ["8086"]}
 ----
 +
-This custom resource specifies that labelling occurs when the `veth` module is loaded and any PCI device with vendor code `8086` exists in the cluster.
+This custom resource specifies that labeling occurs when the `veth` module is loaded and a PCI device with vendor code `8086` exists in the cluster.
 
 . Apply the `nodefeaturerule.yaml` file to your cluster by running the following command:
 +
@@ -43,7 +44,8 @@ This custom resource specifies that labelling occurs when the `veth` module is l
 ----
 $ oc apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/v0.13.6/examples/nodefeaturerule.yaml
 ----
-The example applies the feature label on nodes with the `veth` module loaded and any PCI device with vendor code `8086` exists.
++
+The example applies the feature label on nodes where the `veth` module is loaded and a PCI device with vendor code `8086` exists.
 +
 [NOTE]
 ====

--- a/modules/nfd-using-operator-overview.adoc
+++ b/modules/nfd-using-operator-overview.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nfd-using-operator-overview_{context}"]
+= NFD Operator overview
+
+[role="_abstract"]
+The Node Feature Discovery (NFD) Operator orchestrates all resources needed to run the NFD daemon set. You create a `NodeFeatureDiscovery` custom resource (CR), and the Operator creates the operand components in the selected namespace.
+
+As a cluster administrator, you can create a `NodeFeatureDiscovery` CR by using the {oc-first} or the web console.
+
+[NOTE]
+====
+Starting with version 4.12, the `operand.image` field in the `NodeFeatureDiscovery` CR is mandatory. If the NFD Operator is deployed by using {olm-first}, OLM automatically sets the `operand.image` field. If you create the `NodeFeatureDiscovery` CR by using the {product-title} CLI or the {product-title} web console, you must set the `operand.image` field explicitly.
+====


### PR DESCRIPTION
Version(s): 4.20

Issue: https://redhat.atlassian.net/browse/OSDOCS-18373

Link to docs preview: https://117872--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html or review guide below.

QE review: NA, CQA
- [ ] QE has approved this change.

Additional information:

This is part 2 of 2, split from #117336 for easier review. No merge conflicts with part 1 (#117871) — can be merged in either order.

## Summary
- Rewrites abstracts in `nfd-rules-about.adoc` and `nfd-rules-using.adoc`
- Fixes wording (labelling → labeling, tightens sentences)
- Replaces `psap-using-node-feature-discovery-operator.adoc` include with new `nfd-using-operator-overview.adoc`
- Rewrites the assembly intro text

## Test plan
- [ ] Verify the assembly renders correctly with the updated modules
- [ ] Verify abstract text appears properly in each module

🤖 Generated with [Claude Code](https://claude.com/claude-code)