### PR TITLE
CNV-95175: virt: use new HCO field instead of a feature gate for heterogeneous clusters

### DIFF
--- a/modules/virt-about-architecture-defaults-heterogeneous-clusters.adoc
+++ b/modules/virt-about-architecture-defaults-heterogeneous-clusters.adoc
@@ -13,13 +13,13 @@ To prevent architecture mismatches, {VirtProductName} creates a separate boot so
 
 [IMPORTANT]
 ====
-If you have a heterogeneous cluster and do not enable the `enableMultiArchBootImageImport` feature gate, VMs might fail to start on nodes with a different architecture than the boot source image.
+If you have a heterogeneous cluster and do not enable the `enableMultiArchBootImageImport` field, VMs might fail to start on nodes with a different architecture than the boot source image.
 ====
 
 [id="data-sources-boot-source-images-heterogeneous-clusters_{context}"]
 == How data sources for boot source images work in heterogeneous clusters
 
-After you enable the `enableMultiArchBootImageImport` feature gate, the Scheduling, Scale, and Performance (SSP) Operator creates a new separate boot source for each supported architecture, represented by a `DataSource` object. For example, the `rhel9` boot source image gets the following data sources:
+After you enable the `enableMultiArchBootImageImport` field, the Scheduling, Scale, and Performance (SSP) Operator creates a new separate boot source for each supported architecture, represented by a `DataSource` object. For example, the `rhel9` boot source image gets the following data sources:
 
 * `rhel9-amd64`
 * `rhel9-arm64`

--- a/modules/virt-add-custom-boot-source-image-heterogeneous-cluster.adoc
+++ b/modules/virt-add-custom-boot-source-image-heterogeneous-cluster.adoc
@@ -13,7 +13,7 @@ Add a custom boot source image in a heterogeneous cluster by editing the `HyperC
 
 * You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
-* You have enabled the `enableMultiArchBootImageImport` feature gate in the `HyperConverged` CR.
+* You have enabled the `enableMultiArchBootImageImport` field in the `HyperConverged` CR.
 
 .Procedure
 

--- a/modules/virt-enabling-heterogeneous-clusters.adoc
+++ b/modules/virt-enabling-heterogeneous-clusters.adoc
@@ -7,7 +7,7 @@
 = Enabling heterogeneous cluster support
 
 [role="_abstract"]
-You can enable boot source image support for heterogeneous clusters by setting the `enableMultiArchBootImageImport` feature gate to `true` in the `HyperConverged` custom resource (CR).
+You can enable boot source image support for heterogeneous clusters by setting the `enableMultiArchBootImageImport` field to `true` in the `HyperConverged` custom resource (CR).
 
 .Prerequisites
 
@@ -16,23 +16,22 @@ You can enable boot source image support for heterogeneous clusters by setting t
 
 .Procedure
 
-* Enable the `enableMultiArchBootImageImport` feature gate by running the following command:
+* Enable the `enableMultiArchBootImageImport` field by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
-  --type json -p '[{"op": "add", "path": "/spec/featureGates/-", \
-  "value": {"name": "enableMultiArchBootImageImport"}}]'
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} --type merge \
+  -p '{"spec":{"workloadSources":{"enableMultiArchBootImageImport":true}}}'
 ----
 
 .Verification
 
-* Verify that the feature gate is enabled by running the following command:
+* Verify that the field is enabled by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
-  -o jsonpath='{.spec.featureGates[*].name}'
+  -o jsonpath='{.spec.workloadSources.enableMultiArchBootImageImport}'
 ----
 +
-The output must include `enableMultiArchBootImageImport`.
+The output must be `true`.

--- a/modules/virt-mod-boot-source-image-heterogeneous-clusters.adoc
+++ b/modules/virt-mod-boot-source-image-heterogeneous-clusters.adoc
@@ -13,7 +13,7 @@ You can modify the source of a common boot source image in a heterogeneous clust
 
 * You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
-* You have enabled the `enableMultiArchBootImageImport` feature gate in the `HyperConverged` CR.
+* You have enabled the `enableMultiArchBootImageImport` field in the `HyperConverged` CR.
 
 .Procedure
 


### PR DESCRIPTION
The heterogeneous cluster support in virt is now GA. however, it is disabled by default for the boot source images.

The `enableMultiArchBootImageImport` feature gate in the HyperConverged CR is deprecated. Instead, use the
`spec.workloadSources.enableMultiArchBootImageImport` field.

This PR removes the tech preview warnings, and guides to use the new
field instead of the deprecated feature gate.

Version(s):
v4.23, v5.0

Issue:
[https://redhat.atlassian.net/browse/CNV-95175](https://redhat.atlassian.net/browse/CNV-95175)

QE review:
- [ ] QE has approved this change.

@ctomasko