### PR TITLE
OCPBUGS-60625: Document LDAP console vs CLI login troubleshooting

### DIFF
--- a/authentication/identity_providers/configuring-ldap-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-ldap-identity-provider.adoc
@@ -31,4 +31,6 @@ include::modules/identity-provider-ldap-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
+include::modules/identity-provider-ldap-troubleshooting.adoc[leveloffset=+1]
+
 endif::[]

--- a/modules/identity-provider-about-ldap.adoc
+++ b/modules/identity-provider-about-ldap.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 Review how usernames and passwords are validated against the LDAP directory so you can configure the LDAP identity provider correctly.
 
+The web console and the `oc login` command both authenticate through the OAuth server that runs in the `openshift-authentication` namespace. The OAuth server, not the browser or the CLI, connects to your LDAP directory.
+
 During authentication, the LDAP directory is searched for an entry that matches the provided username. If a single unique match is found, a simple bind is attempted using the distinguished name (DN) of the entry plus the provided
 password.
 

--- a/modules/identity-provider-ldap-troubleshooting.adoc
+++ b/modules/identity-provider-ldap-troubleshooting.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-ldap-identity-provider.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="identity-provider-ldap-troubleshooting_{context}"]
+= Troubleshooting LDAP authentication
+
+[role="_abstract"]
+Troubleshoot LDAP login failures in the web console and the CLI by confirming that the OAuth server can reach your LDAP directory.
+
+The web console and the `oc login` command both authenticate through the OAuth server that runs in the `openshift-authentication` namespace. The OAuth server, not the browser or the `oc` client, connects to your LDAP directory.
+
+A successful login with another identity provider, such as `htpasswd`, does not confirm that the cluster can reach LDAP. Testing LDAP from a workstation is also not equivalent to testing from the OAuth server pods.
+
+A common error in the OAuth server logs is:
+
+----
+LDAP Result Code 200 "Network Error": dial tcp <ldap_host>:636: i/o timeout
+----
+
+This error means the OAuth server timed out while opening a TCP connection to the LDAP host. Typical causes include firewall rules, DNS resolution failures, network policies, or an unreachable LDAPS endpoint.
+
+.Prerequisites
+
+* You configured an LDAP identity provider.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Confirm the configured LDAP URL by running the following command:
++
+[source,terminal]
+----
+$ oc get oauth cluster -o jsonpath='{range .spec.identityProviders[*]}{.name}{"\t"}{.type}{"\t"}{.ldap.url}{"\n"}{end}'
+----
++
+Note the LDAP host and port from the `ldaps://` or `ldap://` URL. The default port is `636` for LDAPS and `389` for LDAP.
+
+. Identify the `oauth-openshift` pods and the nodes that host them by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-authentication -o wide
+----
+
+. Optional: Increase the OAuth server log verbosity by running the following command:
++
+[source,terminal]
+----
+$ oc patch authentications.operator.openshift.io/cluster --type=merge -p '{"spec":{"logLevel":"Debug"}}'
+----
+
+. Reproduce the failed login in the web console, the CLI, or both.
+
+. Review the OAuth server logs by running the following command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-authentication deployment/oauth-openshift --tail=200
+----
++
+Look for `LDAP Result Code 200 "Network Error"` and `i/o timeout` messages. These messages indicate that the OAuth server cannot reach the LDAP host.
+
+. Start a debug session on a node that hosts an `oauth-openshift` pod by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Access the host binaries by running the following command:
++
+[source,terminal]
+----
+# chroot /host
+----
+
+. Resolve the LDAP host name by running the following command:
++
+[source,terminal]
+----
+# getent hosts <ldap_host>
+----
++
+If name resolution fails, fix DNS for the nodes that run the OAuth server pods.
+
+. Test TCP connectivity to the LDAP host and port by running the following command:
++
+[source,terminal]
+----
+# timeout 10 bash -c 'echo >/dev/tcp/<ldap_host>/<port>' && echo "Connection succeeded" || echo "Connection failed"
+----
++
+Replace `<ldap_host>` and `<port>` with the values from the LDAP URL. Use port `636` for LDAPS or port `389` for LDAP unless your directory uses a different port. `Connection failed` or a timeout confirms that the node cannot reach the LDAP service.
++
+Allow egress from the nodes that host `oauth-openshift` pods to the LDAP host and port. Check firewall rules, DNS, and any `NetworkPolicy` objects that restrict egress from the `openshift-authentication` namespace.
+
+. Exit the debug session.
+
+. After you restore connectivity, reset the OAuth server log verbosity by running the following command:
++
+[source,terminal]
+----
+$ oc patch authentications.operator.openshift.io/cluster --type=merge -p '{"spec":{"logLevel":"Normal"}}'
+----
+
+.Verification
+
+* Log in to the web console with LDAP credentials.
+* Log in from the CLI by running the following command:
++
+[source,terminal]
+----
+$ oc login -u <username>
+----


### PR DESCRIPTION
## Summary
- Documents that the web console and `oc login` both authenticate through the OAuth server in `openshift-authentication`. LDAP reachability must be tested from those pods, not from a workstation.
- Adds an LDAP troubleshooting procedure for `LDAP Result Code 200 "Network Error"` / `i/o timeout` failures reported in [OCPBUGS-60625](https://issues.redhat.com/browse/OCPBUGS-60625).
- Notes that a working `htpasswd` login does not prove that the LDAP path works.

## Test plan
- [ ] Preview the LDAP identity provider assembly and confirm the new troubleshooting section renders.
- [ ] Verify the `oc get oauth`, logs, and debug-node commands against a cluster with an LDAP identity provider.

/cc @bergerhoffer

Made with [Cursor](https://cursor.com)