### PR TITLE
Use fully qualified OLM API when deleting Kubernetes NMState Operator subscription

### DIFF
--- a/modules/k8s-nmstate-uninstall-operator.adoc
+++ b/modules/k8s-nmstate-uninstall-operator.adoc
@@ -27,7 +27,7 @@ If you need to reinstall the Kubernetes NMState Operator, see "Installing the Ku
 +
 [source,terminal]
 ----
-$ oc delete --namespace openshift-nmstate subscription kubernetes-nmstate-operator
+$ oc delete --namespace openshift-nmstate subscriptions.operators.coreos.com kubernetes-nmstate-operator
 ----
 
 . Find the `ClusterServiceVersion` (CSV) resource that associates with the Kubernetes NMState Operator:


### PR DESCRIPTION
## Summary

Updates the Kubernetes NMState Operator CLI procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator#k8s-nmstate-uninstall-operator_k8s-nmstate-about-the-k8s-nmstate-operator

## Problem

The procedure currently uses:

```shell
oc delete --namespace openshift-nmstate subscription kubernetes-nmstate-operator
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
oc delete --namespace openshift-nmstate subscriptions.operators.coreos.com kubernetes-nmstate-operator
```

## Files changed

- `modules/k8s-nmstate-uninstall-operator.adoc`

## Test plan

- [ ] Verify docs preview renders the updated command (k8s-nmstate-uninstall-operator)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`Subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)

