### PR TITLE
OSDOCS-21586: adds URL-CEL note

### DIFF
--- a/modules/con-about-grpc-support.adoc
+++ b/modules/con-about-grpc-support.adoc
@@ -34,3 +34,5 @@ The following CRs support `GRPCRoute` CRs in their `targetRef` fields:
 `DNSPolicy` and `TLSPolicy` policies cover attached `GRPCRoute` CRs automatically.
 
 Telemetry works with `GRPCRoute` CRs with no updates required. Although telemetry objects target the `Gateway` object, telemetry captures and reports on gRPC traffic matched by attached `GRPCRoute` CRs. You have the same level of observability for gRPC traffic as you currently do for traffic routed through `HTTPRoute` CRs.
+
+include::snippets/path-normalization-cel-eval.adoc[]

--- a/modules/con-understanding-mcp-gateway-authorization.adoc
+++ b/modules/con-understanding-mcp-gateway-authorization.adoc
@@ -18,6 +18,8 @@ The following steps represent what happens during an authorization evaluation:
 * Authorization check: A Common Expression Language (CEL) expression evaluates the requested tool against the user permissions extracted from the JWT.
 * Access decision: The final step is to `allow` or `deny` based on the authorization check result.
 
+include::snippets/path-normalization-cel-eval.adoc[]
+
 Workflow for setting up authorization evaluation::
 To create an authorization evaluation, you must complete the following steps:
 

--- a/modules/proc-mcp-gateway-authorization.adoc
+++ b/modules/proc-mcp-gateway-authorization.adoc
@@ -115,6 +115,8 @@ spec:
 ** `request.headers['x-mcp-promptname']`: The name of the requested MCP prompt.
 ** `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed capability, tool or prompt, that the user can access, grouped by MCP server.
 * Response handling: Custom `401` and `403` responses for unauthenticated and unauthorized access attempts.
++
+include::snippets/path-normalization-cel-eval.adoc[]
 
 . Apply the `AuthPolicy` CR by running the following command:
 +

--- a/modules/proc-mcp-gateway-ts-authz-issues-cel.adoc
+++ b/modules/proc-mcp-gateway-ts-authz-issues-cel.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 When authorization fails with `CEL` evaluation errors, you can troubleshoot by checking logs, communication, and other configuration.
 
+include::snippets/path-normalization-cel-eval.adoc[]
+
 .Prerequisites
 
 * You installed {mcpg}.

--- a/snippets/path-normalization-cel-eval.adoc
+++ b/snippets/path-normalization-cel-eval.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Ensure that there is not a mismatch between your Envoy proxy layer and upstream application layers in performing URL normalization.
+
+Envoy serves raw request paths to the `wasm-shim` component unless `normalize_path` and `merge_slashes` are explicitly enabled in the Envoy HTTP Connection Manager (HCM) settings. This means that you can treat `/admin` and `//admin` as distinct paths in your CEL predicates, and so on.
+
+However, your application receives the requests. That upstream service can strip redundant slashes or decode URL-encoded values. This means it bypasses your configuration, serving the protected route.
+
+Make sure that you configure your upstream service so that you do not unintentionally bypass your own security. For more information, see link:https://istio.io/latest/docs/ops/best-practices/security/#customize-your-system-on-path-normalization[Customize your system on path normalization].
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.5
rhcl-docs-1.4

Issue:
[OSDOCS-21586](https://redhat.atlassian.net/browse/OSDOCS-21586)

Link to docs preview:
https://118403--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-authorization.html#con-understanding-mcp-gateway-authorization_mcp-gateway-authorization (the Important admonition)

QE review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Behavioral explanation, not a technical change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
