### PR TITLE
ROX-34999: add documentation for central.rolloutStrategy

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -114,6 +114,11 @@ for the config-controller component. This parameter is mainly used for infrastru
 |`central.imagePullSecrets`
 |Use this parameter to specify the image pull secrets for the Central image.
 
+|`central.rolloutStrategy`
+| Specify the deployment rollout strategy for Central. Set to `RollingUpdate` to reduce downtime during upgrades and restarts.
+The default value is `Recreate`. A `RollingUpdate` value will start a new Central pod and keep the old pod running until the new pod is ready.
+The cluster must provide sufficient resources to accomodate the transition phase. 
+
 | `central.db.passwordSecret.name`
 | Specify a secret that has the database password in the `password` data item. Only use this parameter if you want to specify a connection string manually. If omitted, the operator auto-generates a password and stores it in the `password` item in the `central-db-password` secret.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The Central CR for the operator has an additonal field `central.rolloutStrategy`, which enables activation of RollingUpdates for the central deployment instead of Recreate.

This field is documented with this PR.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
- ACS 5.0.0 and upwards

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Feature: https://redhat.atlassian.net/browse/ROX-33759
Doc ticket: https://redhat.atlassian.net/browse/ROX-34999

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
