### PR TITLE
[enterprise-5.0] OSDOCS-16991_h#CQA fixes for AWS UPI and shared modules

### DIFF
--- a/installing/installing_aws/upi/upi-aws-installation-reqs.adoc
+++ b/installing/installing_aws/upi/upi-aws-installation-reqs.adoc
@@ -6,10 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you begin an installation on infrastructure that you provision, be sure that your AWS environment meets the following installation requirements.
+[role="_abstract"]
+Before you install {product-title} on infrastructure that you provision, ensure that your {aws-first} environment meets the installation requirements.
 
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
+For a cluster that has user-provisioned infrastructure, you must deploy all of the required machines.
 
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+1]

--- a/modules/csr-management.adoc
+++ b/modules/csr-management.adoc
@@ -30,6 +30,6 @@
 = Certificate signing requests management
 
 [role="_abstract"]
-On user-provisioned infrastructure, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation when your cluster has limited access to automatic machine management. 
+On user-provisioned infrastructure, you must implement a mechanism for approving cluster certificate signing requests (CSRs) after installation when your cluster has limited access to automatic machine management.
 
-The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
+The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that kubelet credentials request because it cannot confirm that the correct machine issued the request. You must find and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.

--- a/modules/installation-aws-arm-tested-machine-types.adoc
+++ b/modules/installation-aws-arm-tested-machine-types.adoc
@@ -13,17 +13,15 @@
 = Tested instance types for AWS on 64-bit ARM infrastructures
 
 [role="_abstract"]
-There are several Amazon Web Services (AWS) 64-bit ARM instance types tested with {product-title}.
+To ensure cluster stability and performance, use one of the tested {aws-first} 64-bit ARM instance types for your {product-title} machines.
 
-The following AWS 64-bit ARM instance types have been tested with {product-title}.
+The following {aws-short} 64-bit ARM instance types have been tested with {product-title}.
 
 [NOTE]
 ====
-Use the machine types included in the following charts for your AWS ARM instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation".
+Use the machine types included in the following charts for your {aws-short} ARM instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements listed in "Minimum resource requirements for cluster installation".
 ====
 
-.Machine types based on 64-bit ARM architecture
-[%collapsible]
-====
+*Machine types based on 64-bit ARM architecture*
+
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/docs/user/aws/tested_instance_types_aarch64.md[]
-====

--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -27,7 +27,7 @@ endif::[]
 = Obtaining an AWS Marketplace image
 
 [role="_abstract"]
-If you are deploying an {product-title} cluster using an AWS Marketplace image, you must first subscribe through AWS. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy compute nodes.
+If you are deploying an {product-title} cluster by using an {aws-first} Marketplace image, you must first subscribe through {aws-short}. Subscribing to the offer provides you with the Amazon Machine Image (AMI) ID that the installation program uses to deploy compute nodes.
 
 :platform-abbreviation: an AWS
 :platform-abbreviation-short: AWS
@@ -38,20 +38,20 @@ include::snippets/installation-marketplace-note.adoc[]
 
 .Prerequisites
 
-* You have an AWS account to purchase the offer. This account does not have to be the same account that is used to install the cluster.
+* You have an {aws-short} account to buy the offer. This account does not have to be the same account that you use to install the cluster.
 
 .Procedure
 
-. Complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace].
+. Complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[{aws-short} Marketplace].
 ifdef::ipi[]
-. Record the AMI ID for your specific AWS Region. As part of the installation process, you must update the `install-config.yaml` file with this value before deploying the cluster.
+. Record the AMI ID for your specific {aws-short} region. As part of the installation process, you must update the `install-config.yaml` file with this value before deploying the cluster.
 endif::ipi[]
 ifdef::upi[]
-. Record the AMI ID for your specific AWS Region. If you use the CloudFormation template to deploy your compute nodes, you must update the `worker0.type.properties.ImageID` parameter with the AMI ID value.
+. Record the AMI ID for your specific {aws-short} region. If you use the CloudFormation template to deploy your compute nodes, you must update the `worker0.type.properties.ImageID` parameter with the AMI ID value.
 endif::upi[]
 +
 ifdef::ipi[]
-.Sample `install-config.yaml` file with AWS Marketplace compute nodes
+.Sample `install-config.yaml` file with {aws-short} Marketplace compute nodes
 
 [source,yaml]
 ----
@@ -76,9 +76,12 @@ pullSecret: '{"auths": ...}'
 +
 where:
 
-`compute.platform.aws.amiID`:: Specifies the AMI ID from your AWS Marketplace subscription.
-`platform.aws.region`:: Specifies the `platform.aws.region` parameter. Your AMI ID is associated with a specific AWS Region. When creating the installation configuration file, ensure that you select the same AWS Region that you specified when configuring your subscription.
+`compute.platform.aws.amiID`:: Specifies the AMI ID from your {aws-short} Marketplace subscription.
+`platform.aws.region`:: Specifies the `platform.aws.region` parameter. Your AMI ID is associated with a specific {aws-short} region. When creating the installation configuration file, ensure that you select the same {aws-short} region that you specified when configuring your subscription.
 endif::ipi[]
+
+:!platform-abbreviation:
+:!platform-abbreviation-short:
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :!ipi:

--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -9,19 +9,17 @@
 = Required {aws-short} permissions for the IAM user
 
 [role="_abstract"]
-To deploy all components of an {product-title} cluster, you must grant the all the required permissions to the IAM user that you create in {aws-first}.
+To deploy all components of an {product-title} cluster, you must grant all the required permissions to the IAM user that you create in {aws-first}.
 
 [NOTE]
 ====
 Your IAM user must have the permission `tag:GetResources` in the region `us-east-1` to delete the base cluster resources. As part of the {aws-short} API requirement, the {product-title} installation program performs various actions in this region.
 ====
 
-When you attach the `AdministratorAccess` policy to the IAM user that you create in {aws-first}, you grant that user all of the required permissions. To deploy all components of an {product-title}
-cluster, the IAM user requires the following permissions:
+When you attach the `AdministratorAccess` policy to the IAM user that you create in {aws-short}, you grant that user all of the required permissions. To deploy all components of an {product-title} cluster, the IAM user requires the following permissions:
 
-.Required EC2 permissions for installation
-[%collapsible]
-====
+*Required EC2 permissions for installation*
+
 * `ec2:AttachNetworkInterface`
 * `ec2:AuthorizeSecurityGroupEgress`
 * `ec2:AuthorizeSecurityGroupIngress`
@@ -50,7 +48,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:DescribeNetworkAcls`
 * `ec2:DescribeNetworkInterfaces`
 * `ec2:DescribePrefixLists`
-* `ec2:DescribePublicIpv4Pools` (only required if `publicIpv4Pool` is specified in `install-config.yaml`)
+* `ec2:DescribePublicIpv4Pools` (only required if you specify `publicIpv4Pool` in `install-config.yaml`)
 * `ec2:DescribeRegions`
 * `ec2:DescribeRouteTables`
 * `ec2:DescribeSecurityGroupRules`
@@ -63,7 +61,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:DescribeVpcClassicLinkDnsSupport`
 * `ec2:DescribeVpcEndpoints`
 * `ec2:DescribeVpcs`
-* `ec2:DisassociateAddress` (only required if `publicIpv4Pool` is specified in `install-config.yaml`)
+* `ec2:DisassociateAddress` (only required if you specify `publicIpv4Pool` in `install-config.yaml`)
 * `ec2:GetEbsDefaultKmsKeyId`
 * `ec2:ModifyInstanceAttribute`
 * `ec2:ModifyNetworkInterfaceAttribute`
@@ -71,11 +69,9 @@ cluster, the IAM user requires the following permissions:
 * `ec2:RevokeSecurityGroupIngress`
 * `ec2:RunInstances`
 * `ec2:TerminateInstances`
-====
 
-.Required permissions for creating network resources during installation
-[%collapsible]
-====
+*Required permissions for creating network resources during installation*
+
 * `ec2:AllocateAddress`
 * `ec2:AssociateAddress`
 * `ec2:AssociateDhcpOptions`
@@ -93,14 +89,12 @@ cluster, the IAM user requires the following permissions:
 * `ec2:ModifyVpcAttribute`
 
 [NOTE]
-=====
+====
 If you use an existing Virtual Private Cloud (VPC), your account does not require these permissions for creating network resources.
-=====
 ====
 
-.Required Elastic Load Balancing permissions (ELB) for installation
-[%collapsible]
-====
+*Required Elastic Load Balancing permissions (ELB) for installation*
+
 * `elasticloadbalancing:AddTags`
 * `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer`
 * `elasticloadbalancing:AttachLoadBalancerToSubnets`
@@ -128,14 +122,12 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `elasticloadbalancing:SetSecurityGroups`
 
 [IMPORTANT]
-=====
+====
 {product-title} uses both the ELB and ELBv2 API services to provision load balancers. The permission list shows permissions required by both services. A known issue exists in the {aws-short} web console where both services use the same `elasticloadbalancing` action prefix but do not recognize the same actions. You can ignore the warnings about the service not recognizing certain `elasticloadbalancing` actions.
-=====
 ====
 
-.Required IAM permissions for installation
-[%collapsible]
-====
+*Required IAM permissions for installation*
+
 * `iam:AddRoleToInstanceProfile`
 * `iam:CreateInstanceProfile`
 * `iam:CreateRole`
@@ -157,16 +149,14 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `iam:TagRole`
 
 [NOTE]
-=====
+====
 * If you specify an existing IAM role in the `install-config.yaml` file, the following IAM permissions are not required: `iam:CreateRole`,`iam:DeleteRole`, `iam:DeleteRolePolicy`, and `iam:PutRolePolicy`.
 
 * If you have not created a load balancer in your {aws-short} account, the IAM user also requires the `iam:CreateServiceLinkedRole` permission.
-=====
 ====
 
-.Required Route 53 permissions for installation
-[%collapsible]
-====
+*Required Route 53 permissions for installation*
+
 * `route53:ChangeResourceRecordSets`
 * `route53:ChangeTagsForResource`
 * `route53:CreateHostedZone`
@@ -178,11 +168,9 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `route53:ListResourceRecordSets`
 * `route53:ListTagsForResource`
 * `route53:UpdateHostedZoneComment`
-====
 
-.Required Amazon Simple Storage Service (S3) permissions for installation
-[%collapsible]
-====
+*Required Amazon Simple Storage Service (S3) permissions for installation*
+
 * `s3:CreateBucket`
 * `s3:DeleteBucket`
 * `s3:GetAccelerateConfiguration`
@@ -204,11 +192,9 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `s3:PutBucketPolicy`
 * `s3:PutBucketTagging`
 * `s3:PutEncryptionConfiguration`
-====
 
-.S3 permissions that cluster Operators require
-[%collapsible]
-====
+*S3 permissions that cluster Operators require*
+
 * `s3:DeleteObject`
 * `s3:GetObject`
 * `s3:GetObjectAcl`
@@ -217,11 +203,9 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `s3:PutObject`
 * `s3:PutObjectAcl`
 * `s3:PutObjectTagging`
-====
 
-.Required permissions to delete base cluster resources
-[%collapsible]
-====
+*Required permissions to delete base cluster resources*
+
 * `autoscaling:DescribeAutoScalingGroups`
 * `ec2:DeleteNetworkInterface`
 * `ec2:DeletePlacementGroup`
@@ -238,11 +222,9 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `s3:DeleteObject`
 * `s3:ListBucketVersions`
 * `tag:GetResources`
-====
 
-.Required permissions to delete network resources
-[%collapsible]
-====
+*Required permissions to delete network resources*
+
 * `ec2:DeleteDhcpOptions`
 * `ec2:DeleteInternetGateway`
 * `ec2:DeleteNatGateway`
@@ -257,14 +239,12 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `ec2:ReplaceRouteTableAssociation`
 
 [NOTE]
-=====
+====
 If you use an existing VPC, your account does not require these permissions to delete network resources. Instead, your account only requires the `tag:UntagResources` permission to delete network resources.
-=====
 ====
 
-.Optional permissions for installing a cluster with a custom Key Management Service (KMS) key
-[%collapsible]
-====
+*Optional permissions for installing a cluster with a custom Key Management Service (KMS) key*
+
 * `kms:CreateGrant`
 * `kms:Decrypt`
 * `kms:DescribeKey`
@@ -275,26 +255,20 @@ If you use an existing VPC, your account does not require these permissions to d
 * `kms:RevokeGrant`
 
 [NOTE]
-=====
-If you provide an Amazon Machine Image (AMI) that is encrypted with a customer-managed key, you must provide the `kms:ReEncrypt*` permissions in addition to these permissions.
-=====
+====
+If you use an Amazon Machine Image (AMI) encrypted with a customer-managed key, you must grant the `kms:ReEncrypt*` permissions in addition to these permissions.
 ====
 
-.Required permissions to delete a cluster with shared instance roles
-[%collapsible]
-====
+*Required permissions to delete a cluster with shared instance roles*
+
 * `iam:UntagRole`
-====
 
-.Required permissions to delete a cluster with shared instance profiles
-[%collapsible]
-====
+*Required permissions to delete a cluster with shared instance profiles*
+
 * `tag:UntagResources`
-====
 
-.Additional IAM and S3 permissions that are required to create manifests
-[%collapsible]
-====
+*Additional IAM and S3 permissions required to create manifests*
+
 * `iam:GetUserPolicy`
 * `iam:ListAccessKeys`
 * `iam:PutUserPolicy`
@@ -307,39 +281,28 @@ If you provide an Amazon Machine Image (AMI) that is encrypted with a customer-m
 * `s3:PutLifecycleConfiguration`
 
 [NOTE]
-=====
+====
 If you are managing your cloud provider credentials with mint mode, the IAM user also requires the `iam:CreateAccessKey` and `iam:CreateUser` permissions.
-=====
 ====
 
-.Optional permissions for instance and quota checks for installation
-[%collapsible]
-====
+*Optional permissions for instance and quota checks for installation*
+
 * `servicequotas:ListAWSDefaultServiceQuotas`
-====
 
-.Optional permissions for the cluster owner account when installing a cluster on a shared VPC
-[%collapsible]
-====
+*Optional permissions for the cluster owner account when installing a cluster on a shared VPC*
+
 * `sts:AssumeRole`
-====
 
-.Required permissions for enabling Bring your own public IPv4 addresses (BYOIP) feature for installation
-[%collapsible]
-====
+*Required permissions for enabling Bring your own public IPv4 addresses (BYOIP) feature for installation*
+
 * `ec2:DescribePublicIpv4Pools`
 * `ec2:DisassociateAddress`
-====
 
-.Required permissions to install a cluster with dual-stack networking
-[%collapsible]
-====
+*Required permissions to install a cluster with dual-stack networking*
+
 * `ec2:DescribeEgressOnlyInternetGateways`
 * `ec2:CreateEgressOnlyInternetGateway`
-====
 
-.Required permissions to delete a cluster with dual-stack networking
-[%collapsible]
-====
+*Required permissions to delete a cluster with dual-stack networking*
+
 * `ec2:DeleteEgressOnlyInternetGateway`
-====

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -27,55 +27,48 @@ endif::[]
 = Tested instance types for AWS
 
 [role="_abstract"]
-There are several Amazon Web Services (AWS) instance types tested with {product-title}.
+To ensure cluster stability and performance, use one of the tested {aws-first} instance types for your {product-title} machines.
 
-The following AWS instance types have been tested with
+The following {aws-short} instance types have been tested with
 ifndef::local-zone,wavelength-zone[]
 {product-title}.
 endif::local-zone,wavelength-zone[]
 ifdef::local-zone[]
-{product-title} for use with AWS Local Zones.
+{product-title} for use with {aws-short} Local Zones.
 endif::local-zone[]
 ifdef::wavelength-zone[]
-{product-title} for use with AWS Wavelength Zones.
+{product-title} for use with {aws-short} Wavelength Zones.
 endif::wavelength-zone[]
 
 [NOTE]
 ====
-Use the machine types included in the following charts for your AWS instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in the section named "Minimum resource requirements for cluster installation".
+Use the machine types included in the following charts for your {aws-short} instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements in "Minimum resource requirements for cluster installation".
 ====
 
 ifndef::local-zone,wavelength-zone,secretregion[]
-.Machine types based on 64-bit x86 architecture
-[%collapsible]
-====
+*Machine types based on 64-bit x86 architecture*
+
 include::https://raw.githubusercontent.com/openshift/installer/release-4.22/docs/user/aws/tested_instance_types_x86_64.md[]
-====
 endif::local-zone,wavelength-zone,secretregion[]
 ifdef::local-zone[]
-.Machine types based on 64-bit x86 architecture for AWS Local Zones
-[%collapsible]
-====
+*Machine types based on 64-bit x86 architecture for {aws-short} Local Zones*
+
 * `c5.*`
 * `c5d.*`
 * `m6i.*`
 * `m5.*`
 * `r5.*`
 * `t3.*`
-====
 endif::local-zone[]
 ifdef::wavelength-zone[]
-.Machine types based on 64-bit x86 architecture for AWS Wavelength Zones
-[%collapsible]
-====
+*Machine types based on 64-bit x86 architecture for {aws-short} Wavelength Zones*
+
 * `r5.*`
 * `t3.*`
-====
 endif::wavelength-zone[]
 ifdef::secretregion[]
-.Machine types based on 64-bit x86 architecture for secret regions
-[%collapsible]
-====
+*Machine types based on 64-bit x86 architecture for secret regions*
+
 * `c4.*`
 * `c5.*`
 * `i3.*`
@@ -84,7 +77,6 @@ ifdef::secretregion[]
 * `r4.*`
 * `r5.*`
 * `t3.*`
-====
 endif::secretregion[]
 
 ifeval::["{context}" == "installing-aws-localzone"]

--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -46,7 +46,7 @@ The smallest {product-title} clusters require the following hosts:
 
 [IMPORTANT]
 ====
-For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
+For a cluster that has user-provisioned infrastructure, you must deploy all of the required machines.
 ====
 
 .Minimum required hosts
@@ -56,9 +56,7 @@ For a cluster that contains user-provisioned infrastructure, you must deploy all
 |Hosts |Description
 
 |One temporary bootstrap machine
-|The cluster requires the bootstrap machine to deploy the {product-title} cluster
-on the three control plane machines. You can remove the bootstrap machine after
-you install the cluster.
+|The cluster requires the bootstrap machine to deploy the {product-title} cluster on the three control plane machines. You can remove the bootstrap machine after you install the cluster.
 
 |Three control plane machines
 |The control plane machines run the Kubernetes and {product-title} services that form the control plane.
@@ -81,20 +79,19 @@ ifdef::ibm-z[]
 To improve high availability of your cluster, distribute the control plane machines over different hypervisor instances on at least two physical machines.
 endif::ibm-z[]
 ifndef::ibm-z[]
-To maintain high availability of your cluster, use separate physical hosts for
-these cluster machines.
+To keep high availability of your cluster, use separate physical hosts for these cluster machines.
 endif::ibm-z[]
 ====
 
 ifndef::ibm-z,ibm-power[]
-The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first}, {op-system-base-full} 8.6 and later.
+The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can use {op-system-first}, {op-system-base-full} 8.6 and later.
 endif::ibm-z,ibm-power[]
 ifdef::ibm-z,ibm-power[]
 The bootstrap, control plane, and compute machines must use {op-system-first} as the operating system.
 endif::ibm-z,ibm-power[]
 
 ifndef::openshift-origin[]
-Note that {op-system} is based on {op-system-base-full} 9.8 and inherits all of its hardware certifications and requirements.
+{op-system} is based on {op-system-base-full} 9.8 and inherits all of its hardware certifications and requirements.
 endif::[]
 See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux technology capabilities and limits].
 

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -116,14 +116,14 @@ endif::[]
 = Minimum resource requirements for cluster installation
 
 [role="_abstract"]
-Each created cluster must meet minimum requirements so that the cluster runs as expected.
+To ensure that your {product-title} cluster runs as expected, each cluster machine must meet minimum CPU, memory, and storage requirements.
 
 .Minimum resource requirements
 [cols="2,2,2,2,2,2",options="header"]
 |===
 
 |Machine
-|Operating System
+|Operating system
 ifndef::bare-metal,ipi-bare-metal[]
 |vCPU
 |Virtual RAM
@@ -199,26 +199,26 @@ ifdef::ibm-z[]
 * One physical core (IFL) provides two logical cores (threads) when SMT-2 is enabled. The hypervisor can provide two or more vCPUs.
 endif::ibm-z[]
 ifdef::bare-metal,ipi-bare-metal[]
-* One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
+* One CPU is equal to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
 endif::bare-metal,ipi-bare-metal[]
 ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
-* One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
+* One vCPU is equal to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
 endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
 ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
-* {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
-* As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
+* {product-title} and Kubernetes are sensitive to disk performance, and Red Hat recommends faster storage, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. On many cloud platforms, storage size and IOPS scale together, so you might need to provision more storage to get enough performance.
+* As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. {product-title} 4.10 and later do not support {op-system-base} 7 compute machines.
 endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
 ifdef::ibm-power,ipi-bare-metal[]
-* {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
+* {product-title} and Kubernetes are sensitive to disk performance, and Red Hat recommends faster storage, particularly for etcd on the control plane nodes. On many cloud platforms, storage size and IOPS scale together, so you might need to provision more storage to get enough performance.
 endif::ibm-power,ipi-bare-metal[]
 ifdef::vsphere[]
-* {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
-* As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
+* {product-title} and Kubernetes are sensitive to disk performance, and Red Hat recommends faster storage, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. On many cloud platforms, storage size and IOPS scale together, so you might need to provision more storage to get enough performance.
+* As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. {product-title} 4.10 and later do not support {op-system-base} 7 compute machines.
 endif::vsphere[]
 --
 [NOTE]
 ====
-For {product-title} version 4.22, {op-system} is based on {op-system-base} version 9.8, which has the micro-architecture requirements. The following list contains the minimum instruction set architectures (ISA) that each architecture requires:
+In {product-title} version 4.22, {op-system} uses {op-system-base} version 9.8, which updates the micro-architecture requirements. Each architecture requires the following minimum instruction set architectures (ISA):
 
 * x86-64 architecture requires x86-64-v2 ISA
 * ARM64 architecture requires ARMv8.0-A ISA
@@ -231,7 +231,7 @@ For more information, see link:https://access.redhat.com/documentation/en-us/red
 ifdef::azure[]
 [IMPORTANT]
 ====
-You are required to use Azure virtual machines that have the `premiumIO` parameter set to `true`.
+You must use Azure virtual machines that have the `premiumIO` parameter set to `true`.
 ====
 endif::azure[]
 
@@ -242,9 +242,9 @@ ifdef::vsphere[]
 ====
 Do not use memory ballooning in {product-title} clusters. Memory ballooning can cause cluster-wide instabilities, service degradation, or other undefined behaviors.
 
-* Control plane machines should have committed memory equal to or greater than the published minimum resource requirements for a cluster installation.
+* Control plane machines must have committed memory equal to or greater than the published minimum resource requirements for a cluster installation.
 
-* Compute machines should have a minimum reservation equal to or greater than the published minimum resource requirements for a cluster installation.
+* Compute machines must have a minimum reservation equal to or greater than the published minimum resource requirements for a cluster installation.
 
 These minimum CPU and memory requirements do not account for resources required by user workloads.
 

--- a/modules/installation-registry-storage-non-production.adoc
+++ b/modules/installation-registry-storage-non-production.adoc
@@ -19,7 +19,7 @@
 = Configuring storage for the image registry in non-production clusters
 
 [role="_abstract"]
-You must configure storage for the Image Registry Operator. For non-production clusters, you can set the image registry to an empty directory. If you do so, all images are lost if you restart the registry.
+You must configure storage for the Image Registry Operator. For non-production clusters, you can set the image registry to an empty directory, but you lose all images if you restart the registry.
 
 .Procedure
 
@@ -35,9 +35,9 @@ $ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --pa
 Configure this option only for non-production clusters.
 ====
 +
-If you run this command before the Image Registry Operator initializes its
-components, the `oc patch` command fails with the following error:
+If you run this command before the Image Registry Operator initializes its components, the `oc patch` command fails with the following error:
 +
+.Example output
 [source,terminal]
 ----
 Error from server (NotFound): configs.imageregistry.operator.openshift.io "cluster" not found

--- a/modules/installation-three-node-cluster.adoc
+++ b/modules/installation-three-node-cluster.adoc
@@ -48,7 +48,7 @@ ifdef::ibm-z,ibm-z-kvm[]
 To create smaller, resource-efficient clusters for testing and production, deploy a bare-metal cluster with zero compute machines in a minimal three-node cluster. This optional configuration uses only three control plane machines, optimizing infrastructure resources for testing, development, and production purposes.
 endif::ibm-z,ibm-z-kvm[]
 
-In three-node {product-title} environments, the three control plane machines are schedulable, which means that your application workloads are scheduled to run on them.
+In three-node {product-title} environments, the three control plane machines are schedulable, which means that your application workloads run on them.
 
 .Prerequisites
 
@@ -69,13 +69,13 @@ compute:
 +
 [NOTE]
 ====
-You must set the value of the `replicas` parameter for the compute machines to `0` when you install {product-title} on user-provisioned infrastructure, regardless of the number of compute machines you are deploying. In installer-provisioned installations, the parameter controls the number of compute machines that the cluster creates and manages for you. This does not apply to user-provisioned installations, where the compute machines are deployed manually.
+You must set the value of the `replicas` parameter for the compute machines to `0` when you install {product-title} on user-provisioned infrastructure, regardless of the number of compute machines you deploy. In installer-provisioned installations, the parameter controls the number of compute machines that the cluster creates and manages for you. This does not apply to user-provisioned installations, where you deploy the compute machines manually.
 ====
 ifdef::ibm-z,ibm-z-kvm[]
 +
 [NOTE]
 ====
-The preferred resource for control plane nodes is six vCPUs and 21 GB. For three control plane nodes this is the memory + vCPU equivalent of a minimum five-node cluster. You should back the three nodes, each installed on a 120 GB disk, with three IFLs that are SMT2 enabled. The minimum tested setup is three vCPUs and 10 GB on a 120 GB disk for each control plane node.
+The preferred resource for control plane nodes is six vCPUs and 21 GB. For three control plane nodes this is the memory + vCPU equivalent of a minimum five-node cluster. Back the three nodes, each installed on a 120 GB disk, with three IFLs that are SMT2 enabled. The minimum tested setup is three vCPUs and 10 GB on a 120 GB disk for each control plane node.
 ====
 endif::ibm-z,ibm-z-kvm[]
 .Next steps

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -119,29 +119,27 @@ endif::[]
 = Creating the Kubernetes manifest and Ignition config files
 
 [role="_abstract"]
-To customize cluster definitions and manually start machines, generate the Kubernetes manifest and Ignition config files.
+Because you manually provision infrastructure, you must generate the Kubernetes manifest and Ignition config files that the cluster requires.
 
-The installation configuration file transforms into the Kubernetes manifests. The manifests wrap into the Ignition configuration files, which are later used to configure the cluster machines.
+The installation program converts the installation configuration into Kubernetes manifests and then wraps them into Ignition configuration files. You use these Ignition files to configure the cluster machines.
 
 [IMPORTANT]
 ====
-* The Ignition config files that the {product-title} installation program generates contain certificates that expire after 24 hours, which are then renewed at that time. If the cluster is shut down before renewing the certificates and the cluster is later restarted after the 24 hours have elapsed, the cluster automatically recovers the expired certificates. The exception is that you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. See the documentation for _Recovering from expired control plane certificates_ for more information.
+* The Ignition config files that the {product-title} installation program generates contain certificates that expire after 24 hours, which the system then renews. If you shut down the cluster before the system renews the certificates and you later restart the cluster after the 24 hours have elapsed, the cluster automatically recovers the expired certificates. The exception is that you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. See the documentation for _Recovering from expired control plane certificates_ for more information.
 
-* It is recommended that you use Ignition config files within 12 hours after they are generated because the 24-hour certificate rotates from 16 to 22 hours after the cluster is installed. By using the Ignition config files within 12 hours, you can avoid installation failure if the certificate update runs during installation.
+* Use Ignition config files within 12 hours after you generate them, because the 24-hour certificate rotates from 16 to 22 hours after you install the cluster. By using the Ignition config files within 12 hours, you can avoid installation failure if the certificate update runs during installation.
 ====
 
 ifdef::ibm-z[]
 [NOTE]
 ====
-The installation program that generates the manifest and Ignition files is architecture specific and can be obtained from the
-link:https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/latest/[client image mirror]. The Linux version of the installation program runs on s390x only. This installer program is also available as a macOS version.
+The installation program that generates the manifest and Ignition files is architecture specific. You can obtain it from the link:https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/latest/[client image mirror]. The Linux version of the installation program runs on s390x only. This installation program is also available as a macOS version.
 ====
 endif::ibm-z[]
 ifdef::ibm-power[]
 [NOTE]
 ====
-The installation program that generates the manifest and Ignition files is architecture specific and can be obtained from the
-link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/[client image mirror]. The Linux version of the installation program (without an architecture postfix) runs on ppc64le only. This installer program is also available as a macOS version.
+The installation program that generates the manifest and Ignition files is architecture specific. You can obtain it from the link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/[client image mirror]. The Linux version of the installation program (without an architecture postfix) runs on ppc64le only. This installation program is also available as a macOS version.
 ====
 endif::ibm-power[]
 
@@ -164,7 +162,7 @@ endif::gcp[]
 $ ./openshift-install create manifests --dir <installation_directory>
 ----
 +
-where
+where:
 +
 `<installation_directory>`:: Specifies the installation directory that contains the `install-config.yaml` file you created.
 
@@ -190,8 +188,7 @@ endif::aws,ash,azure,gcp[]
 
 ifdef::gcp[]
 ifndef::user-infra-vpc[]
-. Optional: If you do not want the cluster to provision compute machines, remove
-the Kubernetes manifest files that define the worker machines:
+. Optional: If you do not want the cluster to provision compute machines, remove the Kubernetes manifest files that define the worker machines:
 endif::user-infra-vpc[]
 endif::gcp[]
 ifdef::aws,azure,ash,user-infra-vpc[]
@@ -233,24 +230,21 @@ If you are installing a three-node cluster, skip the following step to allow the
 +
 [IMPORTANT]
 ====
-When you configure control plane nodes from the default unschedulable to schedulable, additional subscriptions are required. This is because control plane nodes then become compute nodes.
+When you configure control plane nodes from the default unschedulable to schedulable, you require additional subscriptions because control plane nodes then become compute nodes.
 ====
 endif::baremetal,baremetal-restricted,ibm-z,ibm-power,three-node-cluster[]
 
-. Check that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file is set to `false`. This setting prevents pods from being scheduled on the control plane machines:
+. Verify that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file is set to `false`. This setting prevents pods from being scheduled on the control plane machines:
 +
 .. Open the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` file.
 +
-.. Locate the `mastersSchedulable` parameter and ensure that it is set to `false`.
+.. Locate the `mastersSchedulable` parameter and verify that it is set to `false`.
 +
 .. Save and exit the file.
 
 ifdef::gcp,aws,azure,ash[]
 ifndef::user-infra-vpc[]
-. Optional: If you do not want
-link:https://github.com/openshift/cluster-ingress-operator[the Ingress Operator]
-to create DNS records on your behalf, remove the `privateZone` and `publicZone`
-sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
+. Optional: If you do not want link:https://github.com/openshift/cluster-ingress-operator[the Ingress Operator] to create DNS records on your behalf, remove the `privateZone` and `publicZone` sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
 endif::user-infra-vpc[]
 ifdef::user-infra-vpc[]
 . Remove the `privateZone` sections from the `<installation_directory>/manifests/cluster-dns-02-config.yml` DNS configuration file:
@@ -268,7 +262,7 @@ spec:
   privateZone:
     id: mycluster-100419-private-zone
 ifndef::user-infra-vpc[]
-  publicZone: <1>
+  publicZone:
     id: example.openshift.com
 endif::user-infra-vpc[]
 status: {}
@@ -347,9 +341,7 @@ Later, you must update your bootstrap ignition to include the CA.
 endif::ash[]
 
 ifdef::azure-user-infra[]
-. When configuring Azure on user-provisioned infrastructure, you must export
-some common variables defined in the manifest files to use later in the Azure
-Resource Manager (ARM) templates:
+. When you configure Azure on user-provisioned infrastructure, you must export some common variables defined in the manifest files to use later in the Azure Resource Manager (ARM) templates:
 +
 .. Export the infrastructure ID by using the following command:
 +
@@ -360,7 +352,7 @@ $ export INFRA_ID=<infra_id>
 +
 where:
 +
-`<infra_id>`:: Specifies that the {product-title} cluster has been assigned an identifier (`INFRA_ID`) in the form of `<cluster_name>-<random_string>`. This identifier is used as the base name for most resources created using the provided ARM templates. This is the value of the `.status.infrastructureName` attribute from the `manifests/cluster-infrastructure-02-config.yml` file.
+`<infra_id>`:: Specifies the {product-title} cluster identifier (`INFRA_ID`) in the form of `<cluster_name>-<random_string>`. Most resources that the provided ARM templates create use this identifier as the base name. This is the value of the `.status.infrastructureName` attribute from the `manifests/cluster-infrastructure-02-config.yml` file.
 +
 .. Export the resource group by using the following command:
 +
@@ -371,7 +363,7 @@ $ export RESOURCE_GROUP=<resource_group>
 +
 where:
 +
-`<resource_group>`:: All resources created in this Azure deployment exists as part of a link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups[resource group]. The resource group name is also based on the `INFRA_ID`, in the form of `<cluster_name>-<random_string>-rg`. This is the value of the `.status.platformStatus.azure.resourceGroupName` attribute from the `manifests/cluster-infrastructure-02-config.yml` file.
+`<resource_group>`:: Specifies the link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups[resource group] that contains all resources in this Azure deployment. The resource group name is also based on the `INFRA_ID`, in the form of `<cluster_name>-<random_string>-rg`. This is the value of the `.status.platformStatus.azure.resourceGroupName` attribute from the `manifests/cluster-infrastructure-02-config.yml` file.
 endif::azure-user-infra[]
 
 ifdef::ash[]
@@ -438,7 +430,7 @@ spec:
     - role: Contributor
 ----
 +
-.. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
+.. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. Store the secrets by using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
 +
 .Sample `secrets.yaml` file
 [source,yaml]
@@ -486,7 +478,7 @@ where:
 +
 `<installation_directory>`:: Specifies the same installation directory.
 +
-Ignition config files are created for the bootstrap, control plane, and compute nodes in the installation directory. The `kubeadmin-password` and `kubeconfig` files are created in the `./<installation_directory>/auth` directory:
+The installation program creates Ignition config files for the bootstrap, control plane, and compute nodes in the installation directory. The program also creates the `kubeadmin-password` and `kubeconfig` files in the `./<installation_directory>/auth` directory:
 +
 ----
 .

--- a/modules/installation-user-infra-generate.adoc
+++ b/modules/installation-user-infra-generate.adoc
@@ -85,17 +85,22 @@ endif::[]
 
 ifdef::azure[]
 [role="_abstract"]
-To install {product-title} on {cp-first} using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use.
+To install {product-title} on {cp-first} by using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use.
 
 You generate and customize the `install-config.yaml` file, Kubernetes manifests, and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
 endif::azure[]
 ifdef::ash[]
-To install {product-title} on {cp-first} using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use. You manually create the `install-config.yaml` file, and then generate and customize the Kubernetes manifests and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
+[role="_abstract"]
+To install {product-title} on {cp-first} by using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use. You manually create the `install-config.yaml` file, and then generate and customize the Kubernetes manifests and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
 endif::ash[]
 ifdef::aws,gcp[]
-To install {product-title} on {cp-first} using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use. You generate and customize the `install-config.yaml` file, Kubernetes manifests, and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
+[role="_abstract"]
+To install {product-title} on {cp-first} by using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use.
+
+You generate and customize the `install-config.yaml` file, Kubernetes manifests, and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
 endif::aws,gcp[]
 ifdef::gcp-shared[]
+[role="_abstract"]
 To install {product-title} on {cp-first} into a shared VPC, you must generate the `install-config.yaml` file and modify it so that the cluster uses the correct VPC networks, DNS zones, and project names.
 endif::gcp-shared[]
 

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -15,7 +15,7 @@
 = Logging in to the cluster by using the web console
 
 [role="_abstract"]
-The `kubeadmin` user exists by default after an {product-title} installation. You can log in to your cluster as the `kubeadmin` user by using the {product-title} web console.
+To verify that your cluster deployed successfully and access its features, log in to the {product-title} web console as the `kubeadmin` user.
 
 .Prerequisites
 
@@ -33,7 +33,7 @@ $ cat <installation_directory>/auth/kubeadmin-password
 +
 [NOTE]
 ====
-Alternatively, you can obtain the `kubeadmin` password from the `<installation_directory>/.openshift_install.log` log file on the installation host.
+Or, you can obtain the `kubeadmin` password from the `<installation_directory>/.openshift_install.log` log file on the installation host.
 ====
 
 . List the {product-title} web console route:
@@ -45,7 +45,7 @@ $ oc get routes -n openshift-console | grep 'console-openshift'
 +
 [NOTE]
 ====
-Alternatively, you can obtain the {product-title} route from the `<installation_directory>/.openshift_install.log` log file on the installation host.
+Or, you can obtain the {product-title} route from the `<installation_directory>/.openshift_install.log` log file on the installation host.
 ====
 +
 .Example output

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -33,7 +33,7 @@ endif::[]
 = Disabling the default software catalog sources
 
 [role="_abstract"]
-Operator catalogs that source content provided by Red Hat and community projects are configured for the software catalog by default during an {product-title} installation.
+To use only trusted or locally available Operator catalogs, disable the default software catalog sources that {product-title} configures during installation.
 ifndef::olm-managing-custom-catalogs[]
 In a restricted network environment, you must disable the default catalogs as a cluster administrator.
 endif::[]
@@ -43,8 +43,6 @@ endif::[]
 ifdef::olm-managing-custom-catalogs[]
 As a cluster administrator, you can disable the set of default catalogs.
 endif::[]
-
-Operator catalogs that source content provided by Red Hat and community projects are configured for the software catalog by default during an {product-title} installation.
 
 .Procedure
 
@@ -58,7 +56,7 @@ $ oc patch OperatorHub cluster --type json \
 +
 [TIP]
 ====
-Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
+Or, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
 ====
 
 ifeval::["{context}" == "olm-restricted-networks"]

--- a/modules/registry-configuring-storage-aws-user-infra.adoc
+++ b/modules/registry-configuring-storage-aws-user-infra.adoc
@@ -9,30 +9,25 @@
 = Configuring registry storage for AWS with user-provisioned infrastructure
 
 [role="_abstract"]
-During installation, your cloud credentials are sufficient to create an Amazon S3 bucket and the Registry Operator will automatically configure storage.
-
-If the Registry Operator cannot create an S3 bucket and automatically configure storage, you can create an S3 bucket and configure storage with the following procedure.
+If the Registry Operator cannot automatically create and configure an Amazon S3 bucket during installation, you must manually configure registry storage for your cluster.
 
 [WARNING]
 ====
-To secure your registry images in AWS, link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html[block public access]
-to the S3 bucket.
+To secure your registry images in {aws-first}, link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html[block public access] to the S3 bucket.
 ====
 
 .Prerequisites
 
-* You have a cluster on AWS with user-provisioned infrastructure.
-* For Amazon S3 storage, the secret is expected to contain two keys:
+* You have a cluster on {aws-short} with user-provisioned infrastructure.
+* For Amazon S3 storage, the secret must contain two keys:
 ** `REGISTRY_STORAGE_S3_ACCESSKEY`
 ** `REGISTRY_STORAGE_S3_SECRETKEY`
 
 .Procedure
 
-. Set up a link:https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config[Bucket Lifecycle Policy]
-to abort incomplete multipart uploads that are one day old.
+. Set up a link:https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config[Bucket Lifecycle Policy] to cancel incomplete multipart uploads that are one day old.
 
-. Fill in the storage configuration in
-`configs.imageregistry.operator.openshift.io/cluster`:
+. Enter the storage configuration in `configs.imageregistry.operator.openshift.io/cluster`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
5.0 cherrypick of ab764794979bdb716367c4daf0a9e663a97f9b11
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/118339


Note:
5.0 has two more permission sections (dual-stack networking) that also needed collapsible block removal, accounting for the lines changed difference with https://github.com/openshift/openshift-docs/pull/118339.