### PR TITLE
OSDOCS-20335: CQA-RHCL-7: Registering MCP servers

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -77,21 +77,21 @@ Topics:
 - Name: Configure and deploy a PlanPolicy
   File: rhcl-planpolicy
 ---
-Name: Registering MCP servers and creating policies
+Name: Register MCP servers and creating policies
 Dir: mcp_gateway_config
 Distros: rhcl
 Topics:
 - Name: Registering on-premise MCP servers
   File: mcp-gateway-register-on-prem-mcp-servers
-- Name: Registering external MCP servers
+- Name: Register external MCP servers
   File: mcp-gateway-register-ext-mcp-servers
-- Name: Creating virtual MCP servers
-  File: mcp-gateway-creating-virtual-mcp-servers
+- Name: Create virtual MCP servers
+  File: mcp-gateway-create-virtual-mcp-servers
 - Name: Configuring authentication for the MCP gateway
   File: mcp-gateway-authentication
 - Name: Configuring authorization for the MCP gateway
   File: mcp-gateway-authorization
-- Name: Revoking MCP server tool access
+- Name: Revoke MCP server tool access
   File: mcp-gateway-revoke-tool-access
 - Name: Using credentials to access external APIs
   File: mcp-gateway-vault

--- a/mcp_gateway_config/mcp-gateway-create-virtual-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-create-virtual-mcp-servers.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes.adoc[]
 [id="mcp-gateway-create-virtual-mcp-servers"]
-= Creating virtual MCP servers
+= Create virtual MCP servers
 :context: mcp-gateway-register-virtual-mcp-servers
 
 toc::[]
 
 [role="_abstract"]
-Create focused, curated tool and prompt collections from your aggregated internal and external MCP servers by creating virtual MCP servers from any of your registered MCP servers.
+Create focused, curated tool and prompt collections from your aggregated internal and external Model Context Protocol (MCP) servers by creating virtual MCP servers from any of your registered MCP servers.
 
 include::modules/con-register-virt-mcp-server.adoc[leveloffset=+1]
 

--- a/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes.adoc[]
 [id="mcp-gateway-register-ext-mcp-servers"]
-= Registering external MCP servers
+= Register external MCP servers
 :context: mcp-gateway-register-ext-mcp-servers
 
 toc::[]
 
 [role="_abstract"]
-To use external MCP servers with your MCP gateway, you must configure ingress, create routing resources, and register the server with the MCP gateway. As a best practice, you must also configure security rules.
+To use external Model Context Protocol (MCP) servers with your MCP gateway, you must configure ingress, create routing resources, and register the server with the MCP gateway. As a best practice, you must also configure security rules.
 
 include::modules/proc-register-ext-mcp-server-ingress.adoc[leveloffset=+1]
 

--- a/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+++ b/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes.adoc[]
 [id="mcp-gateway-revoke-mcp-server-tool-access"]
-= Revoking MCP server tool access
+= Revoke MCP server tool access
 :context: mcp-gateway-revoke-mcp-server-tool-access
 
 toc::[]
 
 [role="_abstract"]
-You can revoke tool access for users and groups. Tool revocation prevents a user or group from calling specific MCP tools.
+You can revoke tool access for users and groups. Tool revocation prevents a user or group from calling specific model content protocol (MCP) tools.
 
 include::modules/con-mcp-gateway-understand-tool-access-revocation.adoc[leveloffset=+1]
 

--- a/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
+++ b/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="con-mcp-gateway-understand-tool-access-revocation_{context}"]
-= Understanding tool access revocation
+= Understand tool access revocation
 
 [role="_abstract"]
 Tool revocation uses the authorization setup where tool access is controlled by roles in identity provider JWT tokens. Revoking a tool means removing the corresponding role from a user or group, so their next token no longer grants access.
@@ -21,8 +21,8 @@ The following two enforcement points apply:
 
 The timing of tool revocation depends on the following session events:
 
-* New sessions: Users who authenticate after revocation receive a token without the revoked tool. They are denied immediately.
+* New sessions: Users who authenticate after revocation receive a token without the revoked tool. Denial is immediate.
 
-* Existing sessions: Users with an active token keep access until the token expires. You configure token lifetime in your identity provider, for example, the **Access Token Lifespan** setting in {keycloak}. Shorter token lifetimes mean that tokens are refreshed more frequently, picking up role changes sooner. You must decide on the balance between revocation latency and token-refresh resource utilization.
+* Existing sessions: Users with an active token keep access until the token expires. You configure token lifetime in your identity provider, for example, the **Access Token Lifespan** setting in {keycloak}. Shorter token lifetimes mean that tokens are refreshed more often, picking up role changes sooner. You must decide on the balance between revocation latency and token-refresh resource use.
 
-* In-flight requests: A `tools/call` request that is already being processed completes normally. The authorization check occurs before the request reaches the backend MCP server, so only new requests can be denied.
+* In-flight requests: A `tools/call` request that is already being processed completes normally. The authorization check occurs before the request reaches the backend MCP server. Only new requests are denied.

--- a/modules/con-register-virt-mcp-server.adoc
+++ b/modules/con-register-virt-mcp-server.adoc
@@ -5,12 +5,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="con-create-virt-mcp-server_{context}"]
-= About virtual MCP servers
+= Virtual MCP servers for curating tools and prompts
 
 [role="_abstract"]
-When you aggregate all your MCP servers centrally, you solve for authentication, authorization, and configuration management. At the same time, this aggregation can overwhelm large-language models (LLMs) and AI agents with too many tool and prompt choices. You can create virtual MCP servers to curate tools and prompts for each situation.
+When you aggregate all your model context (MCP) servers centrally, you solve for authentication, authorization, and configuration management. At the same time, this aggregation can overwhelm large-language models (LLMs) and AI agents with too many tool and prompt choices. You can create virtual MCP servers to curate tools and prompts for each situation.
 
-You can narrow the scope for your agentic services and applications by creating virtual MCP servers that filter the complete capabilities based on a curated selection and access only the relevant capabilities with HTTP headers. You can use virtual MCP servers to do the following:
+You can narrow the scope for your agentic services and applications by creating virtual MCP servers. These virtual servers filter the complete capabilities based on a curated selection and access only the relevant capabilities with HTTP headers. You can use virtual MCP servers to do the following:
 
 * Create specialized collections of tools for specific use cases.
 * Reduce the load on LLMs by presenting fewer, more relevant tools and prompts.
@@ -18,4 +18,4 @@ You can narrow the scope for your agentic services and applications by creating 
 * Make it easier for users and agents to find the right tools and prompts.
 * Combine with authorization policies for fine-grained access management.
 
-Virtual MCP servers only filter which tools and prompts a client can discover by using the `tools/list` and `prompts/list` concepts. Virtual MCP servers do not change call routing or authorization.
+Virtual MCP servers only filter those tools and prompts that a client can discover by using the `tools/list` and `prompts/list` concepts. Virtual MCP servers do not change call routing or authorization.

--- a/modules/con-virt-mcp-server-auth-tool-filtering.adoc
+++ b/modules/con-virt-mcp-server-auth-tool-filtering.adoc
@@ -4,14 +4,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="con-virt-mcp-server-auth-tool-filtering_{context}"]
-= About virtual MCP servers authorization and filtering
+= Virtual MCP server authorization and filtering
 
 [role="_abstract"]
-If you have authentication and user-based tool or prompt filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting capabilities list is the intersection of the authentication and the filters.
+When you create virtual Model Context Protocol (MCP) servers, the capabilities list is the intersection of the authentication and user-based tool or prompt filtering that already exists.
 
-The `AuthPolicy` custom resource (CR) configurations you applied when you registered the MCP servers are used. You do not need to make additional configurations when creating virtual MCP servers.
+Each registered MCP server retains its `AuthPolicy` custom resources (CR) and role configurations.
 
-The MCP gateway broker component applies filters sequentially when handling `tools/list` and `prompts/list` requests with a virtual MCP server header. The following are the applied filters in order:
+When requests with a virtual MCP server header `tools/list` and `prompts/list` come in, the MCP gateway broker component applies filters sequentially. The following are the applied filters in order:
 
 . Identity-based filtering: The `x-mcp-authorized` header, injected by the `AuthPolicy` CR, reduces the tools and prompts list to only the capabilities that the user has `resource_access` roles configured for.
 . Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-capabilities list to only those that you defined in the `MCPVirtualServer` CR.

--- a/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-create-virt-mcp-server_{context}"]
-= Creating virtual MCP servers
+= Create virtual MCP servers
 
 [role="_abstract"]
-To create virtual MCP servers for different use cases, you must define the virtual server with an `MCPVirtualServer` custom resource (CR) that specifies required fields. When a client includes the virtual MCP server header, the MCP gateway filters responses to only include the specified tools.
+To create virtual Model Context Protocol (MCP) servers for different use cases, you must define the virtual server with an `MCPVirtualServer` custom resource (CR) that specifies required fields. When a client includes the virtual MCP server header, the MCP gateway filters responses to only include the specified tools.
 
 An `MCPVirtualServer` CR must contain the following information:
 
@@ -30,7 +30,7 @@ Prompt selection is optional. Specify which prompts from the aggregated pool to 
 
 . Create an `MCPVirtualServer` CR for a virtual MCP server that curates development tools by using the following example:
 +
-.Example developer tools MCPVirtualServer CR
+.Example developer tools `MCPVirtualServer` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: mcp.kuadrant.io/v1alpha1
@@ -61,7 +61,7 @@ Replace `_<mcpvs_devtools.yaml>_` with the name of your CR.
 
 . Create an `MCPVirtualServer` CR for a virtual server that curates data analysis tools and prompts by using the following example:
 +
-.Example data analysis tools MCPVirtualServer CR
+.Example data analysis tools `MCPVirtualServer` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: mcp.kuadrant.io/v1alpha1

--- a/modules/proc-mcp-gateway-delete-virtual-server.adoc
+++ b/modules/proc-mcp-gateway-delete-virtual-server.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-delete-virt-mcp-server_{context}"]
-= Deleting virtual MCP servers
+= Delete virtual MCP servers
 
 [role="_abstract"]
-You can delete a virtual MCP server when you no longer need it or when your MCP servers change.
+You can delete a virtual Model Context Protocol (MCP) server when you no longer need it or when your MCP servers change.
 
 .Prerequisites
 
@@ -25,5 +25,5 @@ You can delete a virtual MCP server when you no longer need it or when your MCP 
 $ oc delete mcpvirtualserver _<dev_tools>_ -n _<mcp_system>_
 ----
 +
-* Replace `_<dev_tools>_` with the name of the `MCPVirtualServer` custom resource you want to remove.
-* Replace `_<mcp_system>_` with the namespace where the CR is applied.
+** Replace `_<dev_tools>_` with the name of the `MCPVirtualServer` custom resource you want to remove.
+** Replace `_<mcp_system>_` with the namespace where the CR is applied.

--- a/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
+++ b/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-filter-revoked-tools-display_{context}"]
-= Filtering revoked tools and prompts from display
+= Filter revoked tools and prompts from display
 
 [role="_abstract"]
-After you revoke a tool or prompt by using your identity provider, requests are blocked. However, the revoked capability is still displayed in responses. To filter revoked tools and prompts from the displayed list, you must give the MCP broker component a signed header that carries the user's authorized capabilities.
+After you revoke a tool or prompt by using your identity provider, requests are blocked. However, the revoked capability is still displayed in responses. To filter revoked tools and prompts from the displayed list, you must give the Model Context Protocol (MCP) broker component a signed header that carries the user's authorized capabilities.
 
-You can remove blocked tools from responses by configuring the Authorino Operator to generate the header by using a wristband JWT signed with an ECDSA key pair.
+You can remove blocked tools from responses by configuring the Authorino Operator to generate the header by using a wristband JSON web token (JWT) signed with an Elliptic Curve Digital Signature Algorithm (ECDSA) key pair.
 
 .Prerequisites
 
@@ -80,7 +80,7 @@ You must delete the `AuthPolicy` CR and create a new one. Using `$ oc apply` mer
 
 . Generate a new `x-mcp-authorized` header by creating and applying a new `AuthPolicy` CR. Use the following example:
 +
-.Example AuthPolicy CR
+.Example `AuthPolicy` CR
 [source,yaml]
 ----
 $ oc create -f - <<EOF

--- a/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
+++ b/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-revoking-tool-call-requests_{context}"]
-= Revoking tool and prompt call requests
+= Revoke tool and prompt call requests
 
 [role="_abstract"]
 Use your existing authorization setup to revoke tool and prompt requests for individual users and groups by removing either role from the user or group in your identity provider.
 
-In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced MCPServerRegistration custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`. Use the same process for prompts.
+In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced `MCPServerRegistration` custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`. Use the same process for prompts.
 
 .Prerequisites
 
@@ -17,7 +17,7 @@ In this example, {keycloak} is used. Remove the client-role mapping. The client 
 * You configured a `Gateway` object.
 * You are logged into a running {ocp} cluster with an `admin` role.
 * You configured an `HTTPRoute` object for the gateway.
-* You registered an MCP server.
+* You registered a Model Context Protocol (MCP) server.
 * You created a `Secret` CR for authentication.
 * You configured authorization with a tool-level `AuthPolicy` CR.
 
@@ -35,8 +35,10 @@ In this example, {keycloak} is used. Remove the client-role mapping. The client 
 
 .Verification
 
-. After revoking a tool, verify that the user can no longer call it by using MCP Inspector. Log out of any existing MCP Inspector session and log back in as the affected user to get a fresh token.
+* After revoking a tool, verify that the user can no longer call it by using MCP Inspector.
 
-.. Open MCP Inspector and connect to your gateway's `/mcp` endpoint. Authenticate through the OAuth flow.
+** Log out of any existing MCP Inspector session and log back in as the affected user to get a fresh token.
 
-.. Under **Tools > List Tools**, the revoked tool is displayed. Try calling the revoked tool. The request should return `500`.
+** Open MCP Inspector and connect to your gateway's `/mcp` endpoint. Authenticate through the OAuth flow.
+
+** Under **Tools > List Tools**, the revoked tool is displayed. Try calling the revoked tool. The request should return `500`.

--- a/modules/proc-register-ext-mcp-server-authpolicy.adoc
+++ b/modules/proc-register-ext-mcp-server-authpolicy.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-authpolicy_{context}"]
-= Creating an AuthPolicy for an external MCP server
+= Create an AuthPolicy for an external MCP server
 
 [role="_abstract"]
-To secure your use of an external MCP server, creating an `AuthPolicy` custom resource (CR) to authenticate your sessions is a best practice. The following example uses `Kuadrant/Authorino` for OAuth authentication and creates an `AuthPolicy` CR to handle authorization headers.
+To secure your use of an external Model Context Protocol (MCP) server, creating an `AuthPolicy` custom resource (CR) to authenticate your sessions is a best practice. The following example uses `Kuadrant/Authorino` for OAuth authentication and creates an `AuthPolicy` CR to handle authorization headers.
 
 [NOTE]
 ====
@@ -26,7 +26,7 @@ This step is required if you are using OAuth authentication for your external MC
 
 . Create an `AuthPolicy` CR that handles authorization headers by using the following example:
 +
-.Example AuthPolicy CR
+.Example `AuthPolicy` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: kuadrant.io/v1

--- a/modules/proc-register-ext-mcp-server-httproute.adoc
+++ b/modules/proc-register-ext-mcp-server-httproute.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-httproute_{context}"]
-= Creating an HTTPRoute for an external MCP server
+= Create an HTTPRoute for an external MCP server
 
 [role="_abstract"]
-To use an external MCP server, you must create an `HTTPRoute` custom resource (CR) that matches your internal hostname and routes to the external service by using Istio.
+To use an external Model Context Protocol (MCP) server, you must create an `HTTPRoute` custom resource (CR) that matches your internal hostname and routes to the external service by using Istio.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ To use an external MCP server, you must create an `HTTPRoute` custom resource (C
 
 . Create a `HTTPRoute` CR that routes to the external service by using the following example:
 +
-.Example HTTPRoute CR
+.Example `HTTPRoute` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: gateway.networking.k8s.io/v1

--- a/modules/proc-register-ext-mcp-server-ingress.adoc
+++ b/modules/proc-register-ext-mcp-server-ingress.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-serviceentry_{context}"]
-= Creating a ServiceEntry for an external MCP server
+= Create a ServiceEntry for an external MCP server
 
 [role="_abstract"]
-To register an external MCP server, you must first make sure that it has an ingress pathway by creating a `ServiceEntry` custom resource (CR) in your Istio deployment. {ocp} 4.19 and newer provides Istio through the Gateway API.
+To register an external Model Context Protocol (MCP) server, you must first make sure that it has an ingress pathway by creating a `ServiceEntry` custom resource (CR) in your Istio deployment. {ocp} 4.19 and newer provides Istio through the Gateway API.
 
 .Prerequisites
 
@@ -20,7 +20,7 @@ To register an external MCP server, you must first make sure that it has an ingr
 
 . Create a `ServiceEntry` CR that registers the external server in the Istio service registry by using the following template:
 +
-.Example ServiceEntry CR
+.Example `ServiceEntry` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: networking.istio.io/v1beta1

--- a/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
+++ b/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-mcpserverregistration_{context}"]
-= Creating an MCPServerRegistration for an external MCP server
+= Create an MCPServerRegistration for an external MCP server
 
 [role="_abstract"]
-To use an external MCP server, you must create an `MCPServerRegistration` custom resource (CR) that registers your external MCP server with the MCP gateway.
+To use an external Model Context Protocol (MCP) server, you must create an `MCPServerRegistration` custom resource (CR) that registers your external MCP server with the MCP gateway.
 
 .Prerequisites
 
@@ -22,7 +22,7 @@ To use an external MCP server, you must create an `MCPServerRegistration` custom
 
 . Create a `MCPServerRegistration` CR that registers the external MCP server with the MCP gateway by using the following example:
 +
-.Example MCPServerRegistration CR
+.Example `MCPServerRegistration` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: mcp.kuadrant.io/v1alpha1

--- a/modules/proc-register-ext-mcp-server-secret.adoc
+++ b/modules/proc-register-ext-mcp-server-secret.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-secret_{context}"]
-= Creating a Secret for an external MCP server
+= Create a Secret for an external MCP server
 
 [role="_abstract"]
-To use an external MCP server, you must create a `Secret` custom resource (CR) that stores backend API key credentials.
+To use an external Model Context Protocol (MCP) server, you must create a `Secret` custom resource (CR) that stores backend API key credentials.
 
 This `Secret` CR is referenced in your `MCPServerRegistration` CR in the `credentialRef` parameter. These resources are for backend API key authentication. The `api-key` is stored in the config secret and used by the MCP broker component for upstream connections.
 
@@ -23,7 +23,7 @@ This `Secret` CR is referenced in your `MCPServerRegistration` CR in the `creden
 
 . Create a `Secret` CR that stores backend API key credentials by using the following example:
 +
-.Example Secret CR
+.Example `Secret` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: v1

--- a/modules/proc-register-ext-mcp-server-tls.adoc
+++ b/modules/proc-register-ext-mcp-server-tls.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-tls_{context}"]
-= Creating TLS settings for an external MCP server
+= Create TLS settings for an external MCP server
 
 [role="_abstract"]
-To register an external MCP server, after you create a `ServiceEntry` custom resource (CR) in your Istio deployment, you must configure your TLS settings with a `DestinationRule` CR.
+To register an external Model Context Protocol (MCP) server, after you create a `ServiceEntry` custom resource (CR) in your Istio deployment, you must configure your TLS settings with a `DestinationRule` CR.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ To register an external MCP server, after you create a `ServiceEntry` custom res
 
 . Create a `DestinationRule` CR that configure your TLS settings by using the following template:
 +
-.Example DestinationRule CR
+.Example `DestinationRule` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: networking.istio.io/v1beta1

--- a/modules/proc-register-ext-mcp-server-verify.adoc
+++ b/modules/proc-register-ext-mcp-server-verify.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-register-ext-mcp-server-verify_{context}"]
-= Verifying that your external MCP server is ready to use
+= Verify that your external MCP server is ready to use
 
 [role="_abstract"]
-To verify that an external MCP server is ready to use, check the status of your `MCPServerRegistration` custom resource (CR).
+To verify that an external Model Context Protocol (MCP) server is ready to use, check the status of your `MCPServerRegistration` custom resource (CR).
 
 .Prerequisites
 

--- a/modules/proc-verify-virt-mcp-server.adoc
+++ b/modules/proc-verify-virt-mcp-server.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-verify-virt-mcp-server_{context}"]
-= Verifying virtual MCP servers
+= Verify virtual MCP servers
 
 [role="_abstract"]
-After you create your virtual MCP servers, you can check that they are returning the tool and prompt lists that you want.
+After you create your virtual Model Context Protocol (MCP) servers, you can check that they are returning the tool and prompt lists that you want.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-20335](https://redhat.atlassian.net/browse/OSDOCS-20335)

Link to docs preview:
https://118164--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-create-virtual-mcp-servers.html
https://118164--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.html
https://118164--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-revoke-tool-access.html

QE review:
- N/A internal docs work, no technical changes

Additional information:
CQA PR 2, https://github.com/openshift/openshift-docs/pull/118175
CQA PR 3, https://github.com/openshift/openshift-docs/pull/118187

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
