### PR TITLE
[RHDEVDOCS-7795] Fix DITA metadata issues for AEM migration readiness

### DIFF
--- a/modules/op-about-must-gather.adoc
+++ b/modules/op-about-must-gather.adoc
@@ -2,6 +2,7 @@
 [id="op-about-must-gather_{context}"]
 = About the must-gather tool
 
+[role="_abstract"]
 The `oc adm must-gather` tool collects diagnostic information about your cluster, such as resource definitions, configurations, and logs for project-level and cluster-level resources. 
 
 When you run the command, the tool performs the following actions:

--- a/modules/op-collecting-pipelines-debugging-data.adoc
+++ b/modules/op-collecting-pipelines-debugging-data.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="op-collecting-pipelines-debugging-data_{context}"]
-= Collecting OpenShift Pipelines debugging data
+= Collecting {pipelines-shortname} debugging data
 
-You can use the `oc adm must-gather` CLI command to collect detailed diagnostic data and logs for OpenShift Pipelines components on your cluster.
+[role="_abstract"]
+You can use the `oc adm must-gather` CLI command to collect detailed diagnostic data and logs for {pipelines-shortname} components on your cluster.
 
 .Prerequisites
 

--- a/modules/op-configuring-hub-cluster-multicluster.adoc
+++ b/modules/op-configuring-hub-cluster-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-configuring-hub-cluster-multicluster_{context}"]
 = Configuring the hub cluster for multicluster
 
+[role="_abstract"]
 You can configure an {product-title} cluster as a hub cluster to manage and schedule pipeline runs across multiple spoke clusters.
 
 .Prerequisites

--- a/modules/op-configuring-spoke-clusters-multicluster.adoc
+++ b/modules/op-configuring-spoke-clusters-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-configuring-spoke-clusters-multicluster_{context}"]
 = Configuring spoke clusters for multicluster
 
+[role="_abstract"]
 You can configure {product-title} clusters as spoke clusters to execute pipeline runs scheduled from a hub cluster.
 
 .Prerequisites

--- a/modules/op-creating-pipeline-runs-multicluster.adoc
+++ b/modules/op-creating-pipeline-runs-multicluster.adoc
@@ -6,6 +6,7 @@
 [id="op-creating-pipeline-runs-multicluster_{context}"]
 = Creating pipeline runs in a multicluster environment
 
+[role="_abstract"]
 After you configure multicluster support, you can create pipeline runs on the hub cluster that are automatically scheduled and executed on spoke clusters.
 
 .Prerequisites

--- a/modules/op-verifying-multicluster-setup.adoc
+++ b/modules/op-verifying-multicluster-setup.adoc
@@ -6,6 +6,7 @@
 [id="op-verifying-multicluster-setup_{context}"]
 = Verifying multicluster setup
 
+[role="_abstract"]
 You can verify that your multicluster configuration is working correctly by checking the status of Kueue resources on the hub cluster.
 
 .Prerequisites

--- a/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
+++ b/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="protecting-tekton-workloads-from-eviction-during-node-drains"]
 = Protecting Tekton workload pods from eviction during node drains


### PR DESCRIPTION
## Summary
- Cherry-pick of #117910 to `pipelines-docs-1.23`
- Fixes DITA metadata issues for AEM migration readiness
- Resolved conflicts by removing five files deleted in 1.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)