### PR TITLE
OSDOCS#21658: Update the MicroShift RNs for 4.19.43

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -28,6 +28,8 @@ include::modules/microshift-4-19-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-19-asynchronous-errata-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-19-43-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-19-42-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-19-32-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-19-43-dp.adoc
+++ b/modules/microshift-4-19-43-dp.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-43-dp_{context}"]
+= RHSA-2026:54883 - {microshift-short} 4.19.43 fixed issue and security update advisory
+
+Issued: 19 August 2026
+
+[role="_abstract"]
+{product-title} release 4.19.43 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2026:54883[RHSA-2026:54883] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:54555[RHSA-2026:54555] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-43-dp-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-21658](https://redhat.atlassian.net/browse/OSDOCS-21658)

Link to docs preview:
[4.19.43](https://118440--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-43-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/738)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19?page=1)
