### PR TITLE
OSDOCS-16966: CQA user-access-resources

### DIFF
--- a/extensions/ce/user-access-resources.adoc
+++ b/extensions/ce/user-access-resources.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After a cluster extension has been installed and is being managed by {olmv1-first}, the extension can often provide `CustomResourceDefinition` objects (CRDs) that expose new API resources on the cluster. Cluster administrators typically have full management access to these resources by default, whereas non-cluster administrator users, or _regular users_, might lack sufficient permissions.
+[role="_abstract"]
+After you install a cluster extension managed by {olmv1-first}, the extension might provide `CustomResourceDefinition` (CRD) objects that expose new cluster APIs. While cluster administrators automatically have full access to these resources, regular users usually require additional permissions.
 
 {olmv1} does not automatically configure or manage role-based access control (RBAC) for regular users to interact with the APIs provided by installed extensions. Cluster administrators must define the required RBAC policy to create, view, or edit these custom resources (CRs) for such users.
 
@@ -23,7 +24,7 @@ include::modules/olmv1-default-cluster-roles-users.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles[User-facing roles] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles[User-facing roles (Kubernetes documentation)]
 
 include::modules/olmv1-finding-ce-resources.adoc[leveloffset=+1]
 
@@ -33,5 +34,5 @@ include::modules/olmv1-granting-user-access-aggregated.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles[Aggregated ClusterRoles] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles[Aggregated ClusterRoles (Kubernetes documentation)]
 

--- a/modules/olmv1-default-cluster-roles-users.adoc
+++ b/modules/olmv1-default-cluster-roles-users.adoc
@@ -7,8 +7,11 @@
 [id="olmv1-default-cluster-roles-users_{context}"]
 = Common default cluster roles for users
 
-An installed cluster extension might include default cluster roles to determine role-based access control (RBAC) for regular users to API resources provided by the extension. A common set of cluster roles can resemble the following policies:
+[role="_abstract"]
+An installed cluster extension can include default cluster roles that grant regular users role-based access control (RBAC) to the extension's API resources.
 
-`view` cluster role:: Grants read-only access to all custom resource (CR) objects of specified API resources across the cluster. Intended for regular users who require visibility into the resources without any permissions to modify them. Ideal for monitoring purposes and limited access viewing.
-`edit` cluster role:: Allows users to modify all CR objects within the cluster. Enables users to create, update, and delete resources, making it suitable for team members who must manage resources but should not control RBAC or manage permissions for others.
-`admin` cluster role:: Provides full permissions, including `create`, `update`, and `delete` verbs, over all custom resource objects for the specified API resources across the cluster.
+Cluster extensions commonly include the following default cluster role policies:
+
+`view` cluster role:: Grants read-only access to custom resource (CR) objects for specified API resources across the cluster. This role provides resource visibility without permission to modify resources, which is ideal for monitoring and viewing.
+`edit` cluster role:: Grants permissions to create, update, and delete CR objects across the cluster. This role is intended for users who manage resources but do not manage RBAC or cluster permissions.
+`admin` cluster role:: Grants full administrative permissions, including create, update, and delete actions, over all CR objects for specified API resources across the cluster.

--- a/modules/olmv1-finding-ce-resources.adoc
+++ b/modules/olmv1-finding-ce-resources.adoc
@@ -7,6 +7,7 @@
 [id="olmv1-finding-ce-resources_{context}"]
 = Finding API groups and resources exposed by a cluster extension
 
+[role="_abstract"]
 To create appropriate RBAC policies for granting user access to cluster extension resources, you must know which API groups and resources are exposed by the installed extension. As an administrator, you can inspect custom resource definitions (CRDs) installed on the cluster by using {oc-first}.
 
 .Prerequisites

--- a/modules/olmv1-granting-user-access-aggregated.adoc
+++ b/modules/olmv1-granting-user-access-aggregated.adoc
@@ -7,11 +7,14 @@
 [id="olmv1-granting-user-access-aggregated_{context}"]
 = Granting user access to extension resources by using aggregated cluster roles
 
+[role="_abstract"]
 As a cluster administrator, you can configure role-based access control (RBAC) policies to grant user access to extension resources by using aggregated cluster roles.
 
+
+[NOTE]
+====
 To automatically extend existing default cluster roles, you can add _aggregation labels_ by adding one or more of the following labels to a `ClusterRole` object:
 
-.Aggregation labels in a `ClusterRole` object
 [source,yaml]
 ----
 # ..
@@ -24,6 +27,7 @@ metadata:
 ----
 
 This allows users who already have `view`, `edit`, or `admin` roles to interact with the  custom resource specified by the `ClusterRole` object without requiring additional role or cluster role bindings to specific users or groups.
+====
 
 .Prerequisites
 

--- a/modules/olmv1-granting-user-access-binding.adoc
+++ b/modules/olmv1-granting-user-access-binding.adoc
@@ -7,6 +7,7 @@
 [id="olmv1-granting-user-access-binding_{context}"]
 = Granting user access to extension resources by using custom role bindings
 
+[role="_abstract"]
 As a cluster administrator, you can manually create and configure role-based access control (RBAC) policies to grant user access to extension resources by using custom role bindings.
 
 .Prerequisites
@@ -75,9 +76,9 @@ rules:
   resources:
   - <cluster_extension_custom_resources>
   verbs:
-  - '*' <1>
+  - '*'
 ----
-<1> Setting a wildcard (`*`) in `verbs` allows all actions on the specified resources.
+Setting a wildcard (`*`) in  the `rules.verbs` field allows all actions on the specified resources.
 
 .. Create the cluster roles by running the following command for any YAML files you created:
 +
@@ -91,7 +92,7 @@ $ oc create -f <filename>.yaml
 .. Create an object definition for either a _cluster role binding_ to grant access across all namespaces or a _role binding_ to grant access within a specific namespace:
 +
 --
-*** The following example cluster role bindings grant read-only `view` access to the custom resource across all namespaces:
+* The following example cluster role bindings grant read-only `view` access to the custom resource across all namespaces:
 +
 .Example `ClusterRoleBinding` object for a user
 [source,yaml]
@@ -125,7 +126,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ----
  
-*** The following role binding restricts `edit` permissions to a specific namespace:
+* The following role binding restricts `edit` permissions to a specific namespace:
 +
 .Example `RoleBinding` object for a user
 [source,yaml]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16966](https://redhat.atlassian.net/browse/OSDOCS-16966)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
assembly:
https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html

modules:
* [extensions/ce/user-access-resources.adoc](https://github.com/openshift/openshift-docs/pull/117953/files#diff-98c748a53b105977fb40b546ff57260ab008eb2f313682b045cd6b2f7aa397e8):
** [openshift-enterprise](https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html)
** [modules/olmv1-default-cluster-roles-users.adoc](https://github.com/openshift/openshift-docs/pull/117953/files#diff-40d98a582106f4915070680412d46c89d9461b9921bac80dd00c8bf3a2a4129b):
*** [openshift-enterprise](https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html#olmv1-default-cluster-roles-users_user-access-resources)
** [modules/olmv1-finding-ce-resources.adoc](https://github.com/openshift/openshift-docs/pull/117953/files#diff-4383d12d791c28a860d16e6a2e722afb012d2c9bfc593c8f4ffa85d7e113d684):
*** [openshift-enterprise](https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html#olmv1-finding-ce-resources_user-access-resources)
** [modules/olmv1-granting-user-access-aggregated.adoc](https://github.com/openshift/openshift-docs/pull/117953/files#diff-0e2af6c2dba6f185cea33ed318c6845883cbd5b43670e4d9122f25b3bfd94b51):
*** [openshift-enterprise](https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html#olmv1-granting-user-access-aggregated_user-access-resources)
** [modules/olmv1-granting-user-access-binding.adoc](https://github.com/openshift/openshift-docs/pull/117953/files#diff-7a7f84f2c22feeb6daca2e0c94786c05f0408d6786e6c5b9b655dbd0e3fdd0b6):
*** [openshift-enterprise](https://117953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources.html#olmv1-granting-user-access-binding_user-access-resources)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
