### PR TITLE
OSDOCS#21052:Add files and updates for customizing consoles and downloads routes_Rosa HCP

### DIFF
--- a/modules/about-custom-component-routes-rosa-hcp.adoc
+++ b/modules/about-custom-component-routes-rosa-hcp.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * web_console/web-console-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-custom-component-routes-rosa-hcp_{context}"]
+= About custom component routes on {product-title}
+
+[role="_abstract"]
+By default, {product-title} clusters use service-generated default subdomains for core cluster routes. You can customize these component routes to use personalized, company-owned fully qualified domain names (FQDNs) to satisfy corporate branding and enterprise security requirements.
+
+You can configure custom component routes for the following components on {product-title}:
+
+* OpenShift web console
+* Downloads page (Command-line interface (CLI) tools)
+
+[NOTE]
+====
+Customizing the internal OAuth server route or the API server (`kube-apiserver`) endpoint is not supported on {product-title}.
+====
+
+Custom component routes have the following architecture and requirements:
+
+TLS certificates:: You must provide your own valid TLS certificate chain and private key stored as a Kubernetes secret in the `openshift-config` namespace on the cluster data plane.
+
+DNS management:: You are responsible for creating and maintaining the necessary CNAME or A records with your DNS provider to route traffic from your custom FQDN to the cluster's ingress router.
+
+Automated renewal:: Automated certificate management, such as AWS Certificate Manager or automatic Let's Encrypt rotation, is not natively integrated at the cluster service level. You must manage certificate renewals manually or by using data-plane Operators such as cert-manager.

--- a/modules/configuring-custom-component-routes-rosa-hcp.adoc
+++ b/modules/configuring-custom-component-routes-rosa-hcp.adoc
@@ -1,0 +1,102 @@
+// Module included in the following assemblies:
+//
+// * web_console/web-console-overview.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-custom-component-routes-rosa-hcp_{context}"]
+= Configure custom component routes for {product-title}
+
+[role="_abstract"]
+You can configure custom component routes for the web console and downloads page on your {product-title} cluster. To configure custom routes, you create a TLS secret, configure DNS records, and update the ingress configuration by using the {rosa-cli}.
+
+.Prerequisites
+
+* You have installed the {rosa-cli-first}.
+* You have administrator access to a {product-title} cluster.
+* You have a custom domain or fully qualified domain name (FQDN) registered, for example, `my-custom-hostname.dev`.
+* You have a valid TLS certificate (`tls.crt`) and private key (`tls.key`) for the custom domain.
+
+.Procedure
+
+. Create a TLS secret in the `openshift-config` namespace that has your custom domain's certificate and private key by running the following command:
++
+[source,terminal]
+----
+$ oc create secret tls <secret_name> --cert=<path_to_tls_cert> --key=<path_to_tls_key> -n openshift-config
+----
++
+where:
++
+--
+`<secret_name>`:: Specifies a name for the TLS secret, for example, `custom-console-tls`.
+`<path_to_tls_cert>`:: Specifies the path to your TLS certificate file.
+`<path_to_tls_key>`:: Specifies the path to your TLS private key file.
+--
+
+. In your DNS provider's management console, add a `CNAME` or an `A` record pointing your custom domain to your cluster's router canonical domain name. The router canonical domain name is the load balancer hostname value for your cluster.
++
+* For example, in your AWS Route 53 Dashboard, add a CNAME record where
+- Name: `my-custom-hostname.dev` (your custom hostname)
+- Value: `a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com` (your cluster's load balancer hostname)
++
+[IMPORTANT]
+====
+If you do not configure proper DNS records, you cannot access the custom routes.
+====
+
+. Update the component routes by using the {rosa-cli}:
+
+** To set a custom domain for the web console, run the following command:
++
+[source,terminal]
+----
+$ rosa edit ingress -c <cluster_name> <ingress_id> --component-routes 'console: hostname=<custom_hostname>;tlsSecretRef=<secret_name>'
+----
++
+where:
++
+--
+`<custom_hostname>`:: Specifies the custom hostname for the web console, for example, `my-custom-hostname.dev`.
+`<secret_name>`:: Specifies the name of the TLS secret you created earlier.
+--
+
+** To set a custom domain for the downloads page, run the following command:
++
+[source,terminal]
+----
+$ rosa edit ingress -c <cluster_name> <ingress_id> --component-routes 'downloads: hostname=<custom_hostname>;tlsSecretRef=<secret_name>'
+----
++
+where:
++
+--
+`<custom_hostname>`:: Specifies the custom hostname for the downloads page, for example, `my-custom-hostname.dev`.
+`<secret_name>`:: Specifies the name of the TLS secret you created for the downloads page.
+--
++
+[NOTE]
+====
+You can update both routes by running the following single command:
+[source,terminal]
+----
+$ rosa edit ingress -c <cluster_name> <ingress_id> --component-routes 'console: hostname=<custom_hostname>;tlsSecretRef=<secret_name>, downloads: hostname=<custom_hostname>;tlsSecretRef=<secret_name>'
+----
+====
+
+.Verification
+
+. Verify the ingress is updated by running the following command:
++
+[source,terminal]
+----
+$ rosa list ingress -c <cluster_name>
+----
++
+.Example output
+[source,text]
+----
+ID    APPLICATION ROUTER                                                         PRIVATE  
+r218  https://openshift-console.apps.rosa.dy5e.p1.my-custom-hostname.dev         true
+----
++
+. Add your certificate to the truststore on your local system, then confirm that you can access your components at their new routes by using your local web browser.

--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -20,9 +20,12 @@ web console to set
 ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 a custom logo, product name, links, notifications, and command-line downloads.
 endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
 a custom logo and product name.
-endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa-hcp[]
+a custom logo, product name, and custom component routes.
+endif::openshift-rosa-hcp[]
 This is especially helpful if you need to tailor the web console to meet specific corporate or government requirements.
 
 include::modules/adding-a-custom-logo.adoc[leveloffset=+1]
@@ -78,3 +81,15 @@ include::modules/odc_con_example-yaml-file-changes.adoc[leveloffset=+3]
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc[leveloffset=+2]
 
 endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa-hcp[]
+include::modules/about-custom-component-routes-rosa-hcp.adoc[leveloffset=+1]
+
+include::modules/configuring-custom-component-routes-rosa-hcp.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.aws.amazon.com/managedservices/latest/ctref/management-directory-dns-add-cname-record.html[AWS Add CNAME Record]
+
+endif::openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21052

Link to docs preview:
[About custom component routes on Red Hat OpenShift Service on AWS](https://118088--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/customizing-the-web-console.html#about-custom-component-routes-rosa-hcp_customizing-web-console)
[Configure custom component routes for Red Hat OpenShift Service on AWS](https://118088--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/customizing-the-web-console.html#configuring-custom-component-routes-rosa-hcp_customizing-web-console)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
