### PR TITLE
Remove 1.8 release notes include from main assembly

### DIFF
--- a/release_notes/ob-openshift-builds-release-notes.adoc
+++ b/release_notes/ob-openshift-builds-release-notes.adoc
@@ -29,8 +29,6 @@ include::modules/ob-compatibility-support-matrix.adoc[leveloffset=+1]
 // Modules included, most to least recent
 include::modules/ob-release-notes-1-9.adoc[leveloffset=+1]
 
-include::modules/ob-release-notes-1-8.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 [id="additional-resources_ob-openshift-builds-release-notes"]
 == Additional resources


### PR DESCRIPTION
## Summary
- Removes the include statement for `ob-release-notes-1-8.adoc` from the main release notes assembly file

Cherrypick to build-docs-1.9