### PR TITLE
OSDOCS-21661: Compliance Operator 1.10.0 release note

### DIFF
--- a/modules/compliance-rn-1-10-0.adoc
+++ b/modules/compliance-rn-1-10-0.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="compliance-operator-release-notes-1-10-0_{context}"]
+= Release notes for OpenShift Compliance Operator 1.10.0
+
+[role="_abstract"]
+OpenShift Compliance Operator 1.10.0 is now available. The `stable` update channel tracks and receives updates for the Compliance Operator. For more information, see xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#compliance-operator-updating[Updating the Compliance Operator].
+
+[id="compliance-operator-1-10-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+* With this release, the default `ocp4` `ProfileBundle` includes Common Expression Language (CEL) content. The `ocp4-cis-vm-extension` profile is available without editing the bundle. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4514[CMP-4514]).
+
+* With this release, the CEL scanner supports manual rules that require human judgment. Controls that the scanner cannot evaluate automatically, such as some CIS {VirtProductName} controls, report a `MANUAL` result. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4518[CMP-4518]).
+
+* With this release, the Compliance Operator creates `NetworkPolicy` objects for operand pods. Operand traffic uses a default-deny policy, with required ingress and egress allowed. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4569[CMP-4569]).
+
+* With this release, the Compliance Operator uses the {product-title} API server TLS configuration instead of hard-coded TLS settings. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4147[CMP-4147]).
+
+[id="compliance-operator-1-10-0-bug-fixes_{context}"]
+== Fixed issues
+* Before this release, the node scanner delivered the runtime kubelet configuration with a host symlink. Later scans on the same node could fail to refresh that configuration, and kubelet rules could fail. With this release, the operator copies the kubelet configuration into a shared `emptyDir` volume. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4341[CMP-4341]).
+
+* Before this release, the metrics TLS endpoint could fail to start if the serving certificate was not ready, and metrics stayed unavailable for the life of the pod. With this release, the operator waits for the serving certificate before serving metrics over TLS. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4601[CMP-4601]).
+
+* Before this release, changing the `celContentFile` field on a `ProfileBundle` object did not redeploy the profile parser, so CEL profiles were not created. With this release, the operator detects `celContentFile` changes and re-parses CEL content. For more information, see (link:https://redhat.atlassian.net/browse/CMP-4599[CMP-4599]).

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -14,6 +14,8 @@ These release notes track the development of the Compliance Operator in the {pro
 
 // Release note modules (most recent first)
 
+include::modules/compliance-rn-1-10-0.adoc[leveloffset=+1]
+
 include::modules/compliance-rn-1-9-2.adoc[leveloffset=+1]
 
 include::modules/compliance-rn-1-9-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Document customer-facing changes from the 1.10.0 milestone so administrators can see CEL defaults, operand NetworkPolicies, TLS, and related bug fixes.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-21661
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://118424--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
