### PR TITLE
CNV-94224: Document the template VM creation flow

### DIFF
--- a/modules/virt-creating-vm-from-template-web.adoc
+++ b/modules/virt-creating-vm-from-template-web.adoc
@@ -3,44 +3,37 @@
 // * virt/creating_vm/virt-creating-vms-web.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="virt-creating-vm-custom-configuration-web_{context}"]
-= Create a VM with custom configuration by using the web console
+[id="virt-creating-vm-from-template-web_{context}"]
+= Create a VM from a template by using the web console
 
 [role="_abstract"]
-You can use the *Custom configuration* workflow in the web console to create a virtual machine (VM) by selecting a guest operating system, boot source, compute resources, and advanced settings.
+You can use the *Create from Template* workflow in the web console to create a virtual machine (VM) by selecting a preconfigured template that provides standardized images and settings.
 
 Use this workflow when:
 
-* No existing template matches your requirements.
-* You need a specific combination of compute, storage, and network settings.
-* You want to boot from a custom disk image.
+* A template matches your workload requirements and operating system.
+* You want to use a preconfigured VM with standardized settings.
+* You want to quickly deploy a VM with minimal customization.
 
 .Prerequisites
 
 * You have access to the {product-title} web console.
 * You have `edit` or `admin` permissions in the target project.
+* A template with an available boot source exists in the cluster.
 
 .Procedure
 
 . In the {product-title} web console, navigate to *Virtualization* -> *VirtualMachines*.
 . Click *Create*.
 . On the *Deployment details* page, configure the following settings:
-.. Select *Custom configuration*.
+.. Select *Create from Template*.
 .. In the *Name* field, enter a name for the VM. You can also click the refresh icon to generate a name automatically.
 .. Optional: Enter a *Description* for the VM.
 .. Review the *Location* to verify the target cluster and project. If the folder preview feature is enabled, you can also verify the folder. To change the location, click the edit icon.
 .. Click *Next*.
-. On the *Guest operating system* page, specify the operating system:
-.. Select the guest operating system, such as *RHEL*, *Microsoft Windows*, or *Other Linux*.
-.. Select the operating system version from the *Guest operating system type* list.
-.. Click *Next*.
-. On the *Boot source* page, specify the boot volume:
-.. Select *Boot volume* to use an existing boot volume or add a new one, or select *No boot source* to assign an empty disk that you can configure later.
-.. If you selected *Boot volume*, select an existing volume from the list, or click *Add volume* to configure a new boot volume.
-.. Click *Next*.
-. On the *Compute resources* page, define the instance type:
-.. Select an instance type series, such as *General purpose* or *Compute Exclusive*.
-.. Select the vCPU and memory size from the drop-down list.
+. On the *Template* page, select a template:
+.. Optional: Filter the template list. You can select a project from the *All projects* menu, apply a *Filter* for categories such as operating system or workload type, or enter a keyword in the *Filter by keyword* field.
+.. Click a template tile to select it and view its details.
 .. Click *Next*.
 . Optional: On the *Customization* page, configure advanced settings by navigating the following tabs:
 +

--- a/virt/creating_vm/virt-creating-vms-web.adoc
+++ b/virt/creating_vm/virt-creating-vms-web.adoc
@@ -7,12 +7,21 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can create virtual machines (VMs) by using the {product-title} web console. The web console creation wizard provides workflows for custom configuration, creating a VM from a template, and cloning an existing VM.
+You can create virtual machines (VMs) by using the {product-title} web console. The web console creation wizard provides workflows for configuring a custom VM, creating a VM from a template, and cloning an existing VM.
 
 // Custom configuration procedure (CNV-94223)
 include::modules/virt-creating-vm-custom-configuration-web.adoc[leveloffset=+1]
 
+.Additional resources
+
+* xref:../../virt/managing_vms/virt-list-vms.adoc#virt-organize-vms-web_virt-list-vms[Organize virtual machines by using the web console]
+
 // Template-based creation procedure (CNV-94224)
+include::modules/virt-creating-vm-from-template-web.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../virt/managing_vms/virt-list-vms.adoc#virt-organize-vms-web_virt-list-vms[Organize virtual machines by using the web console]
 
 // Clone existing VM procedure (CNV-94225)
 


### PR DESCRIPTION
Version(s):
Main, 4.22, 5.0

Issue: [CNV-94224](https://redhat.atlassian.net/browse/CNV-94224)

[Link to docs preview](https://117906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-web.html#virt-creating-vm-from-template-web_virt-creating-vms-web)

QE review:
- [x] QE has approved this change.

PR summary:

- I used Claude to draft the new PROCEDURE module based on a source PDF with annotated screenshots of the flow I had created.
- Claude also added the include directive in the assembly and un-commented the topic map entry for SME preview builds at my request.
- I applied my own judgment in keeping the procedure high level. I'll add reference material afterwards.
- I reviewed all suggested peer review fixes after Claude's review, keeping some but discarding others that didn't fit with the documentation work. I also noticed that some edits Claude wanted to make to this module had been missed when it reviewed the custom flow module, so I had Claude update that module as well, for consistency. 
