### PR TITLE
[OSDOCS#17131]:  Made same changes in short descriptions as of 4.20

### DIFF
--- a/modules/rn-ocp-4-22-add-on-support-status.adoc
+++ b/modules/rn-ocp-4-22-add-on-support-status.adoc
@@ -3,6 +3,6 @@
 = {product-title} layered and dependent component support and compatibility
 
 [role=”_abstract”]
-The scope of support for layered and dependent components of {product-title} changes independently of the {product-title} version. 
+You can familiarize yourself with the scope of support for layered and dependent components of {product-title}, which changes independently of the {product-title} version.
 
 To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].

--- a/modules/rn-ocp-about-this-release.adoc
+++ b/modules/rn-ocp-about-this-release.adoc
@@ -4,7 +4,7 @@
 
 [role=”_abstract”]
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHEA-2026:0449[RHEA-2026:0449]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md[Kubernetes 1.35] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} {product-version} release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md[Kubernetes 1.35] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 

--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -3,7 +3,7 @@
 = Fixed issues
 
 [role="_abstract"]
-Review the list of issues resolved in this {product-title} release. You can see if issues affecting your clusters or environments are fixed.
+You can review the list of issues resolved for {product-title} {product-version} to see if any of the issues affect your clusters or environments are fixed.
 
 //Instructions: Add entries in the following format under the appropriate heading:
 //* Before this update, ...

--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -2,7 +2,8 @@
 [id="rn-ocp-release-notes-known-issues_{context}"]
 = Known issues
 
-This section includes several known issues for {product-title} {product-version}.
+[role="_abstract"]
+You can review the list of known issues in {product-title} {product-version} to see if any issues affect your clusters or environments.
 
 * Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])
 

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -3,7 +3,7 @@
 = New features and enhancements
 
 [role="_abstract"]
-This release adds improvements related to the following components and concepts:
+Before working with this release, familiarize yourself with the new features included in the {product-title}{product-version} release.
 
 [id="ocp-release-notes-ai-apps_{context}"]
 == AI applications

--- a/modules/rn-ocp-release-notes-notable-changes.adoc
+++ b/modules/rn-ocp-release-notes-notable-changes.adoc
@@ -3,7 +3,7 @@
 = Notable technical changes
 
 [role="_abstract"]
-This section includes several technical changes for {product-title} {product-version}.
+You can review the list of technical changes for {product-title} {product-version} to see if any of the changes affect your clusters or environments.
 
 // Instructions: Add entries in the following format:
 

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -3,7 +3,9 @@
 = Technology Preview features status
 
 [role="_abstract"]
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+You can determine if a new feature in {product-title}{product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use. 
+
+Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
@@ -46,7 +48,7 @@ In the following tables, features are marked with the following statuses:
 |====
 
 
-[id="ocp-release-notesedge-computing-tp-features_{context}"]
+[id="ocp-release-notes-edge-computing-tp-features_{context}"]
 == Edge computing Technology Preview features
 
 .Edge computing Technology Preview tracker
@@ -182,7 +184,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|{bmaas-first} (formerly known as bare metal as a service)
+|{bmaas-first} (formerly known as bare-metal as a service)
 |Technology Preview
 |Technology Preview
 |General Availability
@@ -197,7 +199,7 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
-|Running firmware upgrades for hosts in deployed bare metal clusters
+|Running firmware upgrades for hosts in deployed bare-metal clusters
 |Technology Preview
 |General Availability
 |General Availability
@@ -286,7 +288,7 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |Technology Preview
 |Technology Preview
 
-|Managing machines with the Cluster API for bare metal
+|Managing machines with the Cluster API for bare-metal
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -516,7 +518,7 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |====
 |Feature |4.20 |4.21 |4.22
 
-|Expanding a bare metal cluster using images from OCI registries
+|Expanding a bare-metal cluster using images from OCI registries
 |Not Available
 |Not Available
 |Technology Preview
@@ -672,7 +674,6 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |General Availability
 |General Availability
 |General Availability
-|
 |====
 
 

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+{product-title} (link:https://access.redhat.com/errata/RHEA-2026:0449[RHEA-2026:0449]) is now available. Before working with this release, familiarize yourself with the new features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+
 Red{nbsp}Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
 Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17131

Link to docs preview:
https://118186--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html

QE review:
N/A

Additional information:
@mburke5678 has suggested CQA compliant short descriptions for 4.20 release notes at https://github.com/openshift/openshift-docs/pull/117190
I am copying the same descriptions for 4.22 to maintain consistency. No other changes are made.
