### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in Security Profiles Operator audit logging procedures

### DIFF
--- a/modules/spo-log-adv-pod.adoc
+++ b/modules/spo-log-adv-pod.adoc
@@ -40,7 +40,7 @@ This profile allows all normal actions (`defaultAction: SCMP_ACT_ALLOW`). It spe
 +
 [source,terminal]
 ----
-# kubectl apply -f profile1.yaml
+# oc apply -f profile1.yaml
 ----
 +
 [NOTE]
@@ -68,14 +68,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl apply -f image_sec_comp.yaml
+# oc apply -f image_sec_comp.yaml
 ----
 
 . Label the namespace to activate the binding by running the following command:
 +
 [source,terminal]
 ----
-# kubectl label ns default spo.x-k8s.io/enable-binding=true
+# oc label ns default spo.x-k8s.io/enable-binding=true
 ----
 
 . Create a file such as `my-pod.yaml` that contains the following pod definition:
@@ -105,14 +105,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl apply -f my-pod.yaml
+# oc apply -f my-pod.yaml
 ----
 
 . Open a shell in the pod by running the following command:
 +
 [source,terminal]
 ----
-# kubectl exec -it my-pod -- /bin/sh
+# oc exec -it my-pod -- /bin/sh
 ----
 
 . Create an empty file in the pod by running the following command:
@@ -126,14 +126,14 @@ spec:
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
+# oc -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
 ----
 
 . Identify the node where the pod runs by running the following command:
 +
 [source,terminal]
 ----
-# kubectl get pod my-pod -o wide
+# oc get pod my-pod -o wide
 ----
 +
 The audit log file specified in the `auditLogPath` field is written to the file system on the node where the pod is running. To inspect the audit logs, access the node and open the file at the configured path, such as `/tmp/logs/audit1.log`.

--- a/modules/spo-log-enabling.adoc
+++ b/modules/spo-log-enabling.adoc
@@ -14,7 +14,7 @@ To enable Advanced Audit Logging, configure the Audit JSON log enricher and spec
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true}}'
 ----
 Monitor the SPOD pods for correct restart and wait for all SPOD pods to show `Running` before proceeding.
 +

--- a/modules/spo-log-json-enrich.adoc
+++ b/modules/spo-log-json-enrich.adoc
@@ -22,7 +22,7 @@ Setting the audit log interval determines how often audit logs are created using
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogIntervalSeconds":30}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding. By default, audit logs go to your standard output in JSON lines format. You can send them to a file instead.
@@ -55,7 +55,7 @@ $ cat patch-volume-source.json
 +
 [source,terminal]
 ----
-# kubectl patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
+# oc patch configmap security-profiles-operator-profile -n openshift-security-profiles --patch-file patch-volume-source.json
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.
@@ -64,7 +64,7 @@ Wait until all SPOD pods show `Running` before proceeding.
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log"}}}'
 ----
 +
 Wait until all SPOD pods show `Running` before proceeding.

--- a/modules/spo-log-mon-audit.adoc
+++ b/modules/spo-log-mon-audit.adoc
@@ -17,14 +17,14 @@ The audit log file is specified in the `auditLogPath` field and is written to th
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
+# oc -n openshift-security-profiles logs --since=1m --selector name=spod -c json-enricher --max-log-requests 6 -f
 ----
 
 . Identify the node on which the pod is scheduled by using the following command:
 +
 [source,terminal]
 ----
-# kubectl get pod my-pod -o wide
+# oc get pod my-pod -o wide
 ----
 
 . Access the node by using the following command:

--- a/modules/spo-log-tune-rot.adoc
+++ b/modules/spo-log-tune-rot.adoc
@@ -14,7 +14,7 @@ For audit logging to a file, you can manage file size and how long each file is 
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log","auditLogMaxSize":500,"auditLogMaxBackups":2,"auditLogMaxAge":10}}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true,"verbosity":0,"jsonEnricherOptions":{"auditLogPath":"/tmp/logs/audit1.log","auditLogMaxSize":500,"auditLogMaxBackups":2,"auditLogMaxAge":10}}}'
 ----
 Wait until all SPOD pods show `Running` before proceeding.
 
@@ -26,6 +26,6 @@ Wait until all SPOD pods show `Running` before proceeding.
 +
 [source,terminal]
 ----
-# kubectl -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true, "verbosity": 1}}'
+# oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableJsonEnricher":true, "verbosity": 1}}'
 ----
 Wait until all SPOD pods show `Running` before proceeding.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated Security Profiles Operator audit logging pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-enabling_spo-audit-logging
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-json-enrich_spo-audit-logging
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-adv-pod_spo-audit-logging
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-tune-rot_spo-audit-logging
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/security-profiles-operator#spo-log-mon-audit_spo-audit-logging

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` in Security Profiles Operator audit logging procedures. Kubernetes annotation keys are unchanged.

This PR combines and supersedes #118002, #118003, #118004, #118005, and #118006 so related changes stay in one reviewable PR, per the contributing guide.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)