### PR TITLE
OSDOCS-16991_g#CQA fixes for AWS UPI supporting modules (4.20)

### DIFF
--- a/modules/installation-cloudformation-vpc.adoc
+++ b/modules/installation-cloudformation-vpc.adoc
@@ -7,14 +7,11 @@
 [id="installation-cloudformation-vpc_{context}"]
 = CloudFormation template for the VPC
 
-You can use the following CloudFormation template to deploy the VPC that
-you need for your {product-title} cluster.
+[role="_abstract"]
+The VPC CloudFormation template creates the {aws-first} networking infrastructure, including the public and private subnets, that your {product-title} cluster requires.
 
 .CloudFormation template for the VPC
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/01_vpc.yaml[]
 ----
-====

--- a/modules/installation-cloudformation-worker.adoc
+++ b/modules/installation-cloudformation-worker.adoc
@@ -7,13 +7,11 @@
 [id="installation-cloudformation-worker_{context}"]
 = CloudFormation template for compute machines
 
-You can deploy the compute machines that you need for your {product-title} cluster by using the following CloudFormation template.
+[role="_abstract"]
+The compute machine CloudFormation template creates the {aws-first} resources for the worker nodes that run your {product-title} application workloads.
 
 .CloudFormation template for compute machines
-[%collapsible]
-====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.20/upi/aws/cloudformation/06_cluster_worker_node.yaml[]
 ----
-====

--- a/modules/installation-create-ingress-dns-records.adoc
+++ b/modules/installation-create-ingress-dns-records.adoc
@@ -5,18 +5,20 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-create-ingress-dns-records_{context}"]
-= Creating the Ingress DNS Records
+= Creating the Ingress DNS records
 
-If you removed the DNS Zone configuration, manually create DNS records that point to the Ingress load balancer.
-You can create either a wildcard record or specific records. While the following procedure uses A records, you can use other record types that you require, such as CNAME or alias.
+[role="_abstract"]
+If you removed the DNS Zone configuration, you must manually create DNS records that point to the Ingress load balancer.
+
+You can create either a wildcard record or specific records. Although the following procedure uses A records, you can use other record types that you require, such as CNAME or alias.
 
 .Prerequisites
 
-* You deployed an {product-title} cluster on Amazon Web Services (AWS) that uses infrastructure that you provisioned.
+* You deployed an {product-title} cluster on {aws-first} that uses infrastructure that you provisioned.
 * You installed the OpenShift CLI (`oc`).
 * You installed the `jq` package.
 * You downloaded the AWS CLI and installed it on your computer. See
-link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)].
+link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)].
 
 .Procedure
 
@@ -57,9 +59,10 @@ router-default   LoadBalancer   172.30.62.215   ab3...28.us-east-2.elb.amazonaws
 +
 [source,terminal]
 ----
-$ aws elb describe-load-balancers | jq -r '.LoadBalancerDescriptions[] | select(.DNSName == "<external_ip>").CanonicalHostedZoneNameID' <1>
+$ aws elb describe-load-balancers | jq -r '.LoadBalancerDescriptions[] | select(.DNSName == "<external_ip>").CanonicalHostedZoneNameID'
 ----
-<1> For `<external_ip>`, specify the value of the external IP address of the Ingress Operator load balancer that you obtained.
++
+where `<external_ip>` is the value of the external IP address of the Ingress Operator load balancer that you obtained.
 +
 .Example output
 [source,terminal]
@@ -75,11 +78,12 @@ The output of this command is the load balancer hosted zone ID.
 [source,terminal]
 ----
 $ aws route53 list-hosted-zones-by-name \
-            --dns-name "<domain_name>" \ <1>
-            --query 'HostedZones[? Config.PrivateZone != `true` && Name == `<domain_name>.`].Id' <1>
+            --dns-name "<domain_name>" \
+            --query 'HostedZones[? Config.PrivateZone != `true` && Name == `<domain_name>.`].Id'
             --output text
 ----
-<1> For `<domain_name>`, specify the Route 53 base domain for your {product-title} cluster.
++
+where `<domain_name>` is the Route 53 base domain for your {product-title} cluster.
 +
 .Example output
 [source,terminal]
@@ -93,16 +97,16 @@ The public hosted zone ID for your domain is shown in the command output. In thi
 +
 [source,terminal]
 ----
-$ aws route53 change-resource-record-sets --hosted-zone-id "<private_hosted_zone_id>" --change-batch '{ <1>
+$ aws route53 change-resource-record-sets --hosted-zone-id "<private_hosted_zone_id>" --change-batch '{
 >   "Changes": [
 >     {
 >       "Action": "CREATE",
 >       "ResourceRecordSet": {
->         "Name": "\\052.apps.<cluster_domain>", <2>
+>         "Name": "\\052.apps.<cluster_domain>",
 >         "Type": "A",
 >         "AliasTarget":{
->           "HostedZoneId": "<hosted_zone_id>", <3>
->           "DNSName": "<external_ip>.", <4>
+>           "HostedZoneId": "<hosted_zone_id>",
+>           "DNSName": "<external_ip>.",
 >           "EvaluateTargetHealth": false
 >         }
 >       }
@@ -110,25 +114,30 @@ $ aws route53 change-resource-record-sets --hosted-zone-id "<private_hosted_zone
 >   ]
 > }'
 ----
-<1> For `<private_hosted_zone_id>`, specify the value from the output of the CloudFormation template for DNS and load balancing.
-<2> For `<cluster_domain>`, specify the domain or subdomain that you use with your {product-title} cluster.
-<3> For `<hosted_zone_id>`, specify the public hosted zone ID for the load balancer that you obtained.
-<4> For `<external_ip>`, specify the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.
++
+where:
++
+--
+`<private_hosted_zone_id>`:: Specifies the value from the output of the CloudFormation template for DNS and load balancing.
+`<cluster_domain>`:: Specifies the domain or subdomain that you use with your {product-title} cluster.
+`<hosted_zone_id>`:: Specifies the public hosted zone ID for the load balancer that you obtained.
+`<external_ip>`:: Specifies the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.
+--
 
 . Add the records to your public zone:
 +
 [source,terminal]
 ----
-$ aws route53 change-resource-record-sets --hosted-zone-id "<public_hosted_zone_id>"" --change-batch '{ <1>
+$ aws route53 change-resource-record-sets --hosted-zone-id "<public_hosted_zone_id>"" --change-batch '{
 >   "Changes": [
 >     {
 >       "Action": "CREATE",
 >       "ResourceRecordSet": {
->         "Name": "\\052.apps.<cluster_domain>", <2>
+>         "Name": "\\052.apps.<cluster_domain>",
 >         "Type": "A",
 >         "AliasTarget":{
->           "HostedZoneId": "<hosted_zone_id>", <3>
->           "DNSName": "<external_ip>.", <4>
+>           "HostedZoneId": "<hosted_zone_id>",
+>           "DNSName": "<external_ip>.",
 >           "EvaluateTargetHealth": false
 >         }
 >       }
@@ -136,7 +145,12 @@ $ aws route53 change-resource-record-sets --hosted-zone-id "<public_hosted_zone_
 >   ]
 > }'
 ----
-<1> For `<public_hosted_zone_id>`, specify the public hosted zone for your domain.
-<2> For `<cluster_domain>`, specify the domain or subdomain that you use with your {product-title} cluster.
-<3> For `<hosted_zone_id>`, specify the public hosted zone ID for the load balancer that you obtained.
-<4> For `<external_ip>`, specify the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.
++
+where:
++
+--
+`<public_hosted_zone_id>`:: Specifies the public hosted zone for your domain.
+`<cluster_domain>`:: Specifies the domain or subdomain that you use with your {product-title} cluster.
+`<hosted_zone_id>`:: Specifies the public hosted zone ID for the load balancer that you obtained.
+`<external_ip>`:: Specifies the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.
+--

--- a/modules/installation-extracting-infraid.adoc
+++ b/modules/installation-extracting-infraid.adoc
@@ -66,23 +66,19 @@ endif::[]
 [id="installation-extracting-infraid_{context}"]
 = Extracting the infrastructure name
 
+[role="_abstract"]
+To identify your cluster resources in {cp-first}, extract the unique infrastructure name from the Ignition config files.
+
 ifdef::aws,gcp[]
-The Ignition config files contain a unique cluster identifier that you can use to
-uniquely identify your cluster in {cp-first}. The infrastructure name is also used to locate the appropriate {cp} resources during an {product-title} installation. The provided {cp-template}
-templates contain references to this infrastructure name, so you must extract
-it.
+The infrastructure name is also used to locate the appropriate {cp} resources during an {product-title} installation. The provided {cp-template} templates contain references to this infrastructure name, so you must extract it.
 endif::aws,gcp[]
 
 ifdef::azure[]
-The Ignition config files contain a unique cluster identifier that you can use to
-uniquely identify your cluster in {cp-first}. The provided {cp-template-first} ({cp-template})
-templates contain references to this infrastructure name, so you must extract
-it.
+The provided {cp-template-first} ({cp-template}) templates contain references to this infrastructure name, so you must extract it.
 endif::azure[]
 
 ifdef::vsphere[]
-The Ignition config files contain a unique cluster identifier that you can use to
-uniquely identify your cluster in {cp-first}. If you plan to use the cluster identifier as the name of your virtual machine folder, you must extract it.
+If you plan to use the cluster identifier as the name of your virtual machine folder, you must extract it.
 endif::vsphere[]
 
 
@@ -100,17 +96,18 @@ metadata, run the following command:
 +
 [source,terminal]
 ----
-$ jq -r .infraID <installation_directory>/metadata.json <1>
+$ jq -r .infraID <installation_directory>/metadata.json
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you stored the
-installation files in.
++
+where `<installation_directory>` is the path to the directory that you stored the installation files in.
 +
 .Example output
 [source,terminal]
 ----
-openshift-vw9j6 <1>
+openshift-vw9j6
 ----
-<1> The output of this command is your cluster name and a random string.
++
+The output of this command is your cluster name and a random string.
 
 ifeval::["{context}" == "installing-aws-user-infra"]
 :!cp-first:

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -44,19 +44,14 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir <installation_directory> <1>
+$ ./openshift-install create install-config --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
++
+where `<installation_directory>` is the directory name to store the files that the installation program creates.
 +
 [IMPORTANT]
 ====
-Specify an empty directory. Some installation assets, like bootstrap X.509
-certificates have short expiration intervals, so you must not reuse an
-installation directory. If you want to reuse individual files from another
-cluster installation, you can copy them into your directory. However, the file
-names for the installation assets might change between releases. Use caution
-when copying installation files from an earlier {product-title} version.
+Specify an empty directory. Some installation assets, such as bootstrap X.509 certificates have short expiration intervals, so you must not reuse an installation directory. If you want to reuse individual files from another cluster installation, you can copy them into your directory. However, the file names for the installation assets might change between releases. Use caution when copying installation files from an earlier {product-title} version.
 ====
 .. At the prompts, provide the configuration details for your cloud:
 ... Optional: Select an SSH key to use to access your cluster machines.
@@ -66,9 +61,7 @@ when copying installation files from an earlier {product-title} version.
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ... Select *aws* as the platform to target.
-... If you do not have an AWS profile stored on your computer, enter the AWS
-access key ID and secret access key for the user that you configured to run the
-installation program.
+... If you do not have an {aws-short} profile stored on your computer, enter the {aws-short} access key ID and secret access key for the user that you configured to run the installation program.
 +
 [NOTE]
 ====
@@ -93,10 +86,7 @@ your registry:
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}'
 ----
 +
-For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
+For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 .. Add the `additionalTrustBundle` parameter and value. The value must be the contents of the certificate file that you used for your mirror registry. The certificate file can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
 +
 [source,yaml]
@@ -139,8 +129,7 @@ endif::three-node-cluster[]
 +
 [IMPORTANT]
 ====
-The `install-config.yaml` file is consumed during the installation process. If
-you want to reuse the file, you must back it up now.
+The `install-config.yaml` file is consumed during the installation process. If you want to reuse the file, you must back it up now.
 ====
 
 ifeval::["{context}" == "installing-aws-user-infra"]


### PR DESCRIPTION
Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:

- [CloudFormation template for the VPC](https://118237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-vpc_installing-aws-user-infra)
- [CloudFormation template for compute machines](https://118237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-worker_installing-aws-user-infra)
- [Creating the Ingress DNS records](https://118237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-create-ingress-dns-records_installing-aws-user-infra)
- [Extracting the infrastructure name](https://118237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-extracting-infraid_installing-aws-user-infra)
- [Creating the installation configuration file](https://118237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-generate-aws-user-infra-install-config_installing-aws-user-infra)

QE review:

QE has approved this change.

Additional information:


## Summary

- Add `[role="_abstract"]` and DITA-compliant short descriptions to CloudFormation template reference modules and other AWS UPI modules
- Remove `[%collapsible]`/`====` from CloudFormation template code blocks (DITA ExampleBlock requirement)
- Replace callouts with `where:` description lists
- Apply `{aws-first}`/`{aws-short}` attribute pattern for AWS product name
- Fix title "Optional: Creating..." → "Creating..." (NoOptionalTitles)
- Fix "Unix" → "UNIX", unwrap hard-wrapped lines, fix "like" → "such as"

🤖 Generated with [Claude Code](https://claude.com/claude-code)