### PR TITLE
OSDOCS-21395: fixes default HTTPRoute example MCP gateway

### DIFF
--- a/modules/con-rhcl-planpolicy-overview.adoc
+++ b/modules/con-rhcl-planpolicy-overview.adoc
@@ -22,6 +22,6 @@ A `PlanPolicy` works in conjunction with `AuthPolicy` and `RateLimitPolicy` cust
 
 The `PlanPolicy` object has the following known limitations:
 
-* A `PlanPolicy` object can only target `HTTPRoute`,` `GRPCRoute`, and `Gateway` custom resources defined in the same namespace as the `PlanPolicy` object.
+* A `PlanPolicy` object can only target `HTTPRoute`, `GRPCRoute`, and `Gateway` custom resources defined in the same namespace as the `PlanPolicy` object.
 * Plan predicates are evaluated in order. More specific predicates must appear before more general ones to ensure correct plan assignment.
 * Plan identification requires authentication to be configured through an AuthPolicy.

--- a/modules/ref-mcp-gateway-auto-route.adoc
+++ b/modules/ref-mcp-gateway-auto-route.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 Applying the `MCPGatewayExtension` custom resources (CR) generates an automatic `HTTPRoute` CR. The following is an example of the route.
 
-.Example automatically generated HTTPRoute CR
+.Example automatically generated `HTTPRoute` CR
 [source,yaml]
 ----
 apiVersion: gateway.networking.k8s.io/v1
@@ -20,7 +20,7 @@ metadata:
 spec:
   parentRefs:
   - name: mcp-gateway
-    namespace: istio-system
+    namespace: gateway-namespace
     sectionName: mcp
   rules:
   - matches:
@@ -35,5 +35,5 @@ spec:
 * The value of the `spec.parentRefs.name:` parameter matches your `Gateway` CR name.
 * The value of the `spec.parentRefs.namespace:` parameter matches your `Gateway` namespace.
 * The value of the `spec.parentRefs.sectionName:` parameter matches the `spec.listeners[*].name` value of your `Gateway` object listener.
-* The value of the `spec.rules.backendRefs.name:` is the Kubernetes service for your MCP gateway.
-* The value of the `spec.rules.backendRefs.port:` is the port that the MCP gateway is listening on.
+* The value of the `spec.rules.backendRefs.name:` is the Kubernetes service for your {mcpg}.
+* The value of the `spec.rules.backendRefs.port:` is the port that the {mcpg} is listening on.


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.5

Issue:
[OSDOCS-21395](https://redhat.atlassian.net/browse/OSDOCS-21395)

Link to docs preview:
https://118310--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html#ref-mcp-gateway-auto-route_mcp-gateway-get-install (curl command fix, QE required)
https://118310--ocpdocs-pr.netlify.app/rhcl/latest/deployment/rhcl-planpolicy.html#con-rhcl-planpolicy-overview_rhcl-planpolicy (minor typo fix, QE not required)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
