### PR TITLE
OCPBUGS-61396: Add NTP prerequisite note to PTP Operator

### DIFF
--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -21,6 +21,7 @@ Engineering considerations::
 * RAN DU RDS configurations are provided for ordinary clocks, boundary clocks, grandmaster clocks, and highly available dual NIC boundary clocks.
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
+* Cluster nodes must have valid NTP configurations to establish accurate time before the PTP Operator takes ownership of node timing.
 * Use the PTP fast events REST API v2.
 The PTP fast events REST API v1 is deprecated.
 The REST API v2 is O-RAN Release 3 compliant.


### PR DESCRIPTION
Adds an NTP prerequisite note to the PTP Operator engineering considerations in the Telco RAN DU RDS.

Cluster nodes must have correct time via NTP before the PTP Operator takes ownership of node timing.

Backport of the note already present on `main` and `enterprise-4.21`. Mirrors the upstream RDS source change (internal GitLab MRs !137, !139, !140).

Tracked by: OCPBUGS-61396 / [TELCODOCS-2562](https://redhat.atlassian.net/browse/TELCODOCS-2562)