### PR TITLE
OSDOCS-21607: Add 4.18.53 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-53.adoc
+++ b/modules/zstream-4-18-53.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-53_{context}"]
+= RHSA-2026:54545 - {product-title} {product-version}.53 bug fix and security update
+
+Issued: 19 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.53 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:54545[RHSA-2026:54545] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.53 --pullspecs
+----
+
+[id="zstream-4-18-53-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the *Quick Starts* page loaded translations with a stored language code instead of the resolved language of i18next, so locale variants such as `zh-CN` did not match the console-app resource bundle. As a consequence, on the *Quick Starts* page, some strings could appear missing or untranslated when the console language was set to `Chinese (zh-CN)`. With this release, the *Quick Starts* page now look up and apply the console-app resource bundle using `i18n.resolvedLanguage`. As a result, *Quick Starts* text displays correctly for `zh-CN` and other locale variants. (link:https://redhat.atlassian.net/browse/OCPBUGS-100069[OCPBUGS-100069])
+
+[id="zstream-4-18-53-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.53 RNs and updating
+include::modules/zstream-4-18-53.adoc[leveloffset=+2]
+
 // 4.18.52 RNs and updating
 include::modules/zstream-4-18-52.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.18

Issue
https://redhat.atlassian.net/browse/OSDOCS-21607

Doc preview link
https://118202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-53_release-notes

QE review
N/A

Additional information 
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/729
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:54545 / RHBA-2026:54543
