### PR TITLE
OADP-8350: Add OADP 1.4.11 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,9 +46,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.10
+:oadp-version: 1.4.11
 :oadp-version-1-3: 1.3.8
-:oadp-version-1-4: 1.4.10
+:oadp-version-1-4: 1.4.11
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -15,6 +15,8 @@ The release notes for {oadp-first} 1.4 describe new features and enhancements, d
 For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
+include::modules/oadp-1-4-11-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-10-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-4-9-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-11-release-notes.adoc
+++ b/modules/oadp-1-4-11-release-notes.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-11-release-notes_{context}"]
+= {oadp-short} 1.4.11 release notes
+
+[role="_abstract"]
+The {oadp-first} 1.4.11 release notes list resolved issues.
+
+The following Red Hat Security Advisory (RHSA) is available for {oadp-short} 1.4.11:
+
+* link:https://access.redhat.com/errata/RHSA-2026:59467[RHSA-2026:59467 - New version of Red{nbsp}Hat OpenShift API for Data Protection]
+
+
+[id="resolved-issues-1-4-11_{context}"]
+== Resolved issues
+
+Nil pointer dereference error no longer occurs when using `spec.configuration.restic` to enable Restic::
+Before this update, configuring a `DataProtectionApplication` (DPA) custom resource (CR) using the legacy `spec.configuration.restic` field triggered a panic in the `openshift-adp-controller-manager` logs similar to the following:
++
+[source,text]
+----
+2026-08-19T07:27:30Z    INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference
+----
++
+As a consequence, `node-agent` pods were not created. With this release, the reconciler properly handles the `spec.configuration.restic` configuration structure during reconciliation. As a result, the controller manager reconciles successfully without crashing, and the expected `node-agent` pods are created as intended.
++
+link:https://redhat.atlassian.net/browse/OADP-8700[OADP-8700]
+
+Restored pods no longer fail to connect due to retained OVN network annotations::
+Before this update, Velero restored pods with the `k8s.ovn.org/pod-networks` annotation preserved from the source cluster. As a consequence, OVN-Kubernetes skipped allocating new network configurations, resulting in stale IP assignments, subnet mismatches, and lost network connectivity for restored pods. With this release, the `k8s.ovn.org/pod-networks` annotation is automatically stripped during restore operations. As a result, OVN-Kubernetes successfully re-allocates fresh logical ports and IP addresses to restored pods, ensuring proper network connectivity.
++
+link:https://redhat.atlassian.net/browse/OADP-8223[OADP-8223]
+
+New `extraArgs` field to configure additional arguments::
+Before this update, configuring additional arguments for the `VeleroConfig` and `NodeAgentConfig` objects required setting full argument overrides. This forced you to manually replicate Operator-generated defaults and risked configuration drift across updates. With this release, a new `extraArgs` field is available for both `VeleroConfig` and `NodeAgentConfig`. You can specify additional command-line arguments or override existing defaults directly without discarding the Operator-managed configurations.
++
+link:https://redhat.atlassian.net/browse/OADP-7829[OADP-7829]
+
+CSI volume snapshot sequential creation no longer exceeds Microsoft Windows VSS freeze timeout for up to two data volumes::
+Before this update, when backing up a Microsoft Windows virtual machine (VM) with many disks by using {oadp-short} with Container Storage Interface (CSI), Velero created `VolumeSnapshots` sequentially for each PVC. As a consequence, the cumulative time to create all snapshots exceeded the Windows VSS 10-second freeze limit. This caused the operating system to automatically unfreeze before all snapshots were complete and resulted in application-inconsistent backups. With this release, the `enableCSISnapshotEarlyFrequentPolling: true` option was introduced in the `DataProtectionApplication` configuration to poll CSI snapshot readiness more often and complete snapshot creation faster. As a result, Windows VMs with up to two data volumes (3 PVCs total) can be backed up and restored within the VSS freeze timeout.
++
+link:https://redhat.atlassian.net/browse/OADP-7542[OADP-7542]
+
+Image stream image pull no longer fails after cross-namespace restore::
+Before this update, restoring an application to a target namespace with a different name retained the `system:image-pullers` `RoleBinding` referencing the original source namespace. As a consequence, restored pods failed to authenticate against the internal OpenShift registry and entered `ErrImagePull` or `ImagePullBackOff` states. With this release, `RoleBinding` is excluded during restore. OpenShift automatically regenerates `RoleBinding` with the correct target namespace references. As a result, restored applications successfully pull images from the internal registry when restored across different namespaces.
++
+link:https://redhat.atlassian.net/browse/OADP-6540[OADP-6540]
+
+Pods no longer go into panic caused by negative `WaitGroup` counter during pod volume backups::
+Before this update, the `PodVolumeBackup` (PVB) event handler invoked `WaitGroup.Done()` multiple times when a PVB transitioned to a final status. As a consequence, the `WaitGroup` counter became negative, causing the Velero process to experience a panic and restart during active backup operations. With this release, the PVB update logic ensures that `WaitGroup.Done()` is called only once per terminal status transition. As a result, Velero pod volume backups execute without unexpected crashes or restarts.
++
+link:https://redhat.atlassian.net/browse/OADP-6536[OADP-6536]
+
+Image stream backups no longer fail when DPA is configured with custom `caCert`::
+Before this update, custom Certificate Authority (CA) certificates provided in the `DataProtectionApplication` (DPA) configuration were not properly propagated or used during registry communication during image stream backups. As a consequence, requests to the target storage location failed with a `x509: certificate signed by unknown authority` error, causing image stream backups to complete in a partially failed state. With this release, the custom CA certificate is correctly applied to the relevant backup plugin workflows when communicating with the object storage endpoint. As a result, image streams are backed up successfully when custom CA certificates are configured in the DPA.
++
+link:https://redhat.atlassian.net/browse/OADP-4817[OADP-4817]


### PR DESCRIPTION
Summary of changes: Update attributes and add OADP 1.4.11 RNs. This PR targets 4.18 only. 

Version(s):
OCP 4.18 only

Issue:
[OADP-8350](https://redhat.atlassian.net/browse/OADP-8350)

Link to docs preview:
[OADP 1.4.11 release notes](https://118149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-11-release-notes_oadp-1-4-release-notes)

QE review:
- [x] QE has approved this change.