### PR TITLE
OSDOCS MCO Add note on marketplace boot images not updated

### DIFF
--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -28,4 +28,6 @@ The following table lists the platforms on which boot image management is availa
 
 |===
 
-For all other platforms, the MCO does not automatically update the boot image with each cluster update. For clusters where automatic updates are disabled or not supported, you can manually update the boot image on your cluster. See "Manually updating the boot image" for information. The method to update or specify the image varies by platform.  
+For all other platforms, the MCO does not automatically update the boot image with each cluster update. Images from the Google Cloud Marketplace or AWS Marketplace are not automatically updated.
+
+For clusters where automatic updates are disabled or not supported, you can manually update the boot image on your cluster. See "Manually updating the boot image" for information. The method to update or specify the image varies by platform.


### PR DESCRIPTION
Adding a note that boot images from GCP and AWS marketplace are not automatically updated. I wanted to add the sentence as a NOTE, but the snippet is used as a NOTE in some modules and apparently, we can't have a note in a note. 

Previews
Machine configuration -> [Boot image management](https://118362--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html)
Nodes -> Working with nodes -> Boot image management -> [About boot image management](https://118362--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images.html#mco-update-boot-images_nodes-update-boot-images)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->