### PR TITLE
OSDOCS#21637: Update the MicroShift RNs for 4.18.53

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -26,6 +26,8 @@ include::modules/microshift-4-18-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-18-asynch-errata-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-18-53-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-18-42-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-18-36-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-53-dp.adoc
+++ b/modules/microshift-4-18-53-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-53-dp_{context}"]
+= RHBA-2026:55539 - {microshift-short} 4.18.53 fixed issue and security advisory
+
+Issued: 19 August 2026
+
+[role="_abstract"]
+{product-title} release 4.18.53 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:55539[RHBA-2026:55539] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:54545[RHSA-2026:54545] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-18-53-bugs_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-21637](https://redhat.atlassian.net/browse/OSDOCS-21637)

Link to docs preview:
[4.18.53](https://118334--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes#microshift-4-18-53-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/740)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18?page=1)
