### PR TITLE
OSDOCS-21003: Fix spelling errors

### DIFF
--- a/modules/albo-validate-install.adoc
+++ b/modules/albo-validate-install.adoc
@@ -122,7 +122,7 @@ spec:
 EOF
 ----
 +
-The `service.beta.kubernetes.io/aws-load-balancer-type` annotation is immutable for existing services. To change the load balancer type, you must recreate the service.
+The `service.beta.kubernetes.io/aws-load-balancer-type` annotation is immutable for existing services. To change the load balancer type, you must re-create the service.
 
 . Test access to the NLB endpoint for the application:
 +

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -40,7 +40,7 @@ where:
 ** The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
 ** The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the http-proxy and https-proxy arguments.
 ** The `http-proxy` and `https-proxy` arguments must point to a valid URL.
-** A comma-separated lis of destination domain names, IP addresses, or network CIDRs to exclude proxying.
+** A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +
 ** Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 ** If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.

--- a/modules/nw-networkpolicy-create-ocm.adoc
+++ b/modules/nw-networkpolicy-create-ocm.adoc
@@ -51,7 +51,7 @@ To define granular rules describing the ingress or egress network traffic allowe
 
 . Add egress rules to your network policy:
 
-.. Select *Add egress rule* to configure a new rule. This action creates a new *Egress rule* row with an *Add allowed destination*"* drop-down menu where you specify how to limit outbound traffic. The drop-down menu offers three options to limit your egress traffic:
+.. Select *Add egress rule* to configure a new rule. This action creates a new *Egress rule* row with an *Add allowed destination* drop-down menu where you specify how to limit outbound traffic. The drop-down menu offers three options to limit your egress traffic:
 +
 *** *Allow pods from the same namespace* limits outbound traffic to pods within the same namespace. You can specify the pods in a namespace, but leaving this option blank allows all of the traffic from pods in the namespace.
 

--- a/modules/removing-cluster-wide-proxy-intro.adoc
+++ b/modules/removing-cluster-wide-proxy-intro.adoc
@@ -7,4 +7,4 @@
 = Removing a cluster-wide proxy
 
 [role="_abstract"]
-You can remove your cluster-wide proxy by using the ROSA CLI. After removing the cluster, you should also remove any trust bundles that you added to the cluster.
+You can remove your cluster-wide proxy by using the ROSA CLI. After removing the proxy, you should also remove any trust bundles that you added to the cluster.


### PR DESCRIPTION
[OSDOCS-21003](https://redhat.atlassian.net/browse/OSDOCS-21003): Fix spelling errors

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21003

Link to docs preview:
- Cluster proxy ROSA HCP: https://118211--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- Cluster proxy ROSA Classic: https://118211--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- Cluster proxy OSD: https://118211--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- Network policy ROSA HCP: https://118211--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html
- Network policy ROSA classic: https://118211--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/creating-network-policy.html
- Network policy OSD: https://118211--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/creating-network-policy.html
- ALBO ROSA HCP: https://118211--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html
- ALBO ROSA Classic: https://118211--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/aws-load-balancer-operator.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
