### PR TITLE
Use fully qualified OLM API for External Secrets Operator subscription CLI commands

### DIFF
--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -29,7 +29,7 @@ $ oc get subscription -n <operator_namespace> | grep external-secrets
 +
 [source,terminal]
 ----
-$ oc delete subscription <subscription_name> -n <operator_namespace>
+$ oc delete subscriptions.operators.coreos.com <subscription_name> -n <operator_namespace>
 ----
 
 . Delete the `ClusterServiceVersion` by running the following command:

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -22,7 +22,7 @@ Remove the community {external-secrets-operator-short} that was installed by an 
 +
 [source,terminal]
 ----
-$ oc get subscription -n <operator_namespace> | grep external-secrets
+$ oc get subscriptions.operators.coreos.com -n <operator_namespace> | grep external-secrets
 ----
 
 . Delete the subscription by running the following command:


### PR DESCRIPTION
## Summary

Updates the External Secrets Operator CLI procedure to use the fully qualified OLM resource type `subscriptions.operators.coreos.com` for subscription get and delete commands.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift#external-secrets-operator-uninstall-olm_external-secrets-operator-migrate-downstream-upstream

## Problem

The procedure currently uses short-form subscription commands:

```shell
$ oc get subscription -n <operator_namespace> | grep external-secrets
$ oc delete subscription <subscription_name> -n <operator_namespace>
```

On clusters where multiple operators expose a resource named `subscription`, short forms such as `oc get subscription` and `oc delete subscription` are ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, these commands may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
$ oc get subscriptions.operators.coreos.com -n <operator_namespace> | grep external-secrets
$ oc delete subscriptions.operators.coreos.com <subscription_name> -n <operator_namespace>
```

## Files changed

- `modules/external-secrets-operator-uninstall-olm.adoc`

## Test plan

- [ ] Verify docs preview renders the updated commands (external-secrets-operator-uninstall-olm)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`subscriptions`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)
