### PR TITLE
OSDOCS-16991_d#CQA for AWS UPI installation modules_2 (4.20)

### DIFF
--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -55,20 +55,13 @@ endif::[]
 You can install {product-title} {product-version} in a restricted network without an active internet connection to obtain software components. Restricted network installations can use installer-provisioned or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
 ifndef::ibm-power,ibm-cloud[]
-If you choose to perform a restricted network installation on a cloud platform, you
-still require access to its cloud APIs. Some cloud functions, like
-Amazon Web Service's Route 53 DNS and IAM services, require internet access.
+If you choose to perform a restricted network installation on a cloud platform, you still require access to its cloud APIs. Some cloud functions, such as Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
-Depending on your network, you might require less internet
-access for an installation on bare-metal hardware, Nutanix, or on VMware vSphere.
+Depending on your network, you might require less internet access for an installation on bare-metal hardware, Nutanix, or on VMware vSphere.
 endif::ibm-power,ibm-cloud[]
 
 ifndef::ibm-cloud[]
-To complete a restricted network installation, you must create a registry that
-mirrors the contents of the {product-registry} and contains the
-installation media. You can create this registry on a mirror host, which can
-access both the internet and your closed network, or by using other methods
-that meet your restrictions.
+To complete a restricted network installation, you must create a registry that mirrors the contents of the {product-registry} and contains the installation media. You can create this registry on a mirror host, which can access both the internet and your closed network, or by using other methods that meet your restrictions.
 endif::ibm-cloud[]
 
 ifndef::ipi[]
@@ -92,8 +85,7 @@ You complete the installation using a bastion host or portable device that can a
 [id="access-to-a-mirror-registry_{context}"]
 == Access to a mirror registry
 
-To complete a restricted network installation, you must create a registry that
-mirrors the contents of the {product-registry} and contains the installation media.
+To complete a restricted network installation, you must create a registry that mirrors the contents of the {product-registry} and contains the installation media.
 
 You can create this registry on a mirror host, which can access both the internet and your restricted network, or by using other methods that meet your organization's security restrictions.
 

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -116,12 +116,12 @@ endif::ibm-z,ibm-z-kvm[]
 +
 [NOTE]
 ====
-You must approve your CSRs within an hour of adding the machines to the cluster. If you do not approve them within an hour, the certificates rotate, and more than two certificates are present for each node. You must approve all of these certificates. After the client CSR is approved, the kubelet creates a secondary CSR for the serving certificate, which requires manual approval. The subsequent serving certificate renewal requests are then automatically approved by the `machine-approver` if the Kubelet requests a new certificate with identical parameters.
+You must approve your CSRs within an hour of adding the machines to the cluster. If you do not approve them within an hour, the certificates rotate, and more than two certificates are present for each node. You must approve all of these certificates. After the client CSR is approved, the kubelet creates a secondary CSR for the serving certificate, which requires manual approval. The subsequent serving certificate renewal requests are then automatically approved by the `machine-approver` if the kubelet requests a new certificate with identical parameters.
 ====
 +
 [NOTE]
 ====
-For clusters running on platforms that are not machine API enabled, such as bare metal and other user-provisioned infrastructure, you must implement a method of automatically approving the kubelet serving certificate requests (CSRs). If a request is not approved, then the `oc exec`, `oc rsh`, and `oc logs` commands cannot succeed, because a serving certificate is required when the API server connects to the kubelet. Any operation that contacts the Kubelet endpoint requires this certificate approval to be in place. The method must watch for new CSRs, confirm that the CSR was submitted by the `node-bootstrapper` service account in the `system:node` or `system:admin` groups, and confirm the identity of the node.
+For clusters running on platforms that are not machine API enabled, such as bare metal and other user-provisioned infrastructure, you must implement a method of automatically approving the kubelet serving certificate requests (CSRs). If a request is not approved, then the `oc exec`, `oc rsh`, and `oc logs` commands cannot succeed, because a serving certificate is required when the API server connects to the kubelet. Any operation that contacts the kubelet endpoint requires this certificate approval to be in place. The method must watch for new CSRs, confirm that the CSR was submitted by the `node-bootstrapper` service account in the `system:node` or `system:admin` groups, and confirm the identity of the node.
 ====
 +
 ** To approve them individually, run the following command for each valid CSR:
@@ -227,7 +227,7 @@ endif::ibm-power[]
 +
 [NOTE]
 ====
-You might need to wait a few minutes after approval of the server CSRs for the machines to transition to the `Ready` status.
+You might need to wait a few minutes after approval of the server CSRs for the machines to change to the `Ready` status.
 ====
 
 ifeval::["{context}" == "installing-ibm-z"]

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -13,7 +13,7 @@
 [role="_abstract"]
 In {product-title}, _stream metadata_ provides standardized metadata about {op-system} in the JSON format and injects the metadata into the cluster. Stream metadata is a stable format that supports multiple architectures and is intended to be self-documenting for maintaining automation.
 
-You can use the `coreos print-stream-json` sub-command of `openshift-install` to access information about the boot images in the stream metadata format. This command provides a method for printing stream metadata in a scriptable, machine-readable format.
+You can use the `coreos print-stream-json` subcommand of `openshift-install` to access information about the boot images in the stream metadata format. This command provides a method for printing stream metadata in a scriptable, machine-readable format.
 
 For user-provisioned installations, the `openshift-install` binary contains references to the version of {op-system} boot images that are tested for use with {product-title}, such as the {aws-first} AMI.
 

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -41,8 +41,7 @@ INFO It is now safe to remove the bootstrap resources
 INFO Time elapsed: 1s
 ----
 +
-If the command exits without a `FATAL` warning, your {product-title} control plane
-has initialized.
+If the command exits without a `FATAL` warning, your {product-title} control plane has initialized.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:
- [About installations in restricted networks](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-about-restricted-networks_installing-restricted-networks-aws)
- [Approving the certificate signing requests for your machines](https://118218--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-approve-csrs_installing-aws-user-infra)
- [Accessing RHCOS AMIs with stream metadata](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-ami-stream-metadata_installing-restricted-networks-aws)
- [Initializing the bootstrap sequence on AWS with user-provisioned infrastructure](https://118160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-bootstrap_installing-restricted-networks-aws)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

## Summary
- Unwrap hard-wrapped lines in `installation-about-restricted-network.adoc` and `installation-aws-user-infra-bootstrap.adoc`
- Fix "Kubelet" → "kubelet" casing (2 instances) in `installation-approve-csrs.adoc`
- Replace "like" with "such as" in `installation-about-restricted-network.adoc`
- Replace "sub-command" with "subcommand" in `installation-aws-ami-stream-metadata.adoc`
- Replace "transition" with "change" in `installation-approve-csrs.adoc`

