### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in bare metal IPI network troubleshooting steps

### DIFF
--- a/modules/ipi-install-troubleshooting-misc-issues.adoc
+++ b/modules/ipi-install-troubleshooting-misc-issues.adoc
@@ -37,7 +37,7 @@ pod/network-operator-69dfd7b577-bg89v   0/1   ContainerCreating 0          149m
 +
 [source,terminal]
 ----
-$ kubectl get network.config.openshift.io cluster -oyaml
+$ oc get network.config.openshift.io cluster -oyaml
 ----
 +
 [source,yaml]
@@ -66,14 +66,14 @@ $ openshift-install create manifests
 +
 [source,terminal]
 ----
-$ kubectl -n openshift-network-operator get pods
+$ oc -n openshift-network-operator get pods
 ----
 
 . Retrieve the logs:
 +
 [source,terminal]
 ----
-$ kubectl -n openshift-network-operator logs -l "name=network-operator"
+$ oc -n openshift-network-operator logs -l "name=network-operator"
 ----
 +
 On high availability clusters with three or more control plane nodes, the Operator will perform leader election and all other Operators will sleep. For additional details, see https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md[Troubleshooting].


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`.
Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/installing_on_bare_metal/ipi-install-troubleshooting-misc-issues

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` in bare metal IPI network troubleshooting steps. Please cherry-pick to all supported `enterprise-4.x` branches that include this module.