### PR TITLE
OSDOCS-16990: AWS IPI CQA pt 5

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -80,19 +80,19 @@ include::modules/nw-operator-cr.adoc[leveloffset=+1]
 
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 
-[NOTE]
-====
-For more information on using a Network Load Balancer (NLB) on {aws-short}, see xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws.adoc#nw-configuring-ingress-cluster-traffic-aws-network-load-balancer_configuring-ingress-cluster-traffic-aws[Configuring Ingress cluster traffic on {aws-short} using a Network Load Balancer].
-====
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws.adoc#nw-configuring-ingress-cluster-traffic-aws-network-load-balancer_configuring-ingress-cluster-traffic-aws[Configuring Ingress cluster traffic on {aws-short} using a Network Load Balancer]
 
 include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-[NOTE]
-====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
-====
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/ipi/installing-aws-multiarch-support.adoc
+++ b/installing/installing_aws/ipi/installing-aws-multiarch-support.adoc
@@ -22,11 +22,8 @@ include::snippets/about-multiarch-tuning-operator.adoc[]
 
 include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
 
-.Next steps
-
-* xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
-
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
 * xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -59,13 +59,18 @@ This command also creates a private key that the cluster requires during install
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
-  --name=<name> \// <1>
-  --region=<aws_region> \// <2>
-  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public <3>
+  --name=<name> \
+  --region=<aws_region> \
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
-<1> `<name>` is the name used to tag any cloud resources that are created for tracking.
-<2> `<aws-region>` is the AWS region in which cloud resources will be created.
-<3> `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
++
+--
+where:
+
+`<name>`:: Specifies the name used to tag any cloud resources that are created for tracking.
+`<aws_region>`:: Specifies the AWS region in which cloud resources will be created.
+`<path_to_ccoctl_output_dir>`:: Specifies the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+--
 +
 .Example output
 [source,text]
@@ -97,13 +102,16 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
++
+where:
+
+`--included`:: Specifies the `--included` parameter, which includes only the manifests that your specific cluster configuration requires.
+`--install-config`:: Specifies the location of the `install-config.yaml` file.
+`-to`:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +

--- a/modules/installation-aws-arm-tested-machine-types.adoc
+++ b/modules/installation-aws-arm-tested-machine-types.adoc
@@ -12,7 +12,10 @@
 [id="installation-aws-arm-tested-machine-types_{context}"]
 = Tested instance types for AWS on 64-bit ARM infrastructures
 
-The following Amazon Web Services (AWS) 64-bit ARM instance types have been tested with {product-title}.
+[role="_abstract"]
+There are several Amazon Web Services (AWS) 64-bit ARM instance types tested with {product-title}.
+
+The following AWS 64-bit ARM instance types have been tested with {product-title}.
 
 [NOTE]
 ====

--- a/modules/installation-aws-config-yaml-customizations.adoc
+++ b/modules/installation-aws-config-yaml-customizations.adoc
@@ -6,6 +6,7 @@
 [id="installation-aws-config-yaml-customizations_{context}"]
 = Sample customized install-config.yaml file for AWS
 
+[role="_abstract"]
 You can customize the installation configuration file (`install-config.yaml`) to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [IMPORTANT]
@@ -17,34 +18,35 @@ For a full list and description of all installation configuration parameters, se
 .Sample `install-config.yaml` file for {aws-short}
 [source,yaml]
 ----
-apiVersion: v1 <1>
+apiVersion: v1
 baseDomain: example.com
 sshKey: ssh-ed25519 AAAA...
 pullSecret: '{"auths": ...}'
 metadata:
   name: example-cluster
-controlPlane: <2>
+controlPlane:
   name: master
   platform:
     aws:
       type: m6i.xlarge
   replicas: 3
-compute: <3>
+compute:
 -  name: worker
   platform:
     aws:
       type: c5.4xlarge
   replicas: 3
-networking: <4>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-platform: <5>
+platform:
   aws:
     region: us-west-2
 ----
-<1> Parameters at the first level of indentation apply to the cluster globally.
-<2> The `controlPlane` stanza applies to control plane machines.
-<3> The `compute` stanza applies to compute machines.
-<4> The `networking` stanza applies to the cluster networking configuration. If you do not provide networking values, the installation program provides default values.
-<5> The `platform` stanza applies to the infrastructure platform that hosts the cluster.
+
+* Parameters at the first level of indentation apply to the cluster globally.
+* The `controlPlane` stanza applies to control plane machines.
+* The `compute` stanza applies to compute machines.
+* The `networking` stanza applies to the cluster networking configuration. If you do not provide networking values, the installation program provides default values.
+* The `platform` stanza applies to the infrastructure platform that hosts the cluster.

--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -26,6 +26,7 @@ endif::[]
 [id="installation-aws-marketplace-subscribe_{context}"]
 = Obtaining an AWS Marketplace image
 
+[role="_abstract"]
 If you are deploying an {product-title} cluster using an AWS Marketplace image, you must first subscribe through AWS. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy compute nodes.
 
 :platform-abbreviation: an AWS
@@ -61,19 +62,22 @@ compute:
   name: worker
   platform:
     aws:
-      amiID: ami-06c4d345f7c207239 <1>
+      amiID: ami-06c4d345f7c207239
       type: m5.4xlarge
   replicas: 3
 metadata:
   name: test-cluster
 platform:
   aws:
-    region: us-east-2 <2>
+    region: us-east-2
 sshKey: ssh-ed25519 AAAA...
 pullSecret: '{"auths": ...}'
 ----
-<1> The AMI ID from your AWS Marketplace subscription.
-<2> Your AMI ID is associated with a specific AWS Region. When creating the installation configuration file, ensure that you select the same AWS Region that you specified when configuring your subscription.
++
+where:
+
+`compute.platform.aws.amiID`:: Specifies the AMI ID from your AWS Marketplace subscription.
+`platform.aws.region`:: Specifies the `platform.aws.region` parameter. Your AMI ID is associated with a specific AWS Region. When creating the installation configuration file, ensure that you select the same AWS Region that you specified when configuring your subscription.
 endif::ipi[]
 
 ifeval::["{context}" == "installing-aws-customizations"]

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -26,7 +26,10 @@ endif::[]
 [id="installation-aws-tested-machine-types_{context}"]
 = Tested instance types for AWS
 
-The following Amazon Web Services (AWS) instance types have been tested with
+[role="_abstract"]
+There are several Amazon Web Services (AWS) instance types tested with {product-title}.
+
+The following AWS instance types have been tested with
 ifndef::local-zone,wavelength-zone[]
 {product-title}.
 endif::local-zone,wavelength-zone[]


### PR DESCRIPTION
[OSDOCS-16990](https://redhat.atlassian.net/browse/OSDOCS-16990)

Version(s): 4.20+

AWS IPI Install CQA changes. This PR modularizes some sections and deletes some redundant stubs.

QE review: Not required for formatting changes