### PR TITLE
OSDOCS-17049pr15: Add cluster-tasks DITA reference modules

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -47,7 +47,7 @@ The following Technology Preview features are enabled by this feature set:
 ** `ClusterAPIMachineManagementAzure`
 ** `ClusterAPIMachineManagementBareMetal`
 ** `ClusterAPIMachineManagementGCP`
-** `ClusterAPIMachineManagementOpenStack
+** `ClusterAPIMachineManagementOpenStack`
 ** `ClusterAPIMachineManagementPowerVS`
 ** `ClusterAPIMachineManagementVSphere`
 ** `ClusterMonitoringConfig`
@@ -125,8 +125,6 @@ The following Technology Preview features are enabled by this feature set:
 ** `VSphereMultiDisk`
 ** `VSphereMultiNetworks`
 --
-
-See the _Additional resources_ sections for information on some of these features.
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/modules/post-install-adding-nodes-assisted.adoc
+++ b/modules/post-install-adding-nodes-assisted.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-assisted_{context}"]
+= Adding worker nodes to clusters managed by the Assisted Installer
+
+[role="_abstract"]
+Add worker nodes to Assisted Installer clusters by using {cluster-manager-first}, the REST API, or a manual ISO process.
+
+For clusters managed by the Assisted Installer, you can add worker nodes by using the {cluster-manager-first} console, the Assisted Installer REST API or you can manually add worker nodes using an ISO image and cluster Ignition config files.

--- a/modules/post-install-adding-nodes-ipi.adoc
+++ b/modules/post-install-adding-nodes-ipi.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-ipi_{context}"]
+= Adding worker nodes to installer-provisioned infrastructure clusters
+
+[role="_abstract"]
+Add worker nodes to installer-provisioned infrastructure clusters by scaling machine sets or provisioning bare-metal hosts.
+
+For installer-provisioned infrastructure clusters, you can manually or automatically scale the `MachineSet` object to match the number of available bare-metal hosts.
+
+To add a bare-metal host, you must configure all network prerequisites, configure an associated `baremetalhost` object, then provision the worker node to the cluster. You can add a bare-metal host manually or by using the web console.

--- a/modules/post-install-adding-nodes-mce.adoc
+++ b/modules/post-install-adding-nodes-mce.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-mce_{context}"]
+= Adding worker nodes to clusters managed by the multicluster engine for Kubernetes
+
+[role="_abstract"]
+Add worker nodes to multicluster engine for Kubernetes clusters by using the dedicated console.
+
+For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.

--- a/modules/post-install-adding-nodes-on-prem.adoc
+++ b/modules/post-install-adding-nodes-on-prem.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-iso_{context}"]
+= Adding worker nodes to an on-premise cluster
+
+[role="_abstract"]
+Add worker nodes to an on-premise {product-title} cluster by using the OpenShift CLI to generate an ISO image.
+
+For on-premise clusters, you can add worker nodes by using the {product-title} CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
+Any configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
+
+Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.

--- a/modules/post-install-adding-nodes-upi.adoc
+++ b/modules/post-install-adding-nodes-upi.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-nodes-upi_{context}"]
+= Adding worker nodes to user-provisioned infrastructure clusters
+
+[role="_abstract"]
+Add worker nodes to user-provisioned infrastructure clusters by using an ISO image and Ignition config files.
+
+For user-provisioned infrastructure clusters, you can add worker nodes by using a {op-system-base} or {op-system} ISO image and connecting it to your cluster using cluster Ignition config files. For RHEL worker nodes, the following example uses Ansible playbooks to add worker nodes to the cluster. For RHCOS worker nodes, the following example uses an ISO image and network booting to add worker nodes to the cluster.

--- a/modules/post-install-adding-worker-nodes.adoc
+++ b/modules/post-install-adding-worker-nodes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="adding-worker-nodes_{context}"]
+= Adding worker nodes
+
+[role="_abstract"]
+After you deploy your {product-title} cluster, you can add worker nodes to scale cluster resources using the method that matches your installation type and environment.
+
+After you deploy your {product-title} cluster, you can add worker nodes to scale cluster resources. There are different ways you can add worker nodes depending on the installation method and the environment of your cluster.

--- a/modules/post-install-additional-config-resources.adoc
+++ b/modules/post-install-additional-config-resources.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
+
+:_mod-docs-content-type: REFERENCE
+[id="additional-configuration-resources_{context}"]
+= Additional configuration resources
+
+[role="_abstract"]
+Review the additional configuration resources that represent a single instance of a particular {product-title} component.
+
+These configuration resources represent a single instance of a particular component. In some cases, you can request multiple
+instances by creating multiple instances of the resource. In other cases, the Operator can use only a specific
+resource instance name in a specific namespace. Reference the component-specific
+documentation for details on how and when you can create additional resource instances.
+
+[cols="2a,2a,2a,8a",options="header"]
+|===
+|Resource name
+|Instance name
+|Namespace
+|Description
+
+|`alertmanager.monitoring.coreos.com`
+|`main`
+|`openshift-monitoring`
+|Controls the link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/latest/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Alertmanager] deployment parameters.
+
+|`ingresscontroller.operator.openshift.io`
+|`default`
+|`openshift-ingress-operator`
+|Configures xref:../networking/networking_operators/ingress-operator.adoc#configuring-ingress-controller[Ingress Operator] behavior such as domain, number of replicas, certificates, and controller placement.
+
+|===

--- a/modules/post-install-adjust-worker-nodes.adoc
+++ b/modules/post-install-adjust-worker-nodes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-adjust-worker-nodes_{context}"]
+= Adjust worker nodes
+
+[role="_abstract"]
+Resize worker nodes by creating new compute machine sets, scaling them up, and scaling down the original machine set before removal.
+
+If you incorrectly sized the worker nodes during deployment, adjust them by creating one or more new compute machine sets, scale them up, then scale the original compute machine set down before removing them.

--- a/modules/post-install-applying-autoscaling.adoc
+++ b/modules/post-install-applying-autoscaling.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="custer-tasks-applying-autoscaling_{context}"]
+= Applying autoscaling to your cluster
+
+[role="_abstract"]
+Deploy a cluster autoscaler and machine autoscalers to apply autoscaling across machine types in your cluster.
+
+Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.

--- a/modules/post-install-assigning-machine-set-resources-to-infra-nodes.adoc
+++ b/modules/post-install-assigning-machine-set-resources-to-infra-nodes.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="assigning-machine-set-resources-to-infra-nodes_{context}"]
+= Assigning machine set resources to infrastructure nodes
+
+[role="_abstract"]
+Apply taints and tolerations to infrastructure nodes so user workloads are not scheduled inadvertently to those nodes.
+
+After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes. Nodes with the `infra` role are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
+
+However, when an infra node is assigned the worker role, there is a chance that user workloads can get assigned inadvertently to the infra node. To avoid this, you can apply a taint to the infra node and tolerations for the pods that you want to control.

--- a/modules/post-install-cluster-config-resources.adoc
+++ b/modules/post-install-cluster-config-resources.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
+
+:_mod-docs-content-type: REFERENCE
+[id="configuration-resources_{context}"]
+= Cluster configuration resources
+
+[role="_abstract"]
+Review the globally scoped cluster configuration resources that control major features of an {product-title} cluster.
+
+All cluster configuration resources are globally scoped (not namespaced) and named `cluster`.
+////
+Config changes should not require coordinated changes between config resources, if you find
+yourself struggling to update these docs to explain coordinated changes, please reach out
+to @api-approvers (github) or #forum-api-review (slack).
+////
+
+[cols="2a,8a",options="header"]
+|===
+|Resource name
+|Description
+
+|`apiserver.config.openshift.io`
+|Provides API server configuration such as xref:../security/certificates/api-server.adoc#api-server-certificates[certificates and certificate authorities].
+
+|`authentication.config.openshift.io`
+|Controls the xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[identity provider] and authentication configuration for the cluster.
+
+|`build.config.openshift.io`
+|Controls default and enforced xref:../cicd/builds/build-configuration.adoc#build-configuration[configuration] for all builds on the cluster.
+
+|`console.config.openshift.io`
+|Configures the behavior of the web console interface, including the xref:../web_console/configuring-web-console.adoc#configuring-web-console[logout behavior].
+
+|`featuregate.config.openshift.io`
+|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[FeatureGates]
+so that you can use Tech Preview features.
+
+|`image.config.openshift.io`
+|Configures how specific xref:../openshift_images/image-configuration.adoc#image-configuration[image registries] should be treated (allowed, disallowed, insecure, CA details).
+
+|`ingress.config.openshift.io`
+|Configuration details related to xref:../networking/networking_operators/ingress-operator.adoc#nw-installation-ingress-config-asset_ingress-operator[routing] such as the default domain for routes.
+
+|`oauth.config.openshift.io`
+|Configures identity providers and other behavior related to xref:../authentication/configuring-internal-oauth.adoc#configuring-internal-oauth[internal OAuth server] flows.
+
+|`project.config.openshift.io`
+|Configures xref:../applications/projects/configuring-project-creation.adoc#configuring-project-creation[how projects are created] including the project template.
+
+|`proxy.config.openshift.io`
+|Defines proxies to be used by components needing external network access. Note: not all components currently consume this value.
+
+|`scheduler.config.openshift.io`
+|Configures xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[scheduler] behavior such as profiles and default node selectors.
+
+|===

--- a/modules/post-install-cpms-setup.adoc
+++ b/modules/post-install-cpms-setup.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-cpms-setup_{context}"]
+= Managing control plane machines
+
+[role="_abstract"]
+Use control plane machine sets to manage control plane machines with capabilities similar to compute machine sets.
+
+Control plane machine sets provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. The availability and initial status of control plane machine sets on your cluster depend on your cloud provider and the version of {product-title} that you installed.

--- a/modules/post-install-creating-infrastructure-machinesets-production.adoc
+++ b/modules/post-install-creating-infrastructure-machinesets-production.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-creating-infrastructure-machinesets-production_{context}"]
+= Creating infrastructure machine sets for production environments
+
+[role="_abstract"]
+Create infrastructure machine sets to host cluster infrastructure components without counting those machines toward subscription limits.
+
+You can create a compute machine set to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
+
+For information on infrastructure nodes and which components can run on infrastructure nodes, see "Creating infrastructure machine sets".
+
+To create an infrastructure node, see "Use a machine set to create an infrastructure node", "Assign a label to infrastructure nodes", or "Use a machine config pool for infrastructure nodes".
+
+For sample machine sets that you can use with these procedures, see "Creating machine sets for different clouds".
+
+Applying a specific node selector to all infrastructure components causes {product-title} to schedule those workloads on nodes with that label; see "Schedule infrastructure workloads using node selectors".

--- a/modules/post-install-enabling-feature-gates.adoc
+++ b/modules/post-install-enabling-feature-gates.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-tp-tasks_{context}"]
+= Enabling Technology Preview features using FeatureGates
+
+[role="_abstract"]
+Enable Technology Preview features cluster-wide by editing the `FeatureGate` custom resource.
+
+You can turn on a subset of the current Technology Preview features on for all nodes in the cluster by editing the `FeatureGate` custom resource (CR).

--- a/modules/post-install-etcd-tasks.adoc
+++ b/modules/post-install-etcd-tasks.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-etcd-tasks_{context}"]
+= etcd tasks
+
+[role="_abstract"]
+Back up etcd, enable or disable etcd encryption, or defragment etcd data.
+
+[NOTE]
+====
+If you deployed a bare-metal cluster, you can scale the cluster up to 5 nodes as part of your post-installation tasks.
+====

--- a/modules/post-install-informational-resources.adoc
+++ b/modules/post-install-informational-resources.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
+
+:_mod-docs-content-type: REFERENCE
+[id="informational-resources_{context}"]
+= Informational resources
+
+[role="_abstract"]
+Review the informational resources that you can use to retrieve information about an {product-title} cluster.
+
+You use these resources to retrieve information about the cluster. Some configurations might require you to edit these resources directly.
+
+[cols="2a,2a,8a",options="header"]
+|===
+|Resource name|Instance name|Description
+
+|`clusterversion.config.openshift.io`
+|`version`
+|In {product-title} {product-version}, you must not customize the `ClusterVersion`
+resource for production clusters. Instead, follow the process to
+xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[update a cluster].
+
+|`dns.config.openshift.io`
+|`cluster`
+|You cannot modify the DNS settings for your cluster. You can
+xref:../networking/networking_operators/dns-operator.adoc#nw-dns-operator-status_dns-operator[check the DNS Operator status].
+
+|`infrastructure.config.openshift.io`
+|`cluster`
+|Configuration details allowing the cluster to interact with its cloud provider.
+
+|`network.config.openshift.io`
+|`cluster`
+|You cannot modify your cluster networking after installation. To customize your network, follow the process to
+xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[customize networking during installation].
+
+|===

--- a/modules/post-install-moving-resources-to-infrastructure-machinesets.adoc
+++ b/modules/post-install-moving-resources-to-infrastructure-machinesets.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="moving-resources-to-infrastructure-machinesets_{context}"]
+= Moving resources to infrastructure machine sets
+
+[role="_abstract"]
+Move default infrastructure resources to the infrastructure machine sets that you created.
+
+Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created.

--- a/modules/post-install-operator-config-resources.adoc
+++ b/modules/post-install-operator-config-resources.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+//
+// This module was created from assembly body content during a CQA pass; it retains the xrefs it inherited per doc_guidelines.adoc's exception for modules split from an assembly, and must only ever be included from one location.
+
+:_mod-docs-content-type: REFERENCE
+[id="operator-configuration-resources_{context}"]
+= Operator configuration resources
+
+[role="_abstract"]
+Review the cluster-scoped Operator configuration resources that control the behavior of specific {product-title} components.
+
+These configuration resources are cluster-scoped instances, named `cluster`, which control the behavior of a specific component as
+owned by a particular Operator.
+
+[cols="2a,8a",options="header"]
+|===
+|Resource name
+|Description
+
+|`consoles.operator.openshift.io`
+|Controls console appearance such as branding customizations
+
+|`config.imageregistry.operator.openshift.io`
+|Configures xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview_configuring-registry-operator[{product-registry} settings] such as public routing, log levels, proxy settings, resource constraints, replica counts, and storage type.
+
+|`config.samples.operator.openshift.io`
+|Configures the
+xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Samples Operator]
+to control which example image streams and templates are installed on the cluster.
+
+|===

--- a/modules/post-install-pod-disruption-budgets.adoc
+++ b/modules/post-install-pod-disruption-budgets.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-install-pod-disruption-budgets_{context}"]
+= Pod disruption budgets
+
+[role="_abstract"]
+Understand and configure pod disruption budgets to control voluntary disruptions during cluster operations.

--- a/modules/post-install-worker-latency-profiles.adoc
+++ b/modules/post-install-worker-latency-profiles.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="post-worker-latency-profiles_{context}"]
+= Improving cluster stability in high latency environments using worker latency profiles
+
+[role="_abstract"]
+Configure worker latency profiles to improve cluster stability in high latency environments.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -14,7 +14,7 @@ After installing {product-title}, you can further expand and customize your clus
 [id="available_cluster_customizations"]
 == Available cluster customizations
 
-You complete most of the cluster configuration and customization after you deploy your {product-title} cluster. A number of _configuration resources_ are available.
+You complete most of the cluster configuration and customization after you deploy your {product-title} cluster. Several _configuration resources_ are available.
 
 [NOTE]
 ====
@@ -25,194 +25,56 @@ You modify the configuration resources to configure the major features of the cl
 
 For current documentation of the settings that you control by using these resources, use the `oc explain` command, for example `oc explain builds --api-version=config.openshift.io/v1`
 
-[id="configuration-resources_{context}"]
-=== Cluster configuration resources
+include::modules/post-install-cluster-config-resources.adoc[leveloffset=+2]
 
-All cluster configuration resources are globally scoped (not namespaced) and named `cluster`.
-////
-Config changes should not require coordinated changes between config resources, if you find
-yourself struggling to update these docs to explain coordinated changes, please reach out
-to @api-approvers (github) or #forum-api-review (slack).
-////
+include::modules/post-install-operator-config-resources.adoc[leveloffset=+2]
 
-[cols="2a,8a",options="header"]
-|===
-|Resource name
-|Description
+include::modules/post-install-additional-config-resources.adoc[leveloffset=+2]
 
-|`apiserver.config.openshift.io`
-|Provides API server configuration such as xref:../security/certificates/api-server.adoc#api-server-certificates[certificates and certificate authorities].
+include::modules/post-install-informational-resources.adoc[leveloffset=+2]
 
-|`authentication.config.openshift.io`
-|Controls the xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[identity provider] and authentication configuration for the cluster.
+include::modules/post-install-adding-worker-nodes.adoc[leveloffset=+1]
 
-|`build.config.openshift.io`
-|Controls default and enforced xref:../cicd/builds/build-configuration.adoc#build-configuration[configuration] for all builds on the cluster.
+include::modules/post-install-adding-nodes-on-prem.adoc[leveloffset=+2]
 
-|`console.config.openshift.io`
-|Configures the behavior of the web console interface, including the xref:../web_console/configuring-web-console.adoc#configuring-web-console[logout behavior].
+[role="_additional-resources"]
+.Additional resources
 
-|`featuregate.config.openshift.io`
-|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[FeatureGates]
-so that you can use Tech Preview features.
+* xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]
 
-|`image.config.openshift.io`
-|Configures how specific xref:../openshift_images/image-configuration.adoc#image-configuration[image registries] should be treated (allowed, disallowed, insecure, CA details).
+include::modules/post-install-adding-nodes-ipi.adoc[leveloffset=+2]
 
-|`ingress.config.openshift.io`
-|Configuration details related to xref:../networking/networking_operators/ingress-operator.adoc#nw-installation-ingress-config-asset_ingress-operator[routing] such as the default domain for routes.
-
-|`oauth.config.openshift.io`
-|Configures identity providers and other behavior related to xref:../authentication/configuring-internal-oauth.adoc#configuring-internal-oauth[internal OAuth server] flows.
-
-|`project.config.openshift.io`
-|Configures xref:../applications/projects/configuring-project-creation.adoc#configuring-project-creation[how projects are created] including the project template.
-
-|`proxy.config.openshift.io`
-|Defines proxies to be used by components needing external network access.  Note: not all components currently consume this value.
-
-|`scheduler.config.openshift.io`
-|Configures xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[scheduler] behavior such as profiles and default node selectors.
-
-|===
-
-[id="operator-configuration-resources_{context}"]
-=== Operator configuration resources
-
-These configuration resources are cluster-scoped instances, named `cluster`, which control the behavior of a specific component as
-owned by a particular Operator.
-
-[cols="2a,8a",options="header"]
-|===
-|Resource name
-|Description
-
-|`consoles.operator.openshift.io`
-|Controls console appearance such as branding customizations
-
-|`config.imageregistry.operator.openshift.io`
-|Configures xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview_configuring-registry-operator[{product-registry} settings] such as public routing, log levels, proxy settings, resource constraints, replica counts, and storage type.
-
-|`config.samples.operator.openshift.io`
-|Configures the
-xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Samples Operator]
-to control which example image streams and templates are installed on the cluster.
-
-|===
-
-[id="additional-configuration-resources_{context}"]
-=== Additional configuration resources
-
-These configuration resources represent a single instance of a particular component. In some cases, you can request multiple
-instances by creating multiple instances of the resource. In other cases, the Operator can use only a specific
-resource instance name in a specific namespace. Reference the component-specific
-documentation for details on how and when you can create additional resource instances.
-
-[cols="2a,2a,2a,8a",options="header"]
-|===
-|Resource name
-|Instance name
-|Namespace
-|Description
-
-|`alertmanager.monitoring.coreos.com`
-|`main`
-|`openshift-monitoring`
-|Controls the link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/latest/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Alertmanager] deployment parameters.
-
-|`ingresscontroller.operator.openshift.io`
-|`default`
-|`openshift-ingress-operator`
-|Configures xref:../networking/networking_operators/ingress-operator.adoc#configuring-ingress-controller[Ingress Operator] behavior such as domain, number of replicas, certificates, and controller placement.
-
-|===
-
-[id="informational-resources_{context}"]
-=== Informational Resources
-
-You use these resources to retrieve information about the cluster. Some configurations might require you to edit these resources directly.
-
-[cols="2a,2a,8a",options="header"]
-|===
-|Resource name|Instance name|Description
-
-|`clusterversion.config.openshift.io`
-|`version`
-|In {product-title} {product-version}, you must not customize the `ClusterVersion`
-resource for production clusters. Instead, follow the process to
-xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[update a cluster].
-
-|`dns.config.openshift.io`
-|`cluster`
-|You cannot modify the DNS settings for your cluster. You can
-xref:../networking/networking_operators/dns-operator.adoc#nw-dns-operator-status_dns-operator[check the DNS Operator status].
-
-|`infrastructure.config.openshift.io`
-|`cluster`
-|Configuration details allowing the cluster to interact with its cloud provider.
-
-|`network.config.openshift.io`
-|`cluster`
-|You cannot modify your cluster networking after installation. To customize your network, follow the process to
-xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[customize networking during installation].
-
-|===
-
-[id="adding-worker-nodes_{context}"]
-== Adding worker nodes
-
-After you deploy your {product-title} cluster, you can add worker nodes to scale cluster resources. There are different ways you can add worker nodes depending on the installation method and the environment of your cluster.
-
-[id="adding-nodes-iso_{context}"]
-=== Adding worker nodes to an on-premise cluster
-
-For on-premise clusters, you can add worker nodes by using the {product-title} CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
-This process can be used regardless of how you installed your cluster.
-
-You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
-Any configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
-
-Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
-
-xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]
-
-=== Adding worker nodes to installer-provisioned infrastructure clusters
-
-For installer-provisioned infrastructure clusters, you can manually or automatically scale the `MachineSet` object to match the number of available bare-metal hosts.
-
-To add a bare-metal host, you must configure all network prerequisites, configure an associated `baremetalhost` object, then provision the worker node to the cluster. You can add a bare-metal host manually or by using the web console.
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-web-console_managing-bare-metal-hosts[Adding worker nodes using the web console]
-
 * xref:../scalability_and_performance/managing-bare-metal-hosts.adoc#adding-bare-metal-host-to-cluster-using-yaml_managing-bare-metal-hosts[Adding worker nodes using YAML in the web console]
-
 * xref:../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#preparing-the-bare-metal-node_bare-metal-expanding[Manually adding a worker node to an installer-provisioned infrastructure cluster]
 
-=== Adding worker nodes to user-provisioned infrastructure clusters
+include::modules/post-install-adding-nodes-upi.adoc[leveloffset=+2]
 
-For user-provisioned infrastructure clusters, you can add worker nodes by using a {op-system-base} or {op-system} ISO image and connecting it to your cluster using cluster Ignition config files. For RHEL worker nodes, the following example uses Ansible playbooks to add worker nodes to the cluster. For RHCOS worker nodes, the following example uses an ISO image and network booting to add worker nodes to the cluster.
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../post_installation_configuration/node-tasks.adoc#post-install-config-adding-fcos-compute[Adding RHCOS worker nodes to a user-provisioned infrastructure cluster]
 
-=== Adding worker nodes to clusters managed by the Assisted Installer
+include::modules/post-install-adding-nodes-assisted.adoc[leveloffset=+2]
 
-For clusters managed by the Assisted Installer, you can add worker nodes by using the {cluster-manager-first} console, the Assisted Installer REST API or you can manually add worker nodes using an ISO image and cluster Ignition config files.
+[role="_additional-resources"]
+.Additional resources
 
-* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-sno-clusters_add-workers[Adding worker nodes using the OpenShift Cluster Manager]
-
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-sno-clusters_add-workers[Adding worker nodes using {cluster-manager}]
 * xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#adding-worker-nodes-using-the-assisted-installer-api[Adding worker nodes using the Assisted Installer REST API]
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers[Manually adding worker nodes to a {sno} cluster]
 
-* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers[Manually adding worker nodes to a SNO cluster]
+include::modules/post-install-adding-nodes-mce.adoc[leveloffset=+2]
 
-=== Adding worker nodes to clusters managed by the multicluster engine for Kubernetes
-
-For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.
+[role="_additional-resources"]
+.Additional resources
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#on-prem-creating-your-cluster-with-the-console[Creating your cluster with the console]
 
-[id="post-install-adjust-worker-nodes"]
-== Adjust worker nodes
-If you incorrectly sized the worker nodes during deployment, adjust them by creating one or more new compute machine sets, scale them up, then scale the original compute machine set down before removing them.
+include::modules/post-install-adjust-worker-nodes.adoc[leveloffset=+1]
 
 include::modules/differences-between-machinesets-and-machineconfigpool.adoc[leveloffset=+2]
 
@@ -222,8 +84,7 @@ include::modules/machineset-delete-policy.adoc[leveloffset=+2]
 
 include::modules/nodes-scheduler-node-selectors-cluster.adoc[leveloffset=+2]
 
-[id="post-worker-latency-profiles"]
-== Improving cluster stability in high latency environments using worker latency profiles
+include::modules/post-install-worker-latency-profiles.adoc[leveloffset=+1]
 
 include::snippets/worker-latency-profile-intro.adoc[]
 
@@ -231,26 +92,28 @@ include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+2
 
 include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+2]
 
-[id="post-install-cpms-setup"]
-== Managing control plane machines
+include::modules/post-install-cpms-setup.adoc[leveloffset=+1]
 
-xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Control plane machine sets] provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. The availability and initial status of control plane machine sets on your cluster depend on your cloud provider and the version of {product-title} that you installed. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with control plane machine sets].
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Control plane machine sets]
+* xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with control plane machine sets]
 
 // Adding a control plane node to your cluster
 include::modules/creating-control-plane-node.adoc[leveloffset=+2]
 
-[id="post-install-creating-infrastructure-machinesets-production"]
-== Creating infrastructure machine sets for production environments
+include::modules/post-install-creating-infrastructure-machinesets-production.adoc[leveloffset=+1]
 
-You can create a compute machine set to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
+[role="_additional-resources"]
+.Additional resources
 
-For information on infrastructure nodes and which components can run on infrastructure nodes, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].
-
-To create an infrastructure node, you can xref:../post_installation_configuration/cluster-tasks.adoc#machineset-creating_post-install-cluster-tasks[use a machine set], xref:../post_installation_configuration/cluster-tasks.adoc#creating-an-infra-node_post-install-cluster-tasks[assign a label to the nodes], or xref:../post_installation_configuration/cluster-tasks.adoc#creating-infra-machines_post-install-cluster-tasks[use a machine config pool].
-
-For sample machine sets that you can use with these procedures, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-clouds[Creating machine sets for different clouds].
-
-Applying a specific node selector to all infrastructure components causes {product-title} to xref:../post_installation_configuration/cluster-tasks.adoc#moving-resources-to-infrastructure-machinesets[schedule those workloads on nodes with that label].
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
+* xref:../post_installation_configuration/cluster-tasks.adoc#machineset-creating_post-install-cluster-tasks[Use a machine set to create an infrastructure node]
+* xref:../post_installation_configuration/cluster-tasks.adoc#creating-an-infra-node_post-install-cluster-tasks[Assign a label to infrastructure nodes]
+* xref:../post_installation_configuration/cluster-tasks.adoc#creating-infra-machines_post-install-cluster-tasks[Use a machine config pool for infrastructure nodes]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-clouds[Creating machine sets for different clouds]
+* xref:../post_installation_configuration/cluster-tasks.adoc#moving-resources-to-infrastructure-machinesets_post-install-cluster-tasks[Schedule infrastructure workloads using node selectors]
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 
@@ -268,12 +131,7 @@ include::modules/creating-infra-machines.adoc[leveloffset=+2]
 
 * xref:../architecture/control-plane.adoc#architecture-machine-config-pools_control-plane[Node configuration management with machine config pools]
 
-[id="assigning-machine-set-resources-to-infra-nodes"]
-== Assigning machine set resources to infrastructure nodes
-
-After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes. Nodes with the `infra` role are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
-
-However, when an infra node is assigned the worker role, there is a chance that user workloads can get assigned inadvertently to the infra node. To avoid this, you can apply a taint to the infra node and tolerations for the pods that you want to control.
+include::modules/post-install-assigning-machine-set-resources-to-infra-nodes.adoc[leveloffset=+1]
 
 include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leveloffset=+2]
 
@@ -282,10 +140,7 @@ include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leve
 
 * xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
 
-[id="moving-resources-to-infrastructure-machinesets"]
-== Moving resources to infrastructure machine sets
-
-Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created.
+include::modules/post-install-moving-resources-to-infrastructure-machinesets.adoc[leveloffset=+1]
 
 include::modules/infrastructure-moving-router.adoc[leveloffset=+2]
 
@@ -301,17 +156,14 @@ include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]
 :FeatureResourceName: ClusterAutoscaler
 include::modules/deploying-resource.adoc[leveloffset=+2]
 
-[id="custer-tasks-applying-autoscaling"]
-== Applying autoscaling to your cluster
+include::modules/post-install-applying-autoscaling.adoc[leveloffset=+1]
 
-Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.
+[role="_additional-resources"]
+.Additional resources
 
-For more information, see xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster].
+* xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster]
 
-[id="post-install-tp-tasks"]
-== Enabling Technology Preview features using FeatureGates
-
-You can turn on a subset of the current Technology Preview features on for all nodes in the cluster by editing the `FeatureGate` custom resource (CR).
+include::modules/post-install-enabling-feature-gates.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+2]
 
@@ -319,14 +171,12 @@ include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+2]
 
-[id="post-install-etcd-tasks"]
-== etcd tasks
-Back up etcd, enable or disable etcd encryption, or defragment etcd data.
+include::modules/post-install-etcd-tasks.adoc[leveloffset=+1]
 
-[NOTE]
-====
-If you deployed a bare-metal cluster, you can scale the cluster up to 5 nodes as part of your post-installation tasks. For more information, see xref:../etcd/etcd-performance.adoc#etcd-node-scaling_etcd-performance[Node scaling for etcd].
-====
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../etcd/etcd-performance.adoc#etcd-node-scaling_etcd-performance[Node scaling for etcd]
 
 include::modules/about-etcd-encryption.adoc[leveloffset=+2]
 
@@ -348,16 +198,14 @@ include::modules/dr-restoring-cluster-state.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+
 * xref:../etcd/etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
 * xref:../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
 * xref:../installing/overview/index.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
 
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+2]
 
-[id="post-install-pod-disruption-budgets"]
-== Pod disruption budgets
-
-Understand and configure pod disruption budgets.
+include::modules/post-install-pod-disruption-budgets.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+2]
 
@@ -367,5 +215,6 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy in the Kubernetes documentation]


### PR DESCRIPTION
Extract cluster configuration tables and adding-nodes xref lists into REFERENCE modules for AsciiDocDITA NestedSection and ConceptLink compliance.

Some of the table fixes are based on https://github.com/openshift/openshift-docs/commit/b1ceba1f2293f00182c91b1c905ea77f66c7ea5b#diff-7fbeedf11ea0f855462d20df3a6f59c1936e346b57b66eb1f2e6cb9191d1a689 which uses single-use modules with xrefs.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-17049
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
