### PR TITLE
OSDOCS-21608: Add 4.13.70 z-stream release notes

### DIFF
--- a/modules/zstream-4-13-70-about.adoc
+++ b/modules/zstream-4-13-70-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-70-about_{context}"]
+= RHSA-2026:54188 - {product-title} 4.13.70 bug fix and security update
+
+Issued: 20 August 2026
+
+[role="_abstract"]
+{product-title} release 4.13.70, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:54188[RHSA-2026:54188] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:54186[RHBA-2026:54186] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.70 --pullspecs
+----

--- a/modules/zstream-4-13-70-bug-fixes.adoc
+++ b/modules/zstream-4-13-70-bug-fixes.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-70-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-13-70-updating.adoc
+++ b/modules/zstream-4-13-70-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-70-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4700,3 +4700,10 @@ include::modules/zstream-4-13-69-about.adoc[leveloffset=+2]
 include::modules/zstream-4-13-69-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-69-updating.adoc[leveloffset=+2]
+
+//4.13.70
+include::modules/zstream-4-13-70-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-70-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-70-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version
4.13

Issue
https://redhat.atlassian.net/browse/OSDOCS-21608

Doc preview link
https://118203--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-70-about_release-notes

QE Review
N/A

Additional information
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/723
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13
- Errata: RHSA-2026:54188 / RHBA-2026:54186