### PR TITLE
Use fully qualified OLM API when deleting Operator subscription during OLM refresh

### DIFF
--- a/modules/olm-refresh-subs.adoc
+++ b/modules/olm-refresh-subs.adoc
@@ -53,7 +53,7 @@ clusterserviceversion.operators.coreos.com/elasticsearch-operator.5.0.0-65   Ope
 +
 [source,terminal]
 ----
-$ oc delete subscription <subscription_name> -n <namespace>
+$ oc delete subscriptions.operators.coreos.com <subscription_name> -n <namespace>
 ----
 
 . Delete the cluster service version:


### PR DESCRIPTION
## Summary

Updates the Operator Lifecycle Manager (OLM) subscription refresh CLI procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/operators/administrator-tasks#olm-refresh-subs_olm-deleting-operators-from-a-cluster

## Problem

The procedure currently uses:

```shell
oc delete subscription <subscription_name> -n <namespace>
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
oc delete subscriptions.operators.coreos.com <subscription_name> -n <namespace>
```

## Files changed

- `modules/olm-refresh-subs.adoc`

## Test plan

- [ ] Verify docs preview renders the updated command (olm-refresh-subs)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`Subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)

