### PR TITLE
Use fully qualified OLM API for subscription CLI commands

### DIFF
--- a/modules/albo-deleting.adoc
+++ b/modules/albo-deleting.adoc
@@ -13,7 +13,7 @@ If you no longer need to use the AWS Load Balancer Operator, you can remove the 
 +
 [source,terminal]
 ----
-$ oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
+$ oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
 ----
 
 . Detach and delete the relevant AWS IAM roles:

--- a/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
@@ -21,7 +21,7 @@ $ oc delete project hello-world
 +
 [source,terminal]
 ----
-$ oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operator
+$ oc delete subscriptions.operators.coreos.com aws-load-balancer-operator -n aws-load-balancer-operator
 $ aws iam detach-role-policy \
   --role-name "${ROSA_CLUSTER_NAME}-alb-operator" \
   --policy-arn $POLICY_ARN

--- a/modules/das-operator-uninstalling-cli.adoc
+++ b/modules/das-operator-uninstalling-cli.adoc
@@ -20,7 +20,7 @@ You can uninstall the Dynamic Accelerator Slicer (DAS) Operator using the OpenSh
 +
 [source,terminal]
 ----
-$ oc get subscriptions -n das-operator
+$ oc get subscriptions.operators.coreos.com -n das-operator
 ----
 +
 .Example output
@@ -34,7 +34,7 @@ das-operator   das-operator   redhat-operators   stable
 +
 [source,terminal]
 ----
-$ oc delete subscription das-operator -n das-operator
+$ oc delete subscriptions.operators.coreos.com das-operator -n das-operator
 ----
 
 . List and delete the cluster service version (CSV) by running the following commands:

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -22,14 +22,14 @@ Remove the community {external-secrets-operator-short} that was installed by an 
 +
 [source,terminal]
 ----
-$ oc get subscription -n <operator_namespace> | grep external-secrets
+$ oc get subscriptions.operators.coreos.com -n <operator_namespace> | grep external-secrets
 ----
 
 . Delete the subscription by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete subscription <subscription_name> -n <operator_namespace>
+$ oc delete subscriptions.operators.coreos.com <subscription_name> -n <operator_namespace>
 ----
 
 . Delete the `ClusterServiceVersion` by running the following command:

--- a/modules/k8s-nmstate-uninstall-operator.adoc
+++ b/modules/k8s-nmstate-uninstall-operator.adoc
@@ -27,7 +27,7 @@ If you need to reinstall the Kubernetes NMState Operator, see "Installing the Ku
 +
 [source,terminal]
 ----
-$ oc delete --namespace openshift-nmstate subscription kubernetes-nmstate-operator
+$ oc delete --namespace openshift-nmstate subscriptions.operators.coreos.com kubernetes-nmstate-operator
 ----
 
 . Find the `ClusterServiceVersion` (CSV) resource that associates with the Kubernetes NMState Operator:

--- a/modules/nw-dpu-operator-uninstall.adoc
+++ b/modules/nw-dpu-operator-uninstall.adoc
@@ -29,7 +29,7 @@ $ oc delete DpuOperatorConfig dpu-operator-config
 +
 [source,terminal]
 ----
-$ oc delete Subscription openshift-dpu-operator-subscription -n openshift-dpu-operator
+$ oc delete subscriptions.operators.coreos.com openshift-dpu-operator-subscription -n openshift-dpu-operator
 ----
 
 . Remove the `OperatorGroup` resource that was created by running the following command:

--- a/modules/olm-refresh-subs.adoc
+++ b/modules/olm-refresh-subs.adoc
@@ -53,7 +53,7 @@ clusterserviceversion.operators.coreos.com/elasticsearch-operator.5.0.0-65   Ope
 +
 [source,terminal]
 ----
-$ oc delete subscription <subscription_name> -n <namespace>
+$ oc delete subscriptions.operators.coreos.com <subscription_name> -n <namespace>
 ----
 
 . Delete the cluster service version:

--- a/modules/update-service-uninstall-cli.adoc
+++ b/modules/update-service-uninstall-cli.adoc
@@ -58,7 +58,7 @@ operatorgroup.operators.coreos.com "openshift-update-service-fprx2" deleted
 +
 [source,terminal]
 ----
-$ oc get subscription
+$ oc get subscriptions.operators.coreos.com
 ----
 +
 .Example output
@@ -72,7 +72,7 @@ update-service-operator   update-service-operator   updateservice-index-catalog 
 +
 [source,terminal]
 ----
-$ oc get subscription update-service-operator -o yaml | grep " currentCSV"
+$ oc get subscriptions.operators.coreos.com update-service-operator -o yaml | grep " currentCSV"
 ----
 +
 .Example output
@@ -85,7 +85,7 @@ $ oc get subscription update-service-operator -o yaml | grep " currentCSV"
 +
 [source,terminal]
 ----
-$ oc delete subscription update-service-operator
+$ oc delete subscriptions.operators.coreos.com update-service-operator
 ----
 +
 .Example output

--- a/modules/virt-deleting-virt-cli.adoc
+++ b/modules/virt-deleting-virt-cli.adoc
@@ -28,7 +28,7 @@ $ oc delete HyperConverged kubevirt-hyperconverged -n {CNVNamespace}
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc delete subscription hco-operatorhub -n {CNVNamespace}
+$ oc delete subscriptions.operators.coreos.com hco-operatorhub -n {CNVNamespace}
 ----
 
 . Delete the {VirtProductName} `ClusterServiceVersion` resource:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
On clusters where ACM is installed, short-form `oc get subscription` / `oc delete subscription` (and `oc get subscriptions`) is ambiguous because both ACM and OLM register a `Subscription` resource. Without the OLM API group, `oc` can target the ACM subscription resource instead of the OLM subscription, so Operator uninstall/get steps in the docs can fail or appear to show no resources even when OLM subscriptions exist.

Link to docs preview:
<!--- Preview requires /ok-to-test; expected pages after the build completes: --->
- Virt uninstall CLI: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt.html#virt-deleting-virt-cli_uninstalling-virt
- AWS Load Balancer Operator (ROSA): https://117986--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/aws-load-balancer.html#aws-load-balancer-operator-deleting_aws-load-balancer-operator
- AWS LB Operator tutorial cleanup (ROSA): https://117986--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.html#cloud-experts-aws-load-balancer-operator-cleanup_cloud-experts-aws-load-balancer-operator
- DAS Operator uninstall CLI: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/das-about-dynamic-accelerator-slicer-operator.html#das-operator-uninstalling-cli_das-about-dynamic-accelerator-slicer-operator
- External Secrets Operator OLM uninstall: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html#external-secrets-operator-uninstall-olm_external-secrets-operator-migrate-downstream-upstream
- Kubernetes NMState Operator uninstall: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#k8s-nmstate-uninstall-operator_k8s-nmstate-about-the-k8s-nmstate-operator
- DPU Operator uninstall: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/dpu-operator/dpu-operator.html#nw-dpu-operator-uninstall_dpu-operator
- OLM refresh failing subscriptions: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-refresh-subs_olm-deleting-operators-from-a-cluster
- OpenShift Update Service uninstall CLI: https://117986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.html#update-service-uninstall-cli_uninstalling-osus

QE review:
- [ ] QE has approved this change.

Additional information:
When ACM is installed, both APIs expose a resource named `subscriptions` / kind `Subscription`:

```
$ oc api-resources | grep -w "Subscription"
subscriptions                              appsub                                                                                 apps.open-cluster-management.io/v1                     true         Subscription
subscriptions                              sub,subs                                                                               operators.coreos.com/v1alpha1                          true         Subscription
```

Running the short-form command targets the ACM subscription resource by default, so it can report no resources even when OLM subscriptions exist:

```
$ oc get subscriptions -A
No resources found
```

Using the fully qualified OLM API group returns the expected Operator subscriptions:

```
$ oc get subscriptions.operators.coreos.com -A
NAMESPACE                 NAME                          PACKAGE                       SOURCE             CHANNEL
multicluster-engine       multicluster-engine           multicluster-engine           redhat-operators   stable-2.17
open-cluster-management   advanced-cluster-management   advanced-cluster-management   redhat-operators   release-2.17
```

This PR updates affected CLI procedures to use `subscriptions.operators.coreos.com` for get and delete commands so the docs always target the OLM subscription resource.

Modules updated (present from these versions onward; cherry-pick applies where the file exists):
- `modules/virt-deleting-virt-cli.adoc` — 4.14+
- `modules/olm-refresh-subs.adoc` — 4.14+
- `modules/update-service-uninstall-cli.adoc` — 4.14+
- `modules/k8s-nmstate-uninstall-operator.adoc` — 4.14+
- `modules/albo-deleting.adoc` — 4.18+
- `modules/das-operator-uninstalling-cli.adoc` — 4.19+
- `modules/external-secrets-operator-uninstall-olm.adoc` — 4.19+
- `modules/nw-dpu-operator-uninstall.adoc` — 4.19+
- `modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc` — 4.21+