### PR TITLE
CNV-94225: Document cloning VM flow for new wizard

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4895,9 +4895,9 @@ Topics:
   Dir: creating_vm
   Topics:
   # Web console procedures (unified wizard — CNV-94223, CNV-94224, CNV-94225, CNV-94226)
-  # Uncomment when CNV-94227 cleanup is complete:
-  #- Name: Create virtual machines by using the web console
-  #  File: virt-creating-vms-web
+  # TODO: Re-comment before merging (uncommented for PM review)
+  - Name: Create virtual machines by using the web console
+    File: virt-creating-vms-web
   # CLI procedures (existing content, moved from Chapter 8)
   - Name: Creating virtual machines by using the CLI
     File: virt-creating-vms-from-cli

--- a/modules/virt-cloning-vm-wizard-web.adoc
+++ b/modules/virt-cloning-vm-wizard-web.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * virt/creating_vm/virt-creating-vms-web.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-cloning-vm-wizard-web_{context}"]
+= Clone an existing VM by using the web console
+
+[role="_abstract"]
+You can use the *Clone existing VirtualMachine* workflow in the web console to create a new virtual machine (VM) by cloning an existing VM and its configuration.
+
+Use this workflow when:
+
+* You want to duplicate an existing VM with the same configuration.
+* You need multiple VMs with a consistent setup.
+
+.Prerequisites
+
+* You have access to the {product-title} web console.
+* You have `edit` or `admin` permissions in the target project.
+* The source VM that you want to clone exists in a project that you can access.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Virtualization* -> *VirtualMachines*.
+. Click *Create*.
+. On the *Deployment details* page, configure the following settings:
+.. Select *Clone existing VirtualMachine*.
+.. Review the *Project* and *Group* under *Location*. To change the target project or group, click the edit icon.
+.. Click *Next*.
+. On the *Source* page, select the VM to clone:
+.. Browse the list of available VMs, or use the search and filter options to locate a specific VM.
++
+You can filter by *Status*, *Operating system*, *Storage class*, *Hardware devices*, *Scheduling*, *Node*, *Guest agent*, and *Architecture type*.
+.. Select the VM that you want to clone.
+.. Click *Next*.
+. On the *Review and create* page, review the VM configuration:
+.. Optional: In the *Name* field, enter a name for the VM. You can also click the refresh icon to generate a name automatically.
+.. Optional: Enter a *Description* for the VM.
+.. Review the *Location* to verify the target cluster and project. If the folder preview feature is enabled, you can also verify the folder. To change the location, click the edit icon.
+.. Optional: The *Start this VirtualMachine after creation* checkbox is selected by default. Clear the checkbox if you do not want the cloned VM to start immediately.
+.. Click *Clone VirtualMachine*.
+
+.Verification
+
+* Navigate to *Virtualization* -> *VirtualMachines* and verify that the VM is displayed in the list.

--- a/modules/virt-cloning-vm-wizard-web.adoc
+++ b/modules/virt-cloning-vm-wizard-web.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt/creating_vm/virt-creating-vms-web.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-cloning-vm-wizard-web_{context}"]
+= Clone an existing VM by using the web console
+
+[role="_abstract"]
+You can use the *Clone existing VirtualMachine* workflow in the web console to create a new virtual machine (VM) by cloning an existing VM and its configuration.
+
+Use this workflow when:
+
+* You want to duplicate an existing VM with the same configuration.
+* You need multiple VMs with a consistent setup.
+
+.Prerequisites
+
+* You have access to the {product-title} web console.
+* You have `edit` or `admin` permissions in the target project.
+* The source VM that you want to clone exists in a project that you can access.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Virtualization* -> *VirtualMachines*.
+. Click *Create*.
+. On the *Deployment details* page, configure the following settings:
+.. Select *Clone existing VirtualMachine*.
+.. In the *Name* field, enter a name for the VM. You can also click the refresh icon to generate a name automatically.
+.. Optional: Enter a *Description* for the VM.
+.. Review the *Location* to verify the target cluster and project. If the folder preview feature is enabled, you can also verify the folder. To change the location, click the edit icon.
+.. Click *Next*.
+. On the *Source* page, select the VM to clone:
+.. Browse the list of available VMs, or use the search and filter options to locate a specific VM.
++
+You can filter by *Status*, *Operating system*, *Storage class*, *Hardware devices*, *Scheduling*, *Node*, *Guest agent*, and *Architecture type*.
+.. Select the VM that you want to clone.
+.. Click *Next*.
+. On the *Review and create* page, review the VM configuration:
+.. Optional: Select the *Start this VirtualMachine after creation* checkbox.
+.. Click *Create VirtualMachine*.
+
+.Verification
+
+* Navigate to *Virtualization* -> *VirtualMachines* and verify that the VM is displayed in the list.

--- a/virt/creating_vm/virt-creating-vms-web.adoc
+++ b/virt/creating_vm/virt-creating-vms-web.adoc
@@ -24,5 +24,10 @@ include::modules/virt-creating-vm-from-template-web.adoc[leveloffset=+1]
 * xref:../../virt/managing_vms/virt-list-vms.adoc#virt-organize-vms-web_virt-list-vms[Organize virtual machines by using the web console]
 
 // Clone existing VM procedure (CNV-94225)
+include::modules/virt-cloning-vm-wizard-web.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../virt/managing_vms/virt-list-vms.adoc#virt-organize-vms-web_virt-list-vms[Organize virtual machines by using the web console]
 
 // VM creation considerations reference (CNV-94226)


### PR DESCRIPTION
Version(s):
Main, 4.22, 5.0

Issue: [CNV-94225](https://redhat.atlassian.net/browse/CNV-94225)

[Link to docs preview](https://118257--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-web.html#virt-cloning-vm-wizard-web_virt-creating-vms-web)

QE review:
- [x] QE has approved this change.

PR summary:

  - Claude drafted the new module, modeled structurally on the existing sibling modules.
  - I provided the source content for claude to build to topic.
  - Claude added the include:: directive for the new module into the assembly.
  - I implemented the updates based on QE review myself. There had been updates to the flow since I had reviewed it, and I got a hold of a new cluster to review the changes and verify them.
  - AI-assisted peer review was run on the new module, and no issues were found.
