### PR TITLE
CNV-94184: Runbook List Update

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -45,6 +45,9 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 | CDIStorageProfilesIncomplete
 | link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIStorageProfilesIncomplete.md[Runbook]
 
+| ClusterVMPanicDetected
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/ClusterVMPanicDetected.md[Runbook]
+
 | CnaoDown
 | link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoDown.md[Runbook]
 
@@ -216,8 +219,12 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 | VMCannotBeEvicted
 | link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMCannotBeEvicted.md[Runbook]
 
+| VMNonRecoverableOSPanic
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMNonRecoverableOSPanic.md[Runbook]
+
 | VMStorageClassWarning
 | link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMStorageClassWarning.md[Runbook]
+
 |===
 
 [id="virt-runbooks-deprecated"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Adding two new runbooks to the downstream listing.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22, 5.0 

Issue:
[CNV-94184](https://redhat.atlassian.net/browse/CNV-94184)

Link to docs preview:
[OpenShift Virtualization runbooks](https://118194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
