### PR TITLE
OSDOCS-20741: Document Gateway API HTTPRoute Hostnames and ParentRefs

### DIFF
--- a/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services.adoc
+++ b/networking/ingress_load_balancing/configuring_gateway_api/routing-http-requests-to-services.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 When you expose your applications through a gateway, you must configure an `HTTPRoute` custom resource (CR) to accurately direct incoming HTTP requests from your network listener to the appropriate backend services. A Gateway API `HTTPRoute` CR specifies the exact routing behavior for these requests by evaluating a set of rules.
 
-The core configuration element of an `HTTPRoute` CR is a rule. You can configure up to 16 rules for a single route. Within each rule, you can establish the following routing behaviors:
+The core configuration element of an `HTTPRoute` CR comes from hostname, parentRefs, and rules. You can configure up to 16 rules for a single route. Within each rule, you can establish the following routing behaviors:
 
 * `Matches`: Define the conditions an HTTP request must meet based on paths, headers, query parameters, or methods.
 * `Filters`: Apply processing directions to the request, such as header modifications, mirrors, or redirects.


### PR DESCRIPTION
Superseded by https://github.com/openshift/openshift-docs/pull/119010.

- https://redhat.atlassian.net/browse/OSDOCS-17711

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
