### PR TITLE
Revert "[enterprise-4.22] OSDOCS-17917: short term preconfig updates for OVE"

### DIFF
--- a/modules/installing-ove-iso.adoc
+++ b/modules/installing-ove-iso.adoc
@@ -31,10 +31,4 @@ The size of the ISO image can vary depending on the release you select.
 
 . Click *Next*.
 
-. Optional: Preconfigure the ISO on the *Optional configurations* page:
-
-.. Upload a SSH public key in the *SSH public key* field.
-
-. Click *Next*.
-
 . Click *Download ISO*.


### PR DESCRIPTION
Reverts openshift/openshift-docs#118234

Reverting this merge because the 4.22 z ISO is not yet available