### PR TITLE
Use oc instead of kubectl in Virt storage migration permission examples

### DIFF
--- a/modules/virt-migrating-storage-permissions.adoc
+++ b/modules/virt-migrating-storage-permissions.adoc
@@ -20,7 +20,7 @@ Cluster administrators must grant users permission to perform storage migrations
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding <role_binding_name> \
+$ oc create rolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate \
     --user=<user_name> -n <namespace>
 ----
@@ -35,7 +35,7 @@ where:
 +
 [source,terminal]
 ----
-$ kubectl create clusterrolebinding <role_binding_name> \
+$ oc create clusterrolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
     --user=<user_name>
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in OpenShift Virtualization storage migration permission examples

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/managing-vms#virt-migrating-storage-permissions_virt-migrating-storage-class