### PR TITLE
Fix coreos multipath installation

### DIFF
--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -50,6 +50,11 @@ $ mpathconf --enable && systemctl start multipathd.service
 
 . Append the kernel arguments by invoking the `coreos-installer` program:
 +
+[NOTE]
+====
+Starting in {product-title} 4.22, you no longer need to include the `--append-karg root=/dev/disk/by-label/dm-mpath-root` parameter in these commands. Including this parameter could lead to non-booting nodes. The installation program now refers to the root disk by uuid, and automatically adds the `root=/dev/disk/by-label/dm-mpath-$UUID` parameter.
+====
++
 * If there is only one multipath device connected to the machine, the device should be available at path `/dev/mapper/mpatha`. For example:
 +
 ifndef::restricted[]
@@ -58,7 +63,6 @@ ifndef::restricted[]
 $ coreos-installer install /dev/mapper/mpatha \
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw
 ----
 endif::[]
@@ -68,7 +72,6 @@ ifdef::restricted[]
 $ coreos-installer install /dev/mapper/mpatha \
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw \
 --offline
 ----
@@ -86,7 +89,6 @@ ifndef::restricted[]
 $ coreos-installer install /dev/disk/by-id/wwn-<wwn_ID> \
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw
 ----
 endif::[]
@@ -96,7 +98,6 @@ ifdef::restricted[]
 $ coreos-installer install /dev/disk/by-id/wwn-<wwn_ID> \
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw \
 --offline
 ----


### PR DESCRIPTION
Addressed https://redhat.atlassian.net/browse/OCPBUGS-112076.

Added note and updated code blocks in step 2. The `<wwn_ID>`  typo fixed via https://github.com/openshift/openshift-docs/pull/118432

Link to docs preview:
Installing a user-provisioned cluster on bare metal -> [Enabling multipathing with kernel arguments on RHCOS](https://118401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#rhcos-enabling-multipath_installing-bare-metal)
Installing a user-provisioned bare metal cluster with network customizations -> [Enabling multipathing with kernel arguments on RHCOS](https://118401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#rhcos-enabling-multipath_installing-bare-metal-network-customizations)
Enabling multipathing with kernel arguments on RHCOS -> [Installing a user-provisioned bare metal cluster on a disconnected environment](https://118401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#rhcos-enabling-multipath_installing-restricted-networks-bare-metal)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
