### PR TITLE
OSDOCS-16990: AWS IPI CQA pt 4

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -54,42 +54,23 @@ include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
-[id="installing-aws-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an {aws-short} cluster to use short-term credentials].
+// Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-aws-alternatives-storing-secrets.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-=== Configuring an {aws-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+include::modules/config-aws-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-==== Creating {aws-short} resources with the Cloud Credential Operator utility
-
-You have the following options when creating {aws-short} resources:
-
-* You can use the `ccoctl aws create-all` command to create the {aws-short} resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#cco-ccoctl-creating-at-once_installing-aws-customizations[Creating {aws-short} resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the {aws-short} resources individually. See xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#cco-ccoctl-creating-individually_installing-aws-customizations[Creating {aws-short} resources individually].
-
 //Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
 //Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
 
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]

--- a/installing/installing_aws/ipi/installing-aws-private.adoc
+++ b/installing/installing_aws/ipi/installing-aws-private.adoc
@@ -49,42 +49,23 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
-[id="installing-aws-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-aws-private.adoc#manually-create-iam_installing-aws-private[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-aws-private.adoc#installing-aws-with-short-term-creds_installing-aws-private[Configuring an AWS cluster to use short-term credentials].
+// Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-aws-alternatives-storing-secrets.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-=== Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+include::modules/config-aws-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-==== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-aws-private.adoc#cco-ccoctl-creating-at-once_installing-aws-private[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../../installing/installing_aws/ipi/installing-aws-private.adoc#cco-ccoctl-creating-individually_installing-aws-private[Creating AWS resources individually].
-
 //Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
 //Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
 
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]

--- a/installing/installing_aws/ipi/installing-aws-specialized-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-specialized-region.adoc
@@ -107,42 +107,23 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
-[id="installing-aws-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#manually-create-iam_installing-aws-specialized-region[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-with-short-term-creds_installing-aws-specialized-region[Configuring an AWS cluster to use short-term credentials].
+// Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-aws-alternatives-storing-secrets.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-=== Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+include::modules/config-aws-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-==== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#cco-ccoctl-creating-at-once_installing-aws-specialized-region[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#cco-ccoctl-creating-individually_installing-aws-specialized-region[Creating AWS resources individually].
-
 //Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
 //Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
 
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]

--- a/installing/installing_aws/ipi/installing-aws-vpc.adoc
+++ b/installing/installing_aws/ipi/installing-aws-vpc.adoc
@@ -67,42 +67,23 @@ include::modules/nw-allocating-load-balancers-to-subnets.adoc[leveloffset=+3]
 // Specifying AWS Subnets for OpenShift Ingress Load Balancers at Installation
 include::modules/nw-allocate-load-balancers-to-subnets-procedure.adoc[leveloffset=+3]
 
-[id="installing-aws-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-aws-vpc.adoc#manually-create-iam_installing-aws-vpc[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-aws-vpc.adoc#installing-aws-with-short-term-creds_installing-aws-vpc[Configuring an AWS cluster to use short-term credentials].
+// Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-aws-alternatives-storing-secrets.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-=== Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+include::modules/config-aws-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-==== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-aws-vpc.adoc#cco-ccoctl-creating-at-once_installing-aws-vpc[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../../installing/installing_aws/ipi/installing-aws-vpc.adoc#cco-ccoctl-creating-individually_installing-aws-vpc[Creating AWS resources individually].
-
 //Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
 //Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
 
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -65,42 +65,24 @@ include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
-[id="installing-aws-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
 
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-aws-installer-provisioned[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#installing-aws-with-short-term-creds_installing-restricted-networks-aws-installer-provisioned[Configuring an AWS cluster to use short-term credentials].
+// Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-aws-alternatives-storing-secrets.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-=== Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+include::modules/config-aws-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-==== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-at-once_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-individually_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources individually].
-
 //Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
 //Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
 
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -14,7 +14,10 @@
 [id="cco-ccoctl-creating-individually_{context}"]
 = Creating AWS resources individually
 
-You can use the `ccoctl` tool to create AWS resources individually. This option might be useful for an organization that shares the responsibility for creating these resources among different users or departments.
+[role="_abstract"]
+If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually.
+
+This option might be useful for an organization that shares the responsibility for creating these resources among different users or departments.
 
 Otherwise, you can use the `ccoctl aws create-all` command to create the AWS resources automatically. For more information, see "Creating AWS resources with a single command".
 

--- a/modules/config-aws-short-term-creds.adoc
+++ b/modules/config-aws-short-term-creds.adoc
@@ -1,0 +1,13 @@
+// Included in:
+// * installing/installing_aws/ipi/installing-aws-customizations.adoc
+// * installing/installing_aws/ipi/installing-aws-private.adoc
+// * installing/installing_aws/ipi/installing-aws-specialized-region.adoc
+// * installing/installing_aws/ipi/installing-aws-vpc.adoc
+// * installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-aws-with-short-term-creds_{context}"]
+= Configuring an {aws-short} cluster to use short-term credentials
+
+[role="_abstract"]
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.

--- a/modules/installing-aws-alternatives-storing-secrets.adoc
+++ b/modules/installing-aws-alternatives-storing-secrets.adoc
@@ -1,0 +1,19 @@
+// Included in:
+// * installing/installing_aws/ipi/installing-aws-customizations.adoc
+// * installing/installing_aws/ipi/installing-aws-private.adoc
+// * installing/installing_aws/ipi/installing-aws-vpc.adoc
+// * installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+// * installing/installing_aws/ipi/installing-aws-specialized-region.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-aws-manual-modes_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
+
+[role="_abstract"]
+By default, administrator secrets are stored in the `kube-system` project.
+
+If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
+
+* To manage long-term cloud credentials manually, follow the procedure in "Manually creating long-term credentials".
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in "Configuring an {aws-short} cluster to use short-term credentials".


### PR DESCRIPTION
[OSDOCS-16990](https://redhat.atlassian.net/browse/OSDOCS-16990)

Version(s): 4.20+

AWS IPI Install CQA changes. This PR modularizes some sections and deletes some redundant stubs.

QE review: Not required for formatting changes

Previews:
https://117975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html
https://117975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-private.html
https://117975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-specialized-region.html
https://117975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc.html
https://117975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.html
