### PR TITLE
OSDOCS#21618: Use oc instead of kubectl in Service Mesh Gateway API examples

### DIFF
--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -79,11 +79,11 @@ In a multitenant mesh deployment, CRD scan is disabled, and Istio has no way to 
 +
 {SMProductShortName} 2.3.1 and later versions support both `v1alpha2` and `v1beta1` CRDs. Therefore, both CRD versions must be present for a multitenant mesh deployment to support the Gateway API.
 +
-Workaround: In the following example, the `kubectl get` operation installs the `v1alpha2` and `v1beta1` CRDs. Note the URL contains the additional `experimental` segment and updates any of your existing scripts accordingly:
+Workaround: In the following example, the `oc get` operation installs the `v1alpha2` and `v1beta1` CRDs. Note the URL contains the additional `experimental` segment and updates any of your existing scripts accordingly:
 +
 [source,terminal]
 ----
-$ kubectl get crd gateways.gateway.networking.k8s.io ||   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | kubectl apply -f -; }
+$ oc get crd gateways.gateway.networking.k8s.io ||   { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | oc apply -f -; }
 ----
 
 * https://issues.redhat.com/browse/OSSM-2042[OSSM-2042] Deployment of SMCP named `default` fails. If you are creating an SMCP object, and set its version field to v2.3, the name of the object cannot be `default`. If the name is `default`, then the control plane fails to deploy, and OpenShift generates a `Warning` event with the following message:

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -1178,7 +1178,7 @@ The Gateway API CRDs do not come preinstalled by default on OpenShift clusters. 
 
 [source,terminal]
 ----
-$ kubectl get crd gateways.gateway.networking.k8s.io || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -; }
+$ oc get crd gateways.gateway.networking.k8s.io || { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | oc apply -f -; }
 ----
 
 ==== Enabling Kubernetes Gateway API


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21618

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated Service Mesh pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/service_mesh/index#installing-the-gateway-api-crds
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/service_mesh/index#ossm-rn-known-issues_ossm-release-notes

QE review:
- [ ] QE has approved this change.

Additional information:
Replaces `kubectl` with `oc` in Service Mesh Gateway API CRD install and known-issue workaround examples. Leaves `kubectl.kubernetes.io` annotation references unchanged.

This PR combines and supersedes #118016 and #118017 so related changes stay in one reviewable PR, per the contributing guide.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)