### PR TITLE
TELCODOCS-2906: Promote bond CNI transmit hash policy to GA

### DIFF
--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -7,7 +7,7 @@
 = Configuration for a Bond CNI secondary network
 
 [role="_abstract"]
-The Bond Container Network Interface (Bond CNI) enables the aggregation of multiple network interfaces into a single logical bonded interface within a container, which enhanches network redundancy and fault tolerance. Only SR-IOV Virtual Functions (VFs) are supported for bonding with this plugin.
+The Bond Container Network Interface (Bond CNI) combines multiple network interfaces into a single logical interface inside a container, improving redundancy and fault tolerance. {product-title} supports Bond CNI only when using kernel-mode SR-IOV virtual functions (VFs).
 
 The following table describes the configuration parameters for the Bond CNI plugin:
 
@@ -42,11 +42,11 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |`mode`
 |`string`
-|Specifies the bonding policy.
+|Specifies the bonding policy. The supported values are `balance-rr`, `active-backup`, and `balance-xor`.
 
 |`xmitHashPolicy`
 |`string`
-|Specifies the transmit hash policy for load balancing across the aggregated interfaces. This parameter defaults to `layer2` and supports the following values: `layer2`, `layer2+3` and `layer3+4`.
+|Specifies the transmit hash policy that the `balance-xor` mode uses for load balancing across the aggregated interfaces. This parameter defaults to `layer2` and supports the following values: `layer2`, `layer2+3`, and `layer3+4`.
 
 |`linksInContainer`
 |`boolean`
@@ -62,8 +62,14 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |====
 
-:FeatureName: xmitHashPolicy
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+When you use SR-IOV virtual functions (VFs) from multiple physical functions (PFs) in an active-active bond (such as `balance-rr` or `balance-xor`), you must configure the upstream network switch with a link aggregation group (LAG) that spans all participating PFs.
+
+When you configure a switch LAG across multiple PFs, every workload using VFs from those PFs must use an active-active bonding policy. You cannot mix active-active bonds, active-backup bonds, or single-VF workloads on PFs participating in a switch LAG.
+
+When using an active-active bond across multiple PFs without an upstream switch LAG, traffic drops occur. Configurations using active-backup or single-VF workloads can only receive traffic on a single designated PF, so any frames routed by the switch to an alternate PF are silently dropped.
+====
 
 [id="nw-multus-bond-cni-config-example_{context}"]
 == Bond CNI plugin configuration example
@@ -96,15 +102,15 @@ The following example configures a secondary network named `bond-net1`:
 }
 ----
 
-The following example configures a secondary network named `bond-tlb-net` with the `xmitHashPolicy` feature enabled:
+The following example configures a secondary network named `bond-xor-net` that uses the `balance-xor` mode with the `xmitHashPolicy` parameter enabled:
 
 [source,json]
 ----
 {
  "type": "bond",
  "cniVersion": "0.3.1",
- "name": "bond-tlb-net",
- "mode": "tlb",
+ "name": "bond-xor-net",
+ "mode": "balance-xor",
  "xmitHashPolicy": "layer2+3",
  "failOverMac": 0,
  "linksInContainer": true,
@@ -124,7 +130,5 @@ The following example configures a secondary network named `bond-tlb-net` with t
     }
 }
 ----
-
-
 
 * `xmitHashPolicy`: This parameter dictates how outgoing network traffic is distributed across the `net1` and `net2` active member interfaces within the bond. The hashing algorithm combines layer 2 information, specifically source and destination MAC addresses, with layer 3 information, which includes source and destination IP addresses.


### PR DESCRIPTION
[TELCODOCS-2906]: Promote bond CNI transmit hash policy (xmitHashPolicy) to GA

Version(s): main (latest)

Issue: https://issues.redhat.com/browse/TELCODOCS-2906

Link to docs preview: https://118392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html

This PR promotes the bond CNI `xmitHashPolicy` parameter from Technology Preview to GA and aligns the reference with SME guidance ([CNF-20380](https://redhat.atlassian.net/browse/CNF-20380)):

- Remove the Technology Preview note for `xmitHashPolicy`.
- Document `active-backup` and `balance-xor` as the supported bonding modes.
- Clarify that `xmitHashPolicy` is used by `balance-xor` mode (values: `layer2`, `layer2+3`, `layer3+4`).
- Update the second example to use `balance-xor` instead of `tlb` (renamed `bond-tlb-net` -> `bond-xor-net`).
- Fix a typo ("enhanches" -> "enhances").

Note: The corresponding release note TP->GA table move is tracked separately and will follow.

QE review:
- [ ] QE has approved this change.