### PR TITLE
Use oc instead of kubectl in SPO audit log rotation and verbosity steps

### DIFF
--- a/modules/spo-log-tune-rot.adoc
+++ b/modules/spo-log-tune-rot.adoc
@@ -14,7 +14,7 @@ For audit logging to a file, you can manage file size and how long each file is 
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log","auditLogMaxSize":500,"auditLogMaxBackups":2,"auditLogMaxAge":10}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log","auditLogMaxSize":500,"auditLogMaxBackups":2,"auditLogMaxAge":10}}}'
 ----
 Wait until all SPOD pods show `Running` before proceeding.
 
@@ -26,6 +26,6 @@ Wait until all SPOD pods show `Running` before proceeding.
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true, "verbosity": 1}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true, "verbosity": 1}}'
 ----
 Wait until all SPOD pods show `Running` before proceeding.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the audit log rotation and verbosity procedure (`spo-log-tune-rot`)

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-tune-rot_spo-audit-logging