### PR TITLE
OSDOCS-21604: Add 4.21.29 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-29.adoc
+++ b/modules/zstream-4-21-29.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-29_{context}"]
+= RHSA-2026:54602 - {product-title} {product-version}.29 bug fix and security update
+
+Issued: 18 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.29 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:54602[RHSA-2026:54602] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:54598[RHBA-2026:54598] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.29 --pullspecs
+----
+
+[id="zstream-4-21-29-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when you opened the *Quick Starts* page in the {product-title} web console with the language set to Chinese (zh-CN), Quick Starts chrome strings loaded the console-app resource bundle using the full locale code (`zh-CN`) instead of the language-only bundle (`zh`) used by the rest of the console. As a consequence, filter labels, status text, and item counts on the *Quick Starts* page could remain in English even though other console UI was translated. With this release, Quick Starts load the console-app bundle using `i18next` resolved language (falling back to `en`) and guard against missing bundles. As a result, Quick Starts chrome text displays correctly in Chinese and other locale variants. (link:https://redhat.atlassian.net/browse/OCPBUGS-100058[OCPBUGS-100058])
+
+* Before this update, on a Telecom Boundary Clock (T-BC) PTP configuration, `ts2phc` could start before the upstream PTP source was stable enough and before `phc2sys` was ready. As a consequence, the T-BC took a long time to converge, and `phc2sys` could adjust the system clock too early based on an irrelevant `ts2phc` offset. With this release, `ts2phc` start on T-BC is delayed until the upstream source is qualified and `phc2sys` is ready; T-GM behavior is unchanged. As a result, T-BC no longer starts `ts2phc` against an unqualified upstream source. (link:https://redhat.atlassian.net/browse/OCPBUGS-105275[OCPBUGS-105275])
+
+* Before this update, when you added a new vSphere failure domain that used a MachineSet with a custom `providerSpec.Template` name, the Machine Config Operator boot image controller looked up the VM template only by its own computed name and ignored `providerSpec.Template` name. As a consequence, reconciliation for that failure domain could fail, and a customer-managed VM with the same computed name outside the MCO workspace folder could be mistaken for the MCO template and overwritten. With this release, the controller checks `providerSpec.Template` first, falls back to the computed name only when the template is not found, creates the template from the OVA when needed, and leaves name matches outside `providerSpec.Workspace.Folder` untouched. As a result, new vSphere failure domains with custom template names reconcile successfully, and customer-managed VMs outside the MCO workspace folder are no longer at risk of being overwritten. (link:https://redhat.atlassian.net/browse/OCPBUGS-105303[OCPBUGS-105303])
+
+
+
+[id="zstream-4-21-29-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -47,6 +47,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.29 RNs and updating
+include::modules/zstream-4-21-29.adoc[leveloffset=+2]
+
 // 4.21.28 RNs and updating
 include::modules/zstream-4-21-28.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.21

Issue
https://redhat.atlassian.net/browse/OSDOCS-21604

Link to docs preview:
https://118198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-29_release-notes

QE review:
N/A

Additional information
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/732
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:54602 / RHBA-2026:54598

