### PR TITLE
Nfd worker scheduling

### DIFF
--- a/hardware_enablement/psap-node-feature-discovery-operator.adoc
+++ b/hardware_enablement/psap-node-feature-discovery-operator.adoc
@@ -23,6 +23,8 @@ include::modules/creating-nfd-cr-web-console.adoc[leveloffset=+2]
 
 include::modules/psap-configuring-node-feature-discovery.adoc[leveloffset=+1]
 
+include::modules/configuring-nfd-worker-master-pod-scheduling.adoc[leveloffset=+1]
+
 include::modules/nfd-rules-about.adoc[leveloffset=+1]
 
 include::modules/nfd-rules-using.adoc[leveloffset=+1]

--- a/modules/configuring-nfd-worker-master-pod-scheduling.adoc
+++ b/modules/configuring-nfd-worker-master-pod-scheduling.adoc
@@ -1,0 +1,114 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-nfd-worker-master-pod-scheduling_{context}"]
+= Configure node feature discovery worker and controller pod scheduling
+
+[role="_abstract"]
+You can control where Node Feature Discovery (NFD) worker and controller pods are scheduled by configuring node selectors and tolerations in the `NodeFeatureDiscovery` custom resource.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster.
+* You installed the {oc-first}.
+* You logged in as a user with `cluster-admin` privileges.
+* You installed the NFD Operator.
+{empty}
+
+[NOTE]
+====
+If you specify `workerNodeSelector` without the required `workerTolerations`, NFD worker pods are not scheduled on tainted nodes, even when the nodes match the configured node selector.
+====
+
+.Procedure
+
+. Label the target node with the label you will use in `workerNodeSelector`:
++
+[source,terminal]
+----
+$ oc label node <node_name> special-node=true
+----
+
+. Edit the `NodeFeatureDiscovery` custom resource:
++
+[source,terminal]
+----
+$ oc edit NodeFeatureDiscovery nfd-instance -n openshift-nfd
+----
+
+. Configure the scheduling options:
++
+[source,yaml]
+----
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  enableTaints: false
+  instance: ""
+
+  operand:
+    imagePullPolicy: IfNotPresent
+    servicePort: 12000
+
+    workerNodeSelector:
+      special-node: "true"
+
+    workerTolerations:
+      - key: "node-role.kubernetes.io/ai"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+      - key: "node-role.kubernetes.io/ai"
+        operator: "Exists"
+        effect: "NoExecute"
+
+    masterTolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  prunerOnDelete: false
+  topologyUpdater: false
+----
++
+where:
++
+`workerNodeSelector`:: Controls where the NFD worker DaemonSet is scheduled. Configure this field under `spec.operand`.
+`workerTolerations`:: Allows the NFD worker pods to tolerate taints applied to the selected nodes. Configure this field under `spec.operand`.
+`masterTolerations`:: Allows NFD controller pods to tolerate taints on control plane nodes. The tolerations must match the node taints for the controller pods to schedule successfully.
+
+.Verification
+
+. Verify that the NFD worker pods are scheduled on the expected nodes:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-nfd -o wide
+----
+
+. Verify the node labels:
++
+[source,terminal]
+----
+$ oc get nodes --show-labels
+----
+
+. Verify the node taints:
++
+[source,terminal]
+----
+$ oc get node <node_name> -o jsonpath='{.spec.taints}'
+----
+
+After verification, NFD worker pods should appear on nodes with the `special-node=true` label, or with the label you configured in `workerNodeSelector`. Controller pods should remain `Running` in the `openshift-nfd` namespace.
+
+


### PR DESCRIPTION
The current Node Feature Discovery (NFD) Operator [documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/specialized_hardware_and_driver_enablement/psap-node-feature-discovery-operator#psap-node-feature-discovery-operator-using-the-operator) does not describe the workerNodeSelector and workerTolerations fields available under spec.operand of the NodeFeatureDiscovery custom resource.

These fields allow cluster administrators to:

Schedule NFD worker pods only on selected nodes by using workerNodeSelector.
Schedule NFD worker pods on tainted nodes by configuring workerTolerations
The masterTolerations field allows NFD master pods to tolerate taints applied to control plane/master nodes.
Beginning with Red Hat OpenShift Container Platform 4.20, the NodeFeatureDiscovery custom resource supports configuring the placement of NFD worker and master pods through the spec.operand section.

Ref:
https://github.com/openshift/cluster-nfd-operator/blob/98a074e63cd08de9748892a1d2361e33665efaf1/api/v1/nodefeaturediscovery_types.go#L112

```
masterTolerations	<[]Object>         <<<<<<----------------
    effect	<string>
    key	<string>

 workerNodeSelector	<map[string]string>   <<<<<<------------------
  workerPriorityClassName	<string>
  workerTolerations	<[]Object>
    effect	<string>
Additional Information
```

Version(s): 4.20+

Issue:  https://redhat.atlassian.net/browse/OSDOCS-XXXXX

Link to docs preview:  https://117893--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html#configuring-nfd-worker-master-pod-scheduling

QE review:
[ ] QE has approved this change.