### PR TITLE
Use fully qualified OLM API when deleting AWS Load Balancer Operator subscription

### DIFF
--- a/modules/albo-deleting.adoc
+++ b/modules/albo-deleting.adoc
@@ -13,7 +13,7 @@ If you no longer need to use the AWS Load Balancer Operator, you can remove the 
 +
 [source,terminal]
 ----
-$ oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
+$ oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
 ----
 
 . Detach and delete the relevant AWS IAM roles:


### PR DESCRIPTION
## Summary

Updates the AWS Load Balancer Operator CLI procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking_operators/aws-load-balancer#aws-load-balancer-operator-deleting_aws-load-balancer-operator

## Problem

The procedure currently uses:

```shell
oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
```

## Files changed

- `modules/albo-deleting.adoc`

## Test plan

- [ ] Verify docs preview renders the updated command (albo-deleting)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`Subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)

