### PR TITLE
Replace credentialsFile with spec.credential in OADP VSL examples

### DIFF
--- a/modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc
@@ -215,8 +215,10 @@ spec:
      enable: false
  snapshotLocations:
    - velero:
+       credential:
+         key: credentials
+         name: cloud-credentials
        config:
-         credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials
          enableSharedConfig: 'true'
          profile: default
          region: ${REGION}

--- a/modules/installing-oadp-aws-sts.adoc
+++ b/modules/installing-oadp-aws-sts.adoc
@@ -222,8 +222,10 @@ $ cat << EOF | oc create -f -
         uploaderType: restic
     snapshotLocations:
       - velero:
+          credential:
+            key: credentials
+            name: cloud-credentials
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials
             enableSharedConfig: "true"
             profile: default
             region: ${REGION}
@@ -235,7 +237,6 @@ where:
 +
 `backupImages`:: Specifies whether to use image backup. Set to `false` if you do not want to use image backup.
 `nodeAgent`:: Specifies the node agent configuration. See the important note regarding the `nodeAgent` attribute at the end of this procedure.
-`credentialsFile`:: Specifies the mounted location of the bucket credential on the pod.
 `enableSharedConfig`:: Specifies whether the `snapshotLocations` can share or reuse the credential defined for the bucket.
 `profile`:: Specifies the profile name set in the {aws-short} credentials file.
 `region`:: Specifies your {aws-short} region. This must be the same as the cluster region.

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -252,8 +252,10 @@ $ cat << EOF | oc create -f -
         uploaderType: restic
     snapshotLocations:
       - velero:
+          credential:
+            key: credentials
+            name: cloud-credentials
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials
             enableSharedConfig: "true"
             profile: default
             region: ${REGION}
@@ -270,7 +272,6 @@ ifdef::openshift-rosa,openshift-rosa-hcp[]
 `backupImages`:: {product-title} supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::openshift-rosa,openshift-rosa-hcp[]
 `nodeAgent`:: See the important note regarding the `nodeAgent` attribute at the end of this procedure.
-`credentialsFile`:: Specifies the mounted location of the bucket credential on the pod.
 `enableSharedConfig`:: Specifies whether the `snapshotLocations` can share or reuse the credential defined for the bucket.
 `profile`:: Specifies the profile name set in the {aws-short} credentials file.
 `region`:: Specifies your {aws-short} region. This must be the same as the cluster region.


### PR DESCRIPTION
## Summary

Upstream Velero ([velero-io/velero#10254](https://github.com/velero-io/velero/pull/10254)) now strips a user-provided `credentialsFile` from BackupStorageLocation/VolumeSnapshotLocation config before it reaches plugins — it was a raw filesystem path handed to plugin code and vulnerable to path traversal.

OADP is aligning with this upstream change in [openshift/oadp-operator#2388](https://github.com/openshift/oadp-operator/pull/2388) (tracked in [openshift/oadp-operator#2383](https://github.com/openshift/oadp-operator/issues/2383)): `config.credentialsFile` is no longer supported, and starting with that change, a `VolumeSnapshotLocation` configured with `credentialsFile` will fail OADP's `DataProtectionApplication` validation instead of being silently accepted.

These three modules currently instruct users to set `config.credentialsFile` on the VSL as part of the AWS/ROSA STS install flow. This PR updates them to use `spec.credential` (a name/key secret selector) instead, matching how the BSL is already configured in the same examples.

## Changes

- `modules/installing-oadp-aws-sts.adoc`
- `modules/installing-oadp-rosa-sts.adoc`
- `modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc`

Each module's `snapshotLocations` example now sets:

```yaml
snapshotLocations:
  - velero:
      credential:
        key: credentials
        name: cloud-credentials
      config:
        enableSharedConfig: "true"
        profile: default
        region: ${REGION}
      provider: aws
```

instead of `config.credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials`. The `credentialsFile` attribute description line was also removed from the two `installing-oadp-*-sts.adoc` modules' attribute lists.

## Notes for reviewers

- This should land in a release branch that lines up with the corresponding OADP release; happy to open backport PRs to affected `enterprise-*` branches once the target version is confirmed.
- Not addressed here (tracked in the OADP issue): E2E coverage for AWS/ROSA STS with this config shape, and release notes for existing DPAs upgrading from `credentialsFile`.

*Posted via [Claude Code](https://claude.ai/code)*