### PR TITLE
OSDOCS-20898: Document NetworkPolicy whitelist for health probes in ambient mode

### DIFF
--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -20,6 +20,8 @@ include::modules/ossm-about-istio-ambient-mode.adoc[leveloffset=+1]
 
 include::modules/ossm-installing-istio-ambient-mode.adoc[leveloffset=+1]
 
+include::modules/ossm-ambient-networkpolicy-health-probes.adoc[leveloffset=+1]
+
 include::modules/ossm-about-discovery-selectors-istio-ambient-mode.adoc[leveloffset=+1]
 
 include::modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc[leveloffset=+2]

--- a/modules/ossm-ambient-networkpolicy-health-probes.adoc
+++ b/modules/ossm-ambient-networkpolicy-health-probes.adoc
@@ -1,0 +1,32 @@
+////
+This module included in the following assemblies:
+* install/ossm-istio-ambient-mode.adoc
+////
+:_mod-docs-content-type: CONCEPT
+[id="ossm-ambient-networkpolicy-health-probes_{context}"]
+= Configuring network policies for health probes in ambient mode
+
+In {SMProductName} 3 ambient mode, `routingViaHost` must be set to `true` in the `gatewayConfig` spec to enable OVN-Kubernetes local gateway mode. In this mode, kubelet liveness and readiness probe traffic is routed through the host network. Istio uses source network address translation (NAT) to rewrite the probe traffic's source address to the link-local address `169.254.7.127`, which must be allowed by `NetworkPolicies`.
+
+If you apply a restrictive `NetworkPolicy` resource, such as a deny-all ingress policy, to a namespace enrolled in the ambient mesh, the probe traffic from `169.254.7.127` is blocked. This causes pod startup, readiness, or liveness probe failures.
+
+To allow health probes to function, you must add an ingress rule that permits traffic from `169.254.7.127/32` in your `NetworkPolicy` resource:
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ambient-health-probes
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - ipBlock:
+          cidr: 169.254.7.127/32
+----
+
+[NOTE]
+====
+On dual-stack or IPv6-only clusters, also allow the IPv6 address `fd16:9254:7127:1337:ffff:ffff:ffff:ffff/128`.
+====


### PR DESCRIPTION
## Summary

Fixes https://redhat.atlassian.net/browse/OSDOCS-20898

In OSSM 3 ambient mode, when OVN-Kubernetes local gateway mode is enabled
(`routingViaHost: true`), the ztunnel proxy performs health checks on behalf
of the kubelet using SNAT with the link-local IP `169.254.7.127`. If a
restrictive `NetworkPolicy` (e.g. deny-all ingress) is applied to a namespace
enrolled in the ambient mesh, health probe traffic is blocked, causing pod
startup, readiness, or liveness probe failures.

This PR adds a new module documenting the requirement to allow ingress from
`169.254.7.127/32` in `NetworkPolicy` resources.

**Versions:** OSSM 3.0+

## What changed

- New module: `modules/ossm-ambient-networkpolicy-health-probes.adoc`
- Modified assembly: `install/ossm-istio-ambient-mode.adoc`
  (added include after the installation section)

## References

- Upstream: https://istio.io/latest/docs/ambient/usage/networkpolicy/
- Related issue: https://github.com/istio/istio/issues/56983

## Test plan

- [ ] Verify the new module renders correctly in the Netlify preview
- [ ] Confirm the YAML example is valid

> **Note:** This replaces #117141, which was incorrectly opened against `main`.

