### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in Virtualization permission examples

### DIFF
--- a/modules/virt-grant-token-generation-permission-VNC.adoc
+++ b/modules/virt-grant-token-generation-permission-VNC.adoc
@@ -17,12 +17,12 @@ As a cluster administrator, you can install a cluster role and bind it to a user
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --user="${USER_NAME}"
+$ oc create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --user="${USER_NAME}"
 ----
 
 ** Run the following command to bind the cluster role to a service account:
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --serviceaccount="${SERVICE_ACCOUNT_NAME}"
+$ oc create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --serviceaccount="${SERVICE_ACCOUNT_NAME}"
 ----

--- a/modules/virt-migrating-storage-permissions.adoc
+++ b/modules/virt-migrating-storage-permissions.adoc
@@ -20,7 +20,7 @@ Cluster administrators must grant users permission to perform storage migrations
 +
 [source,terminal]
 ----
-$ kubectl create rolebinding <role_binding_name> \
+$ oc create rolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate \
     --user=<user_name> -n <namespace>
 ----
@@ -35,7 +35,7 @@ where:
 +
 [source,terminal]
 ----
-$ kubectl create clusterrolebinding <role_binding_name> \
+$ oc create clusterrolebinding <role_binding_name> \
     --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
     --user=<user_name>
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated Virtualization pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/managing-vms

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` in Virtualization storage migration and VNC token-generation rolebinding examples.

This PR combines and supersedes #118013 and #118014 so related changes stay in one reviewable PR, per the contributing guide.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)