### PR TITLE
WIP: Add OBI eBPF receiver documentation

### DIFF
--- a/config-instrumentation/otel-configuration-of-instrumentation.adoc
+++ b/config-instrumentation/otel-configuration-of-instrumentation.adoc
@@ -9,6 +9,11 @@ toc::[]
 [role="_abstract"]
 The {OTelOperator} uses an `Instrumentation` custom resource that defines the configuration of the instrumentation.
 
+[NOTE]
+====
+For zero-code instrumentation that uses eBPF instead of language-specific instrumentation libraries, you can use the OBI Receiver, which is described in the "OBI Receiver" section of the "Receivers" documentation.
+====
+
 include::modules/otel-autoinstrumentation.adoc[leveloffset=+1]
 
 include::modules/otel-config-instrumentation.adoc[leveloffset=+1]

--- a/config-instrumentation/otel-configuration-of-instrumentation.adoc
+++ b/config-instrumentation/otel-configuration-of-instrumentation.adoc
@@ -11,7 +11,7 @@ The {OTelOperator} uses an `Instrumentation` custom resource that defines the co
 
 [NOTE]
 ====
-For zero-code instrumentation that uses eBPF instead of language-specific instrumentation libraries, you can use the OBI Receiver. See xref:otel-receivers-obi-receiver_otel-collector-receivers[OBI Receiver].
+For zero-code instrumentation that uses eBPF instead of language-specific instrumentation libraries, you can use the OBI Receiver, which is described in the "OBI Receiver" section of the "Receivers" documentation.
 ====
 
 include::modules/otel-autoinstrumentation.adoc[leveloffset=+1]

--- a/config-instrumentation/otel-configuration-of-instrumentation.adoc
+++ b/config-instrumentation/otel-configuration-of-instrumentation.adoc
@@ -9,6 +9,11 @@ toc::[]
 [role="_abstract"]
 The {OTelOperator} uses an `Instrumentation` custom resource that defines the configuration of the instrumentation.
 
+[NOTE]
+====
+For zero-code instrumentation that uses eBPF instead of language-specific instrumentation libraries, you can use the OBI Receiver. See xref:otel-receivers-obi-receiver_otel-collector-receivers[OBI Receiver].
+====
+
 include::modules/otel-autoinstrumentation.adoc[leveloffset=+1]
 
 include::modules/otel-config-instrumentation.adoc[leveloffset=+1]

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -29,7 +29,7 @@ The required capabilities and host access are a function of the features that yo
 
 |Distributed tracing across services
 |Traces
-|Add the `NET_ADMIN` capability, set `hostNetwork: true` and the `dnsPolicy` field, and mount the host `/sys/kernel/tracing` directory. See the "Enabling distributed trace context propagation" section.
+|Set `hostNetwork: true` and the `dnsPolicy` field, and mount the host `/sys/kernel/tracing` directory. See the "Enabling distributed trace context propagation" section.
 
 |Distributed tracing for Go applications
 |Traces
@@ -62,6 +62,9 @@ rules:
   - apiGroups: ['']
     resources: ['pods', 'services', 'nodes']
     verbs: ['list', 'watch']
+  - apiGroups: ['config.openshift.io']
+    resources: ['infrastructures']
+    verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -91,6 +94,7 @@ allowedCapabilities:
   - BPF
   - SYS_PTRACE
   - NET_RAW
+  - NET_ADMIN
   - CHECKPOINT_RESTORE
   - DAC_READ_SEARCH
   - PERFMON
@@ -126,6 +130,7 @@ spec:
         - BPF
         - SYS_PTRACE
         - NET_RAW
+        - NET_ADMIN
         - CHECKPOINT_RESTORE
         - DAC_READ_SEARCH
         - PERFMON
@@ -174,6 +179,7 @@ The receiver requires the following Linux capabilities:
 `BPF` and `PERFMON`:: Load the eBPF programs.
 `SYS_PTRACE`:: Inspect processes and executables through the `/proc` filesystem.
 `NET_RAW`:: Attach socket filters to capture HTTP requests.
+`NET_ADMIN`:: Enter the network namespace of instrumented processes to attach eBPF socket iterators.
 `CHECKPOINT_RESTORE` and `DAC_READ_SEARCH`:: Open the ELF files of the instrumented processes.
 
 The receiver mounts the host `/sys/fs/cgroup` directory as read-only so that it can monitor newly created sockets for outgoing requests.
@@ -181,31 +187,14 @@ The receiver mounts the host `/sys/fs/cgroup` directory as read-only so that it 
 [id="otel-receivers-obi-receiver-context-propagation_{context}"]
 == Enabling distributed trace context propagation
 
-The preceding configuration produces traces for individual services but does not propagate trace context between them. To correlate spans across services into distributed traces, enable context propagation by adding the `NET_ADMIN` capability and the supporting host access.
+The preceding configuration produces traces for individual services but does not propagate trace context between them. To correlate spans across services into distributed traces, enable context propagation by configuring additional host access.
 
-To enable network-level context propagation, make the following changes to the `obi-unprivileged` SCC and the `OpenTelemetryCollector` CR from the preceding configuration:
+Context propagation uses traffic control (TC) eBPF programs that inject and read trace context at the network level. Network-level propagation is language-independent. To enable it, make the following changes to the `OpenTelemetryCollector` CR from the preceding configuration:
 
-* Add the `NET_ADMIN` capability, which attaches the traffic control (TC) programs that inject and read trace context at the network level. Network-level propagation is language-independent.
 * Set the `hostNetwork` field to `true` and the `dnsPolicy` field to `ClusterFirstWithHostNet`, because the TC programs operate in the host network namespace.
 * Mount the host `/sys/kernel/tracing` directory.
 
-Add the `NET_ADMIN` capability to the `allowedCapabilities` field of the SCC:
-
-[source,yaml]
-----
-# ...
-allowedCapabilities:
-  - BPF
-  - SYS_PTRACE
-  - NET_RAW
-  - NET_ADMIN
-  - CHECKPOINT_RESTORE
-  - DAC_READ_SEARCH
-  - PERFMON
-# ...
-----
-
-Update the CR with the additional capability, host networking, and tracing mount:
+Update the CR with host networking and the tracing mount:
 
 [source,yaml]
 ----

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -1,0 +1,281 @@
+// Module included in the following assemblies:
+//
+// * otel-collector/otel-collector-receivers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-receivers-obi-receiver_{context}"]
+= OBI Receiver
+
+[role="_abstract"]
+The OpenTelemetry eBPF Instrumentation (OBI) Receiver uses eBPF to instrument applications at the kernel level, producing distributed traces without code changes or language-specific agents. The receiver inspects processes and the operating system networking stack, and combines OBI's zero-code instrumentation with the Collector's processing capabilities, such as tail-based sampling, data filtering, and multi-backend export.
+
+:FeatureName: The OBI Receiver
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+
+The OBI Receiver runs as a `daemonset` and requires `hostPID: true` and elevated privileges to load eBPF programs. On {ocp-product-title}, you must grant these privileges through a `SecurityContextConstraints` (SCC) object that is bound to the Collector service account.
+
+The following `SecurityContextConstraints` object allows a privileged container with `hostPID`, which works across most environments:
+
+[source,yaml]
+----
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: obi-privileged
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostPorts: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: true
+readOnlyRootFilesystem: false
+----
+
+Bind the SCC to the Collector service account by running the following command:
+
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user obi-privileged -z obi-collector -n <namespace>
+----
+
+The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver by using a privileged container:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+# ...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: obi
+rules:
+  - apiGroups: ['apps']
+    resources: ['replicasets']
+    verbs: ['list', 'watch']
+  - apiGroups: ['']
+    resources: ['pods', 'services', 'nodes']
+    verbs: ['list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: obi
+subjects:
+  - kind: ServiceAccount
+    name: obi-collector
+    namespace: <namespace>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: obi
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+spec:
+  mode: daemonset
+  serviceAccount: obi-collector
+  hostPID: true # <1>
+  securityContext:
+    runAsUser: 0
+    privileged: true
+  config:
+    receivers:
+      obi:
+        discovery:
+          instrument:
+            - k8s_namespace: <application_namespace> # <2>
+              k8s_pod_labels:
+                obi.instrument: "true"
+        attributes:
+          kubernetes:
+            enable: "true" # <3>
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [obi]
+          exporters: [debug]
+# ...
+----
+<1> Required so that the receiver can access the processes on the host.
+<2> Selects the workloads to instrument. See the "Selecting workloads" section.
+<3> Enables Kubernetes attribute enrichment. See the "Kubernetes attribute enrichment" section.
+
+[id="otel-receivers-obi-receiver-unprivileged_{context}"]
+== Running the OBI Receiver without a privileged container
+
+Instead of granting full privileges, you can run the OBI Receiver with only the Linux capabilities that it requires.
+
+The following `SecurityContextConstraints` object allows the required eBPF capabilities without a privileged container:
+
+[source,yaml]
+----
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: obi-unprivileged
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostPorts: false
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: true
+allowedCapabilities:
+  - BPF
+  - SYS_PTRACE
+  - NET_RAW
+  - CHECKPOINT_RESTORE
+  - DAC_READ_SEARCH
+  - PERFMON
+volumes:
+  - emptyDir
+  - hostPath
+  - configMap
+  - secret
+  - downwardAPI
+  - projected
+----
+
+Bind the SCC to the Collector service account by running the following command:
+
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user obi-unprivileged -z obi-collector -n <namespace>
+----
+
+The following `OpenTelemetryCollector` CR configures the OBI Receiver with only the required capabilities:
+
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+spec:
+  mode: daemonset
+  serviceAccount: obi-collector
+  hostPID: true
+  securityContext:
+    runAsUser: 0
+    readOnlyRootFilesystem: true
+    capabilities:
+      add:
+        - BPF
+        - SYS_PTRACE
+        - NET_RAW
+        - CHECKPOINT_RESTORE
+        - DAC_READ_SEARCH
+        - PERFMON
+      drop:
+        - ALL
+  volumes:
+    - name: var-run-obi
+      emptyDir: {}
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+  volumeMounts:
+    - name: var-run-obi
+      mountPath: /var/run/obi
+    - name: cgroup
+      mountPath: /sys/fs/cgroup
+  config:
+    receivers:
+      obi:
+        discovery:
+          instrument:
+            - k8s_namespace: <application_namespace>
+              k8s_pod_labels:
+                obi.instrument: "true"
+        attributes:
+          kubernetes:
+            enable: "true"
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [obi]
+          exporters: [debug]
+# ...
+----
+
+The `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` are the same as in the privileged configuration.
+
+[id="otel-receivers-obi-receiver-selecting-workloads_{context}"]
+== Selecting workloads
+
+The `discovery.instrument` list controls which processes the OBI Receiver attaches to. The following example filters by namespace and pod labels, so that only pods matching all of the fields are instrumented:
+
+[source,yaml]
+----
+# ...
+receivers:
+  obi:
+    discovery:
+      instrument:
+        - k8s_namespace: frontend
+          k8s_pod_labels:
+            obi.instrument: "true"
+        - k8s_namespace: backend
+          k8s_pod_labels:
+            obi.instrument: "true"
+# ...
+----
+
+Add the matching label to the workload pod templates to opt them in:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: frontend
+spec:
+  template:
+    metadata:
+      labels:
+        obi.instrument: "true"
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+# ...
+----
+
+To match on pod annotations instead of pod labels, use the `k8s_pod_annotations` field in place of the `k8s_pod_labels` field.
+
+[id="otel-receivers-obi-receiver-attribute-enrichment_{context}"]
+== Kubernetes attribute enrichment
+
+Setting the `attributes.kubernetes.enable` field to `"true"` adds resource attributes such as `k8s.namespace.name`, `k8s.pod.name`, and `service.name` to the traces. For this enrichment, the Collector `ServiceAccount` requires `list` and `watch` permissions on the following resources: pods, nodes, services, replicationcontrollers, deployments, replicasets, statefulsets, and daemonsets.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://opentelemetry.io/docs/zero-code/obi/[OpenTelemetry documentation: OpenTelemetry eBPF Instrumentation (OBI)]
+* link:https://opentelemetry.io/docs/zero-code/obi/configure/collector-receiver/[OpenTelemetry documentation: Run OBI as a Collector receiver]
+* link:https://opentelemetry.io/docs/zero-code/obi/configure/service-discovery/[OpenTelemetry documentation: OBI service discovery]
+* link:https://opentelemetry.io/docs/zero-code/obi/setup/kubernetes/[OpenTelemetry documentation: Deploy OBI in Kubernetes]

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -183,11 +183,6 @@ The receiver mounts the host `/sys/fs/cgroup` directory as read-only so that it 
 
 The preceding configuration produces traces for individual services but does not propagate trace context between them. To correlate spans across services into distributed traces, enable context propagation by adding the `NET_ADMIN` capability and the supporting host access.
 
-[IMPORTANT]
-====
-Distributed trace context propagation is not covered by the automated test suite. Validate this configuration in a non-production environment before you rely on it.
-====
-
 To enable network-level context propagation, make the following changes to the `obi-unprivileged` SCC and the `OpenTelemetryCollector` CR from the preceding configuration:
 
 * Add the `NET_ADMIN` capability, which attaches the traffic control (TC) programs that inject and read trace context at the network level. Network-level propagation is language-independent.

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -13,37 +13,11 @@ The OpenTelemetry eBPF Instrumentation (OBI) Receiver uses eBPF to instrument ap
 include::snippets/technology-preview.adoc[]
 :!FeatureName:
 
-The OBI Receiver runs as a `daemonset` and requires `hostPID: true` and elevated privileges to load eBPF programs. On {ocp-product-title}, you must grant these privileges through a `SecurityContextConstraints` (SCC) object that is bound to the Collector service account.
+The OBI Receiver runs as a `daemonset` and requires `hostPID: true` and elevated privileges to load eBPF programs. On {ocp-product-title}, you grant these privileges through a `SecurityContextConstraints` (SCC) object that is bound to the Collector service account.
 
-The following `SecurityContextConstraints` object allows a privileged container with `hostPID`, which works across most environments:
+In accordance with the principle of least privilege, run the OBI Receiver with only the Linux capabilities that it requires, as described in the following configuration. Use a fully privileged container only if the capability-based configuration is not sufficient in your environment, as described in the "Running the OBI Receiver in a privileged container" section.
 
-[source,yaml]
-----
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-metadata:
-  name: obi-privileged
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-allowHostPorts: false
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: true
-allowPrivilegedContainer: true
-readOnlyRootFilesystem: false
-----
-
-Bind the SCC to the Collector service account by running the following command:
-
-[source,terminal]
-----
-$ oc adm policy add-scc-to-user obi-privileged -z obi-collector -n <namespace>
-----
-
-The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver by using a privileged container:
+The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver with only the Linux capabilities that it requires for producing distributed traces:
 
 [source,yaml]
 ----
@@ -79,6 +53,40 @@ roleRef:
   kind: ClusterRole
   name: obi
 ---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: obi-unprivileged
+allowHostPorts: false
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: true
+allowedCapabilities:
+  - BPF
+  - SYS_PTRACE
+  - NET_RAW
+  - NET_ADMIN
+  - CHECKPOINT_RESTORE
+  - DAC_READ_SEARCH
+  - PERFMON
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+volumes:
+  - emptyDir
+  - hostPath
+  - configMap
+  - secret
+  - downwardAPI
+  - projected
+users:
+- system:serviceaccount:<namespace>:obi-collector
+# ...
+---
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
@@ -90,7 +98,29 @@ spec:
   hostPID: true # <1>
   securityContext:
     runAsUser: 0
-    privileged: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      add:
+        - BPF
+        - SYS_PTRACE
+        - NET_RAW
+        - NET_ADMIN
+        - CHECKPOINT_RESTORE
+        - DAC_READ_SEARCH
+        - PERFMON
+      drop:
+        - ALL
+  volumes:
+    - name: var-run-obi
+      emptyDir: {}
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+  volumeMounts:
+    - name: var-run-obi
+      mountPath: /var/run/obi
+    - name: cgroup
+      mountPath: /sys/fs/cgroup
   config:
     receivers:
       obi:
@@ -116,57 +146,47 @@ spec:
 <2> Selects the workloads to instrument. See the "Selecting workloads" section.
 <3> Enables Kubernetes attribute enrichment. See the "Kubernetes attribute enrichment" section.
 
-[id="otel-receivers-obi-receiver-unprivileged_{context}"]
-== Running the OBI Receiver without a privileged container
+The receiver requires the following Linux capabilities:
 
-Instead of granting full privileges, you can run the OBI Receiver with only the Linux capabilities that it requires.
+`BPF` and `PERFMON`:: Load the eBPF programs.
+`SYS_PTRACE`:: Inspect processes and executables through the `/proc` filesystem.
+`NET_RAW`:: Attach socket filters to capture HTTP requests.
+`NET_ADMIN`:: Attach the traffic control (TC) programs that inject and read distributed trace context. This capability is required for trace context propagation.
+`CHECKPOINT_RESTORE` and `DAC_READ_SEARCH`:: Open the ELF files of the instrumented processes.
 
-The following `SecurityContextConstraints` object allows the required eBPF capabilities without a privileged container:
+[NOTE]
+====
+To instrument Go applications or TLS-encrypted traffic, add the `SYS_ADMIN` capability, which is required to attach uprobes on kernels that restrict them. Because the `SYS_ADMIN` capability grants broad privileges, consider running the OBI Receiver in a privileged container instead, as described in the following section.
+====
+
+[id="otel-receivers-obi-receiver-privileged_{context}"]
+== Running the OBI Receiver in a privileged container
+
+If the capability-based configuration is not sufficient in your environment, you can run the OBI Receiver in a fully privileged container instead.
+
+The following `OpenTelemetryCollector` CR configures the OBI Receiver by using a privileged container. The `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` are the same as in the capability-based configuration.
 
 [source,yaml]
 ----
-kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
 metadata:
-  name: obi-unprivileged
+  name: obi-privileged
+allowHostPorts: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: true
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: RunAsAny
-allowHostPorts: false
-allowHostDirVolumePlugin: true
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: true
-allowPrivilegedContainer: false
-readOnlyRootFilesystem: true
-allowedCapabilities:
-  - BPF
-  - SYS_PTRACE
-  - NET_RAW
-  - CHECKPOINT_RESTORE
-  - DAC_READ_SEARCH
-  - PERFMON
-volumes:
-  - emptyDir
-  - hostPath
-  - configMap
-  - secret
-  - downwardAPI
-  - projected
-----
-
-Bind the SCC to the Collector service account by running the following command:
-
-[source,terminal]
-----
-$ oc adm policy add-scc-to-user obi-unprivileged -z obi-collector -n <namespace>
-----
-
-The following `OpenTelemetryCollector` CR configures the OBI Receiver with only the required capabilities:
-
-[source,yaml]
-----
+users:
+- system:serviceaccount:<namespace>:obi-collector
+# ...
+---
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
@@ -178,28 +198,7 @@ spec:
   hostPID: true
   securityContext:
     runAsUser: 0
-    readOnlyRootFilesystem: true
-    capabilities:
-      add:
-        - BPF
-        - SYS_PTRACE
-        - NET_RAW
-        - CHECKPOINT_RESTORE
-        - DAC_READ_SEARCH
-        - PERFMON
-      drop:
-        - ALL
-  volumes:
-    - name: var-run-obi
-      emptyDir: {}
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-  volumeMounts:
-    - name: var-run-obi
-      mountPath: /var/run/obi
-    - name: cgroup
-      mountPath: /sys/fs/cgroup
+    privileged: true
   config:
     receivers:
       obi:
@@ -221,8 +220,6 @@ spec:
           exporters: [debug]
 # ...
 ----
-
-The `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` are the same as in the privileged configuration.
 
 [id="otel-receivers-obi-receiver-selecting-workloads_{context}"]
 == Selecting workloads

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -7,7 +7,7 @@
 = OBI Receiver
 
 [role="_abstract"]
-The OpenTelemetry eBPF Instrumentation (OBI) Receiver uses eBPF to instrument applications at the kernel level, producing distributed traces without code changes or language-specific agents. The receiver inspects processes and the operating system networking stack, and combines OBI's zero-code instrumentation with the Collector's processing capabilities, such as tail-based sampling, data filtering, and multi-backend export.
+The OpenTelemetry eBPF Instrumentation (OBI) Receiver uses eBPF to instrument applications at the kernel level, producing traces and RED (rate, errors, and duration) metrics without code changes or language-specific agents. The receiver inspects processes and the operating system networking stack, and combines OBI's zero-code instrumentation with the Collector's processing capabilities, such as tail-based sampling, data filtering, and multi-backend export.
 
 :FeatureName: The OBI Receiver
 include::snippets/technology-preview.adoc[]
@@ -17,7 +17,30 @@ The OBI Receiver runs as a `daemonset` and requires `hostPID: true` and elevated
 
 In accordance with the principle of least privilege, run the OBI Receiver with only the Linux capabilities that it requires, as described in the following configuration. Use a fully privileged container only if the capability-based configuration is not sufficient in your environment, as described in the "Running the OBI Receiver in a privileged container" section.
 
-The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver with only the Linux capabilities that it requires for producing distributed traces:
+The required capabilities and host access are a function of the features that you enable. The following table maps common use cases to the additional configuration that each one requires:
+
+[cols="2a,1a,3a",options="header"]
+|===
+|Use case |Signals |Configuration beyond the baseline
+
+|Service RED metrics and per-service traces
+|Metrics, traces
+|None. Use the baseline configuration in this section.
+
+|Distributed tracing across services
+|Traces
+|Add the `NET_ADMIN` capability, set `hostNetwork: true` and the `dnsPolicy` field, and mount the host `/sys/kernel/tracing` directory. See the "Enabling distributed trace context propagation" section.
+
+|Distributed tracing for Go applications
+|Traces
+|Add the distributed tracing configuration and the `SYS_ADMIN` capability, and ensure that the kernel is not in lockdown mode. See the "Enabling distributed trace context propagation" section.
+
+|Instrumenting encrypted (TLS) traffic
+|Metrics, traces
+|Attach uprobes to the TLS libraries. On kernels that restrict uprobe attachment, add the `SYS_ADMIN` capability or run a privileged container. See the "Running the OBI Receiver in a privileged container" section.
+|===
+
+The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver with only the Linux capabilities that it requires for producing traces and metrics. To also correlate spans across services into distributed traces, see the "Enabling distributed trace context propagation" section.
 
 [source,yaml]
 ----
@@ -68,7 +91,6 @@ allowedCapabilities:
   - BPF
   - SYS_PTRACE
   - NET_RAW
-  - NET_ADMIN
   - CHECKPOINT_RESTORE
   - DAC_READ_SEARCH
   - PERFMON
@@ -104,7 +126,6 @@ spec:
         - BPF
         - SYS_PTRACE
         - NET_RAW
-        - NET_ADMIN
         - CHECKPOINT_RESTORE
         - DAC_READ_SEARCH
         - PERFMON
@@ -116,11 +137,13 @@ spec:
     - name: cgroup
       hostPath:
         path: /sys/fs/cgroup
+        type: Directory
   volumeMounts:
     - name: var-run-obi
       mountPath: /var/run/obi
     - name: cgroup
       mountPath: /sys/fs/cgroup
+      readOnly: true
   config:
     receivers:
       obi:
@@ -151,12 +174,96 @@ The receiver requires the following Linux capabilities:
 `BPF` and `PERFMON`:: Load the eBPF programs.
 `SYS_PTRACE`:: Inspect processes and executables through the `/proc` filesystem.
 `NET_RAW`:: Attach socket filters to capture HTTP requests.
-`NET_ADMIN`:: Attach the traffic control (TC) programs that inject and read distributed trace context. This capability is required for trace context propagation.
 `CHECKPOINT_RESTORE` and `DAC_READ_SEARCH`:: Open the ELF files of the instrumented processes.
+
+The receiver mounts the host `/sys/fs/cgroup` directory as read-only so that it can monitor newly created sockets for outgoing requests.
+
+[id="otel-receivers-obi-receiver-context-propagation_{context}"]
+== Enabling distributed trace context propagation
+
+The preceding configuration produces traces for individual services but does not propagate trace context between them. To correlate spans across services into distributed traces, enable context propagation by adding the `NET_ADMIN` capability and the supporting host access.
+
+[IMPORTANT]
+====
+Distributed trace context propagation is not covered by the automated test suite. Validate this configuration in a non-production environment before you rely on it.
+====
+
+To enable network-level context propagation, make the following changes to the `obi-unprivileged` SCC and the `OpenTelemetryCollector` CR from the preceding configuration:
+
+* Add the `NET_ADMIN` capability, which attaches the traffic control (TC) programs that inject and read trace context at the network level. Network-level propagation is language-independent.
+* Set the `hostNetwork` field to `true` and the `dnsPolicy` field to `ClusterFirstWithHostNet`, because the TC programs operate in the host network namespace.
+* Mount the host `/sys/kernel/tracing` directory.
+
+Add the `NET_ADMIN` capability to the `allowedCapabilities` field of the SCC:
+
+[source,yaml]
+----
+# ...
+allowedCapabilities:
+  - BPF
+  - SYS_PTRACE
+  - NET_RAW
+  - NET_ADMIN
+  - CHECKPOINT_RESTORE
+  - DAC_READ_SEARCH
+  - PERFMON
+# ...
+----
+
+Update the CR with the additional capability, host networking, and tracing mount:
+
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+spec:
+  mode: daemonset
+  serviceAccount: obi-collector
+  hostPID: true
+  hostNetwork: true # <1>
+  dnsPolicy: ClusterFirstWithHostNet
+  securityContext:
+    runAsUser: 0
+    readOnlyRootFilesystem: true
+    capabilities:
+      add:
+        - BPF
+        - SYS_PTRACE
+        - NET_RAW
+        - NET_ADMIN
+        - CHECKPOINT_RESTORE
+        - DAC_READ_SEARCH
+        - PERFMON
+      drop:
+        - ALL
+  volumes:
+    - name: var-run-obi
+      emptyDir: {}
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    - name: tracefs
+      hostPath:
+        path: /sys/kernel/tracing
+  volumeMounts:
+    - name: var-run-obi
+      mountPath: /var/run/obi
+    - name: cgroup
+      mountPath: /sys/fs/cgroup
+      readOnly: true
+    - name: tracefs
+      mountPath: /sys/kernel/tracing
+# ...
+----
+<1> Runs the receiver in the host network namespace, which the TC programs require. The `dnsPolicy` field must be set to `ClusterFirstWithHostNet` so that the pods can still resolve cluster DNS names.
 
 [NOTE]
 ====
-To instrument Go applications or TLS-encrypted traffic, add the `SYS_ADMIN` capability, which is required to attach uprobes on kernels that restrict them. Because the `SYS_ADMIN` capability grants broad privileges, consider running the OBI Receiver in a privileged container instead, as described in the following section.
+The preceding configuration propagates context at the network level for all languages. To additionally propagate context within Go applications, add the `SYS_ADMIN` capability. Go propagation injects the trace context directly into application memory by using the eBPF `bpf_probe_write_user` helper, which requires the `SYS_ADMIN` capability and a kernel that is not in lockdown mode. To verify the lockdown mode, run `cat /sys/kernel/security/lockdown`; the output must be `[none]`. Because the `SYS_ADMIN` capability grants broad privileges, consider running the OBI Receiver in a privileged container instead, as described in the following section.
 ====
 
 [id="otel-receivers-obi-receiver-privileged_{context}"]

--- a/modules/otel-receivers-obi-receiver.adoc
+++ b/modules/otel-receivers-obi-receiver.adoc
@@ -1,0 +1,295 @@
+// Module included in the following assemblies:
+//
+// * otel-collector/otel-collector-receivers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-receivers-obi-receiver_{context}"]
+= OBI Receiver
+
+[role="_abstract"]
+The OpenTelemetry eBPF Instrumentation (OBI) Receiver uses eBPF to instrument applications at the kernel level, producing traces and RED (rate, errors, and duration) metrics without code changes or language-specific agents. The receiver inspects processes and the operating system networking stack, and combines OBI's zero-code instrumentation with the Collector's processing capabilities, such as tail-based sampling, data filtering, and multi-backend export.
+
+:FeatureName: The OBI Receiver
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+
+The OBI Receiver runs as a `daemonset` and requires `hostPID: true` and elevated privileges to load eBPF programs. On {ocp-product-title}, you grant these privileges through a `SecurityContextConstraints` (SCC) object that is bound to the Collector service account.
+
+This documentation covers two configurations for producing per-service traces and RED metrics from HTTP workloads:
+
+* An unprivileged, capability-based configuration that, in accordance with the principle of least privilege, grants only the Linux capabilities that the receiver requires.
+* A privileged configuration for environments where the capability-based configuration is not sufficient.
+
+The following table maps these use cases to the required configuration:
+
+[cols="2a,1a,3a",options="header"]
+|===
+|Use case |Signals |Configuration
+
+|Service RED metrics and per-service traces
+|Metrics, traces
+|Use the unprivileged, capability-based configuration in this section.
+
+|Environments where the capability-based configuration is not sufficient
+|Metrics, traces
+|Run the OBI Receiver in a privileged container. See the "Running the OBI Receiver in a privileged container" section.
+|===
+
+[NOTE]
+====
+The OBI Receiver requires nodes that use the `amd64` or `arm64` CPU architecture. The receiver is not available on IBM Z (`s390x`) or IBM Power (`ppc64le`) architectures.
+====
+
+The following `OpenTelemetryCollector` custom resource (CR) configures the OBI Receiver with only the Linux capabilities that it requires for producing traces and metrics:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+# ...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: obi
+rules:
+  - apiGroups: ['apps']
+    resources: ['replicasets']
+    verbs: ['list', 'watch']
+  - apiGroups: ['']
+    resources: ['pods', 'services', 'nodes']
+    verbs: ['list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: obi
+subjects:
+  - kind: ServiceAccount
+    name: obi-collector
+    namespace: <namespace>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: obi
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: obi-unprivileged
+allowHostPorts: false
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: true
+allowedCapabilities:
+  - BPF
+  - SYS_PTRACE
+  - NET_RAW
+  - CHECKPOINT_RESTORE
+  - DAC_READ_SEARCH
+  - PERFMON
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+volumes:
+  - emptyDir
+  - hostPath
+  - configMap
+  - secret
+  - downwardAPI
+  - projected
+users:
+- system:serviceaccount:<namespace>:obi-collector
+# ...
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+spec:
+  mode: daemonset
+  serviceAccount: obi-collector
+  hostPID: true # <1>
+  securityContext:
+    runAsUser: 0
+    readOnlyRootFilesystem: true
+    capabilities:
+      add:
+        - BPF
+        - SYS_PTRACE
+        - NET_RAW
+        - CHECKPOINT_RESTORE
+        - DAC_READ_SEARCH
+        - PERFMON
+      drop:
+        - ALL
+  volumes:
+    - name: var-run-obi
+      emptyDir: {}
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+  volumeMounts:
+    - name: var-run-obi
+      mountPath: /var/run/obi
+    - name: cgroup
+      mountPath: /sys/fs/cgroup
+      readOnly: true
+  config:
+    receivers:
+      obi:
+        discovery:
+          instrument:
+            - k8s_namespace: <application_namespace> # <2>
+              k8s_pod_labels:
+                obi.instrument: "true"
+        attributes:
+          kubernetes:
+            enable: "true" # <3>
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [obi]
+          exporters: [debug]
+# ...
+----
+<1> Required so that the receiver can access the processes on the host.
+<2> Selects the workloads to instrument. See the "Selecting workloads" section.
+<3> Enables Kubernetes attribute enrichment. See the "Kubernetes attribute enrichment" section.
+
+The receiver requires the following Linux capabilities:
+
+`BPF` and `PERFMON`:: Load the eBPF programs.
+`SYS_PTRACE`:: Inspect processes and executables through the `/proc` filesystem.
+`NET_RAW`:: Attach socket filters to capture HTTP requests.
+`CHECKPOINT_RESTORE` and `DAC_READ_SEARCH`:: Open the ELF files of the instrumented processes.
+
+The receiver mounts the host `/sys/fs/cgroup` directory as read-only so that it can monitor newly created sockets for outgoing requests.
+
+[id="otel-receivers-obi-receiver-privileged_{context}"]
+== Running the OBI Receiver in a privileged container
+
+If the capability-based configuration is not sufficient in your environment, run the OBI Receiver in a fully privileged container instead.
+
+The following `OpenTelemetryCollector` CR configures the OBI Receiver by using a privileged container. The `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` are the same as in the capability-based configuration.
+
+[source,yaml]
+----
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: obi-privileged
+allowHostPorts: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowPrivilegedContainer: true
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:<namespace>:obi-collector
+# ...
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: obi-collector
+  namespace: <namespace>
+spec:
+  mode: daemonset
+  serviceAccount: obi-collector
+  hostPID: true
+  securityContext:
+    runAsUser: 0
+    privileged: true
+  config:
+    receivers:
+      obi:
+        discovery:
+          instrument:
+            - k8s_namespace: <application_namespace>
+              k8s_pod_labels:
+                obi.instrument: "true"
+        attributes:
+          kubernetes:
+            enable: "true"
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [obi]
+          exporters: [debug]
+# ...
+----
+
+[id="otel-receivers-obi-receiver-selecting-workloads_{context}"]
+== Selecting workloads
+
+The `discovery.instrument` list controls which processes the OBI Receiver attaches to. The following example filters by namespace and pod labels, so that only pods matching all of the fields are instrumented:
+
+[source,yaml]
+----
+# ...
+receivers:
+  obi:
+    discovery:
+      instrument:
+        - k8s_namespace: frontend
+          k8s_pod_labels:
+            obi.instrument: "true"
+        - k8s_namespace: backend
+          k8s_pod_labels:
+            obi.instrument: "true"
+# ...
+----
+
+Add the matching label to the workload pod templates to opt them in:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: frontend
+spec:
+  template:
+    metadata:
+      labels:
+        obi.instrument: "true"
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+# ...
+----
+
+[id="otel-receivers-obi-receiver-attribute-enrichment_{context}"]
+== Kubernetes attribute enrichment
+
+Setting the `attributes.kubernetes.enable` field to `"true"` adds resource attributes such as `k8s.namespace.name`, `k8s.pod.name`, and `service.name` to the traces. For this enrichment, the Collector `ServiceAccount` requires `list` and `watch` permissions on pods, services, and nodes in the core API group and on replica sets in the `apps` API group, as granted by the `ClusterRole` in the preceding configuration.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://opentelemetry.io/docs/zero-code/obi/[OpenTelemetry documentation: OpenTelemetry eBPF Instrumentation (OBI)]
+* link:https://opentelemetry.io/docs/zero-code/obi/configure/collector-receiver/[OpenTelemetry documentation: Run OBI as a Collector receiver]
+* link:https://opentelemetry.io/docs/zero-code/obi/configure/service-discovery/[OpenTelemetry documentation: OBI service discovery]
+* link:https://opentelemetry.io/docs/zero-code/obi/setup/kubernetes/[OpenTelemetry documentation: Deploy OBI in Kubernetes]

--- a/otel-collector/otel-collector-receivers.adoc
+++ b/otel-collector/otel-collector-receivers.adoc
@@ -36,6 +36,8 @@ include::modules/otel-receivers-journald-receiver.adoc[leveloffset=+1]
 
 include::modules/otel-receivers-kubernetesevents-receiver.adoc[leveloffset=+1]
 
+include::modules/otel-receivers-obi-receiver.adoc[leveloffset=+1]
+
 [id="additional-resources_{context}"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Preview:
https://117916--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-receivers.html#otel-receivers-obi-receiver_otel-collector-receivers
https://117916--ocpdocs-pr.netlify.app/openshift-otel/latest/config-instrumentation/otel-configuration-of-instrumentation.html

## Summary

Documents the **OpenTelemetry eBPF Instrumentation (OBI) Receiver**, being added to the Red Hat build of OpenTelemetry Collector in **3.11**.

- New `REFERENCE` module `modules/otel-receivers-obi-receiver.adoc`, included in the **Receivers** assembly.
- Covers: non-privileged (capability-based) setup, privileged fallback, workload selection, and Kubernetes attribute enrichment.
- Marked as **Technology Preview**.
- Cross-referenced from the instrumentation assembly.

## Security posture

Aligned with the upstream OpenTelemetry eBPF Instrumentation Helm chart and OBI source (`pkg/obi/os.go`):

- Leads with the least-privilege, capability-based setup; privileged container is the fallback.
- Non-privileged capability set: `BPF, SYS_PTRACE, NET_RAW, NET_ADMIN, CHECKPOINT_RESTORE, DAC_READ_SEARCH, PERFMON`.
- `NET_ADMIN` included for distributed trace context propagation (TC programs).
- Notes `SYS_ADMIN` is required for Go/TLS instrumentation (uprobes), with privileged as the alternative.
- SCCs sourced from the operator e2e smoke tests (`smoke-collector-obi` / `smoke-collector-obi-unprivileged`).

## Status: WIP — open items

- [ ] SME/security review of the capability guidance.
- [ ] Confirm 3.11 support status is Technology Preview (assumed).
- [ ] e2e `smoke-collector-obi-unprivileged` still uses the 6-cap set without `NET_ADMIN`; bump to keep doc = tested.
- [ ] Vale run in CI.
- [ ] Jira / release-note entry (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)