### PR TITLE
Use oc instead of kubectl in Zero Trust Spire deploy rollout checks

### DIFF
--- a/modules/zero-trust-manager-deploy-spire.adoc
+++ b/modules/zero-trust-manager-deploy-spire.adoc
@@ -93,7 +93,7 @@ $ until oc get statefulset/spire-server -n "${ZTWIM_NS}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Create the `SpireAgent` CR:
@@ -131,7 +131,7 @@ $ until oc get daemonset/spire-agent -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpiffeCSIDriver` CR:
@@ -158,7 +158,7 @@ $ until oc get daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" &> /dev/null; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpireOIDCDiscoveryProvider` CR:


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in Zero Trust Spire deploy rollout status checks

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-deploy-spire_zero-trust-manager-mesh-integration