### PR TITLE
OCPBUGS-61396: Add NTP prerequisite note to PTP Operator

### DIFF
--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -43,4 +43,5 @@ Engineering considerations::
 ** Variations with and without HA
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
+* Cluster nodes must have valid NTP configurations to establish accurate time before the PTP Operator takes ownership of node timing.
 * The PTP fast events REST API v1 is end of life.


### PR DESCRIPTION
Adds an NTP prerequisite note to the PTP Operator engineering considerations in the Telco RAN DU RDS.

Cluster nodes must have correct time via NTP before the PTP Operator takes ownership of node timing.

Backport of the note already present on `main` and `enterprise-4.21`. Mirrors the upstream RDS source change (internal GitLab MRs !137, !139, !140).

Tracked by: OCPBUGS-61396 / [TELCODOCS-2562](https://redhat.atlassian.net/browse/TELCODOCS-2562)