### PR TITLE
Use fully qualified OLM API when deleting DPU Operator subscription

### DIFF
--- a/modules/nw-dpu-operator-uninstall.adoc
+++ b/modules/nw-dpu-operator-uninstall.adoc
@@ -29,7 +29,7 @@ $ oc delete DpuOperatorConfig dpu-operator-config
 +
 [source,terminal]
 ----
-$ oc delete Subscription openshift-dpu-operator-subscription -n openshift-dpu-operator
+$ oc delete subscriptions.operators.coreos.com openshift-dpu-operator-subscription -n openshift-dpu-operator
 ----
 
 . Remove the `OperatorGroup` resource that was created by running the following command:


### PR DESCRIPTION
## Summary

Updates the DPU Operator CLI procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/networking_operators/dpu-operator-1#nw-dpu-operator-uninstall_dpu-operator

## Problem

The procedure currently uses:

```shell
oc delete Subscription openshift-dpu-operator-subscription -n openshift-dpu-operator
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
oc delete subscriptions.operators.coreos.com openshift-dpu-operator-subscription -n openshift-dpu-operator
```

## Files changed

- `modules/nw-dpu-operator-uninstall.adoc`

## Test plan

- [ ] Verify docs preview renders the updated command (nw-dpu-operator-uninstall)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`Subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)

