### PR TITLE
Use oc instead of kubectl when retrieving HCP custom admin kubeconfig secret

### DIFF
--- a/modules/hcp-kube-api-server-cert.adoc
+++ b/modules/hcp-kube-api-server-cert.adoc
@@ -75,7 +75,7 @@ After the configuration is applied, the HyperShift Operator generates a new `kub
 +
 [source,terminal]
 ----
-$ kubectl get secret <hosted_cluster_name>-custom-admin-kubeconfig \
+$ oc get secret <hosted_cluster_name>-custom-admin-kubeconfig \
   -n <cluster_namespace> \
   -o jsonpath='{.data.kubeconfig}' | base64 -d
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` when retrieving the hosted cluster custom admin kubeconfig secret

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes/hcp-certificates#hcp-kube-api-server-cert_hcp-certificates