### PR TITLE
[RHDEVDOCS-7709] Add OpenTelemetry observability metrics reference

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -91,7 +91,9 @@ Topics:
   File: using-tekton-results-for-openshift-pipelines-observability
 - Name: Understanding the Tekton Results retention policy
   File: understanding-the-tekton-results-retention-policy
----
+- Name: OpenTelemetry metrics reference
+  File: op-observability-metrics-reference
+  ---
 Name: Pipelines as Code
 Dir: pac
 Distros: openshift-pipelines

--- a/modules/op-observability-metrics-reference.adoc
+++ b/modules/op-observability-metrics-reference.adoc
@@ -1,0 +1,361 @@
+:_mod-docs-content-type: REFERENCE
+[id="op-observability-metrics-reference_{context}"]
+= OpenTelemetry observability metrics reference for OpenShift Pipelines
+
+OpenShift Pipelines exports component metrics in OpenTelemetry format. You can scrape and visualize these metrics using Prometheus, Grafana, or an OpenTelemetry Collector to monitor infrastructure health, pipeline execution rates, controller queue performance, and system resource utilization.
+
+== Core pipeline metrics
+
+.PipelineRun metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_pipelinerun_duration_seconds`
+| Histogram
+| Total execution time of PipelineRuns
+| `pipeline`, `pipelinerun`, `namespace`, `status`
+| seconds
+
+| `tekton_pipelines_pipelinerun_total`
+| Counter
+| Total number of PipelineRuns created
+| `pipeline`, `pipelinerun`, `namespace`, `status`, `reason`
+| count
+
+| `tekton_pipelines_running_pipelineruns`
+| Gauge
+| Number of PipelineRuns currently executing
+| `namespace`
+| count
+
+| `tekton_pipelines_running_pipelineruns_waiting_on_pipeline_resolution`
+| Gauge
+| Running PipelineRuns waiting for pipeline resolution
+| `namespace`
+| count
+
+| `tekton_pipelines_running_pipelineruns_waiting_on_task_resolution`
+| Gauge
+| Running PipelineRuns waiting for task resolution of TaskRun children
+| `namespace`
+| count
+|===
+
+.TaskRun metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_taskrun_duration_seconds`
+| Histogram
+| Total execution time of TaskRuns
+| `task`, `taskrun`, `namespace`, `status`
+| seconds
+
+| `tekton_pipelines_pipelinerun_taskrun_duration_seconds`
+| Histogram
+| Execution time of TaskRuns within a PipelineRun
+| `pipeline`, `pipelinerun`, `task`, `taskrun`, `namespace`, `status`
+| seconds
+
+| `tekton_pipelines_taskrun_total`
+| Counter
+| Total number of TaskRuns created
+| `task`, `taskrun`, `namespace`, `status`, `reason`
+| count
+
+| `tekton_pipelines_running_taskruns`
+| Gauge
+| Number of TaskRuns currently executing
+| `namespace`
+| count
+
+| `tekton_pipelines_running_taskruns_waiting_on_task_resolution_count`
+| Gauge
+| Running TaskRuns waiting for task resolution
+| `namespace`
+| count
+
+| `tekton_pipelines_running_taskruns_throttled_by_quota`
+| Gauge
+| TaskRuns throttled by Kubernetes ResourceQuotas
+| `namespace`
+| count
+
+| `tekton_pipelines_running_taskruns_throttled_by_node`
+| Gauge
+| TaskRuns throttled by Node-level constraints
+| `namespace`
+| count
+
+| `tekton_pipelines_taskruns_pod_latency_milliseconds`
+| Histogram
+| Scheduling latency for TaskRun pods (creation -> scheduling)
+| `task`, `taskrun`, `namespace`, `pod`
+| milliseconds
+|===
+
+== Controller infrastructure metrics
+
+.Reconciliation metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_controller_work_queue_depth`
+| Gauge
+| Current depth of controller work queue
+| `reconciler`
+| count
+
+| `tekton_pipelines_controller_reconcile_count`
+| Counter
+| Total number of reconcile operations performed
+| `reconciler`, `success`, `namespace`
+| count
+
+| `tekton_pipelines_controller_reconcile_latency`
+| Histogram
+| Latency of reconcile operations
+| `reconciler`, `success`, `namespace`
+| milliseconds
+|===
+
+[NOTE]
+====
+Reconciler label values include `pipelinerun.tekton.dev`, `taskrun.tekton.dev`, `pipeline.tekton.dev`, `task.tekton.dev`, and `resolutionrequest.resolution.tekton.dev`.
+====
+
+.Workqueue metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_controller_workqueue_adds_total`
+| Counter
+| Items added to workqueue
+| `name`
+| count
+
+| `tekton_pipelines_controller_workqueue_depth`
+| Gauge
+| Current workqueue depth
+| `name`
+| count
+
+| `tekton_pipelines_controller_workqueue_queue_latency_seconds`
+| Histogram
+| Time an item stays in queue before processing
+| `name`
+| seconds
+
+| `tekton_pipelines_controller_workqueue_retries_total`
+| Counter
+| Total retries handled by workqueue
+| `name`
+| count
+
+| `tekton_pipelines_controller_workqueue_work_duration_seconds`
+| Histogram
+| Time spent processing an item
+| `name`
+| seconds
+
+| `tekton_pipelines_controller_workqueue_unfinished_work_seconds`
+| Gauge
+| Total time unfinished items in flight
+| `name`
+| seconds
+
+| `tekton_pipelines_controller_workqueue_longest_running_processor_seconds`
+| Gauge
+| Longest item currently in flight
+| `name`
+| seconds
+|===
+
+[NOTE]
+====
+Workqueue name label values include `pipelinerun`, `taskrun`, `pipeline`, and `task`.
+====
+
+.Kubernetes client metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_controller_client_latency`
+| Histogram
+| Latency of Kubernetes API requests
+| `verb`, `host`, `resource`
+| seconds
+
+| `tekton_pipelines_controller_client_results`
+| Counter
+| Number of Kubernetes API requests by status code
+| `verb`, `host`, `resource`, `code`
+| count
+|===
+
+.Admission webhook metrics
+[cols="30%,10%,25%,20%,15%",options="header"]
+|===
+| Metric name | Type | Description | Labels | Unit
+
+| `tekton_pipelines_webhook_request_count`
+| Counter
+| Number of webhook requests received
+| `request_operation`, `kind_group`, `kind_version`, `kind_kind`, `resource_group`, `resource_version`, `resource_resource`, `resource_namespace`, `admission_allowed`
+| count
+
+| `tekton_pipelines_webhook_request_latencies`
+| Histogram
+| Response time for webhook requests
+| `request_operation`, `kind_group`, `kind_version`, `kind_kind`, `resource_group`, `resource_version`, `resource_resource`, `resource_namespace`, `admission_allowed`
+| milliseconds
+|===
+
+.Go runtime memory metrics
+[cols="35%,15%,35%,15%",options="header"]
+|===
+| Metric name | Type | Description | Unit
+
+| `tekton_pipelines_controller_go_alloc`
+| Gauge
+| Bytes of allocated heap objects
+| bytes
+
+| `tekton_pipelines_controller_go_total_alloc`
+| Counter
+| Cumulative bytes allocated for heap objects
+| bytes
+
+| `tekton_pipelines_controller_go_sys`
+| Gauge
+| Total bytes of memory obtained from OS
+| bytes
+
+| `tekton_pipelines_controller_go_heap_alloc`
+| Gauge
+| Bytes of allocated heap objects
+| bytes
+
+| `tekton_pipelines_controller_go_heap_sys`
+| Gauge
+| Bytes of heap memory obtained from OS
+| bytes
+
+| `tekton_pipelines_controller_go_heap_idle`
+| Gauge
+| Bytes in idle (unused) spans
+| bytes
+
+| `tekton_pipelines_controller_go_heap_inuse`
+| Gauge
+| Bytes in in-use spans
+| bytes
+
+| `tekton_pipelines_controller_go_heap_objects`
+| Gauge
+| Number of allocated heap objects
+| count
+
+| `tekton_pipelines_controller_go_num_gc`
+| Counter
+| Number of completed GC cycles
+| count
+
+| `tekton_pipelines_controller_go_gc_cpu_fraction`
+| Gauge
+| Fraction of CPU time used by GC
+| fraction
+|===
+
+[NOTE]
+====
+Similar memory metrics exist for the webhook component with the prefix `tekton_pipelines_webhook_go_*`.
+====
+
+== PromQL query examples
+
+[cols="30%,40%,30%",options="header"]
+|===
+| Query purpose | PromQL query | Description
+
+| PipelineRun success rate
+| `sum(rate(tekton_pipelines_pipelinerun_total{status="True"}[5m])) / sum(rate(tekton_pipelines_pipelinerun_total[5m]))`
+| Overall success rate across pipeline runs.
+
+| TaskRun failure count by namespace
+| `sum by (namespace) (tekton_pipelines_taskrun_total{status="False"})`
+| Failures per namespace.
+
+| Currently running PipelineRuns
+| `sum(tekton_pipelines_running_pipelineruns)`
+| Total active PipelineRuns.
+
+| Avg reconcile latency per controller
+| `histogram_quantile(0.5, sum by (reconciler, le) (rate(tekton_pipelines_controller_reconcile_latency_bucket[5m])))`
+| Median reconcile time.
+
+| Workqueue depth alert
+| `tekton_pipelines_controller_workqueue_depth > 100`
+| Alert trigger on high queue depth.
+
+| API client error rate
+| `sum by (verb, code) (rate(tekton_pipelines_controller_client_results{code!~"2.."}[5m]))`
+| Non-2xx API responses by verb.
+
+| TaskRun pod scheduling delays (P95)
+| `histogram_quantile(0.95, sum by (namespace, le) (rate(tekton_pipelines_taskruns_pod_latency_milliseconds_bucket[5m])))`
+| 95th percentile pod latency.
+
+| PipelineRuns waiting on resolution
+| `sum(tekton_pipelines_running_pipelineruns_waiting_on_pipeline_resolution) + sum(tekton_pipelines_running_pipelineruns_waiting_on_task_resolution)`
+| Total blocked PipelineRuns.
+
+| TaskRuns throttled by resources
+| `sum(tekton_pipelines_running_taskruns_throttled_by_quota) + sum(tekton_pipelines_running_taskruns_throttled_by_node)`
+| Resource-throttled TaskRuns.
+
+| Webhook request rate
+| `sum(rate(tekton_pipelines_webhook_request_count[5m])) by (request_operation, kind_kind)`
+| Webhook requests per operation.
+|===
+
+== Component metric endpoints
+
+[cols="20%,20%,20%,10%,10%,20%",options="header"]
+|===
+| Component | Service | Namespace | Port | Path | Example command
+
+| Pipeline Controller
+| `tekton-pipelines-controller`
+| `openshift-pipelines`
+| `9090`
+| `/metrics`
+| `kubectl get --raw /api/v1/namespaces/openshift-pipelines/services/tekton-pipelines-controller:9090/proxy/metrics`
+
+| Webhook
+| `tekton-pipelines-webhook`
+| `openshift-pipelines`
+| `9090`
+| `/metrics`
+| `kubectl get --raw /api/v1/namespaces/openshift-pipelines/services/tekton-pipelines-webhook:9090/proxy/metrics`
+
+| Events Controller
+| `tekton-events-controller`
+| `openshift-pipelines`
+| `9090`
+| `/metrics`
+| `kubectl get --raw /api/v1/namespaces/openshift-pipelines/services/tekton-events-controller:9090/proxy/metrics`
+|===
+
+== Metric prefix patterns
+
+* `tekton_pipelines_`: Core pipeline metrics (PipelineRuns, TaskRuns, execution counts).
+* `tekton_pipelines_controller_`: Controller infrastructure metrics (reconciliation, workqueues, Kubernetes client).
+* `tekton_pipelines_webhook_`: Webhook-specific metrics.
+* `tekton_pipelines_controller_go_`: Go runtime performance and memory metrics for controller.
+* `tekton_pipelines_webhook_go_`: Go runtime performance and memory metrics for webhook.

--- a/records/op-observability-metrics-reference.adoc
+++ b/records/op-observability-metrics-reference.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="op-observability-metrics-reference"]
+= OpenTelemetry metrics reference for OpenShift Pipelines
+include::_attributes/common-attributes.adoc[]
+:context: op-observability-metrics-reference
+
+toc::[]
+
+include::modules/op-observability-metrics-reference.adoc[leveloffset=+1]


### PR DESCRIPTION
**Jira Ticket**
[RHDEVDOCS-7709](https://redhat.atlassian.net/browse/RHDEVDOCS-7709)

**Target Release**
pipelines-docs-1.24

**Peer Review:**

**QE / SME Review**

Link: 

**Summary of Changes**
Added a comprehensive reference module and assembly for OpenTelemetry (OTel) observability metrics across OpenShift Pipelines 1.24 components:
* **Metrics Reference Module:** Added detailed metric tables for core `PipelineRun` and `TaskRun` executions, controller reconciliation loops, workqueues, Kubernetes client requests, admission webhooks, and Go runtime memory usage.
* **PromQL Examples & Endpoints:** Included practical PromQL queries for pipeline success rates and queue depth alerts, along with component metric scraping endpoints and port configurations.
* **Topic Map Integration:** Registered the new assembly under the `Observability in OpenShift Pipelines` section in `_topic_maps/_topic_map.yml`.



