### PR TITLE
[enterprise-4.20]OSDOCS-20768: Add missing --render and --render-sensitive flag descriptions

### DIFF
--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -89,6 +89,8 @@ where:
 * `--control-plane-availability-policy` specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 * `--release-image` specifies the supported {product-title} version that you want to use, such as `4.20.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
 * `--node-pool-replicas` specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
+* `--render` renders the output as YAML to stdout instead of applying the resources to the cluster. By default, secrets are not included in the rendered output.
+* `--render-sensitive` includes secrets in the rendered output when used with the `--render` flag.
 
 . Configure the service publishing strategy. By default, hosted clusters use the `NodePort` service publishing strategy because node ports are always available without additional infrastructure. However, you can configure the service publishing strategy to use a load balancer.
 


### PR DESCRIPTION
cherrypicked from https://github.com/openshift/openshift-docs/pull/117066
