### PR TITLE
OSDOCS#21630: Update the MicroShift RNs for 4.21.29

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-29-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-16-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-11-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-29-async.adoc
+++ b/modules/microshift-4-21-29-async.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-29-async_{context}"]
+= RHBA-2026:55535 - {microshift-short} 4.21.29 fixed issue update
+
+Issued: 18 August 2026
+
+[role="_abstract"]
+{product-title} release 4.21.29 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:55535[RHBA-2026:55535] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:54602[RHSA-2026:54602] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-21-29-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-21630](https://redhat.atlassian.net/browse/OSDOCS-21630)

Link to docs preview:
[4.21.29](https://118307--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-29-async_release-notes)

QE review:
- [ ] QE has approved this change.
Not required for RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/741)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21?page=1)
