### PR TITLE
OSDOCS-16965: CQA of-terms

### DIFF
--- a/extensions/arch/catalogd.adoc
+++ b/extensions/arch/catalogd.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {olmv1-first} uses the catalogd component and its resources to manage Operator and extension catalogs.
 
 include::modules/olmv1-about-catalogs.adoc[leveloffset=+1]

--- a/extensions/arch/components.adoc
+++ b/extensions/arch/components.adoc
@@ -6,8 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{olmv1-first} comprises the following component projects:
+[role="_abstract"]
+{olmv1-first} uses two key microservice components, Operator Controller and Catalogd, to unpack content and manage extensions on your cluster.
 
-Operator Controller:: xref:../../extensions/arch/operator-controller.adoc#operator-controller[Operator Controller] is the central component of {olmv1} that extends Kubernetes with an API through which users can install and manage the lifecycle of Operators and extensions. It consumes information from catalogd.
+Operator Controller:: Extends Kubernetes with an API to install and manage Operators and extensions using metadata from Catalogd.
+Catalogd:: Unpacks file-based catalog (FBC) content and hosts metadata so users can discover installable extensions.
 
-Catalogd:: xref:../../extensions/arch/catalogd.adoc#catalogd[Catalogd] is a Kubernetes extension that unpacks file-based catalog (FBC) content packaged and shipped in container images for consumption by on-cluster clients. As a component of the {olmv1} microservices architecture, catalogd hosts metadata for Kubernetes extensions packaged by the authors of the extensions, and as a result helps users discover installable content.
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../extensions/arch/operator-controller.adoc#operator-controller[Operator Controller]
+* xref:../../extensions/arch/catalogd.adoc#catalogd[Catalogd]

--- a/extensions/of-terms.adoc
+++ b/extensions/of-terms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following terms are related to the Operator Framework, including {olmv1-first}.
+[role="_abstract"]
+Review the Operator Framework terminology, including {olmv1-first} terms, used throughout the documentation.
 
 include::snippets/of-terms-snippet.adoc[leveloffset=+0]

--- a/modules/olmv1-about-target-versions.adoc
+++ b/modules/olmv1-about-target-versions.adoc
@@ -9,6 +9,7 @@
 [id="olmv1-about-target-versions_{context}"]
 = Example custom resources (CRs) that specify a target version
 
+[role="_abstract"]
 In {olmv1-first}, cluster administrators can declaratively set the target version of an Operator or extension in the custom resource (CR).
 
 You can define a target version by specifying any of the following fields:
@@ -35,9 +36,9 @@ apiVersion: olm.operatorframework.io/v1
       catalog:
         packageName: <package_name>
         channels:
-          - latest <1>
+          - latest
 ----
-<1> Optional: Installs the latest release that can be resolved from the specified channel. Updates to the channel are automatically installed. Specify the value of the `channels` parameter as an array.
+Installs the latest release that can be resolved from the specified channel. Updates to the channel are automatically installed. Specify the value of the `channels` parameter as an array. This field is optional
 
 If you specify the Operator or extension's target version in the CR, {olmv1} installs the specified version. When the target version is specified in the CR, {olmv1} does not change the target version when updates are published to the catalog.
 
@@ -58,9 +59,9 @@ apiVersion: olm.operatorframework.io/v1
       sourceType: Catalog
       catalog:
         packageName: <package_name>
-        version: "1.11.1" <1>
+        version: "1.11.1"
 ----
-<1> Optional: Specifies the target version. If you want to update the version of the Operator or extension that is installed, you must manually update this field the CR to the desired target version.
+Specifies the target version. If you want to update the version of the Operator or extension that is installed, you must manually update this field the CR to the desired target version. This field is optional.
 
 If you want to define a range of acceptable versions for an Operator or extension, you can specify a version range by using a comparison string. When you specify a version range, {olmv1} installs the latest version of an Operator or extension that can be resolved by the Operator Controller.
 
@@ -79,9 +80,9 @@ apiVersion: olm.operatorframework.io/v1
       sourceType: Catalog
       catalog:
         packageName: <package_name>
-        version: ">1.11.1" <1>
+        version: ">1.11.1"
 ----
-<1> Optional: Specifies that the desired version range is greater than version `1.11.1`. For more information, see "Support for version ranges".
+Specifies that the desired version range is greater than version `1.11.1`. This field is optional.
 
 After you create or update a CR, apply the configuration file by running the following command:
 

--- a/modules/olmv1-object-ownership.adoc
+++ b/modules/olmv1-object-ownership.adoc
@@ -7,14 +7,13 @@
 [id="olmv1-object-ownership_{context}"]
 = Object ownership for cluster extensions
 
+[role="_abstract"]
 In {olmv1-first}, a Kubernetes object can only be owned by a single `ClusterExtension` object at a time. This ensures that objects within an {product-title} cluster are managed consistently and prevents conflicts between multiple cluster extensions attempting to control the same object.
 
 [id="olmv1-single-ownership_{context}"]
 == Single ownership
 
-The core ownership principle enforced by {olmv1} is that each object can only have one cluster extension as its owner. This prevents overlapping or conflicting management by multiple cluster extensions, ensuring that each object is uniquely associated with only one bundle.
-
-.Implications of single ownership
+The core ownership principle enforced by {olmv1} is that each object can only have one cluster extension as its owner. This prevents overlapping or conflicting management by multiple cluster extensions, ensuring that each object is uniquely associated with only one bundle. Single ownership has the following implications:
 
 * Bundles that provide a `CustomResourceDefinition` (CRD) object can only be installed once.
 +


### PR DESCRIPTION
[OSDOCS-16965](https://redhat.atlassian.net/browse/OSDOCS-16965): CQA EXT catalogd, components, and operator-controller

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16965](https://redhat.atlassian.net/browse/OSDOCS-16965)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://117948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/update-paths.html
https://117948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html

* [extensions/arch/catalogd.adoc](https://github.com/openshift/openshift-docs/pull/117948/files#diff-e29dd0790491c2e7fa9b48b49424e62c16525fa38c6c24734edd98bdf8c2eb2e):
** [openshift-enterprise](https://117948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/catalogd.html)
* [extensions/arch/components.adoc](https://github.com/openshift/openshift-docs/pull/117948/files#diff-9f473070e7b1eeaf02e7b04d53434c811ffffbdf28d6f02751387af56af33a6b):
** [openshift-enterprise](https://117948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/components.html)
* [extensions/of-terms.adoc](https://github.com/openshift/openshift-docs/pull/117948/files#diff-d5c3ba5d58ec23581276172faa7bced8adf0b83358bdda0e4cbe2fdcf981292b):
** [openshift-enterprise](https://117948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
