### PR TITLE
Use oc instead of kubectl in SPO Audit JSON Log Enricher config steps

### DIFF
--- a/modules/spo-log-json-enrich.adoc
+++ b/modules/spo-log-json-enrich.adoc
@@ -22,7 +22,7 @@ Setting the audit log interval determines how often audit logs are created using
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding. By default, audit logs go to your standard output in JSON lines format. You can send them to a file instead.
@@ -55,7 +55,7 @@ $ cat patch-volume-source.json
 +
 [source,terminal]
 ----
-# kubectl patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
+# oc patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.
@@ -64,7 +64,7 @@ Wait until all SPOD pods show `Running` before proceeding.
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Audit JSON Log Enricher configuration procedure (`spo-log-json-enrich`)

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-json-enrich_spo-audit-logging