### PR TITLE
OSDOCS#21618: Use oc instead of kubectl when applying ProjectHelmChartRepository

### DIFF
--- a/modules/helm-creating-credentials-and-certificates-to-add-helm-repositories.adoc
+++ b/modules/helm-creating-credentials-and-certificates-to-add-helm-repositories.adoc
@@ -53,7 +53,7 @@ The `ConfigMap` and `Secret` are consumed in the HelmChartRepository CR using th
 +
 [source,terminal]
 ----
-$ cat <<EOF | kubectl apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`.
Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/building_applications/helm-creating-credentials-and-certificates-to-add-helm-repositories

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` when applying a `ProjectHelmChartRepository`. Please cherry-pick to all supported `enterprise-4.x` branches that include this module.