### PR TITLE
OSDOCS#21618: Use oc instead of kubectl when listing API resources for quotas

### DIFF
--- a/modules/admin-quota-overview.adoc
+++ b/modules/admin-quota-overview.adoc
@@ -116,4 +116,4 @@ where:
 
 `<resource>`:: Specifies the name of the resource. 
 
-`<group>`:: Specifies the API group, if applicable. You can use the `kubectl api-resources` command for a list of resources and their associated API groups.
+`<group>`:: Specifies the API group, if applicable. You can use the `oc api-resources` command for a list of resources and their associated API groups.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`.
Related published section: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/compute-resource-quotas#admin-quota-overview_using-quotas-and-limit-ranges

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl api-resources` with `oc api-resources` in the resource quota overview. Please cherry-pick to all supported `enterprise-4.x` branches that include this module.