### PR TITLE
[OSDOCS#21527] created RNs for ESO 1-1-1

### DIFF
--- a/modules/external-secrets-operator-rn-1-1-1.adoc
+++ b/modules/external-secrets-operator-rn-1-1-1.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-1-1-1_{context}"]
+= Release notes for {external-secrets-operator} 1.1.1
+
+[role="_abstract"]
+{external-secrets-operator} 1.1.1 is based on the upstream external-secrets version 0.20.4.
+
+Issued: 13 August 2026
+
+This release fixes some Common Vulnerabilities and Exposures (CVEs) and provides related Red Hat advisories.
+
+The following advisories are available for the {external-secrets-operator}:
+
+* https://access.redhat.com/errata/RHBA-2026:54480[RHBA-2026:54480]
+* https://access.redhat.com/errata/RHSA-2026:54525[RHSA-2026:54525]
+* https://access.redhat.com/errata/RHBA-2026:54526[RHBA-2026:54526]
+* https://access.redhat.com/errata/RHBA-2026:54537[RHBA-2026:54537]
+
+[is="external-secrets-operator-1-1-1-cves_{context}"]
+== CVEs
+
+* https://access.redhat.com/security/cve/cve-2026-44740[CVE-2026-44740]
+* https://access.redhat.com/security/cve/cve-2026-27145[CVE-2026-27145]
+* https://access.redhat.com/security/cve/cve-2026-39835[CVE-2026-39835]
+* https://access.redhat.com/security/cve/cve-2026-56852[CVE-2026-56852]
+
+[id="external-secrets-operator-1-1-1-features-enhancements_{context}"]
+== New features and enhancements
+
+*Operand container arguments can be overridden by using the Operator Subscription*
+
+With this release, you can override container arguments for the `external-secrets` operand components by setting environment variables in the `spec.config.env` field of the {external-secrets-operator-short} Subscription. The supported variables are `OPERAND_EXTERNAL_SECRETS_ARGS`, `OPERAND_WEBHOOK_ARGS`, `OPERAND_CERT_CONTROLLER_ARGS`, and `OPERAND_BITWARDEN_SDK_SERVER_ARGS`. Use comma-separated `--key=value` flags. Commas inside values such as `--tls-ciphers` are supported.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-log-levels[Customizing the External Secrets Operator for Red Hat OpenShift].
+

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -16,6 +16,10 @@ For more information, see xref:../../security/external_secrets_operator/index.ad
 // ESO RN 1.2
 include::modules/external-secrets-operator-rn-1-2.adoc[leveloffset=+1]
 
+// ESO RN 1.1.1
+include::modules/external-secrets-operator-rn-1-1-1.adoc[leveloffset=+1]
+
+
 // ESO RN 1.1
 include::modules/external-secrets-operator-rn-1-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21527

Link to docs preview:
https://117880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html#external-secrets-operator-rn-1-1-1_external-secrets-operator-release-notes


QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
