### PR TITLE
OSDOCS-19992: fix small formatting and command errors in install

### DIFF
--- a/modules/proc-install-on-ocp-cli-istio.adoc
+++ b/modules/proc-install-on-ocp-cli-istio.adoc
@@ -27,16 +27,15 @@ If you are using {service-mesh}, you can install {prodname} with {oc-first} usin
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create ns _<kuadrant-system>_
+$ oc create ns _<kuadrant_system>_
 ----
 +
-You can replace the default _<kuadrant-system>_ with the namespace you want to use.
+You can replace the default `_<kuadrant_system>_` with the namespace you want to use.
 
 . Install {prodname} by running the following command:
 +
-[source,terminal]
+[source,yaml]
 ----
-$ oc apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -60,10 +59,14 @@ metadata:
   namespace: kuadrant-system
 spec:
   upgradeStrategy: Default
-EOF
 ----
+
+. Apply the `Subscription` CR by running the following command:
 +
-Replace _<kuadrant-system>_ with the namespace you used.
+[source,terminal]
+----
+$ oc apply -f kuadrant-system-subscription.yaml
+----
 
 . Confirm that the {prodname} installation has finished by running one of the following commands:
 +
@@ -82,18 +85,23 @@ Expect the status of `installplan.operators.coreos.com/install-<suffix>` when {p
 
 . Create your {prodname} custom resource (CR) by running the following command:
 +
-[source,terminal,subs="+quotes"]
+[source,yaml,subs="+quotes"]
 ----
-$ oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
   name: kuadrant
-  namespace: _<kuadrant-system>_
-EOF
+  namespace: _<kuadrant_system>_
 ----
 +
-Replace _<kuadrant-system>_ with the namespace you used.
+Replace `_<kuadrant_system>_` with the namespace you used.
+
+. Apply the `Kuadrant` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f kuadrant.yaml
+----
 
 .Verification
 
@@ -101,10 +109,10 @@ Replace _<kuadrant-system>_ with the namespace you used.
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc wait kuadrant/kuadrant --for="condition=Ready=true" -n _<kuadrant-system>_ --timeout=300s
+$ oc wait kuadrant/kuadrant --for="condition=Ready=true" -n _<kuadrant_system>_ --timeout=300s
 ----
 +
-Replace _<kuadrant-system>_ with the namespace you used.
+Replace _<kuadrant_system>_ with the namespace you used.
 +
 .Example output
 [source,terminal,subs="+quotes"]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-19992](https://redhat.atlassian.net/browse/OSDOCS-19992)

Link to docs preview:
https://118312--ocpdocs-pr.netlify.app/rhcl/latest/install_rhcl/install-guide.html#proc-install-on-ocp-cmd-istio_install-on-ocp

QE review:
N/A internal docs work, no technical changes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
