### PR TITLE
OSDOCS-16991_c: CQA fixes for AWS UPI modules_1 (4.20)

### DIFF
--- a/installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc
+++ b/installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc
@@ -6,14 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures.
+[role="_abstract"]
+To run workloads across `x86_64` and ARM nodes, you can install an {product-title} cluster on {aws-first} with multi-architecture compute machine support.
 
 [NOTE]
 ====
-When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, see xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines].
+When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture.
 ====
 
-You can install an AWS cluster with the support for configuring multi-architecture compute machines. After installing the AWS cluster, you can add multi-architecture compute machines to the cluster in the following ways:
+You can install an {aws-short} cluster with the support for configuring multi-architecture compute machines. After installing the {aws-short} cluster, you can add multi-architecture compute machines to the cluster in the following ways:
 
 * Adding 64-bit x86 compute machines to a cluster that uses 64-bit ARM control plane machines and already includes 64-bit ARM compute machines. In this case, 64-bit x86 is considered the secondary architecture.
 * Adding 64-bit ARM compute machines to a cluster that uses 64-bit x86 control plane machines and already includes 64-bit x86 compute machines. In this case, 64-bit ARM is considered the secondary architecture.
@@ -22,10 +23,9 @@ include::snippets/about-multiarch-tuning-operator.adoc[]
 
 include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
 
-.Next steps
-* xref:../../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installation-launching-installer_installing-aws-localzone[Deploying the cluster]
-
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installation-launching-installer_installing-aws-localzone[Deploying the cluster]
+* xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines]
 * xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -60,7 +60,7 @@ still require access to its cloud APIs. Some cloud functions, like
 Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
 Depending on your network, you might require less internet
-access for an installation on bare metal hardware, Nutanix, or on VMware vSphere.
+access for an installation on bare-metal hardware, Nutanix, or on VMware vSphere.
 endif::ibm-power,ibm-cloud[]
 
 ifndef::ibm-cloud[]

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -17,17 +17,15 @@ You can use the `coreos print-stream-json` sub-command of `openshift-install` to
 
 For user-provisioned installations, the `openshift-install` binary contains references to the version of {op-system} boot images that are tested for use with {product-title}, such as the {aws-first} AMI.
 
-.Procedure
-
 To parse the stream metadata, use one of the following methods:
+
+.Procedure
 
 * From a Go program, use the official `stream-metadata-go` library at https://github.com/coreos/stream-metadata-go. You can also view example code in the library.
 
 * From another programming language, such as Python or Ruby, use the JSON library of your preferred programming language.
 
-* From a command-line utility that handles JSON data, such as `jq`:
-
-** Print the current `x86_64`
+* From a command-line utility that handles JSON data, such as `jq`, print the current `x86_64`
 ifndef::openshift-origin[]
 or `aarch64`
 endif::openshift-origin[]

--- a/modules/installation-aws-creating-cloudformation-stack-compute.adoc
+++ b/modules/installation-aws-creating-cloudformation-stack-compute.adoc
@@ -8,7 +8,7 @@
 = Creating the CloudFormation stack for compute machines
 
 [role="_abstract"]
-You can create a stack of {aws-short} resources for the compute machines by using the CloudFormation template that was previously shared.
+You can create a stack of {aws-first} resources for the compute machines by using the CloudFormation template that was previously shared.
 
 [IMPORTANT]
 ====

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -7,8 +7,8 @@
 [id="installation-aws-user-infra-bootstrap_{context}"]
 = Initializing the bootstrap sequence on AWS with user-provisioned infrastructure
 
-After you create all of the required infrastructure in Amazon Web Services (AWS),
-you can start the bootstrap sequence that initializes the {product-title} control plane.
+[role="_abstract"]
+After you create all of the required infrastructure in {aws-first}, you can start the bootstrap sequence that initializes the {product-title} control plane.
 
 .Prerequisites
 
@@ -20,13 +20,16 @@ you can start the bootstrap sequence that initializes the {product-title} contro
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
-    --log-level=info <2>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \
+    --log-level=info
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you
-stored the installation files in.
-<2> To view different installation details, specify `warn`, `debug`, or
-`error` instead of `info`.
++
+where:
++
+--
+`<installation_directory>`:: Specifies the path to the directory that you stored the installation files in.
+`--log-level`:: Specifies the log level. To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/installation-aws-user-infra-delete-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-delete-bootstrap.adoc
@@ -7,7 +7,8 @@
 [id="installation-aws-user-infra-delete-bootstrap_{context}"]
 = Deleting the bootstrap resources
 
-After you complete the initial Operator configuration for the cluster, remove the bootstrap resources from Amazon Web Services (AWS).
+[role="_abstract"]
+After the control plane and initial Operators are running, the bootstrap machine is no longer needed. Remove the bootstrap resources from {aws-first} to avoid unnecessary costs.
 
 .Prerequisites
 
@@ -17,11 +18,12 @@ After you complete the initial Operator configuration for the cluster, remove th
 
 . Delete the bootstrap resources. If you used the CloudFormation template,
 link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html[delete its stack]:
-** Delete the stack by using the AWS CLI:
+** Delete the stack by using the {aws-short} CLI:
 +
 [source,terminal]
 ----
-$ aws cloudformation delete-stack --stack-name <name> <1>
+$ aws cloudformation delete-stack --stack-name <name>
 ----
-<1> `<name>` is the name of your bootstrap stack.
-** Delete the stack by using the link:https://console.aws.amazon.com/cloudformation/[AWS CloudFormation console].
++
+where `<name>` is the name of your bootstrap stack.
+** Delete the stack by using the link:https://console.aws.amazon.com/cloudformation/[{aws-short} CloudFormation console].

--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -14,12 +14,12 @@ endif::[]
 [id="installation-aws-user-infra-installation_{context}"]
 = Completing an AWS installation on user-provisioned infrastructure
 
-After you start the {product-title} installation on Amazon Web Service (AWS)
-user-provisioned infrastructure, monitor the deployment to completion.
+[role="_abstract"]
+After you start the {product-title} installation on {aws-first} user-provisioned infrastructure, monitor the deployment to verify that the control plane and compute nodes initialize successfully.
 
 .Prerequisites
 
-* You removed the bootstrap node for an {product-title} cluster on user-provisioned AWS infrastructure.
+* You removed the bootstrap node for an {product-title} cluster on user-provisioned {aws-short} infrastructure.
 * You installed the `oc` CLI.
 
 .Procedure
@@ -34,10 +34,10 @@ the cluster installation:
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you
-stored the installation files in.
++
+where `<installation_directory>` is the path to the directory that you stored the installation files in.
 +
 .Example output
 [source,terminal]

--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -7,7 +7,8 @@
 [id="installation-aws-user-infra-rhcos-ami_{context}"]
 = {op-system} AMIs for the AWS infrastructure
 
-Red Hat provides {op-system-first} AMIs that are valid for the various AWS regions and instance architectures that you can manually specify for your {product-title} nodes.
+[role="_abstract"]
+To deploy {product-title} nodes on {aws-first}, select from the valid {op-system-first} AMIs for your region and instance architecture.
 
 [NOTE]
 ====

--- a/modules/installation-cloudformation-bootstrap.adoc
+++ b/modules/installation-cloudformation-bootstrap.adoc
@@ -7,13 +7,11 @@
 [id="installation-cloudformation-bootstrap_{context}"]
 = CloudFormation template for the bootstrap machine
 
-You can use the following CloudFormation template to deploy the bootstrap machine that you need for your {product-title} cluster.
+[role="_abstract"]
+The bootstrap machine CloudFormation template creates the temporary {aws-first} resources that the {product-title} bootstrap process requires to initialize the control plane.
 
 .CloudFormation template for the bootstrap machine
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/04_cluster_bootstrap.yaml[]
 ----
-====

--- a/modules/installation-cloudformation-control-plane.adoc
+++ b/modules/installation-cloudformation-control-plane.adoc
@@ -7,14 +7,11 @@
 [id="installation-cloudformation-control-plane_{context}"]
 = CloudFormation template for control plane machines
 
-You can use the following CloudFormation template to deploy the control plane
-machines that you need for your {product-title} cluster.
+[role="_abstract"]
+The control plane CloudFormation template creates the {aws-first} resources for the three control plane machines that manage your {product-title} cluster.
 
 .CloudFormation template for control plane machines
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/05_cluster_master_nodes.yaml[]
 ----
-====

--- a/modules/installation-cloudformation-dns.adoc
+++ b/modules/installation-cloudformation-dns.adoc
@@ -7,17 +7,14 @@
 [id="installation-cloudformation-dns_{context}"]
 = CloudFormation template for the network and load balancers
 
-You can use the following CloudFormation template to deploy the networking
-objects and load balancers that you need for your {product-title} cluster.
+[role="_abstract"]
+The networking CloudFormation template creates the Route 53 DNS entries and load balancers on {aws-first} that route traffic to your {product-title} control plane and applications.
 
 .CloudFormation template for the network and load balancers
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/02_cluster_infra.yaml[]
 ----
-====
 
 [IMPORTANT]
 ====

--- a/modules/installation-cloudformation-security.adoc
+++ b/modules/installation-cloudformation-security.adoc
@@ -7,14 +7,11 @@
 [id="installation-cloudformation-security_{context}"]
 = CloudFormation template for security objects
 
-You can use the following CloudFormation template to deploy the security objects
-that you need for your {product-title} cluster.
+[role="_abstract"]
+The security CloudFormation template creates the IAM roles and security groups on {aws-first} that control access to your {product-title} cluster resources.
 
 .CloudFormation template for security objects
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/03_cluster_security.yaml[]
 ----
-====


### PR DESCRIPTION
Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:

- [Installing a cluster with the support for configuring multi-architecture compute machines](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-multiarch-support-upi.html)
- [About installations in restricted networks](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-about-restricted-networks_installing-restricted-networks-aws)
- [Accessing RHCOS AMIs with stream metadata](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-ami-stream-metadata_installing-restricted-networks-aws)
- [Creating the CloudFormation stack for compute machines](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-creating-cloudformation-stack_installing-restricted-networks-aws)
- [Initializing the bootstrap sequence on AWS with user-provisioned infrastructure](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-bootstrap_installing-restricted-networks-aws)
- [Deleting the bootstrap resources](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-delete-bootstrap_installing-restricted-networks-aws)
- [Completing an AWS installation on user-provisioned infrastructure](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-installation_installing-restricted-networks-aws)
- [RHCOS AMIs for the AWS infrastructure](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws)
- [CloudFormation template for the bootstrap machine](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-cloudformation-bootstrap_installing-restricted-networks-aws)
- [CloudFormation template for control plane machines](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-cloudformation-control-plane_installing-restricted-networks-aws)
- [CloudFormation template for the network and load balancers](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-cloudformation-dns_installing-restricted-networks-aws)
- [CloudFormation template for security objects](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-cloudformation-security_installing-restricted-networks-aws)

QE review:

Non-technical update (style, formatting, DITA compliance). QE review not required per contribution guide.

Additional information:

## Summary
- Add `[role="_abstract"]` DITA short descriptions to 9 files that were missing them, written to include WHAT and WHY per short description guidelines
- Replace unsupported DITA callouts (`<1>`, `<2>`) with `where:` description lists in 3 procedure modules
- Fix "bare metal hardware" → "bare-metal hardware" terminology error
- Move inline xrefs from NOTE block and `.Next steps` into `[role="_additional-resources"]` section
- Move intro paragraph before `.Procedure` heading in `installation-aws-ami-stream-metadata.adoc` to fix TaskStep mapping
- Apply `{aws-first}` for first body-text occurrence and `{aws-short}` for subsequent occurrences across all 12 changed files
- Unwrap hard-wrapped lines in paragraphs edited for shortdesc