### PR TITLE
Outdated - do not use these skills

### DIFF
--- a/.claude/skills/jtbd-coverage-map/SKILL.md
+++ b/.claude/skills/jtbd-coverage-map/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: jtbd-coverage-map
+description: >
+  Cross-reference a JTBD mapping CSV with existing documentation to produce a
+  coverage map showing which modules belong to each job. Use when starting JTBD
+  implementation for a new feature area or distro.
+disable-model-invocation: true
+---
+
+# JTBD Coverage Map
+
+Generate a coverage analysis that maps existing documentation modules to the
+jobs defined in a JTBD mapping spreadsheet.
+
+## Inputs
+
+You need two things from the user before proceeding:
+
+1. **JTBD CSV file path** -- a CSV export of the JTBD mapping spreadsheet
+   (e.g., `~/Downloads/JTBD-Install.csv`)
+2. **Documentation directory** -- the path to the relevant docs directory in
+   the repo (e.g., the assembly/module directories that cover this feature area)
+
+If the user invoked this skill without providing both, ask for them.
+
+## What to produce
+
+Create a CSV file (saved to the user's working directory) with the following
+structure. Use a tab named "Modules per Job" as the conceptual grouping:
+
+### Per job (one section per job from the CSV):
+
+- **Job name** -- from the CSV
+- **Job statement** -- from the CSV
+- **Modules** -- list of existing modules (by filename) that should be included
+  in this job, determined by cross-referencing the job's scope with the content
+  of existing assemblies and modules
+- **Coverage status** for each module:
+  - `full` -- module content fully addresses the job step
+  - `partial` -- module is relevant but doesn't fully cover the job step
+  - `gap` -- no existing module covers this aspect of the job
+
+### Summary section:
+
+- **Journey gaps** -- jobs or job steps with no corresponding modules at all
+- **Duplicate jobs** -- jobs that substantially overlap in module coverage
+- **Unmapped assemblies** -- existing assemblies whose modules don't map to any job
+
+## How to analyze
+
+1. Read the CSV to extract all jobs and their job statements
+2. Read the existing assemblies in the documentation directory to build a list
+   of all modules and their content summaries
+3. For each job, identify which existing modules are relevant based on:
+   - Topic alignment between the job statement and module content
+   - Procedural steps that match the job's intent
+   - Prerequisite or context modules that support the job
+4. Flag gaps where a job has no suitable modules
+5. Flag assemblies whose modules don't map to any job
+
+## Output format
+
+Save the result as a CSV file. Tell the user the output path and summarize:
+- Total jobs found
+- Jobs with full coverage
+- Jobs with gaps
+- Number of unmapped assemblies
+
+The user will review and adjust this coverage map before proceeding to
+`/jtbd-create-jobs` to generate the actual map files.

--- a/.claude/skills/jtbd-create-jobs/SKILL.md
+++ b/.claude/skills/jtbd-create-jobs/SKILL.md
@@ -114,11 +114,20 @@ jobs following the same pattern. For each job:
 Create the distro directory under `maps/` if it doesn't already exist
 (e.g., `maps/ocp/`).
 
-### Step 4: Summary
+### Step 4: Offer to convert module headings from gerunds to imperatives
+
+After all the jobs have been created, ask the user if they want to convert
+the headings of modules included in the jobs created by this skill from gerunds
+to imperatives. If so, convert each module heading from gerund to imperative form.
+For example, "= Creating an application" should become "= Create an application".
+Do not change the filename. Do not change the ID. Only change the heading.
+
+### Step 5: Summary
 
 After all jobs are created, provide a summary:
 - List of job map files created
 - List of new intro concept modules created
+- Number of modules that were changed from gerund to imperative heading
 - The updated category map content
 - Any jobs from the coverage map that were skipped and why
 

--- a/.claude/skills/jtbd-create-jobs/SKILL.md
+++ b/.claude/skills/jtbd-create-jobs/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: jtbd-create-jobs
+description: >
+  Create JTBD job map files in maps/jobs/ and wire them into a distro category
+  map, using a coverage map CSV and existing repo modules. Use after
+  /jtbd-coverage-map has been run and the coverage map has been reviewed.
+disable-model-invocation: true
+---
+
+# JTBD Create Jobs
+
+Create AsciiDoc job map files and wire them into category maps based on a
+reviewed JTBD coverage map.
+
+## Inputs
+
+You need three things from the user before proceeding:
+
+1. **Coverage map CSV** -- the reviewed output from `/jtbd-coverage-map`
+   (or a manually prepared equivalent) that lists modules per job
+2. **Distro name** -- which distro this is for (e.g., `ocp`, `rosa`,
+   `microshift`). This determines the category map directory under `maps/`.
+3. **Category name** -- which category these jobs belong to (e.g., `install`,
+   `configure`, `upgrade`). This is the category map file the jobs will be
+   included in.
+
+If the user invoked this skill without providing all three, ask for them.
+
+## Reference: existing structure
+
+The maps directory structure is:
+
+```
+maps/
+  jobs/                          # shared job maps (all distros)
+    modules/                     # shared modules used by job maps
+    prepare-your-environment-mirroring.adoc   # example job map
+  microshift/                    # distro-specific category maps
+    navigation.adoc              # top-level nav
+    install.adoc                 # category map that includes job maps
+```
+
+Here is a real example of each file type:
+
+### Job map file (`maps/jobs/prepare-your-environment-mirroring.adoc`):
+
+@maps/jobs/prepare-your-environment-mirroring.adoc
+
+### Category map with job includes (`maps/microshift/install.adoc` from the JTBD branch):
+
+```asciidoc
+:_mod-docs-content-type: MAP
+
+= Install
+
+include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1,chunk="to-content",navtitle="Prepare your environment (mirroring)"]
+
+include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1,navtitle="Install with image mode for RHEL"]
+```
+
+### Intro concept module (`maps/jobs/modules/microshift-mirror-container-images.adoc`):
+
+@maps/jobs/modules/microshift-mirror-container-images.adoc
+
+## Procedure: do one first, then replicate
+
+**Do NOT create all jobs at once.** Follow this iterative approach:
+
+### Step 1: Create the first job
+
+Pick the first non-hidden job from the coverage map and create it:
+
+1. Create a new job map file in `maps/jobs/` named after the job
+   (kebab-case, e.g., `prepare-your-environment-mirroring.adoc`)
+
+2. The job map file must:
+   - Start with `:_mod-docs-content-type: MAP`
+   - Include modules from the coverage map using relative paths to
+     `modules/` (for modules in `maps/jobs/modules/`) or absolute paths
+     from repo root for modules elsewhere
+   - Use `leveloffset=+0` for the first module and `leveloffset=+1` for
+     subsequent modules
+   - Use `toc="no"` on all include statements
+
+3. **Intro concept module**: every job needs one as its first include.
+   - If a suitable existing concept module exists, use it as the first
+     include with `leveloffset=+0,toc="no"`
+   - If no suitable intro exists, create a new concept module in
+     `maps/jobs/modules/` with:
+     - Content type: CONCEPT
+     - A concise 1-2 sentence short description based on the Job Statement
+     - The `[role="_abstract"]` attribute
+   - The first module in the job map gets `chunk="to-content"` when
+     included in the **category map** (not in the job map itself)
+
+4. Add the job to the category map at
+   `maps/<distro>/<category>.adoc`:
+   ```asciidoc
+   include::jobs/<job-name>.adoc[leveloffset=+1,chunk="to-content",navtitle="<Job display name>"]
+   ```
+
+### Step 2: Show and confirm
+
+Present the created job map and category map entry to the user. Explain
+what modules were included and why. Wait for the user to review and
+confirm before continuing.
+
+### Step 3: Replicate for remaining jobs
+
+Only after the user confirms the first job looks good, create the remaining
+jobs following the same pattern. For each job:
+
+1. Create the job map file in `maps/jobs/`
+2. Create an intro concept module if needed
+3. Add the include to the category map
+
+Create the distro directory under `maps/` if it doesn't already exist
+(e.g., `maps/ocp/`).
+
+### Step 4: Summary
+
+After all jobs are created, provide a summary:
+- List of job map files created
+- List of new intro concept modules created
+- The updated category map content
+- Any jobs from the coverage map that were skipped and why
+
+## Important conventions
+
+- Job map filenames use kebab-case matching the job name
+- All modules in job maps use `toc="no"` in their include attributes
+- The `chunk="to-content"` attribute goes on the job include in the
+  **category map**, not on individual module includes within the job map
+- `navtitle` in the category map should match the human-readable job name
+- If the coverage map flags a job as having gaps (missing modules), note
+  this to the user rather than silently skipping content

--- a/.claude/skills/jtbd-create-jobs/SKILL.md
+++ b/.claude/skills/jtbd-create-jobs/SKILL.md
@@ -75,6 +75,12 @@ Pick the first non-hidden job from the coverage map and create it:
 
 2. The job map file must:
    - Start with `:_mod-docs-content-type: MAP`
+   - Set a `:context:` variable on the line after the content type,
+     using the job map filename without the `.adoc` extension
+     (e.g., `:context: prepare-your-environment-mirroring` for
+     `prepare-your-environment-mirroring.adoc`). This is required
+     because modules use `_{context}` in their IDs and each job
+     must produce unique IDs.
    - Include modules from the coverage map using relative paths to
      `modules/` (for modules in `maps/jobs/modules/`)
    - Use `leveloffset=+0` for the first module and `leveloffset=+1` for
@@ -82,12 +88,19 @@ Pick the first non-hidden job from the coverage map and create it:
    - Use `chunk="to-content"` on the intro concept module and `toc="no"` on all include statements
 
 3. **Intro concept module**: every job needs one as its first include.
-   - If a suitable existing concept module exists, use it as the first
-     include with `leveloffset=+0,chunk="to-content"`
-   - If no suitable intro exists, create a new concept module in
-     `maps/jobs/modules/` with:
+   - If a suitable existing concept module exists, use it as-is as the
+     first include with `leveloffset=+0,chunk="to-content"`. Do not
+     rename or modify the existing module's heading.
+   - If no suitable intro exists, check any existing assembly that is
+     relevant to this job for introductory content in its
+     abstract/shortdesc section. Use that content as the basis for the
+     new intro module.
+   - Create the new concept module in `maps/jobs/modules/` with:
      - Content type: CONCEPT
-     - A concise 1-2 sentence short description based on the Job Statement
+     - A heading that matches the job title
+     - A concise 1-2 sentence short description, sourced from the
+       relevant assembly's abstract/shortdesc if available, or based
+       on the Job Statement if no assembly content is suitable
      - The `[role="_abstract"]` attribute
 
 4. Add the job to the category map at

--- a/.claude/skills/jtbd-create-jobs/SKILL.md
+++ b/.claude/skills/jtbd-create-jobs/SKILL.md
@@ -33,7 +33,7 @@ The maps directory structure is:
 ```
 maps/
   jobs/                          # shared job maps (all distros)
-    modules/                     # shared modules used by job maps
+    modules -> ../../modules/                     # symlink to shared modules used by job maps
     prepare-your-environment-mirroring.adoc   # example job map
   microshift/                    # distro-specific category maps
     navigation.adoc              # top-level nav
@@ -53,9 +53,9 @@ Here is a real example of each file type:
 
 = Install
 
-include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1,chunk="to-content",navtitle="Prepare your environment (mirroring)"]
+include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1]
 
-include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1,navtitle="Install with image mode for RHEL"]
+include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1]
 ```
 
 ### Intro concept module (`maps/jobs/modules/microshift-mirror-container-images.adoc`):
@@ -76,27 +76,24 @@ Pick the first non-hidden job from the coverage map and create it:
 2. The job map file must:
    - Start with `:_mod-docs-content-type: MAP`
    - Include modules from the coverage map using relative paths to
-     `modules/` (for modules in `maps/jobs/modules/`) or absolute paths
-     from repo root for modules elsewhere
+     `modules/` (for modules in `maps/jobs/modules/`)
    - Use `leveloffset=+0` for the first module and `leveloffset=+1` for
      subsequent modules
-   - Use `toc="no"` on all include statements
+   - Use `chunk="to-content"` on the intro concept module and `toc="no"` on all include statements
 
 3. **Intro concept module**: every job needs one as its first include.
    - If a suitable existing concept module exists, use it as the first
-     include with `leveloffset=+0,toc="no"`
+     include with `leveloffset=+0,chunk="to-content"`
    - If no suitable intro exists, create a new concept module in
      `maps/jobs/modules/` with:
      - Content type: CONCEPT
      - A concise 1-2 sentence short description based on the Job Statement
      - The `[role="_abstract"]` attribute
-   - The first module in the job map gets `chunk="to-content"` when
-     included in the **category map** (not in the job map itself)
 
 4. Add the job to the category map at
    `maps/<distro>/<category>.adoc`:
    ```asciidoc
-   include::jobs/<job-name>.adoc[leveloffset=+1,chunk="to-content",navtitle="<Job display name>"]
+   include::jobs/<job-name>.adoc[leveloffset=+1]
    ```
 
 ### Step 2: Show and confirm
@@ -129,8 +126,7 @@ After all jobs are created, provide a summary:
 
 - Job map filenames use kebab-case matching the job name
 - All modules in job maps use `toc="no"` in their include attributes
-- The `chunk="to-content"` attribute goes on the job include in the
-  **category map**, not on individual module includes within the job map
-- `navtitle` in the category map should match the human-readable job name
+  except the concept topic that introduces the job
+- The `chunk="to-content"` attribute goes on the first include in the job map
 - If the coverage map flags a job as having gaps (missing modules), note
   this to the user rather than silently skipping content

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ dev_guide/builds/images/chained-build.png.cache
 bin
 commercial_package
 .vscode
-.claude
 .vale/
 !.vale/templates
 !.vale/config/vocabularies


### PR DESCRIPTION
This PR creates two skills:

1. **/jtbd-coverage-map**, which reads a CSV containing jobs and job statements for a given distro and category (IE MicroShift Install). When run from the root of the repo, it looks for relevant assemblies and modules and cross-references them with the job mappings to produce a list of modules to comprise the jobs. It stores them in a CSV in the working directory
2. **/jtbd-create-jobs**, which reads the CSV created by the previous step and builds out the relevant category map by creating the jobs from the mapping sheet. It includes the modules it found in the previous step, determines if one of those modules is a sufficient introductory concept topic, and creates an intro topic if not. It will also offer to convert module headings from gerund to imperative after completing the jobs.