### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in Zero Trust deploy rollout checks

### DIFF
--- a/modules/zero-trust-manager-deploy-istio.adoc
+++ b/modules/zero-trust-manager-deploy-istio.adoc
@@ -68,7 +68,7 @@ $ until oc get daemonset/istio-cni-node -n "${OSSM_CNI}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
+$ oc rollout status daemonset/istio-cni-node -n "${OSSM_CNI}" --timeout=300s
 ----
 +
 The `until` loop waits for the {SMProductName} Operator to create the `istio-cni-node` DaemonSet. The `oc rollout status` command waits for the DaemonSet pods to become ready.

--- a/modules/zero-trust-manager-deploy-spire.adoc
+++ b/modules/zero-trust-manager-deploy-spire.adoc
@@ -93,7 +93,7 @@ $ until oc get statefulset/spire-server -n "${ZTWIM_NS}" &> /dev/null; do sleep 
 +
 [source,terminal]
 ----
-$ kubectl rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status statefulset/spire-server -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Create the `SpireAgent` CR:
@@ -131,7 +131,7 @@ $ until oc get daemonset/spire-agent -n "${ZTWIM_NS}" &> /dev/null; do sleep 3; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-agent -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpiffeCSIDriver` CR:
@@ -158,7 +158,7 @@ $ until oc get daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" &> /dev/null; 
 +
 [source,terminal]
 ----
-$ kubectl rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
+$ oc rollout status daemonset/spire-spiffe-csi-driver -n "${ZTWIM_NS}" --timeout=300s
 ----
 
 .. Deploy the `SpireOIDCDiscoveryProvider` CR:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated Zero Trust deploy pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` in Zero Trust Spire and Istio deploy rollout status checks.

This PR combines and supersedes #118007 and #118008 so related changes stay in one reviewable PR, per the contributing guide.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)