### PR TITLE
OSDOCS-21623: Fix label selector in SPIRE agent verification commands

### DIFF
--- a/modules/zero-trust-manager-spire-agent-config.adoc
+++ b/modules/zero-trust-manager-spire-agent-config.adoc
@@ -82,7 +82,7 @@ $ oc apply -f SpireAgent.yaml
 +
 [source,terminal]
 ----
-$ oc get daemonset -l app.kubernetes.io/name=agent -n zero-trust-workload-identity-manager
+$ oc get daemonset -l app.kubernetes.io/name=spire-agent -n zero-trust-workload-identity-manager
 ----
 +
 .Example output
@@ -96,7 +96,7 @@ spire-agent   3         3         3       3            3           <none>       
 +
 [source,terminal]
 ----
-$ oc get po -l app.kubernetes.io/name=agent -n zero-trust-workload-identity-manager
+$ oc get po -l app.kubernetes.io/name=spire-agent -n zero-trust-workload-identity-manager
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.18, 4.19, 4.20, 4.21, 4.22, (main/5.0)

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21623

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-spire-agent-config_zero-trust-manager-configuration

QE review:
- [x] QE has approved this change.

Additional information:
This PR fixes an incorrect label selector in the SPIRE agent verification section (`zero-trust-manager-spire-agent-config` module):

* Updated the label selector in verification commands from `app.kubernetes.io/name=agent` to `app.kubernetes.io/name=spire-agent` so the commands return the actual SPIRE agent resources.


```
$ oc get daemonset -l app.kubernetes.io/name=agent -n zero-trust-workload-identity-manager
No resources found in zero-trust-workload-identity-manager namespace.
$ oc get po -l app.kubernetes.io/name=agent -n zero-trust-workload-identity-manager
No resources found in zero-trust-workload-identity-manager namespace.


Validated Correct Value:

$ oc get daemonset -o yaml 
apiVersion: v1
items:
- apiVersion: apps/v1
  kind: DaemonSet
  metadata:
    annotations:
      deprecated.daemonset.template.generation: "1"
    creationTimestamp: "2026-08-12T14:01:02Z"
    generation: 1
    labels:
      app.kubernetes.io/component: node-agent
      app.kubernetes.io/instance: cluster-zero-trust-workload-identity-manager
      app.kubernetes.io/managed-by: zero-trust-workload-identity-manager
      app.kubernetes.io/name: spire-agent
      app.kubernetes.io/part-of: zero-trust-workload-identity-manager
      app.kubernetes.io/version: 1.14.7


Correct command: 

 $ oc get po -l app.kubernetes.io/name=spire-agent -n zero-trust-workload-identity-manager
NAME                READY   STATUS    RESTARTS   AGE
spire-agent-fdb6n   1/1     Running   0          5m13s
spire-agent-l9vjd   1/1     Running   0          5m13s
$ oc get daemonset -l app.kubernetes.io/name=spire-agent -n zero-trust-workload-identity-manager
NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
spire-agent   2         2         2       2            2           <none>          5m25s

