### PR TITLE
OSDOCS-20656: SFTP token required in caseManagementAccountSecretRef secret in Configuring a Support Log Gather instance

### DIFF
--- a/modules/support-log-gather-config-params.adoc
+++ b/modules/support-log-gather-config-params.adoc
@@ -102,7 +102,7 @@ Because the `default` service account has minimal permissions, you can specify t
 |`string`
 
 |`spec.uploadTarget.sftp.caseManagementAccountSecretRef`
-|Defines the credentials required for authenticating and uploading the files to the Red{nbsp}Hat Customer Portal support case. The value must contain a `username` and `password` field.
+|Defines the credentials required for authenticating and uploading the files to the Red{nbsp}Hat Customer Portal support case. The secret must contain a `username` field and a `password` field. The `password` field must contain a Red{nbsp}Hat Secure FTP token, not your Customer Portal password. To generate an SFTP token, see link:https://access.redhat.com/sftp-token/#/external[Red Hat Secure FTP Token Generator]. For more information about using SFTP, see link:https://access.redhat.com/articles/5594481[How to Upload Files to Cases Using Red Hat Secure FTP].
 |`Object`
 
 |`spec.uploadTarget.sftp.caseManagementAccountSecretRef.name`

--- a/modules/support-log-gather-configure-cli.adoc
+++ b/modules/support-log-gather-configure-cli.adoc
@@ -20,7 +20,7 @@ include::snippets/technology-preview.adoc[]
 
 * You have a Red{nbsp}Hat Support case ID.
 
-* You have created a Kubernetes secret containing your Red Hat Customer Portal credentials. The secret must contain a username field and a password field.
+* You have created a Kubernetes secret containing your Red Hat Customer Portal credentials. The secret must contain a `username` field and a `password` field. The `password` field must contain a Red{nbsp}Hat Secure FTP token, not your Customer Portal password. To generate an SFTP token, see link:https://access.redhat.com/sftp-token/#/external[Red Hat Secure FTP Token Generator]. For more information about using SFTP, see link:https://access.redhat.com/articles/5594481[How to Upload Files to Cases Using Red Hat Secure FTP].
 
 * If you are using a custom image, you have configured an `ImageStream` resource in the Operator namespace that references an approved custom image URL.
 

--- a/modules/support-log-gather-configure-cli.adoc
+++ b/modules/support-log-gather-configure-cli.adoc
@@ -20,7 +20,7 @@ include::snippets/technology-preview.adoc[]
 
 * You have a Red{nbsp}Hat Support case ID.
 
-* You have created a Kubernetes secret containing your Red Hat Customer Portal credentials. The secret must contain a `username` field and a `password` field. The `password` field must contain a Red{nbsp}Hat Secure FTP token, not your Customer Portal password. To generate an SFTP token, see link:https://access.redhat.com/sftp-token/#/external[Red Hat Secure FTP Token Generator]. For more information about using SFTP, see link:https://access.redhat.com/articles/5594481[How to Upload Files to Cases Using Red Hat Secure FTP].
+* You have created a Kubernetes secret containing your Red{nbsp}Hat Customer Portal credentials. The secret must contain a `username` field and a `password` field. The `password` field must contain a Red{nbsp}Hat Secure FTP token, not your Customer Portal password. To generate an SFTP token, see link:https://access.redhat.com/sftp-token/#/external[Red Hat Secure FTP Token Generator]. For more information about using SFTP, see link:https://access.redhat.com/articles/5594481[How to Upload Files to Cases Using Red Hat Secure FTP].
 
 * If you are using a custom image, you have configured an `ImageStream` resource in the Operator namespace that references an approved custom image URL.
 


### PR DESCRIPTION
Version(s): All supported versions

Issue: [OSDOCS-20656](https://redhat.atlassian.net/browse/OSDOCS-20656)

Link to docs preview: N/A

QE review:
- [ ] QE has approved this change.

Additional information:

**Summary of changes:**
- Updates the **Prerequisites** section in `support-log-gather-configure-cli.adoc` to explicitly state that the `password` field in the `caseManagementAccountSecretRef` secret must contain a Red Hat Secure FTP token, not the Customer Portal password.
- Updates the **Configuration parameters** table in `support-log-gather-config-params.adoc` with the same clarification.
- Adds links to the [Red Hat Secure FTP Token Generator](https://access.redhat.com/sftp-token/#/external) and [How to Upload Files to Cases Using Red Hat Secure FTP](https://access.redhat.com/articles/5594481) in both locations.

**Root cause:**
Red Hat Secure FTP does not support authentication using Red Hat Customer Portal passwords. Uploads must use a Secure FTP token generated through the Red Hat Secure FTP token service. When a Customer Portal password is used instead of a valid SFTP token, authentication is rejected and the upload fails with a "Permission denied" error.

**KCS reference:** https://access.redhat.com/articles/5594481