### PR TITLE
OSDOCS-16943: CQA osdk-token-auth

### DIFF
--- a/modules/osdk-cco-aws-sts-alt.adoc
+++ b/modules/osdk-cco-aws-sts-alt.adoc
@@ -6,6 +6,7 @@
 [id="osdk-cco-aws-sts-alt_{context}"]
 = Alternative method
 
+[role="_abstract"]
 As an alternative method for Operator authors, you can indicate that the user is responsible for creating the `CredentialsRequest` object for the Cloud Credential Operator (CCO) before installing the Operator.
 
 The Operator instructions must indicate the following to users:

--- a/modules/osdk-cco-aws-sts-role.adoc
+++ b/modules/osdk-cco-aws-sts-role.adoc
@@ -6,11 +6,12 @@
 [id="osdk-cco-aws-sts-role_{context}"]
 = Role specification
 
-The Operator description should contain the specifics of the role required to be created before installation, ideally in the form of a script that the administrator can run. For example:
+[role="_abstract"]
+To install an Operator that uses AWS Security Token Service (STS), you must specify the IAM role that the Operator requires, ideally as a script that an administrator can run.
+
+The following example shows a script that creates the required AWS IAM role and attaches the trust policy:
 
 .Example role creation script
-[%collapsible]
-====
 [source,bash]
 ----
 #!/bin/bash
@@ -55,4 +56,3 @@ while IFS= read -r POLICY_ARN; do
    echo "ok."
 done <<< "$POLICY_ARN_STRINGS"
 ----
-====

--- a/modules/osdk-cco-aws-sts-tshooting-auth-fail.adoc
+++ b/modules/osdk-cco-aws-sts-tshooting-auth-fail.adoc
@@ -3,12 +3,10 @@
 // * operators/operator_sdk/osdk-token-auth.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="osdk-cco-aws-sts-tshooting_{context}"]
-= Troubleshooting
-
 [id="osdk-cco-aws-sts-tshooting-auth-fail_{context}"]
-== Authentication failure
+= Troubleshoot authentication failures
 
+[role="_abstract"]
 If authentication was not successful, ensure you can assume the role with web identity by using the token provided to the Operator.
 
 .Procedure
@@ -26,9 +24,10 @@ $ oc exec operator-pod -n <namespace_name> \
 [source,terminal]
 ----
 $ oc exec operator-pod -n <namespace_name> \
-    -- cat /<path>/<to>/<secret_name> <1>
+    -- cat /<path>/<to>/<secret_name>
 ----
-<1> Do not use root for the path.
++
+Do not use root for the path.
 
 . Try assuming the role with the web identity token:
 +
@@ -39,8 +38,3 @@ $ aws sts assume-role-with-web-identity \
     --role-session-name <session_name> \
     --web-identity-token $TOKEN
 ----
-
-[id="osdk-cco-aws-sts-tshooting-mounting_{context}"]
-== Secret not mounting correctly
-
-Pods that run as non-root users cannot write to the `/root` directory where the AWS shared credentials file is expected to exist by default. If the secret is not mounting correctly to the AWS credentials file path, consider mounting the secret to a different location and enabling the shared credentials file option in the AWS SDK.

--- a/modules/osdk-cco-aws-sts-tshooting-mounting.adoc
+++ b/modules/osdk-cco-aws-sts-tshooting-mounting.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-token-auth.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="osdk-cco-aws-sts-tshooting-mounting_{context}"]
+= Troubleshoot secrets not mounting correctly
+
+[role="_abstract"]
+To avoid credentials file mount failures on non-root pods, mount the secret to a writable location and enable the shared credentials file option in the AWS SDK.

--- a/modules/osdk-cco-azure-enabling.adoc
+++ b/modules/osdk-cco-azure-enabling.adoc
@@ -6,6 +6,7 @@
 [id="osdk-cco-azure-enabling_{context}"]
 = Enabling Operators to support CCO-based workflows with {entra-first}
 
+[role="_abstract"]
 As an Operator author designing your project to run on Operator Lifecycle Manager (OLM), you can enable your Operator to authenticate against {entra-first}-enabled {product-title} clusters by customizing your project to support the Cloud Credential Operator (CCO).
 
 With this method, the Operator is responsible for and requires RBAC permissions for creating the `CredentialsRequest` object and reading the resulting `Secret` object.
@@ -28,8 +29,6 @@ By default, pods related to the Operator deployment mount a `serviceAccountToken
 .. Ensure your Operator has RBAC permission to create `CredentialsRequests` objects:
 +
 .Example `clusterPermissions` list
-[%collapsible]
-====
 [source,yaml]
 ----
 # ...
@@ -50,7 +49,6 @@ install:
         - update
         - watch
 ----
-====
 
 .. Add the following annotation to claim support for this method of CCO-based workflow with {entra-short}:
 +
@@ -85,8 +83,6 @@ Adding a `CredentialsRequest` object to the Operator bundle is not currently sup
 .. Add the Azure credentials information and web identity token path to the credentials request and apply it during Operator initialization:
 +
 .Example applying `CredentialsRequest` object during Operator initialization
-[%collapsible]
-====
 [source,go]
 ----
 // apply CredentialsRequest on install
@@ -104,13 +100,10 @@ if err := c.Create(context.TODO(), credReq); err != nil {
     }
 }
 ----
-====
 
 .. Ensure your Operator can wait for a `Secret` object to show up from the CCO, as shown in the following example, which is called along with the other items you are reconciling in your Operator:
 +
 .Example wait for `Secret` object
-[%collapsible]
-====
 [source,go]
 ----
 // WaitForSecret is a function that takes a Kubernetes client, a namespace, and a v1 "k8s.io/api/core/v1" name as arguments
@@ -118,7 +111,7 @@ if err := c.Create(context.TODO(), credReq); err != nil {
 // It returns the secret object or an error if the timeout is exceeded
 func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Secret, error) {
   // set a timeout of 10 minutes
-  timeout := time.After(10 * time.Minute) <1>
+  timeout := time.After(10 * time.Minute)
 
   // set a polling interval of 10 seconds
   ticker := time.NewTicker(10 * time.Second)
@@ -149,7 +142,7 @@ func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Sec
   }
 }
 ----
-<1> The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
-====
++
+The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
 
 .. Read the secret created by the CCO from the `CredentialsRequest` object to authenticate with Azure and receive the necessary credentials.

--- a/modules/osdk-cco-gcp-enabling.adoc
+++ b/modules/osdk-cco-gcp-enabling.adoc
@@ -6,6 +6,7 @@
 [id="osdk-cco-gcp-enabling_{context}"]
 = Enabling Operators to support CCO-based workflows with {gcp-wid-short}
 
+[role="_abstract"]
 As an Operator author designing your project to run on Operator Lifecycle Manager (OLM), you can enable your Operator to authenticate against {gcp-wid-first} on {product-title} clusters by customizing your project to support the Cloud Credential Operator (CCO).
 
 With this method, the Operator is responsible for and requires RBAC permissions for creating the `CredentialsRequest` object and reading the resulting `Secret` object.
@@ -28,13 +29,11 @@ By default, pods related to the Operator deployment mount a `serviceAccountToken
 .. Ensure Operator deployment in the CSV has the following `volumeMounts` and `volumes` fields so that the Operator can assume the role with web identity:
 +
 .Example `volumeMounts` and `volumes` fields
-[%collapsible]
-====
 [source,yaml]
 ----
 # ...
       volumeMounts:
-  
+
       - name: bound-sa-token
         mountPath: /var/run/secrets/openshift/serviceaccount
         readOnly: true
@@ -47,13 +46,10 @@ By default, pods related to the Operator deployment mount a `serviceAccountToken
                path: token
                audience: openshift
 ----
-====
 
 .. Ensure your Operator has RBAC permission to create `CredentialsRequests` objects:
 +
 .Example `clusterPermissions` list
-[%collapsible]
-====
 [source,yaml]
 ----
 # ...
@@ -74,7 +70,6 @@ install:
         - update
         - watch
 ----
-====
 
 .. Add the following annotation to claim support for this method of CCO-based workflow with {gcp-wid-short}:
 +
@@ -108,8 +103,6 @@ Adding a `CredentialsRequest` object to the Operator bundle is not currently sup
 .. Add the {gcp-wid-short} variables to the credentials request and apply it during Operator initialization:
 +
 .Example applying `CredentialsRequest` object during Operator initialization
-[%collapsible]
-====
 [source,go]
 ----
 // apply CredentialsRequest on install
@@ -126,13 +119,10 @@ Adding a `CredentialsRequest` object to the Operator bundle is not currently sup
        }
    }
 ----
-====
 
 .. Ensure your Operator can wait for a `Secret` object to show up from the CCO, as shown in the following example, which is called along with the other items you are reconciling in your Operator:
 +
 .Example wait for `Secret` object
-[%collapsible]
-====
 [source,go]
 ----
 // WaitForSecret is a function that takes a Kubernetes client, a namespace, and a v1 "k8s.io/api/core/v1" name as arguments
@@ -140,7 +130,7 @@ Adding a `CredentialsRequest` object to the Operator bundle is not currently sup
 // It returns the secret object or an error if the timeout is exceeded
 func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Secret, error) {
   // set a timeout of 10 minutes
-  timeout := time.After(10 * time.Minute) <1>
+  timeout := time.After(10 * time.Minute)
 
   // set a polling interval of 10 seconds
   ticker := time.NewTicker(10 * time.Second)
@@ -171,8 +161,8 @@ func WaitForSecret(client kubernetes.Interface, namespace, name string) (*v1.Sec
   }
 }
 ----
-<1> The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
-====
++
+The `timeout` value is based on an estimate of how fast the CCO might detect an added `CredentialsRequest` object and generate a `Secret` object. You might consider lowering the time or creating custom feedback for cluster administrators that could be wondering why the Operator is not yet accessing the cloud resources.
 
 .. Read the `service_account.json` field from the secret and use it to authenticate your {gcp-short} client:
 +

--- a/operators/operator_sdk/token_auth/osdk-cco-aws-sts.adoc
+++ b/operators/operator_sdk/token_auth/osdk-cco-aws-sts.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When an {product-title} cluster running on AWS is in Security Token Service (STS) mode, it means the cluster is utilizing features of AWS and {product-title} to use IAM roles at an application level. STS enables applications to provide a JSON Web Token (JWT) that can assume an IAM role.
 
 The JWT includes an Amazon Resource Name (ARN) for the `sts:AssumeRoleWithWebIdentity` IAM action to allow temporarily-granted permission for the service account. The JWT contains the signing keys for the `ProjectedServiceAccountToken` that AWS IAM can validate. The service account token itself, which is signed, is used as the JWT required for assuming the AWS role.
@@ -44,6 +45,8 @@ include::modules/osdk-cco-aws-sts-enabling.adoc[leveloffset=+1]
 
 include::modules/osdk-cco-aws-sts-role.adoc[leveloffset=+1]
 
-include::modules/osdk-cco-aws-sts-tshooting.adoc[leveloffset=+1]
+include::modules/osdk-cco-aws-sts-tshooting-auth-fail.adoc[leveloffset=+1]
+
+include::modules/osdk-cco-aws-sts-tshooting-mounting.adoc[leveloffset=+1]
 
 include::modules/osdk-cco-aws-sts-alt.adoc[leveloffset=+1]

--- a/operators/operator_sdk/token_auth/osdk-cco-azure.adoc
+++ b/operators/operator_sdk/token_auth/osdk-cco-azure.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When an {product-title} cluster running on Azure is in *Workload Identity / Federated Identity* mode, it means the cluster is utilizing features of Azure and {product-title} to apply _user-assigned managed identities_ or _app registrations_ in {entra-first} at an application level.
 
 The Cloud Credential Operator (CCO) is a cluster Operator installed by default in {product-title} clusters running on cloud providers. Starting in {product-title} 4.14.8, the CCO supports workflows for OLM-managed Operators with {entra-short}.

--- a/operators/operator_sdk/token_auth/osdk-cco-gcp.adoc
+++ b/operators/operator_sdk/token_auth/osdk-cco-gcp.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When an {product-title} cluster running on {gcp-first} is in *{gcp-wid-short} / Federated Identity* mode, it means the cluster is utilizing features of {gcp-first} and {product-title} to apply permissions in {gcp-wid-short} at an application level.
 
 The Cloud Credential Operator (CCO) is a cluster Operator installed by default in {product-title} clusters running on cloud providers. Starting in {product-title} 4.17, the CCO supports workflows for OLM-managed Operators with {gcp-wid-short}.

--- a/operators/operator_sdk/token_auth/osdk-token-auth.adoc
+++ b/operators/operator_sdk/token_auth/osdk-token-auth.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Many cloud providers can enable authentication by using account tokens that provide short-term, limited-privilege security credentials.
 
 {product-title} includes the Cloud Credential Operator (CCO) to manage cloud provider credentials as custom resource definitions (CRDs). The CCO syncs on `CredentialsRequest` custom resources (CRs) to allow {product-title} components to request cloud provider credentials with any specific permissions required.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first. If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16943](https://redhat.atlassian.net/browse/OSDOCS-16943)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [operators/operator_sdk/token_auth/osdk-cco-aws-sts.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-f0a80bc9cbd69b4cb578ade6dcadeddd11b393c79ecf79a9a1f5e3d892d63956):
** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-aws-sts.html)
** [modules/osdk-cco-aws-sts-alt.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-8374cbe20a04b3a057caaeaec34d221919a268c20cbf5d22ed8749a3e683b57e):
*** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-aws-sts.html#osdk-cco-aws-sts-alt_osdk-cco-aws-sts)
** [modules/osdk-cco-aws-sts-role.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-1f9d81e89eeb3b88899e2f35b416afa27e0b2d85370bfd062042df2fd204fab2):
*** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-aws-sts.html#osdk-cco-aws-sts-role_osdk-cco-aws-sts)
* [operators/operator_sdk/token_auth/osdk-cco-azure.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-e74187832da0ca8e843645c99704106b807b18e372c15d6a738e7f5736b3a55c):
** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-azure.html)
** [modules/osdk-cco-azure-enabling.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-d5638b0717884567f7dbeec765dffcdda4aa52c40530ac4558550b2d1be06f7f):
*** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-azure.html#osdk-cco-azure-enabling_osdk-cco-azure)
* [operators/operator_sdk/token_auth/osdk-cco-gcp.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-ca80249947fc91c7152611d101c6b8ad963bf8d1b6cb41a147aff9a4e0a4e4e7):
** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-gcp.html)
** [modules/osdk-cco-gcp-enabling.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-de9d0a4074e5fba20301d882f801c4dd27f6e8b22a875f403d344575d077da18):
*** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-cco-gcp.html#osdk-cco-gcp-enabling_osdk-cco-gcp)
* [operators/operator_sdk/token_auth/osdk-token-auth.adoc](https://github.com/openshift/openshift-docs/pull/118021/files#diff-3c3dd6c1b49313e2c6aa0d30728b70aae6f534fe6591313ed702cdb91807e9fb):
** [openshift-enterprise](https://118021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/token_auth/osdk-token-auth.html)


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. <!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->