### PR TITLE
OSDOCS-20538: adds GA relnote disconnected install

### DIFF
--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -9,8 +9,10 @@
 [role="_abstract"]
 You can use the new features and enhancements that are available with {product-title} {version}.
 
-{rhdh} plugin is Generally Available::
+Disconnected installation is now Generally Available::
+Installing {prodname} in a disconnected environment in now Generally Available. You can apply cloud-like traffic management within your private, secure network. For more information, see xref:../install_rhcl/rhcl-install-disconnected.adoc#rhcl-install-disconnected[Install {prodname} in a disconnected environment].
 
+{rhdh} plugin is Generally Available::
 The {rhdh} plugin for {rhcl} is Generally Available. With a {rhdh} subscription, you can create a self-service API catalog that makes API consumption easier and enables teams to work together more effectively. For more information, see xref:../develop/rhdh_plugin/rhdh-plugin-installation.adoc#rhdh-plugin-installation[Manage APIs through Red Hat Developer Hub].
 
 //Notable technical changes::


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5

Issue:
[OSDOCS-20538](https://redhat.atlassian.net/browse/OSDOCS-20538)

Link to docs preview:
https://118306--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-features-enhancements_rhcl-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature PR, https://github.com/openshift/openshift-docs/pull/117976

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
