### PR TITLE
Clarify oc-mirror mirrors all channels when channels field is omitted

### DIFF
--- a/modules/oc-mirror-operator-catalog-filtering.adoc
+++ b/modules/oc-mirror-operator-catalog-filtering.adoc
@@ -11,6 +11,11 @@ oc-mirror plugin v2 selects the list of bundles for mirroring by processing the 
 
 When oc-mirror plugin v2 selects bundles for mirroring, it does not infer Group Version Kind (GVK) or bundle dependencies, omitting them from the mirroring set. Instead, it strictly adheres to the user instructions. You must explicitly specify any required dependent packages and their versions.
 
+[NOTE]
+====
+When no `channels` field is specified for a package, oc-mirror includes all channels of that package and mirrors the head bundle from each channel. To mirror only specific channels, add a `channels` block listing the desired channel names.
+====
+
 .Use the following table to see what bundle versions are included in different scenarios
 [cols="1,2",options="header"]
 
@@ -51,7 +56,7 @@ mirror:
      packages:
     - name: compliance-operator
 ----
-|One bundle, corresponding to the head version for each channel of that package.
+|All channels of that package are included. For each channel, one bundle corresponding to the channel head version is mirrored.
 
 a|Scenario 4
 


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/114629

## Summary
- Add a NOTE explaining that when no `channels` field is specified for a package, oc-mirror includes all channels and mirrors the head bundle from each channel.
- Clarify Scenario 3 expected bundle versions wording to state explicitly that all channels are included.

## QE review
N/A — documentation clarification only; no change to product behavior.

@openshift/team-documentation