### PR TITLE
OCPBUGS-63453#Add user namespaces for storage to main

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -32,33 +32,33 @@ For a list of third-party-certified CSI drivers, see the "Red Hat ecosystem port
 
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-aro[]
-In addition to the drivers listed in the following table, {product-title} functions with CSI drivers from third-party storage vendors. Red Hat does not oversee third-party provisioners or the connected CSI drivers and the vendors fully control source code, deployment, operation, and Kubernetes compatibility. These volume provisioners are considered customer-managed and the respective vendors are responsible for providing support. For more information, see the "Shared responsibilities for {product-title}"".
+In addition to the drivers listed in the following table, {product-title} functions with CSI drivers from third-party storage vendors. Red Hat does not oversee third-party provisioners or the connected CSI drivers and the vendors fully control source code, deployment, operation, and Kubernetes compatibility. These volume provisioners are considered customer-managed and the respective vendors are responsible for providing support. For more information, see the "Shared responsibilities for {product-title}".
 endif::openshift-rosa,openshift-rosa-hcp,openshift-aro[]
 
 .Supported CSI drivers and features in {product-title}
-[cols=",^v,^v,^v,^v,^v,^v width="100%",options="header"]
+[cols=",^v,^v,^v,^v,^v,^v,^v width="100%",options="header"]
 |===
-|CSI driver |CSI volume snapshots  |CSI volume group snapshots ^[1]^ |CSI cloning  |CSI resize |Inline ephemeral volumes
-|AWS EBS | ✅ |  |  | ✅|
-|AWS EFS |  |  |  |  |
+|CSI driver |CSI volume snapshots  |CSI volume group snapshots ^[1]^ |CSI cloning  |CSI resize |Inline ephemeral volumes |User namespaces
+|AWS EBS | ✅ |  |  | ✅| | ✅
+|AWS EFS |  |  |  |  | |
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-|Google Compute Platform (GCP) persistent disk (PD)|  ✅|  |✅^[2]^ | ✅|
-|GCP Filestore | ✅ |  | | ✅|
+|Google Compute Platform (GCP) persistent disk (PD)|  ✅|  |✅^[2]^ | ✅|  | ✅
+|GCP Filestore | ✅ |  | | ✅| |
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|{ibm-power-server-name} Block |   |  |   | ✅ |
-|{ibm-cloud-name} Block | ✅^[3]^ |  |   | ✅^[3]^|
+|{ibm-power-server-name} Block |   |  |   | ✅ | | ✅
+|{ibm-cloud-name} Block | ✅^[3]^ |  |   | ✅^[3]^| | ✅
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|LVM Storage | ✅ |  | ✅ | ✅ |
+|{lvms} | ✅ |  | ✅ | ✅ | | ✅
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|Microsoft Azure Disk | ✅ |  | ✅ | ✅|
-|Microsoft Azure Stack Hub | ✅ |  | ✅ | ✅|
-|Microsoft Azure File | ✅  |  | ✅ | ✅| ✅
-|OpenStack Cinder | ✅ |  | ✅ | ✅|
-|OpenShift Data Foundation | ✅ | ✅ | ✅ | ✅|
-|OpenStack Manila | ✅ |  |   | ✅  |
-|CIFS/SMB |   |  | ✅  |   |
-|VMware vSphere | ✅^[4]^ |  |   | ✅^[5]^|
+|Microsoft Azure Disk | ✅ |  | ✅ | ✅| | ✅
+|Microsoft Azure Stack Hub | ✅ |  | ✅ | ✅| | ✅
+|Microsoft Azure File | ✅  |  | ✅ | ✅| ✅ |
+|OpenStack Cinder | ✅ |  | ✅ | ✅| | ✅
+|{rh-storage} | ✅ | ✅ | ✅ | ✅| | ✅ ^[4]^
+|OpenStack Manila | ✅ |  |   | ✅  | |
+|CIFS/SMB |   |  | ✅  |   | |
+|VMware vSphere | ✅^[5]^ |  |   | ✅^[6]^| | ✅ ^[7]^
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |===
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
@@ -70,20 +70,29 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 2.
 
-* Cloning is not supported on hyperdisk-balanced disks with storage pools.
+Cloning is not supported on hyperdisk-balanced disks with storage pools.
 
 3.
 
-* Does not support offline snapshots or resize. Volume must be attached to a running pod.
+Does not support offline snapshots or resize. Volume must be attached to a running pod.
 
 4.
+
+RBD supports user namespaces; CephFS does not.
+
+5.
 
 * Requires VMware vSphere version 8.0 Update 1 or later, or VMware vSphere Foundation (VVF) 9, or VMware Cloud Foundation (VCF) 9, for both vCenter Server and ESXi.
 
 * Does not support fileshare volumes.
 
-5.
+6.
 
-* Online expansion is supported from VMware vSphere version 8.0 Update 1 and later, or VVF 9, or VCF 9.
+Online expansion is supported from VMware vSphere version 8.0 Update 1 and later, or VVF 9, or VCF 9.
+
+7.
+
+File persistent volumes (PVs), such as vSAN file service, do not support user namespaces.
+
 --
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/nodes/pods/nodes-pods-user-namespaces.adoc
+++ b/nodes/pods/nodes-pods-user-namespaces.adoc
@@ -22,6 +22,8 @@ When running a pod in an isolated user namespace, the UID/GID inside a pod conta
 Not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network/distributed file systems. Any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 and later.
 ====
 
+To check user namespaces support for storage options, see "CSI drivers supported by {product-title}".
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
@@ -34,4 +36,5 @@ include::modules/nodes-pods-user-namespaces-configuring.adoc[leveloffset=+1]
 
 * xref:../../authentication/managing-security-context-constraints.adoc#configuring-internal-oauth[Managing security context constraints]
 * xref:../../cli_reference/openshift_cli/administrator-cli-commands.adoc#cli-administrator-commands[OpenShift CLI administrator command reference]
+* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}]
 

--- a/storage/persistent_storage/persistent-storage-nfs.adoc
+++ b/storage/persistent_storage/persistent-storage-nfs.adoc
@@ -11,6 +11,11 @@ You can provision {product-title} clusters with persistent storage using NFS.
 
 Persistent volumes (PVs) and persistent volume claims (PVCs) provide a convenient method for sharing a volume across a project. While the NFS-specific information contained in a PV definition could also be defined directly in a pod definition, doing so does not create the volume as a distinct cluster resource, making the volume more susceptible to conflicts.
 
+[NOTE]
+====
+The in-tree NFS provisioner does not support user namespaces.
+====
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
This PR is to add changes from this [PR](https://github.com/openshift/openshift-docs/pull/101913) that added user namespace content to 4.20+, but was individually CP'd to the enterprise branches, but not main.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): main only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-63453
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @gcharot 
