### PR TITLE
OBSDOCS-3860: Add Logging 6.5.2 z-stream release notes

### DIFF
--- a/modules/logging-release-notes-6-5-2-cves.adoc
+++ b/modules/logging-release-notes-6-5-2-cves.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-2-cves_{context}"]
+= CVEs
+
+[role="_abstract"]
+The following CVEs are included in this release of {LoggingProductName}.
+
+* https://access.redhat.com/security/cve/cve-2026-25681[CVE-2026-25681]
+* https://access.redhat.com/security/cve/cve-2026-27136[CVE-2026-27136]
+* https://access.redhat.com/security/cve/cve-2026-32281[CVE-2026-32281]
+* https://access.redhat.com/security/cve/cve-2026-32282[CVE-2026-32282]
+* https://access.redhat.com/security/cve/cve-2026-33811[CVE-2026-33811]
+* https://access.redhat.com/security/cve/cve-2026-33813[CVE-2026-33813]
+* https://access.redhat.com/security/cve/cve-2026-39820[CVE-2026-39820]
+* https://access.redhat.com/security/cve/cve-2026-39821[CVE-2026-39821]
+* https://access.redhat.com/security/cve/cve-2026-42151[CVE-2026-42151]
+* https://access.redhat.com/security/cve/cve-2026-42154[CVE-2026-42154]
+* https://access.redhat.com/security/cve/cve-2026-42499[CVE-2026-42499]
+* https://access.redhat.com/security/cve/cve-2026-42502[CVE-2026-42502]
+* https://access.redhat.com/security/cve/cve-2026-42504[CVE-2026-42504]
+* https://access.redhat.com/security/cve/cve-2026-56852[CVE-2026-56852]

--- a/modules/logging-release-notes-6-5-2-deprecated-features.adoc
+++ b/modules/logging-release-notes-6-5-2-deprecated-features.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-2-deprecated-features_{context}"]
+= Deprecated features
+
+[role="_abstract"]
+The following features are deprecated in this release of {LoggingProductName}.
+
+Azure Monitor Data Collector API deprecated::
+The `azureMonitor` output type is deprecated in this release. This output type uses the Azure HTTP Data Collector API. Microsoft will disable the Data Collector API on September 14, 2026. If you currently use the `azureMonitor` output type, you must migrate to the new `azureLogsIngestion` output type before this date to avoid service disruption. The `azureLogsIngestion` output type uses the Azure Monitor Logs Ingestion API with Data Collection Rules (DCR). This new API provides enhanced security, schema flexibility, and improved reliability compared to the deprecated API. Both output types can coexist in the same `ClusterLogForwarder` custom resource during the migration period. This allows you to validate the new configuration before you remove the deprecated output.
++
+https://redhat.atlassian.net/browse/LOG-9195[LOG-9195]

--- a/modules/logging-release-notes-6-5-2-fixed-issues.adoc
+++ b/modules/logging-release-notes-6-5-2-fixed-issues.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-2-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed in this release of {LoggingProductName}. Some linked Jira tickets are accessible only with Red Hat credentials.
+
+Cluster Logging Operator no longer floods the API when multiple ClusterLogForwarder instances share the same service account::
+Before this update, when multiple `ClusterLogForwarder` instances in the same namespace shared the same `ClusterLogForwarder.spec.serviceAccount`, the Cluster Logging Operator (CLO) updated the `Role/$serviceAccount-scc` resource in a loop, alternating the `ownerReferences` between the `ClusterLogForwarder` instances. As a consequence, the API server was flooded with update requests, leading to cluster instability. With this update, the Operator no longer loops when updating the `Role/$serviceAccount-scc` resource. As a result, multiple `ClusterLogForwarder` instances sharing the same service account no longer flood the API server.
++
+https://redhat.atlassian.net/browse/LOG-9424[LOG-9424]
+
+Vector no longer reports mapping errors for missing pod metadata::
+Before this update, Vector reported errors when attempting to annotate events with pod metadata for pods that no longer existed. As a consequence, this caused pipeline failures with `function call error for match_any` messages. With this update, Vector handles missing pod metadata gracefully. As a result, Vector no longer reports mapping errors when processing logs from recently deleted pods.
++
+https://redhat.atlassian.net/browse/LOG-9584[LOG-9584]
+
+Collector pods no longer corrupt the disk buffer on shutdown::
+Before this update, the OpenShift Logging Operator hardcoded `terminationGracePeriodSeconds` to 10 seconds for Vector collector pods. In environments with high log volume and `deliveryMode: AtLeastOnce` enabled, this timeout was insufficient for Vector to flush in-memory events to disk and close connections to remote sinks (which have default 60-second timeouts). As a consequence, `SIGKILL` was sent during active write operations, corrupting the disk buffer and causing `CrashLoopBackOff` with `InvalidProtobufPayload` errors. With this update, the `terminationGracePeriodSeconds` default is increased to 60 seconds and is configurable via the `ClusterLogForwarder` resource. As a result, collector pods have sufficient time to flush buffers and shut down gracefully without corrupting the disk buffer.
++
+https://redhat.atlassian.net/browse/LOG-9641[LOG-9641]
+
+Logging Operator restarts collectors when CA certificate changes::
+Before this update, when the CA certificate referenced in `.spec.outputs.tls.ca.configMapName` was updated, the Logging Operator did not restart the collector pods to use the new certificate. As a consequence, collectors continued to use the previous certificate for `LokiStack` and Loki sinks. With this update, the Operator watches for changes to TLS CA `ConfigMaps` and restarts collectors when certificates are updated. As a result, collectors use the updated CA certificate without requiring a manual restart.
++
+https://redhat.atlassian.net/browse/LOG-9683[LOG-9683]

--- a/modules/logging-release-notes-6-5-2.adoc
+++ b/modules/logging-release-notes-6-5-2.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-2_{context}"]
+= Logging 6.5.2 release notes
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:56340[RHSA-2026:56340].

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -10,6 +10,14 @@ toc::[]
 [role="_abstract"]
 This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
 
+include::modules/logging-release-notes-6-5-2.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-5-2-deprecated-features.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-5-2-fixed-issues.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-5-2-cves.adoc[leveloffset=+2]
+
 include::modules/logging-release-notes-6-5-1.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-5-1-fixed-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds release notes for OpenShift Logging 6.5.2 z-stream release
- Includes 5 bug fixes (including 1 deprecated functionality notice)
- Uses errata placeholder pending actual errata number
- Issue: https://redhat.atlassian.net/browse/OBSDOCS-3860
- Preview: https://118176--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html

## Changes
- Created `modules/logging-release-notes-6-5-2.adoc` (main module)
- Created `modules/logging-release-notes-6-5-2-fixed-issues.adoc` (bug fixes)
- Updated `release_notes/logging-release-notes.adoc` to include new modules

## Fixed Issues
- [LOG-9195](https://redhat.atlassian.net/browse/LOG-9195): Azure Monitor Logs output type deprecated
- [LOG-9424](https://redhat.atlassian.net/browse/LOG-9424): CLO floods API when MultiCLF shares the same serviceAccount
- [LOG-9584](https://redhat.atlassian.net/browse/LOG-9584): Vector mapping errors with pod metadata annotation failures
- [LOG-9641](https://redhat.atlassian.net/browse/LOG-9641): Vector terminationGracePeriodSeconds causes disk buffer corruption
- [LOG-9683](https://redhat.atlassian.net/browse/LOG-9683): Logging Operator does not restart collectors when CA certificate changes

## Follow-up
Errata number placeholder (RHSA-YYYY:NNNNN) will need to be updated once the actual errata is available.

Signed-off-by: John Wilkins <jowilkin@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)