### PR TITLE
OSDOCS-21001 Duplicate Anchor IDs

### DIFF
--- a/modules/running-network-verification-manually-ocm.adoc
+++ b/modules/running-network-verification-manually-ocm.adoc
@@ -3,14 +3,12 @@
 // * networking/network-verification.adoc
 
 :_mod-docs-content-type: PROCEDURE
-ifdef::openshift-dedicated[]
 [id="running-network-verification-manually-ocm_{context}"]
+ifdef::openshift-dedicated[]
 = Running the network verification manually
 
 endif::openshift-dedicated[]
 ifdef::openshift-rosa[]
-
-[id="running-network-verification-manually-ocm_{context}"]
 = Running the network verification manually using {cluster-manager}
 
 endif::openshift-rosa[]


### PR DESCRIPTION
[OSDOCS-21001](https://redhat.atlassian.net/browse/OSDOCS-21001) Duplicate Anchor IDs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21001

Link to docs preview:
OSD: https://118212--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network-verification.html
ROSA: https://118212--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network-verification.html
ROSA Classic: https://118212--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network-verification.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
