### PR TITLE
[OSDOCS#17131]: Made same changes in short descriptions as of 4.20

### DIFF
--- a/modules/rn-ocp-about-this-release.adoc
+++ b/modules/rn-ocp-about-this-release.adoc
@@ -2,9 +2,10 @@
 [id="rn-ocp-about-this-release_{context}"]
 = About this release
 
-[role=”_abstract”]
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md[Kubernetes 1.34] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+[role=”_abstract”]
+
+{product-title} {product-version} release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md[Kubernetes 1.34] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 

--- a/modules/rn-ocp-release-notes-add-on-support-status.adoc
+++ b/modules/rn-ocp-release-notes-add-on-support-status.adoc
@@ -3,6 +3,6 @@
 = {product-title} layered and dependent component support and compatibility
 
 [role=”_abstract”]
-The scope of support for layered and dependent components of {product-title} changes independently of the {product-title} version. 
+You can familiarize yourself with the scope of support for layered and dependent components of {product-title}, which changes independently of the {product-title} version.
 
 To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].

--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -3,7 +3,7 @@
 = Deprecated and removed features
 
 [role="_abstract"]
-You must plan to migrate from deprecated features, because they are scheduled for removal in a future release. 
+You can plan your cluster maintenance and upgrades effectively based on the features that are deprecated or removed in {product-title}. 
 
 Review the following tables to identify features that are deprecated or removed in {product-title} {product-version}.
 

--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -3,7 +3,7 @@
 = Fixed issues
 
 [role="_abstract"]
-Review the list of issues resolved in this {product-title} release. You can see if issues affecting your clusters or environments are fixed.
+You can review the list of issues resolved for {product-title} {product-version} to see if any of the issues affect your clusters or environments are fixed.
 
 ////
 Instructions: Add entries in the following format under the appropriate heading:

--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -3,7 +3,7 @@
 = Known issues
 
 [role="_abstract"]
-This section includes several known issues for {product-title} {product-version}.
+You can review the list of known issues in {product-title} {product-version} to see if any issues affect your clusters or environments.
 
 * Currently, due to a known issue, the {product-title} 4.21 versions of the Cluster Resource Override Operator and the DPU Operator will be available in an upcoming 4.21 maintenance release.  (link:https://issues.redhat.com/browse/OCPBUGS-74224[OCPBUGS-74224])
 

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -3,7 +3,7 @@
 = New features and enhancements
 
 [role="_abstract"]
-You can take advantage of the latest platform improvements by reviewing the new features and enhancements in {product-title}{product-version}.
+Before working with this release, familiarize yourself with the new features included in the {product-title}{product-version} release.
 
 [id="ocp-release-notes-api_{context}"]
 == API server

--- a/modules/rn-ocp-release-notes-notable-changes.adoc
+++ b/modules/rn-ocp-release-notes-notable-changes.adoc
@@ -3,7 +3,7 @@
 = Notable technical changes
 
 [role="_abstract"]
-This section includes several technical changes for {product-title} {product-version}.
+You can review the list of technical changes for {product-title} {product-version} to see if any of the changes affect your clusters or environments.
 
 ////
 Instructions: Add entries in the following format:

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -3,7 +3,7 @@
 = Technology Preview features status
 
 [role="_abstract"]
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. 
+You can determine if a new feature in {product-title}{product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use. 
 
 Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+{product-title} (link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481]) is now available. Before working with this release, familiarize yourself with the new features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+
 Red{nbsp}Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
 Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.


### PR DESCRIPTION

Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17131

Link to docs preview:
https://118179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html

QE review:
N/A

Additional information:
@mburke5678 has suggested CQA compliant short descriptions for 4.20 release notes at https://github.com/openshift/openshift-docs/pull/117190
 I am copying the same descriptions for 4.21 to maintain consistency. No other changes are made.
