### PR TITLE
[TELCODOCS#2937]: Clarify LSO LocalVolumeSet limits for image-based upgrade

### DIFF
--- a/modules/cnf-image-based-upgrade-backup-guide.adoc
+++ b/modules/cnf-image-based-upgrade-backup-guide.adoc
@@ -6,7 +6,7 @@
 = {oadp-short} backup and restore guidelines
 
 [role="_abstract"]
-Use the {oadp-short} Operator to back up and restore applications during the image-based upgrade by creating `Backup` and `Restore` CRs wrapped in `ConfigMap` objects.
+Use the {oadp-short} Operator to back up and restore applications during the image-based upgrade by creating `Backup` and `Restore` custom resources (CRs) wrapped in `ConfigMap` objects.
 
 With the {oadp-short} Operator, you can back up and restore your applications on your target clusters by using `Backup` and `Restore` CRs wrapped in `ConfigMap` objects.
 The application must work on the current and the target {product-title} versions so that they can be restored after the upgrade.
@@ -24,7 +24,11 @@ The following resources must be excluded from the backup:
 
 There are two local storage implementations for {sno}:
 
-Local Storage Operator (LSO):: The {lcao} automatically backs up and restores the required artifacts, including `localvolume` resources and their associated `StorageClass` resources. You must exclude the `persistentvolumes` resource in the application `Backup` CR.
+Local Storage Operator (LSO):: The {lcao} automatically backs up and restores the required artifacts, including `LocalVolume` resources and their associated `StorageClass` resources.
+You must exclude the `persistentvolumes` resource in the application `Backup` CR.
+The image-based upgrade does not support the `LocalVolumeSet` and `LocalVolumeDiscovery` CRs.
+If you use these CRs, the {lcao} does not restore them.
+Only persistent volumes that a `LocalVolume` CR created are preserved and available after the upgrade.
 
 {lvms}:: You must create the `Backup` and `Restore` CRs for {lvms} artifacts. You must include the `persistentVolumes` resource in the application `Backup` CR.
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2937

Link to docs preview: https://118267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.html
<!--- Add after Netlify preview is available --->

QE review:
- [x] QE has approved this change.

Additional information:
Clarifies that `LocalVolumeSet` and `LocalVolumeDiscovery` are not supported for image-based upgrade with LSO; only `LocalVolume`-created PVs are restored. Backport to supported 4.18+ branches after merge.
