### PR TITLE
Use fully qualified OLM API when deleting AWS LB Operator subscription in tutorial cleanup

### DIFF
--- a/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
@@ -21,7 +21,7 @@ $ oc delete project hello-world
 +
 [source,terminal]
 ----
-$ oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
+$ oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
 $ aws iam detach-role-policy \
   --role-name "${ROSA_CLUSTER_NAME}-alb-operator" \
   --policy-arn $POLICY_ARN


### PR DESCRIPTION
## Summary

Updates the AWS Load Balancer Operator (cloud experts tutorial cleanup) CLI procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/tutorials/cloud-experts-aws-load-balancer-operator#cloud-experts-aws-load-balancer-operator-cleanup_cloud-experts-aws-load-balancer-operator

## Problem

The procedure currently uses:

```shell
oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
```

## Files changed

- `modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc`

## Test plan

- [ ] Verify docs preview renders the updated command (cloud-experts-aws-load-balancer-operator-cleanup)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`Subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)

