### PR TITLE
[RHDEVDOCS-7794] Fix DITA structural issues for AEM migration readiness

### DIFF
--- a/modules/op-about-multicluster-support.adoc
+++ b/modules/op-about-multicluster-support.adoc
@@ -11,15 +11,14 @@ Multicluster support enables you to distribute pipeline workloads across multipl
 
 When you run many tasks concurrently on a single cluster, performance can degrade due to resource contention on critical components such as the Kubernetes API server and etcd. A multicluster approach addresses these challenges by distributing workloads across multiple clusters, which helps alleviate resource bottlenecks, reduce the impact of failures, and improve overall scalability.
 
-.Key benefits
-
+Key benefits::
++
 * *Horizontal scalability*: Distribute pipeline workloads across multiple clusters to handle increased capacity demands without overloading a single cluster.
 * *Improved performance*: Reduce resource contention on the Kubernetes API server and etcd by spreading workloads across clusters.
 * *Reduced failure impact*: Minimize the effect of cluster failures by isolating workloads across different clusters.
 * *Resource optimization*: Use Kueue to schedule pipeline runs based on resource availability across your cluster infrastructure.
 
-.How it works
-
+How it works::
 In a multicluster setup:
 
 . You create pipeline runs on the hub cluster which initially enter a pending state.

--- a/modules/op-authenticating-pipelines-repos-using-secrets.adoc
+++ b/modules/op-authenticating-pipelines-repos-using-secrets.adoc
@@ -50,5 +50,5 @@ params:
   - name: url
     value: https://bitbucket.org/<workspace>/<repository>.git
 ----
-
++
 At runtime, the `git-clone` task uses credentials from the `bitbucket-auth` secret when accessing HTTPS Git URLs matching `https://bitbucket.org`.

--- a/modules/op-configuring-cosign-for-sbom-verification.adoc
+++ b/modules/op-configuring-cosign-for-sbom-verification.adoc
@@ -1,0 +1,84 @@
+// This module is included in the following assemblies:
+// * secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-configuring-cosign-for-sbom-verification_{context}"]
+= Setting up {pipelines-shortname} to download or view software bills of materials
+
+[role="_abstract"]
+The `PipelineRun` details page provides an option to download or view Software Bill of Materials (SBOMs), enhancing transparency and control within your supply chain. SBOMs lists all the software libraries that a component uses. Those libraries can enable specific functionality or help development.
+
+You can use a software bill of materials (SBOM) to better understand the composition of your software, identify vulnerabilities, and assess the potential impact of any security issues that might arise.
+
+.Options to download or view SBOMs
+image::sbom.png[Options to download or view SBOMs]
+
+.Prerequisites
+
+* You have link:https://docs.openshift.com/container-platform/4.14/web_console/web-console.html#web-console[logged in to the web console].
+
+* You have the appropriate link:https://docs.openshift.com/container-platform/4.14/authentication/using-rbac.html#default-roles_using-rbac[roles and permissions] in a project to create applications and other workloads in {product-title}.
+
+.Procedure
+
+. In the *Developer* or *Administrator* perspective, switch to the relevant project where you want a visual representation of SBOMs.
+
+. Add a task in the following format to view or download the SBOM information:
++
+.Example SBOM task
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sbom-task
+  annotations:
+    task.output.location: results
+    task.results.format: application/text
+    task.results.key: LINK_TO_SBOM
+    task.results.type: external-link
+spec:
+  results:
+    - description: Contains the SBOM link
+      name: LINK_TO_SBOM
+  steps:
+    - name: print-sbom-results
+      image: quay.io/image
+      script: |
+        #!/bin/sh
+        syft version
+        syft quay.io/<username>/quarkus-demo:v2 --output cyclonedx-json=sbom-image.json
+        echo 'BEGIN SBOM'
+        cat sbom-image.json
+        echo 'END SBOM'
+        echo 'quay.io/user/workloads/<namespace>/node-express/node-express:build-8e536-1692702836' | tee $(results.LINK_TO_SBOM.path)
+----
+`name`:: The name of your task.
+`task.output.location`:: The location for storing the task outputs.
+`task.results.key`:: The SBOM task result name. Do not change the name of the SBOM result task.
+`task.results.type`:: (Optional) Set to open the SBOM in a new tab.
+`- description: Contains the SBOM link`:: The description of the result.
+`image`:: The image that generates the SBOM.
+`script`:: The script that generates the SBOM image.
+`<namespace>`:: The SBOM image along with the path name.
+
+. Update the Pipeline to reference the newly created SBOM task.
++
+[source,yaml]
+----
+...
+spec:
+  tasks:
+    - name: sbom-task
+      taskRef:
+        name: sbom-task
+  results:
+    - name: IMAGE_URL
+      description: url
+      value: <oci_image_registry_url>
+----
+`name`:: The same name as created in Step 2.
+`- name: IMAGE_URL`:: The name of the result.
+`<oci_image_registry_url>`:: The OCI image repository URL that has the `.sbom` images.
+
+. Rerun the affected OpenShift Pipeline.

--- a/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
@@ -55,7 +55,8 @@ $ tkn task start <task_name>
 `<secret_name>`:: Replace `<workspace_name>` with the name of the workspace that you configured and `<secret_name>` with the name of the secret that you created.
 +
 --
-.Example task for cloning a Git repository by using an SSH key for authentication
+The following is an example task for cloning a Git repository by using an SSH key for authentication:
+
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-configuring-gitops-command-prefix.adoc
+++ b/modules/op-configuring-gitops-command-prefix.adoc
@@ -65,7 +65,7 @@ For example, if the custom prefix is set to `pac`, use the following command to 
 ----
 /pac test <pipelinerun_name>
 ----
-
++
 [NOTE]
 ====
 The prefix setting does not affect custom GitOps commands.

--- a/modules/op-creating-pipeline-runs-multicluster.adoc
+++ b/modules/op-creating-pipeline-runs-multicluster.adoc
@@ -93,10 +93,9 @@ The pipeline run initially shows a `Pending` status. When MultiKueue schedules i
 In the web console, multicluster pipeline runs are indicated with a multicluster icon next to the pipeline run name in both the list view and details page.
 ====
 
-.Using HTTP resolver to fetch pipeline definitions
-
+Using HTTP resolver to fetch pipeline definitions::
 You can use the HTTP resolver to fetch pipeline definitions from a remote location. The following example shows how to create a pipeline run that uses the HTTP resolver:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -114,11 +113,12 @@ spec:
     - name: url
       value: https://raw.githubusercontent.com/example/repo/main/pipeline.yaml
 ----
-
++
 Replace the `url` parameter value with the URL to your pipeline definition.
 
-.Using {pac} with multicluster
-
+Using {pac} with multicluster::
++
+--
 {pac} is compatible with multicluster configurations. When you configure a repository for {pac} on the hub cluster, ensure that pipeline runs created by {pac} include the `managedBy: kueue.x-k8s.io/multikueue` field in the specification.
 
 The following example shows a {pac} pipeline run configuration that works in a multicluster environment:
@@ -167,3 +167,4 @@ Secret synchronization for PAC is handled automatically by the syncer-service, w
 ** Remote resolvers such as Git or HTTP resolvers to fetch pipeline definitions from external sources
 * Only the pipeline run and its associated ConfigMaps and Secrets are synchronized to spoke clusters. Other resources are not synchronized.
 ====
+--

--- a/modules/op-downloading-an-sbom.adoc
+++ b/modules/op-downloading-an-sbom.adoc
@@ -1,0 +1,33 @@
+// This module is included in the following assemblies:
+// * secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-downloading-an-sbom_{context}"]
+= Downloading an SBOM in the CLI
+
+[role="_abstract"]
+You can download a software bill of materials (SBOM) for a pipeline run by using the Cosign CLI tool.
+
+.Prerequisites
+
+* You have installed the Cosign CLI tool. For information about installing the Cosign tool, see the link:https://docs.sigstore.dev/cosign/system_config/installation/[Sigstore documentation for Cosign].
+
+* You have set up {pipelines-shortname} to download or view SBOMs.
+
+.Procedure
+
+. Open terminal, log in to *Developer* or *Administrator* perspective, and then switch to the relevant project.
+
+. From the OpenShift web console, copy the `download sbom` command and run it on your terminal.
++
+[source,terminal]
+----
+$ cosign download sbom quay.io/<workspace>/user-workload@sha256
+----
+
+.. (Optional) To view the full SBOM in a searchable format, run the following command to redirect the output:
++
+[source,terminal]
+----
+$ cosign download sbom quay.io/<workspace>/user-workload@sha256 > sbom.txt
+----

--- a/modules/op-multicluster-kueue-resources-reference.adoc
+++ b/modules/op-multicluster-kueue-resources-reference.adoc
@@ -7,12 +7,13 @@
 = Kueue resources for multicluster configuration
 
 [role="_abstract"]
-Kueue resources define quotas, queues, and multicluster configuration for managing pipeline runs across clusters. The following tables describe the key Kueue resources used in a multicluster {pipelines-shortname} setup.
+Kueue resources define quotas, queues, and multicluster configuration for managing pipeline runs across clusters.
 
-.ResourceFlavor
+The following tables describe the key Kueue resources used in a multicluster {pipelines-shortname} setup.
 
+ResourceFlavor::
 A ResourceFlavor represents a variation of available resources. In multicluster configurations, it typically defines a default set of resources.
-
++
 [cols="1,2",options="header"]
 |===
 |Field
@@ -22,10 +23,9 @@ A ResourceFlavor represents a variation of available resources. In multicluster 
 |The name of the resource flavor.
 |===
 
-.ClusterQueue
-
+ClusterQueue::
 A ClusterQueue defines resource quotas and admission checks for workloads across namespaces.
-
++
 [cols="1,2",options="header"]
 |===
 |Field
@@ -62,10 +62,9 @@ A ClusterQueue defines resource quotas and admission checks for workloads across
 |A list of admission checks that workloads must pass before admission. For multicluster, this typically references a MultiKueue admission check.
 |===
 
-.LocalQueue
-
+LocalQueue::
 A LocalQueue provides a namespace-scoped interface to a ClusterQueue.
-
++
 [cols="1,2",options="header"]
 |===
 |Field
@@ -81,10 +80,9 @@ A LocalQueue provides a namespace-scoped interface to a ClusterQueue.
 |The name of the ClusterQueue that this LocalQueue references.
 |===
 
-.AdmissionCheck
-
+AdmissionCheck::
 An AdmissionCheck defines a condition that workloads must satisfy before being admitted.
-
++
 [cols="1,2",options="header"]
 |===
 |Field
@@ -106,10 +104,9 @@ An AdmissionCheck defines a condition that workloads must satisfy before being a
 |The name of the MultiKueueConfig resource.
 |===
 
-.MultiKueueConfig
-
+MultiKueueConfig::
 A MultiKueueConfig defines the configuration for multicluster workload distribution.
-
++
 [cols="1,2",options="header"]
 |===
 |Field
@@ -122,10 +119,9 @@ A MultiKueueConfig defines the configuration for multicluster workload distribut
 |A list of MultiKueueCluster names that workloads can be scheduled to.
 |===
 
-.MultiKueueCluster
-
+MultiKueueCluster::
 A MultiKueueCluster defines a spoke cluster configuration.
-
++
 [cols="1,2",options="header"]
 |===
 |Field

--- a/modules/op-multicluster-limitations.adoc
+++ b/modules/op-multicluster-limitations.adoc
@@ -14,8 +14,7 @@ When working with pipeline runs in a multicluster environment, be aware of the f
 Some or all of these limitations might be removed in future releases as the multicluster support continues to evolve.
 ====
 
-.Web console limitations
-
+Web console limitations::
 The following actions are not fully supported in the web console for multicluster pipeline runs:
 
 Stop action::
@@ -24,8 +23,7 @@ The Stop action does not work for pipeline runs executing on spoke clusters. Thi
 Cancel action::
 The Cancel action might be disabled or unavailable in the web console for multicluster pipeline runs. This action immediately cancels the pipeline run and all active tasks. The availability of this action depends on whether the hub cluster detects active tasks, which might not be accurately reflected for pipeline runs executing on spoke clusters.
 
-.Workaround
-
+Workaround::
 To stop or cancel a multicluster pipeline run, you must cancel it directly on the spoke cluster where it is executing:
 
 . Log in to the spoke cluster where the pipeline run is executing.
@@ -40,7 +38,7 @@ The cancellation status is synchronized back to the hub cluster.
 
 [NOTE]
 ====
-Both the Stop and Cancel actions are designed to execute finally tasks as part of cleanup. Cancelling from the spoke cluster allows finally tasks to execute properly.
+Both the Stop and Cancel actions are designed to execute finally tasks as part of cleanup. Canceling from the spoke cluster allows finally tasks to execute properly.
 ====
 
 Logs and status display::
@@ -49,30 +47,29 @@ When viewing logs or status for pipeline runs executing on spoke clusters, you m
 Pending admission state::
 Pipeline runs created on the hub cluster show a "waiting to be admitted to a spoke cluster" status before MultiKueue schedules them to a spoke cluster. This is normal behavior while the system determines the best spoke cluster based on resource availability.
 
-.API version requirement
-
+API version requirement::
 Multicluster pipeline runs must use the `tekton.dev/v1` API version. The `tekton.dev/v1beta1` API version is not supported.
 
-.Reference limitations
-
+Reference limitations::
 You cannot use `pipelineRef` or `taskRef` to reference existing pipelines or tasks stored in the cluster using the cluster resolver. Instead, you must use one of the following approaches:
 
 * Embedded pipeline specifications
 * Remote resolvers such as Git, HTTP, or Bundle resolvers
 
-.Additional limitations
-
-PipelineRun name length::
+Additional limitations::
++
+--
+PipelineRun name length:::
 The name of a pipeline run must not exceed 45 characters. This limit exists because MultiKueue generates workload names by adding additional characters to the pipeline run name.
 
-Namespace requirements::
+Namespace requirements:::
 Namespaces must be pre-created on spoke clusters before pipeline runs can be scheduled to them. If a namespace does not exist on a spoke cluster, MultiKueue cannot schedule pipeline runs to that cluster.
 
-LocalQueue requirements::
+LocalQueue requirements:::
 Each spoke cluster must have a matching LocalQueue resource in the same namespace where pipeline runs are created. The LocalQueue name must match the name referenced in the pipeline run's `kueue.x-k8s.io/queue-name` label.
+--
 
-.tkn CLI limitations
-
+tkn CLI limitations::
 The `tkn` CLI tool has limited functionality in multicluster environments:
 
 * On the hub cluster, the following commands do not work:

--- a/modules/op-reading-the-sbom.adoc
+++ b/modules/op-reading-the-sbom.adoc
@@ -1,0 +1,54 @@
+// This module is included in the following assemblies:
+// * secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-reading-the-sbom_{context}"]
+= Reading the SBOM
+
+[role="_abstract"]
+In the SBOM, you can see four characteristics of each library that a project uses. This information helps you verify that individual libraries are safely-sourced, updated, and compliant.
+
+The following characteristics are listed for each library:
+
+* Its author or publisher
+
+* Its name
+
+* Its version
+
+* Its licenses
+
+The following example shows a sample excerpt from an SBOM:
+
+[source,json]
+----
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "serialNumber": "urn:uuid:89146fc4-342f-496b-9cc9-07a6a1554220",
+    "version": 1,
+    "metadata": {
+        ...
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:pypi/flask@2.1.0?package-id=d6ad7ed5aac04a8",
+            "type": "library",
+            "author": "Armin Ronacher <armin.ronacher@active-4.com>",
+            "name": "Flask",
+            "version": "2.1.0",
+            "licenses": [
+                {
+                    "license": {
+                        "id": "BSD-3-Clause"
+                    }
+                }
+            ],
+            "cpe": "cpe:2.3:a:armin-ronacher:python-Flask:2.1.0:*:*:*:*:*:*:*",
+            "purl": "pkg:pypi/Flask@2.1.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "python-package-cataloger"
+                    ...
+----

--- a/modules/op-resolver-bundle.adoc
+++ b/modules/op-resolver-bundle.adoc
@@ -74,9 +74,9 @@ spec:
   - name: username
     value: "pipelines"
 ----
-
++
 The following example pipeline references a remote task from a Tekton bundle:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -99,9 +99,9 @@ spec:
     - name: sample-task-parameter
       value: test
 ----
-
++
 The following example task run references a remote task from a Tekton bundle:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -122,9 +122,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from a Tekton bundle:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-resolver-cluster.adoc
+++ b/modules/op-resolver-cluster.adoc
@@ -69,9 +69,9 @@ spec:
   - name: sample-pipeline-parameter
     value: test
 ----
-
++
 The following example pipeline references a task from the same cluster:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -94,9 +94,9 @@ spec:
     - name: sample-task-parameter
       value: test
 ----
-
++
 The following example task run references a task from the same cluster:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -117,9 +117,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from the same cluster:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-resolver-git-anon.adoc
+++ b/modules/op-resolver-git-anon.adoc
@@ -77,9 +77,9 @@ spec:
     - name: sample-pipeline-parameter
       value: test
 ----
-
++
 The following example pipeline references a remote task from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -102,9 +102,9 @@ spec:
       - name: sample-task-parameter
         value: test
 ----
-
++
 The following example task run references a remote task from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -125,9 +125,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-resolver-git-scm.adoc
+++ b/modules/op-resolver-git-scm.adoc
@@ -89,9 +89,9 @@ spec:
   - name: sample-pipeline-parameter
     value: test
 ----
-
++
 The following example pipeline references a remote task from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -116,9 +116,9 @@ spec:
     - name: sample-task-parameter
       value: test
 ----
-
++
 The following example task run references a remote task from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -141,9 +141,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from a Git repository:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-resolver-http.adoc
+++ b/modules/op-resolver-http.adoc
@@ -54,9 +54,9 @@ spec:
   - name: username
     value: "pipelines"
 ----
-
++
 The following example pipeline defines a task that references a remote task from an HTTPS URL:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -75,9 +75,9 @@ spec:
     - name: sample-task-parameter
       value: test
 ----
-
++
 The following example task run references a remote task from an HTTPS URL:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -94,9 +94,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from an HTTPS URL:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-resolver-hub.adoc
+++ b/modules/op-resolver-hub.adoc
@@ -90,9 +90,9 @@ spec:
   - name: sample-pipeline-parameter
     value: test
 ----
-
++
 The following example pipeline references a remote task from a catalog:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -119,9 +119,9 @@ spec:
     - name: sample-task-parameter
       value: test
 ----
-
++
 The following example task run references a remote task from a catalog:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -146,9 +146,9 @@ spec:
   - name: sample-task-parameter
     value: test
 ----
-
++
 The following example task includes a step that references a `StepAction` definition from a catalog:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -175,9 +175,9 @@ spec:
     - name: sample-stepaction-parameter
       value: test
 ----
-
++
 The following example task run references a remote task from a private hub instance by using the `url` parameter:
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-results-opc-pipelinerunlist.adoc
+++ b/modules/op-results-opc-pipelinerunlist.adoc
@@ -28,7 +28,7 @@ $ opc results pipelinerun list -n <namespace_name>
 Optionally, specify the `--limit` command line option, for example, `--limit=10`. With this setting, the `opc` command displays the specified number of lines containing pipeline run names and then exits. If you add the `--single-page=false` command line option, the command displays the specified number of lines and then prompts you to continue or quit.
 +
 Optionally, specify the `--labels` command line option, for example, `--labels="app.kubernetes.io/name=test-app, app.kubernetes.io/component=database`. With this setting, the list includes only the pipeline runs that have the specified labels or annotations.
-
++
 .Example output of the `opc results pipelinerun list` command
 [source,terminal]
 ----
@@ -39,7 +39,7 @@ openshift-pipelines-main-release-tests-jdc24   e34daea2-66fb-4c7d-9d4b-d9d82a07b
 openshift-pipelines-main-release-tests-6zj7f   9b3e5d68-70ab-4c23-8872-e7ad7121e60b   1 week ago   5s         Failed(CouldntGetPipeline)
 openshift-pipelines-main-release-tests-kkk9t   2fd28c48-388b-4e6a-9ec3-2bcd9dedebc3   1 week ago   5s         Failed(CouldntGetPipeline)
 ----
-
++
 ** To view pipeline runs related to specified named pipelines, enter the following command:
 +
 [source,terminal]

--- a/modules/op-specifying-manual-approval-task.adoc
+++ b/modules/op-specifying-manual-approval-task.adoc
@@ -123,9 +123,9 @@ The following table describes the parameters for a manual approval task.
 |===
 +
 You can define approval tasks for different workflows depending on your requirements. The following are a few examples of approval configurations.
-
++
 The following is an example for multi user approval.
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -161,9 +161,9 @@ spec:
       name: deploy-task
     runAfter: [approval-gate]
 ----
-
++
 The following is an example for a group-based user approval.
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -198,9 +198,9 @@ spec:
       name: deploy-task
     runAfter: [approval-gate]
 ----
-
++
 The following is an example for mixed user and group approvals.
-
++
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1

--- a/modules/op-viewing-an-sbom.adoc
+++ b/modules/op-viewing-an-sbom.adoc
@@ -1,0 +1,25 @@
+// This module is included in the following assemblies:
+// * secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-viewing-an-sbom_{context}"]
+= Viewing an SBOM in the web UI
+
+[role="_abstract"]
+You can view a software bill of materials (SBOM) for a pipeline run directly in the {product-title} web console.
+
+.Prerequisites
+
+* You have set up {pipelines-shortname} to download or view SBOMs.
+
+.Procedure
+
+. Navigate to the Activity -> `PipelineRuns` tab.
+
+. For the project whose SBOM you want to view, select its most recent pipeline run.
+
+. On the `PipelineRun` details page, select *View SBOM*.
+
+.. You can use your web browser to immediately search the SBOM for terms that indicate vulnerabilities in your software supply chain. For example, try searching for `log4j`.
+
+.. You can select *Download* to download the SBOM, or *Expand* to view it full-screen.

--- a/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
+++ b/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.adoc
@@ -25,7 +25,13 @@ The `PipelineRun` displays the signed badge next to its name only if you have co
 
 include::modules/op-setting-up-openshift-pipelines-to-view-project-vulnerabilities.adoc[leveloffset=+1]
 
-include::modules/op-setting-up-openshift-pipelines-to-download-or-view-sboms.adoc[leveloffset=+1]
+include::modules/op-configuring-cosign-for-sbom-verification.adoc[leveloffset=+1]
+
+include::modules/op-viewing-an-sbom.adoc[leveloffset=+1]
+
+include::modules/op-downloading-an-sbom.adoc[leveloffset=+1]
+
+include::modules/op-reading-the-sbom.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
## Summary
- Cherry-pick of #117900 to `pipelines-docs-1.23`
- Fixes DITA structural issues for AEM migration readiness
- Resolved conflicts by removing two files deleted in 1.23: `op-troubleshooting-task-params-changed.adoc` and `op-verify-clustertask-migration.adoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)