### PR TITLE
OSDOCS-21051 - Add deletion protection to ROSA Install clusters

### DIFF
--- a/modules/rosa-classic-cluster-terraform-file-creation.adoc
+++ b/modules/rosa-classic-cluster-terraform-file-creation.adoc
@@ -115,6 +115,16 @@ module "rosa-classic" {
 #  admin_credentials_username = <username>
 #  admin_credentials_password = <password>
 
+# Optional: Enable cluster delete protection to prevent accidental deletion.
+#  delete_protection = true
+# By default, clusters are created with delete protection disabled.
+# When enabled, it blocks the 'terraform destroy' command until you set
+# 'delete_protection = false' and apply the change by running 'terraform apply'.
+# Note that delete protection only blocks deletion requests made through
+# Terraform. It does not set any AWS-level resource protections,
+# and you can still delete cluster resources directly in AWS,
+# risking data loss or cluster outage.
+
   depends_on = [time_sleep.wait_60_seconds]
 }
 EOF
@@ -132,7 +142,7 @@ You can optionally create an administrator user during cluster creation by uncom
 Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ cat<<-EOF>variables.tf
 #
@@ -153,7 +163,7 @@ $ cat<<-EOF>variables.tf
 variable "openshift_version" {
   type        = string
   default     = "4.14.20"
-  description = "Desired version of OpenShift for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
+  description = "Desired version of {OCP-short} for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
 }
 
 variable "create_vpc" {
@@ -161,11 +171,11 @@ variable "create_vpc" {
   description = "If you would like to create a new VPC, set this value to 'true'. If you do not want to create a new VPC, set this value to 'false'."
 }
 
-# ROSA Cluster info
+# {product-title} cluster info
 variable "cluster_name" {
   default     = null
   type        = string
-  description = "The name of the ROSA cluster to create"
+  description = "The name of the {product-title} cluster to create"
 }
 
 variable "additional_tags" {

--- a/modules/rosa-classic-cluster-terraform-file-creation.adoc
+++ b/modules/rosa-classic-cluster-terraform-file-creation.adoc
@@ -115,6 +115,16 @@ module "rosa-classic" {
 #  admin_credentials_username = <username>
 #  admin_credentials_password = <password>
 
+# Optional: Enable cluster deletion protection to prevent accidental deletion.
+#  delete_protection = true
+# By default, clusters are created with deletion protection disabled.
+# When enabled, it blocks the 'terraform destroy' command until you set
+# 'delete_protection = false' and apply the change by running 'terraform apply'.
+# Deletion protection only blocks deletion requests made through
+# Terraform. It does not set any AWS-level resource protections,
+# and you can still delete cluster resources directly in AWS,
+# risking data loss or cluster outage.
+
   depends_on = [time_sleep.wait_60_seconds]
 }
 EOF
@@ -132,7 +142,7 @@ You can optionally create an administrator user during cluster creation by uncom
 Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ cat<<-EOF>variables.tf
 #
@@ -153,7 +163,7 @@ $ cat<<-EOF>variables.tf
 variable "openshift_version" {
   type        = string
   default     = "4.14.20"
-  description = "Desired version of OpenShift for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
+  description = "Desired version of {OCP-short} for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
 }
 
 variable "create_vpc" {
@@ -161,11 +171,11 @@ variable "create_vpc" {
   description = "If you would like to create a new VPC, set this value to 'true'. If you do not want to create a new VPC, set this value to 'false'."
 }
 
-# ROSA Cluster info
+# {product-title} cluster info
 variable "cluster_name" {
   default     = null
   type        = string
-  description = "The name of the ROSA cluster to create"
+  description = "The name of the {product-title} cluster to create"
 }
 
 variable "additional_tags" {

--- a/modules/rosa-creating-cluster.adoc
+++ b/modules/rosa-creating-cluster.adoc
@@ -7,15 +7,15 @@
 = Creating your cluster
 
 [role="_abstract"]
-You can create a {product-title} cluster using the {product-title} CLI (`rosa`).
+You can create a {product-title} cluster using the {rosa-cli-first}.
 
 .Prerequisites
 
-* You have installed the {rosa-cli-first}.
+* You have installed the {rosa-cli}.
 
 [NOTE]
 ====
-link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Shared VPCs] are not currently supported for ROSA installs.
+link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Shared Virtual Private Clouds (VPCs)] are not currently supported for {product-title} installs.
 ====
 
 .Procedure
@@ -90,7 +90,7 @@ Details Page: https://console.redhat.com/examplename/details/idnumber
 If installation fails or the `State` field does not change to `ready` after 40 minutes, check the installation troubleshooting documentation for more details.
 ====
 
-. Track the progress of the cluster creation by watching the OpenShift installer logs:
+. Track the progress of the cluster creation by watching the {OCP-short} installer logs:
 +
 [source,terminal]
 ----

--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -14,7 +14,7 @@ ifndef::sts[]
 
 endif::sts[]
 ifdef::sts[]
-= Deleting a ROSA cluster and the cluster-specific IAM resources
+= Deleting a cluster and the cluster-specific IAM resources
 
 endif::sts[]
 
@@ -25,9 +25,9 @@ endif::sts[]
 
 ifdef::sts[]
 [role="_abstract"]
-You can delete a {product-title} (ROSA) with AWS Security Token Service (STS) cluster by using the ROSA CLI (`rosa`) or {cluster-manager-first}.
+You can delete a {product-title} cluster with AWS Security Token Service (STS) by using the {rosa-cli-first} or {cluster-manager-first}.
 
-After deleting the cluster, you can clean up the cluster-specific Identity and Access Management (IAM) resources in your AWS account by using the ROSA CLI (`rosa`). The cluster-specific resources include the Operator roles and the OpenID Connect (OIDC) provider.
+After deleting the cluster, you can clean up the cluster-specific Identity and Access Management (IAM) resources in your AWS account by using the {rosa-cli}. The cluster-specific resources include the Operator roles and the OpenID Connect (OIDC) provider.
 
 [NOTE]
 ====
@@ -43,8 +43,8 @@ If the cluster that created the VPC during the installation is deleted, the asso
 ====
 .Prerequisites
 
-* You have installed a ROSA cluster.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
+* You have installed a {product-title} cluster.
+* You have installed and configured the latest {rosa-cli} on your installation host.
 
 .Procedure
 
@@ -84,17 +84,24 @@ OIDC Endpoint URL:          https://oidc.op1.openshiftapps.com/<oidc_config_id>
 +
 [IMPORTANT]
 ====
-You require the cluster ID to delete the cluster-specific STS resources using the ROSA CLI (`rosa`) after the cluster is deleted.
+You require the cluster ID to delete the cluster-specific STS resources using the {rosa-cli} after the cluster is deleted.
 ====
 endif::sts[]
 
 ifdef::sts[]
+. Optional: If deletion protection is enabled on the cluster, disable it by running the following command:
++
+[source,terminal]
+----
+$ rosa edit cluster -c <cluster_name> --enable-delete-protection=false
+----
+
 . Delete the cluster:
 ** To delete the cluster by using {cluster-manager-first}:
 .. Navigate to {cluster-manager-url}.
 .. Click the Options menu {kebab} next to your cluster and select *Delete cluster*.
-.. Type the name of your cluster at the prompt and click *Delete*.
-** To delete the cluster using the ROSA CLI (`rosa`):
+.. Enter the name of your cluster at the prompt and click *Delete*.
+** To delete the cluster by using the {rosa-cli}:
 .. Enter the following command to delete the cluster and watch the logs, replacing `<cluster_name>` with the name or ID of your cluster:
 endif::sts[]
 ifndef::sts[]
@@ -109,7 +116,7 @@ ifdef::sts[]
 +
 [IMPORTANT]
 ====
-You must wait for the cluster deletion to complete before you remove the Operator roles and the OIDC provider. The cluster-specific Operator roles are required to clean-up the resources created by the OpenShift Operators. The Operators use the OIDC provider to authenticate.
+You must wait for the cluster deletion to complete before you remove the Operator roles and the OIDC provider. The cluster-specific Operator roles are required to clean up the resources created by the {OCP-short} Operators. The Operators use the OIDC provider to authenticate.
 ====
 endif::sts[]
 
@@ -139,7 +146,7 @@ You can use the `-y` option to automatically answer yes to the prompts.
 +
 [IMPORTANT]
 ====
-The account-wide IAM roles can be used by other ROSA clusters in the same AWS account. Only remove the roles if they are not required by other clusters.
+The account-wide IAM roles can be used by other {product-title} clusters in the same AWS account. Only remove the roles if they are not required by other clusters.
 ====
 +
 [source,terminal]

--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -14,7 +14,7 @@ ifndef::sts[]
 
 endif::sts[]
 ifdef::sts[]
-= Deleting a ROSA cluster and the cluster-specific IAM resources
+= Deleting a cluster and the cluster-specific IAM resources
 
 endif::sts[]
 
@@ -25,9 +25,9 @@ endif::sts[]
 
 ifdef::sts[]
 [role="_abstract"]
-You can delete a {product-title} (ROSA) with AWS Security Token Service (STS) cluster by using the ROSA CLI (`rosa`) or {cluster-manager-first}.
+You can delete a {product-title} cluster with AWS Security Token Service (STS) by using the {rosa-cli-first} or {cluster-manager-first}.
 
-After deleting the cluster, you can clean up the cluster-specific Identity and Access Management (IAM) resources in your AWS account by using the ROSA CLI (`rosa`). The cluster-specific resources include the Operator roles and the OpenID Connect (OIDC) provider.
+After deleting the cluster, you can clean up the cluster-specific Identity and Access Management (IAM) resources in your AWS account by using the {rosa-cli}. The cluster-specific resources include the Operator roles and the OpenID Connect (OIDC) provider.
 
 [NOTE]
 ====
@@ -43,8 +43,8 @@ If the cluster that created the VPC during the installation is deleted, the asso
 ====
 .Prerequisites
 
-* You have installed a ROSA cluster.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
+* You have installed a {product-title} cluster.
+* You have installed and configured the latest {rosa-cli} on your installation host.
 
 .Procedure
 
@@ -84,17 +84,24 @@ OIDC Endpoint URL:          https://oidc.op1.openshiftapps.com/<oidc_config_id>
 +
 [IMPORTANT]
 ====
-You require the cluster ID to delete the cluster-specific STS resources using the ROSA CLI (`rosa`) after the cluster is deleted.
+You require the cluster ID to delete the cluster-specific STS resources using the {rosa-cli} after the cluster is deleted.
 ====
 endif::sts[]
 
 ifdef::sts[]
+. Optional: If deletion protection is enabled on the cluster, disable it by running the following command:
++
+[source,terminal]
+----
+$ rosa edit cluster -c <cluster_name> --enable-delete-protection=false
+----
+
 . Delete the cluster:
 ** To delete the cluster by using {cluster-manager-first}:
 .. Navigate to {cluster-manager-url}.
 .. Click the Options menu {kebab} next to your cluster and select *Delete cluster*.
-.. Type the name of your cluster at the prompt and click *Delete*.
-** To delete the cluster using the ROSA CLI (`rosa`):
+.. Enter the name of your cluster at the prompt and click *Delete*.
+** To delete the cluster using the {rosa-cli}:
 .. Enter the following command to delete the cluster and watch the logs, replacing `<cluster_name>` with the name or ID of your cluster:
 endif::sts[]
 ifndef::sts[]
@@ -109,7 +116,7 @@ ifdef::sts[]
 +
 [IMPORTANT]
 ====
-You must wait for the cluster deletion to complete before you remove the Operator roles and the OIDC provider. The cluster-specific Operator roles are required to clean-up the resources created by the OpenShift Operators. The Operators use the OIDC provider to authenticate.
+You must wait for the cluster deletion to complete before you remove the Operator roles and the OIDC provider. The cluster-specific Operator roles are required to clean up the resources created by the {OCP-short} Operators. The Operators use the OIDC provider to authenticate.
 ====
 endif::sts[]
 
@@ -139,7 +146,7 @@ You can use the `-y` option to automatically answer yes to the prompts.
 +
 [IMPORTANT]
 ====
-The account-wide IAM roles can be used by other ROSA clusters in the same AWS account. Only remove the roles if they are not required by other clusters.
+The account-wide IAM roles can be used by other {product-title} clusters in the same AWS account. Only remove the roles if they are not required by other clusters.
 ====
 +
 [source,terminal]

--- a/modules/rosa-hcp-cluster-terraform-file-creation.adoc
+++ b/modules/rosa-hcp-cluster-terraform-file-creation.adoc
@@ -99,7 +99,7 @@ module "rosa-hcp" {
   create_account_roles   = true
   create_operator_roles  = true
 # Optional: Configure a cluster administrator user
-# 
+#
 # Option 1: Default cluster-admin user
 # Create an administrator user (cluster-admin) and automatically
 # generate a password by uncommenting the following parameter:
@@ -112,12 +112,21 @@ module "rosa-hcp" {
 #  admin_credentials_username = <username>
 #  admin_credentials_password = <password>
 
+# Optional: Enable cluster delete protection to prevent accidental deletion.
+# To enable, uncomment the following parameter:
+#  delete_protection = true
+# By default, clusters are created with delete protection disabled.
+
   depends_on = [time_sleep.wait_60_seconds]
 }
 EOF
 ----
 +
-If you want to create an administrator user during cluster creation, uncomment the appropriate parameters in the `Optional: Configure a cluster administrator user` section and edit their values.
+** If you want to create an administrator user during cluster creation, uncomment the appropriate parameters in the `Optional: Configure a cluster administrator user` section and edit their values.
++
+** If you want to enable delete protection during cluster creation, uncomment the corresponding parameter in the `Optional: Enable cluster delete protection` section. When enabled, delete protection blocks the `terraform destroy` command until you set `delete_protection = false` and apply the change by running `terraform apply`.
++
+Note that delete protection only blocks deletion requests made through Terraform. It doesn't set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage. Additionally, delete protection does not override the Red{nbsp}Hat link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-delete-policy_rosa-hcp-life-cycle[Deletion policy]. Red{nbsp}Hat reserves the right to delete clusters that violate service requirements.
 
 . Create the `variables.tf` file by running the following command:
 +
@@ -126,7 +135,7 @@ If you want to create an administrator user during cluster creation, uncomment t
 Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ cat<<-EOF>variables.tf
 #
@@ -147,7 +156,7 @@ $ cat<<-EOF>variables.tf
 variable "openshift_version" {
   type        = string
   default     = "4.14.20"
-  description = "Desired version of OpenShift for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
+  description = "Desired version of {OCP-short} for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
 }
 
 variable "create_vpc" {
@@ -155,11 +164,11 @@ variable "create_vpc" {
   description = "If you would like to create a new VPC, set this value to 'true'. If you do not want to create a new VPC, set this value to 'false'."
 }
 
-# ROSA Cluster info
+# {product-title} cluster info
 variable "cluster_name" {
   default     = null
   type        = string
-  description = "The name of the ROSA cluster to create"
+  description = "The name of the {product-title} cluster to create"
 }
 
 variable "additional_tags" {

--- a/modules/rosa-hcp-cluster-terraform-file-creation.adoc
+++ b/modules/rosa-hcp-cluster-terraform-file-creation.adoc
@@ -99,7 +99,7 @@ module "rosa-hcp" {
   create_account_roles   = true
   create_operator_roles  = true
 # Optional: Configure a cluster administrator user
-# 
+#
 # Option 1: Default cluster-admin user
 # Create an administrator user (cluster-admin) and automatically
 # generate a password by uncommenting the following parameter:
@@ -112,12 +112,21 @@ module "rosa-hcp" {
 #  admin_credentials_username = <username>
 #  admin_credentials_password = <password>
 
+# Optional: Enable cluster deletion protection to prevent accidental deletion.
+# To enable, uncomment the following parameter:
+#  delete_protection = true
+# By default, clusters are created with deletion protection disabled.
+
   depends_on = [time_sleep.wait_60_seconds]
 }
 EOF
 ----
 +
-If you want to create an administrator user during cluster creation, uncomment the appropriate parameters in the `Optional: Configure a cluster administrator user` section and edit their values.
+** If you want to create an administrator user during cluster creation, uncomment the appropriate parameters in the `Optional: Configure a cluster administrator user` section and edit their values.
++
+** If you want to enable deletion protection during cluster creation, uncomment the corresponding parameter in the `Optional: Enable cluster delete protection` section. When enabled, deletion protection blocks the `terraform destroy` command until you set `delete_protection = false` and apply the change by running `terraform apply`.
++
+Deletion protection only blocks deletion requests made through Terraform. It does not set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage. Additionally, deletion protection does not override the Red{nbsp}Hat link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-delete-policy_rosa-hcp-life-cycle[Deletion policy]. Red{nbsp}Hat reserves the right to delete clusters that violate service requirements.
 
 . Create the `variables.tf` file by running the following command:
 +
@@ -126,7 +135,7 @@ If you want to create an administrator user during cluster creation, uncomment t
 Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ cat<<-EOF>variables.tf
 #
@@ -147,7 +156,7 @@ $ cat<<-EOF>variables.tf
 variable "openshift_version" {
   type        = string
   default     = "4.14.20"
-  description = "Desired version of OpenShift for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
+  description = "Desired version of {OCP-short} for the cluster, for example '4.14.20'. If version is greater than the currently running version, an upgrade will be scheduled."
 }
 
 variable "create_vpc" {
@@ -155,11 +164,11 @@ variable "create_vpc" {
   description = "If you would like to create a new VPC, set this value to 'true'. If you do not want to create a new VPC, set this value to 'false'."
 }
 
-# ROSA Cluster info
+# {product-title} cluster info
 variable "cluster_name" {
   default     = null
   type        = string
-  description = "The name of the ROSA cluster to create"
+  description = "The name of the {product-title} cluster to create"
 }
 
 variable "additional_tags" {

--- a/modules/rosa-hcp-deleting-cluster.adoc
+++ b/modules/rosa-hcp-deleting-cluster.adoc
@@ -99,6 +99,13 @@ After the cluster is deleted, you need the cluster ID to delete the cluster-spec
 ====
 --
 
+. Optional: If deletion protection is enabled on the cluster, disable it by running the following command:
++
+[source,terminal]
+----
+$ rosa edit cluster -c <cluster_name> --enable-delete-protection=false
+----
+
 . Delete the cluster by using either the {cluster-manager} or the {rosa-cli}:
 ** To delete the cluster by using the {cluster-manager}:
 .. Navigate to the {cluster-manager-url}.

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -37,8 +37,9 @@ $ rosa create cluster --cluster-name=<cluster_name> \
     --mode=auto --hosted-cp [--private] \
     --operator-roles-prefix <operator-role-prefix> \
     --external-id <external-id> \
-    --oidc-config-id <id-of-oidc-configuration> \ 
-    --subnet-ids=<public-subnet-id>,<private-subnet-id>
+    --oidc-config-id <id-of-oidc-configuration> \
+    --subnet-ids=<public-subnet-id>,<private-subnet-id> \
+    --enable-delete-protection
 ----
 +
 --
@@ -48,6 +49,11 @@ where:
 `--private`:: Optional. Use the `--private` argument to create private {product-title} clusters. If you use this argument, ensure that you only use your private subnet ID for `--subnet-ids`.
 `<operator-role-prefix>`:: By default, the cluster-specific Operator role names are prefixed with the cluster name and a random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _About custom Operator IAM role prefixes_.
 `<external-id>`:: Optional. A unique identifier that might be required when you assume a role in another account. For more information about external ID, see _About external ID_.
+`--enable-delete-protection`:: Optional. Enables cluster delete protection to prevent accidental deletion. By default, clusters are created with delete protection disabled.
++
+When delete protection is enabled, attempts to delete the cluster using `rosa delete cluster` fail immediately before prompting for deletion confirmation. To delete a cluster, disable the protection first by running `rosa edit cluster -c <cluster_name> --enable-delete-protection=false`.
++
+Note that delete protection only blocks deletion requests made through the {rosa-cli}. It doesn't set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage. Additionally, delete protection does not override the Red{nbsp}Hat link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-delete-policy_rosa-hcp-life-cycle[Deletion policy]. Red{nbsp}Hat reserves the right to delete clusters that violate service requirements.
 
 [NOTE]
 ====
@@ -68,7 +74,7 @@ $ rosa create cluster --private --cluster-name=<cluster_name> \
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name=<cluster_name> --mode=auto \ 
+$ rosa create cluster --cluster-name=<cluster_name> --mode=auto \
     --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
     --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
 ----

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -37,8 +37,9 @@ $ rosa create cluster --cluster-name=<cluster_name> \
     --mode=auto --hosted-cp [--private] \
     --operator-roles-prefix <operator-role-prefix> \
     --external-id <external-id> \
-    --oidc-config-id <id-of-oidc-configuration> \ 
-    --subnet-ids=<public-subnet-id>,<private-subnet-id>
+    --oidc-config-id <id-of-oidc-configuration> \
+    --subnet-ids=<public-subnet-id>,<private-subnet-id> \
+    --enable-delete-protection
 ----
 +
 --
@@ -48,6 +49,11 @@ where:
 `--private`:: Optional. Use the `--private` argument to create private {product-title} clusters. If you use this argument, ensure that you only use your private subnet ID for `--subnet-ids`.
 `<operator-role-prefix>`:: By default, the cluster-specific Operator role names are prefixed with the cluster name and a random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _About custom Operator IAM role prefixes_.
 `<external-id>`:: Optional. A unique identifier that might be required when you assume a role in another account. For more information about external ID, see _About external ID_.
+`--enable-delete-protection`:: Optional. Enables cluster deletion protection to prevent accidental deletion. By default, clusters are created with deletion protection disabled.
++
+When deletion protection is enabled, attempts to delete the cluster using `rosa delete cluster` fail immediately before prompting for deletion confirmation. To delete a cluster, disable the protection first by running `rosa edit cluster -c <cluster_name> --enable-delete-protection=false`.
++
+Deletion protection only blocks deletion requests made through the {rosa-cli}. It does not set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage. Additionally, deletion protection does not override the Red{nbsp}Hat link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-delete-policy_rosa-hcp-life-cycle[Deletion policy]. Red{nbsp}Hat reserves the right to delete clusters that violate service requirements.
 
 [NOTE]
 ====
@@ -68,7 +74,7 @@ $ rosa create cluster --private --cluster-name=<cluster_name> \
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name=<cluster_name> --mode=auto \ 
+$ rosa create cluster --cluster-name=<cluster_name> --mode=auto \
     --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
     --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
 ----

--- a/modules/rosa-release-notes-Q3-2026.adoc
+++ b/modules/rosa-release-notes-Q3-2026.adoc
@@ -8,7 +8,22 @@
 [role="_abstract"]
 The following items were added during the third quarter of 2026.
 
-//This RN is HCP-only. If you're adding this Q3 module to Classic, please, remember to conditionalize this RN for HCP.
+Cluster deletion protection::
++
+With this update, you can enable delete protection on {product-title} clusters to prevent accidental cluster deletion. You can enable delete protection when creating a cluster using the {rosa-cli} or Terraform. For more information, see:
++
+
+ifdef::openshift-rosa-hcp[]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a cluster using the CLI]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/creating-a-red-hat-openshift-service-on-aws-cluster-with-terraform#rosa-hcp-terraform-cluster-creation-overview_rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default cluster using Terraform]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#creating-a-red-hat-openshift-service-on-aws-classic-architecture-cluster-with-terraform[Creating a cluster with Terraform]
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa-hcp[]
 Disaster recovery policies are updated::
 +
 A new backup and recovery strategy for the {product-title} cluster control planes is implemented, minimizing cluster risk from disaster events. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix[Disaster recovery].
+endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-q3-2026.adoc
+++ b/modules/rosa-release-notes-q3-2026.adoc
@@ -8,7 +8,22 @@
 [role="_abstract"]
 The following items were added during the third quarter of 2026.
 
-//This RN is HCP-only. If you're adding this Q3 module to Classic, please, remember to conditionalize this RN for HCP.
+Cluster deletion protection::
++
+You can enable deletion protection when creating {product-title} clusters using the {rosa-cli} or Terraform to prevent accidental deletion. For more information, see the following documentation:
++
+
+ifdef::openshift-rosa-hcp[]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a cluster using the CLI]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/creating-a-red-hat-openshift-service-on-aws-cluster-with-terraform#rosa-hcp-terraform-cluster-creation-overview_rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default cluster using Terraform]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#creating-a-red-hat-openshift-service-on-aws-classic-architecture-cluster-with-terraform[Creating a cluster with Terraform]
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa-hcp[]
 Disaster recovery policies are updated::
 +
 A new backup and recovery strategy for the {product-title} cluster control planes is implemented, minimizing cluster risk from disaster events. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix[Disaster recovery].
+endif::openshift-rosa-hcp[]

--- a/modules/rosa-sts-cluster-terraform-destroy.adoc
+++ b/modules/rosa-sts-cluster-terraform-destroy.adoc
@@ -19,7 +19,12 @@ Use the `terraform destroy` command to remove all resources you create with the 
 
 [NOTE]
 ====
-Keep your Terraform .tf files unchanged before destroying your resources. These variables are matched to resources to delete.
+Keep your Terraform `.tf` files unchanged before destroying your resources. These variables are matched to resources to delete.
+====
+
+[IMPORTANT]
+====
+If deletion protection is enabled on the cluster, disable it by setting `delete_protection = false` in the `main.tf` file, then run `terraform apply` to apply the change.
 ====
 
 .Procedure
@@ -37,12 +42,12 @@ The Terraform interface prompts you for two variables. These should match the an
 var.create_vpc
   If you would like to create a new VPC, set this value to 'true.' If you do not want to create a new VPC, set this value to 'false.'
 
-  Enter a value: 
+  Enter a value:
 
 var.private_cluster
   If you want to create a private cluster, set this value to 'true.' If you want a publicly available cluster, set this value to 'false.'
 
-  Enter a value: 
+  Enter a value:
 ----
 
 . Enter `yes` to start the role and cluster deletion:

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -7,7 +7,7 @@
 = Creating a cluster with customizations using the CLI
 
 [role="_abstract"]
-When you create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can customize your installation interactively.
+When you create a {product-title} cluster that uses the AWS Security Token Service (STS), you can customize your installation interactively.
 
 When you run the `rosa create cluster --interactive` command at cluster creation time, you are presented with a series of interactive prompts that enable you to customize your deployment. For more information, see _Interactive cluster creation mode reference_.
 
@@ -22,15 +22,15 @@ Only public and AWS PrivateLink clusters are supported with STS. Regular private
 
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
-* You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI, `rosa`, on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
-* If you want to use a customer managed AWS Key Management Service (KMS) key for encryption, you must create a symmetric KMS key. You must provide the Amazon Resource Name (ARN) when creating your cluster. To create a customer managed KMS key, follow the procedure for link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[Creating symmetric encryption KMS keys].
+* You have enabled the {product-title} service in the AWS Console.
+* You have installed and configured the latest {rosa-cli-first} on your installation host. Run `rosa version` to see your currently installed version of the {rosa-cli}. If a newer version is available, the CLI provides a link to download this upgrade.
+* If you want to use a customer-managed AWS Key Management Service (KMS) key for encryption, you must create a symmetric KMS key. You must provide the Amazon Resource Name (ARN) when creating your cluster. To create a customer-managed KMS key, follow the procedure for link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[Creating symmetric encryption KMS keys].
 +
 [IMPORTANT]
 ====
 The EBS Operator role is required in addition to the account roles to successfully create your cluster.
 
-This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by {product-title} to manage back-end storage through the Container Storage Interface (CSI).
 
 For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
 
@@ -56,8 +56,7 @@ $ rosa create account-roles --interactive \
 * The `--interactive` option enables you to specify configuration options at the interactive prompts. For more information, see _Interactive cluster creation mode reference_.
 * The `--mode manual` option generates the `aws` CLI commands and JSON files needed to create the account-wide roles and policies. After review, you must run the commands manually to create the resources.
 
-The following example shows sample output:
-
+.Example output
 [source,terminal,subs="attributes+"]
 ----
 I: Logged in as '<red_hat_username>' on 'https://api.openshift.com'
@@ -95,13 +94,13 @@ You must specify an account-wide role prefix that is unique across your AWS acco
 ====
 `Permissions boundary ARN (optional)`:: Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
 `Path (optional)`:: Specify a custom ARN path for your account-wide roles. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
-`Role creation mode`:: Select the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+`Role creation mode`:: Select the role creation mode. You can use `auto` mode to automatically create the account-wide roles and policies. In `manual` mode, the {rosa-cli} generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
 
-After specifying the configuration options, the account-wide installer, control plane, worker and support roles and corresponding IAM policies are created. For more information, see _Account-wide IAM role and policy reference_.
+After you specify the configuration options, the account-wide installer, control plane, worker, and support roles and corresponding IAM policies are created. For more information, see _Account-wide IAM role and policy reference_.
 
 [NOTE]
 ====
-In this step, the ROSA CLI also automatically creates the account-wide Operator IAM policies that are used by the cluster-specific Operator policies to permit the ROSA cluster Operators to run core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
+In this step, the {rosa-cli} also automatically creates the account-wide Operator IAM policies that are used by the cluster-specific Operator policies to permit the {product-title} cluster Operators to run core {OCP-short} functionality. For more information, see _Account-wide IAM role and policy reference_.
 ====
 --
 
@@ -209,9 +208,9 @@ You can reference the ARN of your KMS key when you create the cluster in the nex
 +
 [WARNING]
 ====
-You cannot install a ROSA cluster into an existing VPC that was created by the OpenShift installer. These VPCs are created during the cluster deployment process and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly.
+You cannot install a {product-title} cluster into an existing VPC that was created by the {OCP-short} installer. These VPCs are created during the cluster deployment process and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly.
 
-To verify whether a VPC was created by the OpenShift installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
+To verify whether a VPC was created by the {OCP-short} installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
 ====
 +
 [source,terminal]
@@ -262,6 +261,7 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Enable FIPS support: No
 ? Encrypt etcd data: No
 ? Disable Workload monitoring (optional): No
+? Enable cluster deletion protection (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
    rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.22.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
@@ -306,7 +306,7 @@ If you specified custom ARN paths when you created the associated account-wide r
 ====
 The EBS Operator role is required in addition to the account roles to successfully create your cluster.
 
-This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by {product-title} to manage back-end storage through the Container Storage Interface (CSI).
 
 For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
 

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -156,6 +156,13 @@ By enabling etcd encryption for the key values in etcd, you will incur a perform
 |`Disable workload monitoring (optional)`
 |Disable monitoring for user-defined projects. Monitoring for user-defined projects is enabled by default.
 
+|`Enable cluster deletion protection (optional)`
+|Enable cluster delete protection to prevent accidental deletion. By default, clusters are created with delete protection disabled.
+
+When delete protection is enabled, attempts to delete the cluster using `rosa delete cluster` fail immediately before prompting for deletion confirmation. To delete a cluster, disable the protection first by running `rosa edit cluster -c <cluster_name> --enable-delete-protection=false`.
+
+Note that delete protection only blocks deletion requests made through the {rosa-cli}. It doesn't set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage.
+
 |`Route Selector for ingress (optional)`
 |Specify the route selector for your ingress. The format should be a comma-separated list of key-value pairs. If you do not specify a label, all routes will be exposed on both routers. For legacy ingress support, these labels are inclusion labels; otherwise, they are treated as exclusion labels.
 

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -156,6 +156,13 @@ By enabling etcd encryption for the key values in etcd, you will incur a perform
 |`Disable workload monitoring (optional)`
 |Disable monitoring for user-defined projects. Monitoring for user-defined projects is enabled by default.
 
+|`Enable cluster deletion protection (optional)`
+|Enable cluster deletion protection to prevent accidental deletion. By default, clusters are created with deletion protection disabled.
+
+When deletion protection is enabled, attempts to delete the cluster using `rosa delete cluster` fail immediately before prompting for deletion confirmation. To delete a cluster, disable the protection first by running `rosa edit cluster -c <cluster_name> --enable-delete-protection=false`.
+
+Deletion protection only blocks deletion requests made through the {rosa-cli}. It does not set any AWS-level resource protections, and you can still delete cluster resources directly in AWS, risking data loss or cluster outage.
+
 |`Route Selector for ingress (optional)`
 |Specify the route selector for your ingress. The format should be a comma-separated list of key-value pairs. If you do not specify a label, all routes will be exposed on both routers. For legacy ingress support, these labels are inclusion labels; otherwise, they are treated as exclusion labels.
 

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -87,6 +87,7 @@ ifndef::openshift-rosa-hcp,hcp[]
 * Additional etcd encryption is not enabled
 * The default AWS Key Management Service (KMS) key is used as the encryption key for persistent data
 endif::openshift-rosa-hcp,hcp[]
+* Cluster delete protection: Not enabled
 
 ifdef::openshift-rosa,tf-classic[]
 |Control plane node configuration

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -87,6 +87,7 @@ ifndef::openshift-rosa-hcp,hcp[]
 * Additional etcd encryption is not enabled
 * The default AWS Key Management Service (KMS) key is used as the encryption key for persistent data
 endif::openshift-rosa-hcp,hcp[]
+* Cluster deletion protection: Not enabled
 
 ifdef::openshift-rosa,tf-classic[]
 |Control plane node configuration

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -11,9 +11,7 @@ toc::[]
 [role="_abstract"]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
-ifdef::openshift-rosa-hcp[]
 include::modules/rosa-release-notes-Q3-2026.adoc[leveloffset=+1]
-endif::openshift-rosa-hcp[]
 
 include::modules/rosa-release-notes-Q2-2026.adoc[leveloffset=+1]
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -11,9 +11,7 @@ toc::[]
 [role="_abstract"]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
-ifdef::openshift-rosa-hcp[]
 include::modules/rosa-release-notes-q3-2026.adoc[leveloffset=+1]
-endif::openshift-rosa-hcp[]
 
 include::modules/rosa-release-notes-q2-2026.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.22+
5.0+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21051

**Link to docs preview:**

**ROSA**

- [Release notes](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes) 
- [Overview of the default cluster specifications](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide.html#rosa-sts-overview-of-the-default-cluster-specifications_rosa-hcp-quickstart-guide) - Added "Cluster deletion protection: Not enabled" to the Cluster settings
- Quickstart guide: [Creating a Red Hat OpenShift Service on AWS cluster using the CLI](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide.html#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-quickstart-guide), step 3
- Creating clusters with default options: [Creating a Red Hat OpenShift Service on AWS cluster using the CLI](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly), step 1
- [Deleting a Red Hat OpenShift Service on AWS cluster and the cluster-specific IAM resources](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-deleting-cluster.html#rosa-hcp-deleting-cluster_rosa-hcp-deleting-cluster), new optional step 2

   Terraform:
- [Creating your Terraform files locally](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.html#rosa-hcp-cluster-terraform-file-creation_rosa-hcp-creating-a-cluster-quickly-terraform), bottom of `main.tf`
- [Deleting your Red Hat OpenShift Service on AWS cluster with Terraform](https://118037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.html#sd-terraform-cluster-destroy_rosa-hcp-creating-a-cluster-quickly-terraform)

**ROSA Classic**

- [Release notes](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes)
- [Creating a cluster with customizations using the CLI](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations) - Added "? Enable cluster deletion protection (optional): No" to the interactive mode prompts
- [Interactive cluster creation mode reference](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.html)
- [Deleting a cluster and the cluster-specific IAM resources](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.html#rosa-deleting-cluster_rosa-sts-deleting-cluster)
- [Creating your cluster](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-creating-cluster.html) - only cosmetic changes

   Terraform:
- [Creating your Terraform files locally](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.html#rosa-classic-cluster-terraform-file-creation_rosa-classic-creating-a-cluster-quickly-terraform), bottom of `main.tf`
- [Deleting your Red Hat OpenShift Service on AWS (classic architecture) cluster with Terraform](https://118037--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.html#sd-terraform-cluster-destroy_rosa-classic-creating-a-cluster-quickly-terraform) - module is shared with ROSA HCP

QE review:

Additional information:
