### PR TITLE
RHDEVDOCS-7644, RHDEVDOCS-7645, RHDEVDOCS-7652: Fix OpenShift GitOps documentation errors (gitops-1.18)

### DIFF
--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -23,7 +23,7 @@ As a cluster administrator, to add user-defined permissions to your aggregated c
 +
 [source,terminal]
 ----
-$ oc apply -n <namespace> -f <cluster_role_name>.yaml
+$ oc apply -f <cluster_role_name>.yaml
 ----
 +
 where:

--- a/modules/gitops-openshift-go-common-terms.adoc
+++ b/modules/gitops-openshift-go-common-terms.adoc
@@ -62,7 +62,7 @@ An Argo CD component that performs the following actions:
 * Reads from source repositories such as Git, Helm, or Open Container Initiative (OCI)
 * Generates corresponding application manifests
 * Runs custom configuration management tooling
-* Returns the result to the Argo CD Application Controller
+* Returns the generated manifests to the Argo CD API server and the Argo CD Application Controller
 
 Argo CD resource (`ArgoCD` CR)::
 A CR that describes the wanted state for a given Argo CD instance. It allows you to configure the components and settings that make up an Argo CD instance. At any given time, you can have only one `ArgoCD` CR within a namespace.
@@ -89,7 +89,7 @@ Within a control plane namespace, Argo CD maintains a set of following Kubernete
 `openshift-gitops` is the control plane namespace for the default Argo CD instance.
 
 Declarative setup::
-A declarative description of the infrastructure required in your specified environment, for system and application setup or configuration. You can specify this description in a YAML configuration file in the Git repository. The declarative setup contains an automated process to make your environment and infrastucture match the described state. Examples include defining Argo CD applications, projects, and settings declaratively by using YAML manifests.
+A declarative description of the infrastructure required in your specified environment, for system and application setup or configuration. You can specify this description in a YAML configuration file in the Git repository. The declarative setup contains an automated process to make your environment and infrastructure match the described state. Examples include defining Argo CD applications, projects, and settings declaratively by using YAML manifests.
 
 Default Argo CD instance (Default cluster-scoped instance)::
 A default instance that a {gitops-title} Operator instantiates immediately after its installation, in the `openshift-gitops` namespace, with additional permissions for managing certain cluster-scoped resources.


### PR DESCRIPTION
## Summary

This PR addresses documentation bugs in the OpenShift GitOps 1.18 docs:

- **RHDEVDOCS-7644**: Fix typo  →  in Declarative Setup glossary entry
- **RHDEVDOCS-7645**: Fix Argo CD repo-server description — it returns manifests to both the API server and the Application Controller, not exclusively the Application Controller
- **[RHDEVDOCS-7652](https://redhat.atlassian.net/browse/RHDEVDOCS-7652)**: Remove invalid  flag from  command — ClusterRole is a cluster-scoped resource and does not belong to a namespace

Jira: RHDEVDOCS-7644, RHDEVDOCS-7645, [RHDEVDOCS-7652](https://redhat.atlassian.net/browse/RHDEVDOCS-7652)