### PR TITLE
[OCPBUGS#35866]: Add context for why port security is disabled with SR-IOV

### DIFF
--- a/modules/machineset-yaml-osp-sr-iov.adoc
+++ b/modules/machineset-yaml-osp-sr-iov.adoc
@@ -111,6 +111,8 @@ where:
 The value of the `spec.template.spec.providerSpec.value.ports.vnicType` parameter must be `direct` for each port.
 
 The value of the `spec.template.spec.providerSpec.value.ports.portSecurity` parameter must be `false` for each port. You cannot set security groups and allowed address pairs for ports when port security is disabled. Setting security groups on the instance applies the groups to all ports that are attached to it.
+
+Port security, such as allowed address pairs, does not apply to SR-IOV virtual functions (VFs) because their performance depends on the NIC firmware rather than on Neutron. For the ML2/OVN mechanism driver, port security is enforced at the OVN conntrack layer, which SR-IOV VFs bypass.
 ====
 
 `<uplink_network_UUID>`:: Specifies a network UUID for each port.


### PR DESCRIPTION
Version(s): 4.16+

Issue: [OCPBUGS-35866](https://issues.redhat.com/browse/OCPBUGS-35866)

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:
Explanation confirmed by Emilien Macchi in the Jira ticket.