### PR TITLE
Replace obsolete kubectl rolling-update with oc rollout restart in builds secrets docs

### DIFF
--- a/modules/builds-secrets-overview.adoc
+++ b/modules/builds-secrets-overview.adoc
@@ -65,7 +65,7 @@ secret intended to conform to the key/value requirements of that type.
 
 When you modify the value of a secret, the value used by an already running pod does not dynamically change. To change a secret, you must delete the original pod and create a new pod, in some cases with an identical `PodSpec`.
 
-Updating a secret follows the same workflow as deploying a new container image. You can use the `kubectl rolling-update` command.
+Updating a secret follows the same workflow as deploying a new container image. You can use the `oc rollout restart` command.
 
 The `resourceVersion` value in a secret is not specified when it is referenced. Therefore, if a secret is updated at the same time as pods are starting, the version of the secret that is used for the pod is not defined.
 


### PR DESCRIPTION
## Summary
- Replace obsolete `kubectl rolling-update` wording with `oc rollout restart` in Builds secrets overview updates section

## Test plan
- [ ] Confirm the updated content renders correctly in docs preview
- [ ] Confirm `oc` commands are appropriate for the procedure

Version(s): Please cherry-pick to all supported enterprise-4.x branches that include this module.

Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/builds_using_buildconfig/creating-build-inputs#builds-secrets-overview-updates_creating-build-inputs