### PR TITLE
OSDOCS-21394: fix command verifying MCP endpoint

### DIFF
--- a/modules/proc-mcp-gateway-config-verify.adoc
+++ b/modules/proc-mcp-gateway-config-verify.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-config-verify_{context}"]
-= Verifying that an MCP endpoint is accessible through your MCP gateway
+= Verify that an MCP endpoint is accessible through your {mcpg}
 
 [role="_abstract"]
-You can verify that your MCP gateway is reaching your MCP endpoint by running a curl command to check for communication.
+You can verify that your {mcpg} is reaching your Model Context Protocol (MCP) endpoint by running a curl command to check for communication.
 
 .Prerequisites
 
@@ -15,12 +15,13 @@ You can verify that your MCP gateway is reaching your MCP endpoint by running a 
 
 .Procedure
 
-* Verify that the MCP endpoint is accessible through your MCP gateway instance by running the following command:
+* Verify that the MCP endpoint is accessible through your {mcpg} instance by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ curl -X POST http://_<mcp.example.com:port/mcp>_ \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}'
 ----
 +

--- a/modules/proc-mcp-gateway-custom-route.adoc
+++ b/modules/proc-mcp-gateway-custom-route.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-custom-route_{context}"]
-= Applying a customized HTTPRoute object
+= Apply a customized HTTPRoute object
 
 [role="_abstract"]
 In many production environments, you are likely to require a custom `HTTPRoute` object for your MCP gateway. For example, if any of the following situations apply, use a custom HTTP route:

--- a/modules/proc-mcp-gateway-referencegrant.adoc
+++ b/modules/proc-mcp-gateway-referencegrant.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-referencegrant_{context}"]
-= Applying a ReferenceGrant custom resource
+= Apply a ReferenceGrant custom resource
 
 [role="_abstract"]
 You can isolate teams within a single cluster by applying team-specific `MCPGatewayExtension` custom resources (CRs) in individual namespaces that all target a shared `Gateway` object. When you apply an `MCPGatewayExtension` CR in a different namespace than the `Gateway` CR, you must then create a `ReferenceGrant` in the namespace of the gateway to give access.
@@ -20,7 +20,7 @@ You can isolate teams within a single cluster by applying team-specific `MCPGate
 
 . Create a `ReferenceGrant` CR by using the following example as a template:
 +
-.Example ReferenceGrant CR
+.Example `ReferenceGrant` CR
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-21394](https://redhat.atlassian.net/browse/OSDOCS-21394)

Link to docs preview:
https://118311--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html#proc-mcp-gateway-config-verify_mcp-gateway-get-install (updated command, QE required)
https://118311--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html#proc-mcp-gateway-referencegrant_mcp-gateway-get-install (title fix, QE not required)
https://118311--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html#proc-mcp-gateway-custom-route_mcp-gateway-get-install (title fix, QE not required)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
