### PR TITLE
OSDOCS-21309: Added documentation enhancements to Autonode

### DIFF
--- a/modules/rosa-node-tuning-autonode.adoc
+++ b/modules/rosa-node-tuning-autonode.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-node-tuning-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-node-tuning-autonode_{context}"]
+= Configure node tuning for {autonode} nodes
+
+[role="_abstract"]
+You can apply `sysctl` node tuning configurations to nodes that the {autonode} provisions. To apply a `TuningConfig` to {autonode}-managed nodes, create a Karpenter node pool with a label that maps it to a {product-title} machine pool that has the `TuningConfig` applied.
+
+[IMPORTANT]
+====
+Only `sysctl` configurations are supported for {autonode} nodes. Boot-time kernel parameters are not available.
+====
+
+.Prerequisites
+
+* The {autonode} is enabled on the cluster.
+* You have installed the `oc` CLI and are logged in to the cluster.
+* You have created a `TuningConfig` for your cluster.
+* You have created a {product-title} machine pool with the `TuningConfig` applied.
+
+.Procedure
+
+. Create a Karpenter node pool manifest that includes the `hypershift.openshift.io/nodePool` label:
++
+[source,yaml]
+----
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: tuned-nodepool
+spec:
+  template:
+    metadata:
+      labels:
+        hypershift.openshift.io/nodePool: <rosa_machinepool_name>
+    spec:
+      requirements:
+      - key: node.kubernetes.io/instance-type
+        operator: In
+        values:
+        - m5.xlarge
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+----
+where:
+`<rosa_machinepool_name>`::
+The name of the {product-title} machine pool that has the `TuningConfig` applied.
+
+. Apply the node pool manifest:
++
+[source,terminal]
+----
+$ oc apply -f <nodepool_manifest>.yaml
+----
+
+.Verification
+
+* Verify the node pool is ready:
++
+[source,terminal]
+----
+$ oc get nodepool
+----
++
+.Example output
+[source,terminal]
+----
+NAME             NODECLASS   NODES   READY   AGE
+tuned-nodepool   default     0       True    3s
+----

--- a/modules/rosa-nodes-autonode-managing-iam-setup.adoc
+++ b/modules/rosa-nodes-autonode-managing-iam-setup.adoc
@@ -41,7 +41,8 @@ EOF
 [source,terminal]
 ----
 $ aws iam create-role --role-name rosa-karpenter-controller-role-${CLUSTER_NAME} \
-  --assume-role-policy-document file://trust-policy.json
+  --assume-role-policy-document file://trust-policy.json \
+  --tags Key=red-hat-managed,Value=true
 ----
 
 . Attach the AWS managed IAM policy:

--- a/modules/rosa-nodes-autonode-managing-nodeclass-api-fields.adoc
+++ b/modules/rosa-nodes-autonode-managing-nodeclass-api-fields.adoc
@@ -35,6 +35,11 @@ spec:
   capacityReservationSelectorTerms:
     - tags:
         <reservation_tag_key>: "<reservation_tag_value>"
+  spec:
+    kubelet:
+      podsPerCore: 2
+      maxPods: 20
+      podPidsLimit: 4096
 ----
 where:
 

--- a/nodes/nodes/nodes-node-tuning-operator.adoc
+++ b/nodes/nodes/nodes-node-tuning-operator.adoc
@@ -37,6 +37,8 @@ endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 include::modules/rosa-creating-node-tuning.adoc[leveloffset=+1]
 
+include::modules/rosa-node-tuning-autonode.adoc[leveloffset=+1]
+
 include::modules/rosa-modifying-node-tuning.adoc[leveloffset=+1]
 
 include::modules/rosa-deleting-node-tuning.adoc[leveloffset=+1]

--- a/rosa_cluster_admin/autonode/rosa-autonode-setup.adoc
+++ b/rosa_cluster_admin/autonode/rosa-autonode-setup.adoc
@@ -34,3 +34,5 @@ include::modules/rosa-nodes-autonode-managing-enable-ui.adoc[leveloffset=+1]
 == Additional resources
 
 * link:https://aws.amazon.com/blogs/containers/using-amazon-ec2-spot-instances-with-karpenter/[Using Amazon EC2 Spot Instances with Karpenter]
+* xref:../../nodes/nodes/nodes-node-tuning-operator.adoc#rosa-node-tuning-autonode_nodes-node-tuning-operator[Configure node tuning for {autonode} nodes]
+


### PR DESCRIPTION
Version(s):
`enterprise-4.22+`

Issue:
**[OSDOCS-21309](https://redhat.atlassian.net/browse/OSDOCS-21309)**

Link to docs preview:
- [Prepare an AWS IAM role for the Red Hat build of Karpenter](https://118173--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/autonode/rosa-autonode-setup.html#rosa-nodes-autonode-managing-setup_rosa-autonode-setup)
    <img width="879" height="199" alt="image" src="https://github.com/user-attachments/assets/d687d9db-492c-4778-87be-3c127b0b161d" />
- [`OpenshiftEC2NodeClass` configuration](https://118173--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/autonode/rosa-autonode-nodeclass#rosa-nodes-autonode-managing-nodeclass-api-fields_rosa-autonode-nodeclass) fields
    <img width="897" height="862" alt="image" src="https://github.com/user-attachments/assets/9788ca6f-1151-47fb-a75d-9fddc3d734e8" />
- [Configuring node tuning for Red Hat build of Karpenter nodes](https://118173--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/nodes/nodes-node-tuning-operator#rosa-node-tuning-autonode_nodes-node-tuning-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added some enhancements to the Autonode documentation.