### PR TITLE
Use oc instead of kubectl for HCP Azure private kube-apiserver port-forward

### DIFF
--- a/modules/hcp-azure-private-access.adoc
+++ b/modules/hcp-azure-private-access.adoc
@@ -29,7 +29,7 @@ $ hcp create kubeconfig \
 +
 [source,terminal]
 ----
-$ kubectl port-forward svc/kube-apiserver \
+$ oc port-forward svc/kube-apiserver \
   -n clusters-${CLUSTER_NAME} 6443:6443 &
 ----
 +


### PR DESCRIPTION
## Summary
- Replace `kubectl port-forward` with `oc port-forward` for private access to the hosted kube-apiserver on Azure

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes/deploying-hosted-control-planes#hcp-azure-private-access_hcp-deploy-azure