### PR TITLE
Use fully qualified OLM API for DAS Operator subscription CLI commands

### DIFF
--- a/modules/das-operator-uninstalling-cli.adoc
+++ b/modules/das-operator-uninstalling-cli.adoc
@@ -34,7 +34,7 @@ das-operator   das-operator   redhat-operators   stable
 +
 [source,terminal]
 ----
-$ oc delete subscription das-operator -n das-operator
+$ oc delete subscriptions.operators.coreos.com das-operator -n das-operator
 ----
 
 . List and delete the cluster service version (CSV) by running the following commands:

--- a/modules/das-operator-uninstalling-cli.adoc
+++ b/modules/das-operator-uninstalling-cli.adoc
@@ -20,7 +20,7 @@ You can uninstall the Dynamic Accelerator Slicer (DAS) Operator using the OpenSh
 +
 [source,terminal]
 ----
-$ oc get subscriptions -n das-operator
+$ oc get subscriptions.operators.coreos.com -n das-operator
 ----
 +
 .Example output


### PR DESCRIPTION
## Summary

Updates the Dynamic Accelerator Slicer (DAS) Operator CLI procedure to use the fully qualified OLM resource type `subscriptions.operators.coreos.com` for subscription get and delete commands.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator#das-operator-uninstalling-cli_das-about-dynamic-accelerator-slicer-operator

## Problem

The procedure currently uses short-form subscription commands:

```shell
$ oc get subscriptions -n das-operator
$ oc delete subscription das-operator -n das-operator
```

On clusters where multiple operators expose a resource named `subscription`, short forms such as `oc get subscription` and `oc delete subscription` are ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, these commands may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
$ oc get subscriptions.operators.coreos.com -n das-operator
$ oc delete subscriptions.operators.coreos.com das-operator -n das-operator
```

## Files changed

- `modules/das-operator-uninstalling-cli.adoc`

## Test plan

- [ ] Verify docs preview renders the updated commands (das-operator-uninstalling-cli)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`subscriptions`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)
