### PR TITLE
Use oc instead of kubectl in Service Mesh Gateway API known-issue workaround

### DIFF
--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -79,11 +79,11 @@ In a multitenant mesh deployment, CRD scan is disabled, and Istio has no way to 
 +
 {SMProductShortName} 2.3.1 and later versions support both `v1alpha2` and `v1beta1` CRDs. Therefore, both CRD versions must be present for a multitenant mesh deployment to support the Gateway API.
 +
-Workaround: In the following example, the `kubectl get` operation installs the `v1alpha2` and `v1beta1` CRDs. Note the URL contains the additional `experimental` segment and updates any of your existing scripts accordingly:
+Workaround: In the following example, the `oc get` operation installs the `v1alpha2` and `v1beta1` CRDs. Note the URL contains the additional `experimental` segment and updates any of your existing scripts accordingly:
 +
 [source,terminal]
 ----
-$ kubectl get crd gateways.gateway.networking.k8s.io ||   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | kubectl apply -f -; }
+$ oc get crd gateways.gateway.networking.k8s.io ||   { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | oc apply -f -; }
 ----
 
 * https://issues.redhat.com/browse/OSSM-2042[OSSM-2042] Deployment of SMCP named `default` fails. If you are creating an SMCP object, and set its version field to v2.3, the name of the object cannot be `default`. If the name is `default`, then the control plane fails to deploy, and OpenShift generates a `Warning` event with the following message:


### PR DESCRIPTION
## Summary
- Replace `kubectl` with `oc` in the Service Mesh known-issue Gateway API CRD workaround
- Updates surrounding wording from `kubectl get` to `oc get`

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/service_mesh/index#ossm-rn-known-issues_ossm-release-notes