### PR TITLE
OSDOCS#21617: Replace obsolete kubectl rolling-update with oc rollout restart in secrets docs

### DIFF
--- a/modules/builds-secrets-overview.adoc
+++ b/modules/builds-secrets-overview.adoc
@@ -65,7 +65,7 @@ secret intended to conform to the key/value requirements of that type.
 
 When you modify the value of a secret, the value used by an already running pod does not dynamically change. To change a secret, you must delete the original pod and create a new pod, in some cases with an identical `PodSpec`.
 
-Updating a secret follows the same workflow as deploying a new container image. You can use the `kubectl rolling-update` command.
+Updating a secret follows the same workflow as deploying a new container image. You can use the `oc rollout restart deployment/<deployment>` command.
 
 The `resourceVersion` value in a secret is not specified when it is referenced. Therefore, if a secret is updated at the same time as pods are starting, the version of the secret that is used for the pod is not defined.
 

--- a/modules/nodes-pods-secrets-updating.adoc
+++ b/modules/nodes-pods-secrets-updating.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 To update the values in a secret, you must re-create the pods that use that secret. Because running pods do not automatically detect changes to secret data, restarting the pods ensures they consume the updated configuration.
 
-Updating a secret follows the same workflow as deploying a new container image. You can use the `kubectl rolling-update` command.
+Updating a secret follows the same workflow as deploying a new container image. You can use the `oc rollout restart deployment/<deployment>` command.
 
 The `resourceVersion` value in a secret is not specified when it is referenced. Therefore, if a secret is updated at the same time as pods are starting, the version of the secret that is used for the pod is not defined.
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21617

Link to docs preview:
Netlify preview is generated after an OpenShift org member comments `/ok-to-test`. After that, the updated secrets pages are:
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/nodes/working-with-pods#nodes-pods-secrets-updating_nodes-pods-secrets
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/builds_using_buildconfig/creating-build-inputs#builds-secrets-overview-updates_creating-build-inputs

QE review:
- [ ] QE has approved this change.

Additional information:
`kubectl rolling-update` was a ReplicationController command. Kubernetes deprecated it in 1.7 and removed it in 1.16. OpenShift 4.x does not document that command for secret updates.

The current OpenShift equivalent for restarting a workload so new pods pick up updated secret data is `oc rollout restart`. This matches existing docs examples such as `oc rollout restart <deployment>` / `oc rollout restart deployment/nginx`.

This PR uses `oc rollout restart deployment/<deployment>` rather than a bare `oc rollout restart`, because the command requires a resource.

This is a command change, not only a kubectl-to-oc binary rename. Please verify with QE.

This PR combines and supersedes #118018 and #118019.

Please cherry-pick to all supported `enterprise-4.x` branches that include these modules.

Made with [Cursor](https://cursor.com)