### PR TITLE
Migration from source MTC 1.7.x to destination MTC 1.7.x is unsupported

### DIFF
--- a/modules/migration-mtc-release-notes-1-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8.adoc
@@ -87,7 +87,7 @@ This release has the following technical changes:
 * {mtc-first} 1.8.x only supports migrations from {product-title} 4.10 or later to {product-title} 4.10 or later. For migrations only involving cluster versions 4.10 and later, either 1.7.x or 1.8.x might be used. However, but it must be the same {mtc-short} 1.Y.z on both source and destination.
 ** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.8.x is unsupported.
 ** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is supported.
+** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is unsupported.
 ** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.8.x is supported.
 * {mtc-short} 1.8.x by default installs OADP 1.2.x.
 * Upgrading from {mtc-short} 1.7.x to {mtc-short} 1.8.0, requires manually changing the OADP channel to 1.2. If this is not done, the upgrade of the Operator fails.

--- a/modules/migration-mtc-release-notes-1-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8.adoc
@@ -84,13 +84,7 @@ This release has the following technical changes:
 * Migration from {mtc-short} 1.7.x to {mtc-short} 1.8.x is not supported.
 * You must use {mtc-short} 1.7.x to migrate anything with a source of {product-title} 4.9 or earlier.
 ** {mtc-short} 1.7.x must be used on both source and destination.
-* {mtc-first} 1.8.x only supports migrations from {product-title} 4.10 or later to {product-title} 4.10 or later. For migrations only involving cluster versions 4.10 and later, either 1.7.x or 1.8.x might be used. However, but it must be the same {mtc-short} 1.Y.z on both source and destination.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.8.x is unsupported.
-** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.8.x is supported.
+* {mtc-first} 1.8 supports migrations only from {product-title} 4.10 or later to {product-title} 4.10 or later. The source and destination must use the same {mtc-short} version.
 * {mtc-short} 1.8.x by default installs OADP 1.2.x.
 * Upgrading from {mtc-short} 1.7.x to {mtc-short} 1.8.0, requires manually changing the OADP channel to 1.2. If this is not done, the upgrade of the Operator fails.
-
-
 

--- a/modules/migration-upgrading-mtc-on-ocp-4.adoc
+++ b/modules/migration-upgrading-mtc-on-ocp-4.adoc
@@ -19,11 +19,7 @@ When upgrading the {mtc-short} by using the Operator Lifecycle Manager, you must
 * Migrating from {mtc-short} 1.7.x to {mtc-short} 1.8.x is not supported.
 * You must use {mtc-short} 1.7.x to migrate anything with a source of {product-title} 4.9 or earlier.
 ** {mtc-short} 1.7.x must be used on both source and destination.
-* {mtc-short} 1.8.x only supports migrations from {product-title} 4.10 or later to {product-title} 4.10 or later. For migrations only involving cluster versions 4.10 and later, either 1.7.x or 1.8.x may be used. However, it must be the same {mtc-short} version on both source & destination.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.8.x is unsupported.
-** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.8.x is supported
+* {mtc-first} 1.8 supports migrations only from {product-title} 4.10 or later to {product-title} 4.10 or later. The source and destination must use the same {mtc-short} version.
 
 .Prerequisites
 

--- a/modules/migration-upgrading-mtc-on-ocp-4.adoc
+++ b/modules/migration-upgrading-mtc-on-ocp-4.adoc
@@ -22,7 +22,7 @@ When upgrading the {mtc-short} by using the Operator Lifecycle Manager, you must
 * {mtc-short} 1.8.x only supports migrations from {product-title} 4.10 or later to {product-title} 4.10 or later. For migrations only involving cluster versions 4.10 and later, either 1.7.x or 1.8.x may be used. However, it must be the same {mtc-short} version on both source & destination.
 ** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.8.x is unsupported.
 ** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.7.x is unsupported.
-** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is supported.
+** Migration from source {mtc-short} 1.7.x to destination {mtc-short} 1.7.x is unsupported.
 ** Migration from source {mtc-short} 1.8.x to destination {mtc-short} 1.8.x is supported
 
 .Prerequisites


### PR DESCRIPTION
[MIG-1775](https://redhat.atlassian.net/browse/MIG-1775): https://redhat.atlassian.net/browse/MIG-1775 -- Change:  "Migration from source MTC 1.7.x to destination MTC 1.7.x is supported." To: "Migration from source MTC 1.7.x to destination MTC 1.7.x is unsupported."

Change made in text (requested) and in release notes (not requested, done for completeness) 

Version(s): OCP 4.19 

QE review: Jira specifies that QE is not needed. 

