### PR TITLE
RHDEVDOCS-7645, RHDEVDOCS-7652: Fix OpenShift GitOps documentation errors (gitops-1.19)

### DIFF
--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -23,7 +23,7 @@ As a cluster administrator, to add user-defined permissions to your aggregated c
 +
 [source,terminal]
 ----
-$ oc apply -n <namespace> -f <cluster_role_name>.yaml
+$ oc apply -f <cluster_role_name>.yaml
 ----
 +
 --

--- a/modules/gitops-openshift-go-common-terms.adoc
+++ b/modules/gitops-openshift-go-common-terms.adoc
@@ -62,7 +62,7 @@ An Argo CD component that performs the following actions:
 * Reads from source repositories such as Git, Helm, or Open Container Initiative (OCI)
 * Generates corresponding application manifests
 * Runs custom configuration management tooling
-* Returns the result to the Argo CD Application Controller
+* Returns the generated manifests to the Argo CD API server and the Argo CD Application Controller
 
 Argo CD resource (`ArgoCD` CR)::
 A CR that describes the wanted state for a given Argo CD instance. It allows you to configure the components and settings that make up an Argo CD instance. At any given time, you can have only one `ArgoCD` CR within a namespace.


### PR DESCRIPTION
## Summary

This PR addresses documentation bugs in the OpenShift GitOps 1.19 docs:

- **RHDEVDOCS-7645**: Fix Argo CD repo-server description — it returns manifests to both the API server and the Application Controller, not exclusively the Application Controller
- **[RHDEVDOCS-7652](https://redhat.atlassian.net/browse/RHDEVDOCS-7652)**: Remove invalid  flag from  command — ClusterRole is a cluster-scoped resource and does not belong to a namespace

Jira: RHDEVDOCS-7645, [RHDEVDOCS-7652](https://redhat.atlassian.net/browse/RHDEVDOCS-7652)