### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in hosted control plane kube-apiserver examples

### DIFF
--- a/modules/hcp-azure-private-access.adoc
+++ b/modules/hcp-azure-private-access.adoc
@@ -29,7 +29,7 @@ $ hcp create kubeconfig \
 +
 [source,terminal]
 ----
-$ kubectl port-forward svc/kube-apiserver \
+$ oc port-forward svc/kube-apiserver \
   -n clusters-${CLUSTER_NAME} 6443:6443 &
 ----
 +

--- a/modules/hcp-kube-api-server-cert.adoc
+++ b/modules/hcp-kube-api-server-cert.adoc
@@ -75,7 +75,7 @@ After the configuration is applied, the HyperShift Operator generates a new `kub
 +
 [source,terminal]
 ----
-$ kubectl get secret <hosted_cluster_name>-custom-admin-kubeconfig \
+$ oc get secret <hosted_cluster_name>-custom-admin-kubeconfig \
   -n <cluster_namespace> \
   -o jsonpath='{.data.kubeconfig}' | base64 -d
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated hosted control plane pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` when retrieving the HCP custom admin kubeconfig secret and when port-forwarding the Azure private kube-apiserver.

This PR combines and supersedes #118011 and #118012 so related changes stay in one reviewable PR, per the contributing guide.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)