### PR TITLE
Fix typo

### DIFF
--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -104,7 +104,7 @@ endif::[]
 +
 where:
 +
-* `<wwn_ID>`:: Indicates the WWN ID of the target multipathed device. For example, `0xx194e957fcedb4841`.
+`<wwn_ID>`:: Indicates the WWN ID of the target multipathed device. For example, `0xx194e957fcedb4841`.
 +
 This symlink can also be used as the `coreos.inst.install_dev` kernel argument when using special `coreos.inst.*` arguments to direct the live installer. For more information, see "Installing {op-system} and starting the {product-title} bootstrap process".
 


### PR DESCRIPTION
While working on https://redhat.atlassian.net/browse/OCPBUGS-112076, I noticed a formatting typo [introduced in 4.17](https://github.com/openshift/openshift-docs/pull/105378/changes#diff-d4372e61cf107136f64c7c5c728625482d15812b3a92512e2560e3ac94cc1f4aR77).

Previews:
Installing a user-provisioned cluster on bare metal -> [Enabling multipathing with kernel arguments on RHCOS](https://118432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#rhcos-enabling-multipath_installing-bare-metal)
Installing a user-provisioned bare metal cluster with network customizations -> [Enabling multipathing with kernel arguments on RHCOS](https://118432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#rhcos-enabling-multipath_installing-bare-metal-network-customizations)
Installing a user-provisioned bare metal cluster on a disconnected environment -> [Enabling multipathing with kernel arguments on RHCOS](https://118432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#rhcos-enabling-multipath_installing-restricted-networks-bare-metal)