### PR TITLE
[TELCODOCS#2936]: Stop documenting unused PreCachingConfig override fields

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="talm-prechache-user-specified-images-preparing-crs_{context}"]
@@ -21,7 +22,7 @@ metadata:
   name: exampleconfig
   namespace: default
 spec:
-[...]
+# ...
   spaceRequired: 30Gi
   additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
@@ -83,7 +84,7 @@ All sites are precached concurrently.
 
 .Verification
 
-. Check the precaching status on the hub cluster where the `ClusterUpgradeGroup` CR is applied by running the following command:
+. Check the precaching status on the hub cluster where the `ClusterGroupUpgrade` CR is applied by running the following command:
 +
 [source,terminal]
 ----
@@ -91,7 +92,8 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-The following is example output:
+The following example shows the derived precaching specification.
+The `platformImage` and `operatorsIndexes` values come from the managed policies, not from `PreCachingConfig` overrides.
 +
 [source,yaml]
 ----

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
@@ -114,7 +114,8 @@ Example output:
 }
 ----
 +
-Displays the list of identified clusters.
+The output lists the identified clusters.
+The `platformImage` value in `status.precaching.spec` is derived by {cgu-operator} from the `ClusterVersion` object in the managed policies.
 
 . Check the status of the pre-caching job by running the following command on the spoke cluster:
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
@@ -1,18 +1,22 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="talm-prechache-user-specified-images-concept_{context}"]
 = Precaching user-specified images with {cgu-operator} on {sno} clusters
 
 [role="_abstract"]
-You can precache application-specific workload images on {sno} clusters before upgrading your applications.
+You can precache application-specific workload images on {sno} clusters before updating your applications.
 
 You can specify the configuration options for the precaching jobs by using the following custom resources (CR):
 
 * `PreCachingConfig` CR
 * `ClusterGroupUpgrade` CR
+
+{cgu-operator} derives the platform image from the `ClusterVersion` object in the managed policies.
+{cgu-operator} derives Operator index images from `CatalogSource` objects that the managed policies reference.
 
 [NOTE]
 ====
@@ -30,9 +34,6 @@ metadata:
   namespace: exampleconfig-ns
 spec:
   overrides:
-    platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-    operatorsIndexes:
-      - registry.example.com:5000/custom-redhat-operators:1.0.0
     operatorsPackagesAndChannels:
       - local-storage-operator: stable
       - ptp-operator: stable
@@ -47,8 +48,13 @@ spec:
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
 
-* `overrides` - By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
-* `spaceRequired` - Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
+* `overrides` - Specifies Operator packages and channels to precache instead of the values that {cgu-operator} derives from the managed policies.
+The only supported override is `operatorsPackagesAndChannels`.
+{cgu-operator} ignores the deprecated `platformImage` and `operatorsIndexes` override fields if they are present.
+* `spaceRequired` - Specifies the minimum required disk space on the cluster.
+If unspecified, {cgu-operator} defines a default value for {product-title} images.
+The disk space field must include an integer value and the storage unit.
+For example: `40 GiB`, `200 MB`, `1 TiB`.
 * `excludePrecachePatterns` - Specifies the images to exclude from precaching based on image name matching.
 * `additionalImages` - Specifies the list of additional images to precache.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2936

Link to docs preview:
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.html
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/cnf-talm-for-cluster-upgrades.html

QE review:
- [x] QE has approved this change.

Additional information:
Updates TALM precaching docs so they no longer instruct users to set `PreCachingConfig` `overrides.platformImage` and `overrides.operatorsIndexes`. TALM now derives those images from managed policies (`ClusterVersion` and `CatalogSource` objects). The remaining supported override is `operatorsPackagesAndChannels`. Status examples still show the derived `platformImage` and `operatorsIndexes` values and now state that those values come from policies, not from user overrides.

Cherry-pick status (checked 2026-09-04). This PR is merged to `main`. Each remaining version PR can merge only after the matching TALM operator backport in `openshift-kni/cluster-group-upgrades-operator` is merged.

| Docs branch | Operator branch | Operator PR | Operator status | Docs PR | Next step |
|---|---|---|---|---|---|
| `enterprise-5.0` | `main` | [openshift-kni/cluster-group-upgrades-operator#10171](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10171) | Merged | [#118593](https://github.com/openshift/openshift-docs/pull/118593) merged | Done |
| `enterprise-4.22` | `release-4.22` | [openshift-kni/cluster-group-upgrades-operator#10583](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10583) | Merged | [#118521](https://github.com/openshift/openshift-docs/pull/118521) merged | Done |
| `enterprise-4.21` | `release-4.21` | [openshift-kni/cluster-group-upgrades-operator#10584](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10584) | Merged | [#119286](https://github.com/openshift/openshift-docs/pull/119286) merged | Done |
| `enterprise-4.20` | `release-4.20` | [openshift-kni/cluster-group-upgrades-operator#10585](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10585) | Merged | [#118522](https://github.com/openshift/openshift-docs/pull/118522) merged | Done |
| `enterprise-4.19` | `release-4.19` | [openshift-kni/cluster-group-upgrades-operator#10586](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10586) | Merged | [#119097](https://github.com/openshift/openshift-docs/pull/119097) merged (manual after conflict) | Done |
| `enterprise-4.18` | `release-4.18` | [openshift-kni/cluster-group-upgrades-operator#10587](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10587) | Merged | — | Cherry-pick now |
| `enterprise-4.16` | `release-4.16` | [openshift-kni/cluster-group-upgrades-operator#10588](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10588) | Merged | [#118573](https://github.com/openshift/openshift-docs/pull/118573) merged (manual after conflict) | Done |
| `enterprise-4.14` | `release-4.14` | [openshift-kni/cluster-group-upgrades-operator#10589](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10589) | Merged | — | Cherry-pick now (`PreCachingConfig` exists on 4.14) |
| `enterprise-4.12` | — | — | — | — | Skip (`PreCachingConfig` is not present) |



