### PR TITLE
OSDOCS-21606: Add 4.19.43 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-43.adoc
+++ b/modules/zstream-4-19-43.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-43_{context}"]
+= RHSA-2026:54555 - {product-title} {product-version}.43 bug fix and security update
+
+Issued: 19 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.43 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:54555[RHSA-2026:54555] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:54552[RHSA-2026:54552] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.43 --pullspecs
+----
+
+[id="zstream-4-19-43-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the *Quick Starts* page loaded translations with a stored language code instead of the resolved language of i18next, so locale variants such as `zh-CN` did not match the console-app resource bundle. As a consequence, on the *Quick Starts* page, some strings could appear missing or untranslated when the console language was set to `Chinese (zh-CN)`. With this release, the *Quick Starts* page now look up and apply the console-app resource bundle using `i18n.resolvedLanguage`. As a result, *Quick Starts* text displays correctly for `zh-CN` and other locale variants. (link:https://redhat.atlassian.net/browse/OCPBUGS-100068[OCPBUGS-100068])
+
+[id="zstream-4-19-43-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.43 RNs and updating
+include::modules/zstream-4-19-43.adoc[leveloffset=+2]
+
 // 4.19.42 RNs and updating
 include::modules/zstream-4-19-42.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.19

Issue
https://redhat.atlassian.net/browse/OSDOCS-21606

Doc preview link
https://118200--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-43_release-notes

QE review
N/A

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/730
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:54555 / RHSA-2026:54552

