### PR TITLE
OSDOCS-16990: AWS IPI CQA pt 2

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-localzone.adoc
+++ b/installing/installing_aws/ipi/installing-aws-localzone.adoc
@@ -14,16 +14,11 @@ AWS {zone-type} is an infrastructure that place Cloud Resources close to metropo
 // Infrastructure prerequisites
 include::modules/installing-aws-localzone-prereqs.adoc[leveloffset=+1]
 
-[id="installation-about-local-zone-edge-compute-pool_{context}"]
-== About AWS Local Zones and edge compute pool
-
-Read the following sections to understand infrastructure behaviors and cluster limitations in an AWS {zone-type} environment.
-
 // Cluster limitations
-include::modules/cluster-limitations-aws-zone.adoc[leveloffset=+2]
+include::modules/cluster-limitations-aws-zone.adoc[leveloffset=+1]
 
 // About edge compute pools
-include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+2]
+include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -35,27 +30,17 @@ include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+2]
 * xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc#nw-ingress-sharding_configuring-ingress-cluster-traffic-ingress-controller[Ingress Controller sharding]
 * link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work ({aws-short} documentation)]
 
-[id="installation-prereqs-aws-local-zone_{context}"]
-== Installation prerequisites
-
-Before you install a cluster in an AWS {zone-type} environment, you must configure your infrastructure so that it can adopt Local Zone capabilities.
-
 // Opting in to AWS Local Zones
-include::modules/installation-aws-add-zone-locations.adoc[leveloffset=+2]
+include::modules/installation-aws-add-zone-locations.adoc[leveloffset=+1]
 
 // Obtaining an AWS Marketplace image
-include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+2]
-
-[id="prep-installation-aws-local-zone_{context}"]
-== Preparing for the installation
-
-Before you extend nodes to {zone-type}, you must prepare certain resources for the cluster installation environment.
+include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 // Minimum resource requirements for cluster installation
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+1]
 
 // Tested instance types for AWS
-include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -63,13 +48,13 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 * link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Local Zones features ({aws-short} documentation)]
 
 // Creating the installation configuration file
-include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
+include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+1]
 
 // Examples of installation configuration files with edge compute pools
-include::modules/installation-aws-edge-compute-pools-examples.adoc[leveloffset=+2]
+include::modules/installation-aws-edge-compute-pools-examples.adoc[leveloffset=+1]
 
 // Customizing Cluster Network MTU
-include::modules/installation-aws-cluster-network-mtu.adoc[leveloffset=+2]
+include::modules/installation-aws-cluster-network-mtu.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -161,16 +146,11 @@ include::modules/installing-with-edge-node-public.adoc[leveloffset=+1]
 // Deploying the cluster
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-[id="verify-aws-local-zone-deployed-cluster-status_{context}"]
-== Verifying the status of the deployed cluster
-
-Verify that your {product-title} successfully deployed on AWS {zone-type}.
-
 // Logging in to the cluster by using the CLI
-include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+2]
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 // Logging in to the cluster by using the web console
-include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+2]
+include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -178,7 +158,7 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+2]
 * xref:../../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 // Verifying nodes that were created with edge compute pool
-include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+2]
+include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc
+++ b/installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can quickly install an {product-title} cluster on Amazon Web Services (AWS) {zone-type} by setting the zone names in the edge compute pool of the `install-config.yaml` file, or install a cluster in an existing Amazon Virtual Private Cloud (VPC) with Wavelength Zone subnets.
 
 AWS {zone-type} is an infrastructure that AWS configured for mobile edge computing (MEC) applications.
@@ -19,49 +20,7 @@ A Wavelength Zone embeds AWS compute and storage services within the 5G network 
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-wavelength-zones[Wavelength Zones({aws-short} documentation)]
 
 // Infrastructure prerequisites
-[id="aws-zones-prerequisites_{context}"]
-== Infrastructure prerequisites
-
-* You reviewed details about xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You are familiar with xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users].
-* You xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
-+
-[WARNING]
-====
-If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
-====
-* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
-* If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster must access.
-* You noted the region and supported link:https://aws.amazon.com/wavelength/locations[AWS Wavelength Zone locations] to create the network resources in.
-* You read link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Wavelength features] in the AWS documentation.
-* You read the link:https://docs.aws.amazon.com/wavelength/latest/developerguide/wavelength-quotas.html[Quotas and considerations for Wavelength Zones] in the AWS documentation.
-* You added permissions for creating network resources that support AWS Wavelength Zones to the Identity and Access Management (IAM) user or role. For example:
-+
-.Example of an additional IAM policy that attached `ec2:ModifyAvailabilityZoneGroup`, `ec2:CreateCarrierGateway`, and `ec2:DeleteCarrierGateway` permissions to a user or role
-+
-[source,yaml]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DeleteCarrierGateway",
-        "ec2:CreateCarrierGateway"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Action": [
-        "ec2:ModifyAvailabilityZoneGroup"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-----
+include::modules/installing-aws-wavelength-zone-prereqs.adoc[leveloffset=+1]
 
 [id="about-aws-wavelength-zone-edge-compute-pool_{context}"]
 == About AWS Wavelength Zones and edge compute pool

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -9,33 +9,7 @@ toc::[]
 [role="_abstract"]
 You can install a cluster on {aws-first} in a restricted network by creating an internal mirror of the installation release content on an existing {aws-short} Virtual Private Cloud (VPC). By using this configuration, you can deploy a cluster in an environment with limited internet connectivity to help ensure compliance with security policies.
 
-[id="prerequisites_installing-restricted-networks-aws-installer-provisioned"]
-== Prerequisites
-
-* You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
-+
-[IMPORTANT]
-====
-Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
-====
-* You have an existing VPC in AWS. When installing to a restricted network using installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
-** Contains the mirror registry
-** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
-* You xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
-+
-[IMPORTANT]
-====
-If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
-====
-* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
-* If you use a firewall and plan to use the Telemetry service, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
-+
-[NOTE]
-====
-If you are configuring a proxy, be sure to also review this site list.
-====
+include::modules/installing-aws-restricted-prereqs.adoc[leveloffset=+1]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -113,12 +87,13 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
 
-[id="next-steps_installing-restricted-networks-aws-installer-provisioned"]
-== Next steps
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-* xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
-* xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
+* xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]
+* xref:../../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/installing-aws-restricted-prereqs.adoc
+++ b/modules/installing-aws-restricted-prereqs.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: REFERENCE
+[id="prerequisites_installing-restricted-networks-aws-installer-provisioned"]
+= Prerequisites
+
+[role="_abstract"]
+Before you install a cluster on Amazon Web Services (AWS) in a restricted network by using installer-provisioned infrastructure, you must meet several prerequisites.
+
+The following prerequisites must be met:
+
+* You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
++
+[IMPORTANT]
+====
+Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
+====
+* You have an existing VPC in AWS. When installing to a restricted network using installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
+** Contains the mirror registry
+** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
+* You xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
++
+[IMPORTANT]
+====
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
+====
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
++
+[NOTE]
+====
+If you are configuring a proxy, be sure to also review this site list.
+====

--- a/modules/installing-aws-wavelength-zone-prereqs.adoc
+++ b/modules/installing-aws-wavelength-zone-prereqs.adoc
@@ -1,0 +1,49 @@
+:_mod-docs-content-type: REFERENCE
+[id="aws-zones-prerequisites_{context}"]
+= Infrastructure prerequisites
+
+[role="_abstract"]
+Before you install an {product-title} cluster on Amazon Web Services (AWS) {zone-type}, you must meet several prerequisites.
+
+The following prerequisites must be met:
+
+* You reviewed details about xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You are familiar with xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users].
+* You xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
++
+[WARNING]
+====
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
+====
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
+* If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster must access.
+* You noted the region and supported link:https://aws.amazon.com/wavelength/locations[AWS Wavelength Zone locations] to create the network resources in.
+* You read link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Wavelength features] in the AWS documentation.
+* You read the link:https://docs.aws.amazon.com/wavelength/latest/developerguide/wavelength-quotas.html[Quotas and considerations for Wavelength Zones] in the AWS documentation.
+* You added permissions for creating network resources that support AWS Wavelength Zones to the Identity and Access Management (IAM) user or role. For example:
++
+.Example of an additional IAM policy that attached `ec2:ModifyAvailabilityZoneGroup`, `ec2:CreateCarrierGateway`, and `ec2:DeleteCarrierGateway` permissions to a user or role
++
+[source,yaml]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteCarrierGateway",
+        "ec2:CreateCarrierGateway"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ec2:ModifyAvailabilityZoneGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+----


### PR DESCRIPTION
[OSDOCS-16990](https://redhat.atlassian.net/browse/OSDOCS-16990)

Version(s): 4.20+

AWS IPI Install CQA changes. This PR modularizes some prereqs sections, deletes some redundant stubs, and changes next steps to additional resources.

QE review: Not required for formatting changes

Previews:
https://117969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-localzone.html
https://117969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-wavelength-zone.html
https://117969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.html