### PR TITLE
Use oc instead of kubectl in Zero Trust Istio deploy rollout check

### DIFF
--- a/modules/zero-trust-manager-deploy-istio.adoc
+++ b/modules/zero-trust-manager-deploy-istio.adoc
@@ -68,7 +68,7 @@ $ until oc get daemonset/istio-cni-node -n "${OSSM_CNI}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
+$ oc rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
 ----
 +
 The `until` loop waits for the {SMProductName} Operator to create the `istio-cni-node` DaemonSet. The `oc rollout status` command waits for the DaemonSet pods to become ready.


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in Zero Trust Istio deploy rollout status check

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-deploy-istio_zero-trust-manager-mesh-integration