### PR TITLE
[RHDEVDOCS-7795] Fix DITA metadata issues for AEM migration readiness

### DIFF
--- a/modules/op-about-must-gather.adoc
+++ b/modules/op-about-must-gather.adoc
@@ -2,6 +2,7 @@
 [id="op-about-must-gather_{context}"]
 = About the must-gather tool
 
+[role="_abstract"]
 The `oc adm must-gather` tool collects diagnostic information about your cluster, such as resource definitions, configurations, and logs for project-level and cluster-level resources. 
 
 When you run the command, the tool performs the following actions:

--- a/modules/op-collecting-pipelines-debugging-data.adoc
+++ b/modules/op-collecting-pipelines-debugging-data.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="op-collecting-pipelines-debugging-data_{context}"]
-= Collecting OpenShift Pipelines debugging data
+= Collecting {pipelines-shortname} debugging data
 
-You can use the `oc adm must-gather` CLI command to collect detailed diagnostic data and logs for OpenShift Pipelines components on your cluster.
+[role="_abstract"]
+You can use the `oc adm must-gather` CLI command to collect detailed diagnostic data and logs for {pipelines-shortname} components on your cluster.
 
 .Prerequisites
 

--- a/modules/op-configuring-hub-cluster-multicluster.adoc
+++ b/modules/op-configuring-hub-cluster-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-configuring-hub-cluster-multicluster_{context}"]
 = Configuring the hub cluster for multicluster
 
+[role="_abstract"]
 You can configure an {product-title} cluster as a hub cluster to manage and schedule pipeline runs across multiple spoke clusters.
 
 .Prerequisites

--- a/modules/op-configuring-spoke-clusters-multicluster.adoc
+++ b/modules/op-configuring-spoke-clusters-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-configuring-spoke-clusters-multicluster_{context}"]
 = Configuring spoke clusters for multicluster
 
+[role="_abstract"]
 You can configure {product-title} clusters as spoke clusters to execute pipeline runs scheduled from a hub cluster.
 
 .Prerequisites

--- a/modules/op-creating-pipeline-runs-multicluster.adoc
+++ b/modules/op-creating-pipeline-runs-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-creating-pipeline-runs-multicluster_{context}"]
 = Creating pipeline runs in a multicluster environment
 
+[role="_abstract"]
 After you configure multicluster support, you can create pipeline runs on the hub cluster that are automatically scheduled and executed on spoke clusters.
 
 .Prerequisites

--- a/modules/op-troubleshooting-access-denied.adoc
+++ b/modules/op-troubleshooting-access-denied.adoc
@@ -6,7 +6,10 @@
 [id="troubleshooting-access-denied_{context}"]
 = Resolve namespace access blocked errors
 
-If you receive an error that access to the specified namespace is blocked, the cluster resolver might not have permission to access that namespace. This can occur when the cluster resolver configuration restricts access to certain namespaces, or when RBAC policies prevent the service account from accessing the namespace.
+[role="_abstract"]
+If you receive an error that access to the specified namespace is blocked, the cluster resolver might not have permission to access that namespace.
+
+This can occur when the cluster resolver configuration restricts access to certain namespaces, or when RBAC policies prevent the service account from accessing the namespace.
 
 .Procedure
 

--- a/modules/op-troubleshooting-general-debugging.adoc
+++ b/modules/op-troubleshooting-general-debugging.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-debugging_{context}"]
 = General debugging tips for cluster resolver migration
 
+[role="_abstract"]
 If you encounter other issues during migration, use the following troubleshooting steps.
 
 .Procedure

--- a/modules/op-troubleshooting-resolution-failed.adoc
+++ b/modules/op-troubleshooting-resolution-failed.adoc
@@ -6,7 +6,10 @@
 [id="troubleshooting-resolution-failed_{context}"]
 = Resolve task resolution failed or resource not found errors
 
-If a pipeline run fails with a "resolution failed" or "resource not found" error, the cluster resolver cannot find the specified task. This can occur when the task does not exist in the specified namespace, the task name is misspelled in the pipeline definition, or the namespace name is incorrect.
+[role="_abstract"]
+If a pipeline run fails with a "resolution failed" or "resource not found" error, the cluster resolver cannot find the specified task.
+
+This can occur when the task does not exist in the specified namespace, the task name is misspelled in the pipeline definition, or the namespace name is incorrect.
 
 .Procedure
 

--- a/modules/op-troubleshooting-resolver-not-enabled.adoc
+++ b/modules/op-troubleshooting-resolver-not-enabled.adoc
@@ -6,7 +6,10 @@
 [id="troubleshooting-resolver-not-enabled_{context}"]
 = Resolve cluster resolver not enabled errors
 
-If the cluster resolver is not working, it might not be enabled in your {pipelines-title} installation. This can occur when the cluster resolver feature flag is not enabled, or when the resolver configuration is missing or incorrect.
+[role="_abstract"]
+If the cluster resolver is not working, it might not be enabled in your {pipelines-title} installation.
+
+This can occur when the cluster resolver feature flag is not enabled, or when the resolver configuration is missing or incorrect.
 
 .Procedure
 

--- a/modules/op-troubleshooting-task-params-changed.adoc
+++ b/modules/op-troubleshooting-task-params-changed.adoc
@@ -6,7 +6,10 @@
 [id="troubleshooting-task-params-changed_{context}"]
 = Resolve task parameter changed errors
 
-Tasks in the {pipelines-shortname} namespace might have different parameters than their deprecated `ClusterTask` versions. Review the current task definitions and update your pipelines to use the correct parameter names.
+[role="_abstract"]
+Tasks in the {pipelines-shortname} namespace might have different parameters than their deprecated `ClusterTask` versions.
+
+Review the current task definitions and update your pipelines to use the correct parameter names.
 
 .Procedure
 

--- a/modules/op-verifying-multicluster-setup.adoc
+++ b/modules/op-verifying-multicluster-setup.adoc
@@ -6,6 +6,7 @@
 [id="op-verifying-multicluster-setup_{context}"]
 = Verifying multicluster setup
 
+[role="_abstract"]
 You can verify that your multicluster configuration is working correctly by checking the status of Kueue resources on the hub cluster.
 
 .Prerequisites

--- a/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
+++ b/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="protecting-tekton-workloads-from-eviction-during-node-drains"]
 = Protecting Tekton workload pods from eviction during node drains


### PR DESCRIPTION
Summary
- Added `[role="_abstract"]` to 11 modules missing DITA `<shortdesc>` metadata
- Condensed 4 multi-sentence introductory paragraphs to single-sentence short descriptions
- Fixed legacy `:_content-type:` → `:_mod-docs-content-type:` in 1 assembly
- Replaced 4 hardcoded "OpenShift Pipelines" instances with `{pipelines-shortname}` attribute

Version(s):
- pipelines-docs-1.23
- pipelines-docs-1.22
- pipelines-docs-1.21
- pipelines-jtbd

Issue: [RHDEVDOCS-7795](https://redhat.atlassian.net/browse/RHDEVDOCS-7795)

Link to docs preview:
- https://117910--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-proc-gathering-diagnostic-information.html
- https://117910--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/migrate-from-clustertask-to-cluster-resolver.html
- https://117910--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/configuring-multicluster-support.html
- https://117910--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/protecting-tekton-workloads-from-eviction-during-node-drains.html

QE review: Not required, no new content added.

Additional information: None