### PR TITLE
Use fully qualified OLM API for OpenShift Update Service subscription CLI commands

### DIFF
--- a/modules/update-service-uninstall-cli.adoc
+++ b/modules/update-service-uninstall-cli.adoc
@@ -85,7 +85,7 @@ $ oc get subscription update-service-operator -o yaml | grep " currentCSV"
 +
 [source,terminal]
 ----
-$ oc delete subscription update-service-operator
+$ oc delete subscriptions.operators.coreos.com update-service-operator
 ----
 +
 .Example output

--- a/modules/update-service-uninstall-cli.adoc
+++ b/modules/update-service-uninstall-cli.adoc
@@ -58,7 +58,7 @@ operatorgroup.operators.coreos.com "openshift-update-service-fprx2" deleted
 +
 [source,terminal]
 ----
-$ oc get subscription
+$ oc get subscriptions.operators.coreos.com
 ----
 +
 .Example output
@@ -72,7 +72,7 @@ update-service-operator   update-service-operator   updateservice-index-catalog 
 +
 [source,terminal]
 ----
-$ oc get subscription update-service-operator -o yaml | grep " currentCSV"
+$ oc get subscriptions.operators.coreos.com update-service-operator -o yaml | grep " currentCSV"
 ----
 +
 .Example output


### PR DESCRIPTION
## Summary

Updates the OpenShift Update Service (OSUS) CLI procedure to use the fully qualified OLM resource type `subscriptions.operators.coreos.com` for subscription get and delete commands.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/disconnected_environments/updating-a-cluster-in-a-disconnected-environment#update-service-uninstall-cli_uninstalling-osus

## Problem

The procedure currently uses short-form subscription commands:

```shell
$ oc get subscription
$ oc get subscription update-service-operator -o yaml | grep " currentCSV"
$ oc delete subscription update-service-operator
```

On clusters where multiple operators expose a resource named `subscription`, short forms such as `oc get subscription` and `oc delete subscription` are ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, these commands may target the ACM `Subscription` API group instead of the OLM subscription.

## Solution

Use the fully qualified OLM resource type:

```shell
$ oc get subscriptions.operators.coreos.com
$ oc get subscriptions.operators.coreos.com update-service-operator -o yaml | grep " currentCSV"
$ oc delete subscriptions.operators.coreos.com update-service-operator
```

## Files changed

- `modules/update-service-uninstall-cli.adoc`

## Test plan

- [ ] Verify docs preview renders the updated commands (update-service-uninstall-cli)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of short-form `subscription`/`subscriptions`
- [ ] Confirm no other modules are changed in this PR

## Versions

enterprise-4.22+ (cherry-pick to affected enterprise branches as needed)
