### PR TITLE
OSDOCS#21618: Use oc instead of kubectl when creating Pipelines as Code Repository CR

### DIFF
--- a/modules/op-using-repository-crd-with-pipelines-as-code.adoc
+++ b/modules/op-using-repository-crd-with-pipelines-as-code.adoc
@@ -18,7 +18,7 @@ You can use the `tkn pac` CLI or other alternative methods to create a `Reposito
 
 [source,terminal]
 ----
-cat <<EOF|kubectl create -n my-pipeline-ci -f- <1>
+cat <<EOF|oc create -n my-pipeline-ci -f- <1>
 
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository


### PR DESCRIPTION
Version(s):
OpenShift Pipelines versions that include this module. Related published section is Pipelines 1.23.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`.
Related published section: https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/1.23/html/pipelines_as_code/using-repository-crd#creating-the-repository-custom-resource

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl create` with `oc create` in the Pipelines as Code Repository CR example. Please cherry-pick to all supported branches that include this module.