### PR TITLE
OSDOCS-16991_m#CQA fixes for AWS UPI procedure and proxy modules (4.20)

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -141,13 +141,13 @@ ifndef::gcp[]
 * You have an existing `install-config.yaml` file.
 
 endif::gcp[]
-* You have reviewed the sites that your cluster requires access to and determined whether any of them need to bypass the proxy. By default, all cluster egress traffic is proxied, including calls to hosting cloud provider APIs. You added sites to the `Proxy` object's `spec.noProxy` field to bypass the proxy if necessary.
+* You have reviewed the sites that your cluster requires access to and determined whether any of them need to bypass the proxy. By default, the proxy handles all cluster egress traffic, including calls to hosting cloud provider APIs. You added sites to the `Proxy` object's `spec.noProxy` field to bypass the proxy if necessary.
 +
 [NOTE]
 ====
-The `Proxy` object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The `Proxy` object `status.noProxy` field includes the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
 
-For installations on Amazon Web Services (AWS), {gcp-first}, Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
+For installations on {aws-first}, {gcp-first}, Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field also includes the instance metadata endpoint (`169.254.169.254`).
 ====
 
 .Procedure
@@ -186,8 +186,8 @@ endif::aws[]
 ifdef::vsphere[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere[]
-`additionalTrustBundle`:: If provided, the installation program generates a config map that is named `user-ca-bundle` in the `openshift-config` namespace to hold the additional CA certificates. If you provide `additionalTrustBundle` and at least one proxy setting, the `Proxy` object is configured to reference the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
-`additionalTrustBundlePolicy`:: Specifies the policy that determines the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when `http/https` proxy is configured. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`. Optional parameter.
+`additionalTrustBundle`:: If you specify this value, the installation program generates a config map named `user-ca-bundle` in the `openshift-config` namespace to hold the additional CA certificates. If you specify `additionalTrustBundle` and at least one proxy setting, the `Proxy` object references the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter with the {op-system} trust bundle. You must set the `additionalTrustBundle` field unless an authority from the {op-system} trust bundle signs the proxy's identity certificate.
+`additionalTrustBundlePolicy`:: Specifies the policy that determines the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when you configure an `http/https` proxy. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`. Optional parameter.
 +
 [NOTE]
 ====
@@ -206,11 +206,11 @@ $ ./openshift-install wait-for install-complete --log-level debug
 
 . Save the file and reference it when installing {product-title}.
 +
-The installation program creates a cluster-wide proxy that is named `cluster` that uses the proxy settings in the provided `install-config.yaml` file. If no proxy settings are provided, a `cluster` `Proxy` object is still created, but it will have a nil `spec`.
+The installation program creates a cluster-wide proxy named `cluster` that uses the proxy settings in the `install-config.yaml` file. If you do not give proxy settings, the installation program still creates a `cluster` `Proxy` object, but it has a nil `spec`.
 +
 [NOTE]
 ====
-Only the `Proxy` object named `cluster` is supported, and no additional proxies can be created.
+Only the `Proxy` object named `cluster` is supported, and you cannot create additional proxies.
 ====
 
 ifeval::["{context}" == "installing-aws-china-region"]

--- a/modules/installation-create-ingress-dns-records.adoc
+++ b/modules/installation-create-ingress-dns-records.adoc
@@ -22,7 +22,7 @@ link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Instal
 
 .Procedure
 
-. Determine the routes to create.
+. Find the routes to create.
 ** To create a wildcard record, use `*.apps.<cluster_name>.<domain_name>`, where `<cluster_name>` is your cluster name, and `<domain_name>` is the Route 53 base domain for your {product-title} cluster.
 ** To create specific records, you must create a record for each route that your cluster uses, as shown in the output of the following command:
 +
@@ -41,7 +41,7 @@ alertmanager-main-openshift-monitoring.apps.<cluster_name>.<domain_name>
 prometheus-k8s-openshift-monitoring.apps.<cluster_name>.<domain_name>
 ----
 
-. Retrieve the Ingress Operator load balancer status and note the value of the external IP address that it uses, which is shown in the `EXTERNAL-IP` column:
+. Retrieve the Ingress Operator load balancer status and note the value of the external IP address that it uses, which the `EXTERNAL-IP` column displays:
 +
 [source,terminal]
 ----
@@ -91,7 +91,7 @@ where `<domain_name>` is the Route 53 base domain for your {product-title} clust
 /hostedzone/Z3URY6TWQ91KVV
 ----
 +
-The public hosted zone ID for your domain is shown in the command output. In this example, it is `Z3URY6TWQ91KVV`.
+The command output displays the public hosted zone ID for your domain. In this example, it is `Z3URY6TWQ91KVV`.
 
 . Add the alias records to your private zone:
 +
@@ -118,7 +118,7 @@ $ aws route53 change-resource-record-sets --hosted-zone-id "<private_hosted_zone
 where:
 +
 --
-`<private_hosted_zone_id>`:: Specifies the value from the output of the CloudFormation template for DNS and load balancing.
+`<private_hosted_zone_id>`:: Specifies the value from the output of the `CloudFormation` template for DNS and load balancing.
 `<cluster_domain>`:: Specifies the domain or subdomain that you use with your {product-title} cluster.
 `<hosted_zone_id>`:: Specifies the public hosted zone ID for the load balancer that you obtained.
 `<external_ip>`:: Specifies the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -8,14 +8,14 @@
 = Creating the bootstrap node in AWS
 
 [role="_abstract"]
-To initialize the {product-title} control plane, create the bootstrap node in {aws-first} by uploading the Ignition config to an S3 bucket and launching the CloudFormation template.
+To initialize the {product-title} control plane, create the bootstrap node in {aws-first} by uploading the Ignition config to an S3 bucket and launching the `CloudFormation` template.
 
-* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is located in your installation directory. The provided CloudFormation Template assumes that the Ignition config files for your cluster are served from an S3 bucket. If you choose to serve the files from another location, you must modify the templates.
-* Using the provided CloudFormation template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the bootstrap node that your {product-title} installation requires.
+* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is in your installation directory. The provided `CloudFormation` template assumes that you serve the Ignition config files for your cluster from an S3 bucket. If you choose to serve the files from another location, you must change the templates.
+* Using the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the bootstrap node that your {product-title} installation requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your bootstrap node, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your bootstrap node, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
@@ -29,10 +29,10 @@ If you do not use the provided CloudFormation template to create your bootstrap 
 +
 [source,terminal]
 ----
-$ aws s3 mb s3://<cluster-name>-infra
+$ aws s3 mb s3://<cluster_name>-infra
 ----
 +
-where `<cluster-name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster-name>` with the name specified for the cluster.
+where `<cluster_name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster_name>` with the name specified for the cluster.
 +
 --
 You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, if you are:
@@ -46,7 +46,7 @@ You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, 
 +
 [source,terminal]
 ----
-$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster-name>-infra/bootstrap.ign
+$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster_name>-infra/bootstrap.ign
 ----
 +
 where `<installation_directory>` is the path to the directory that you stored the installation files in.
@@ -55,7 +55,7 @@ where `<installation_directory>` is the path to the directory that you stored th
 +
 [source,terminal]
 ----
-$ aws s3 ls s3://<cluster-name>-infra/
+$ aws s3 ls s3://<cluster_name>-infra/
 ----
 +
 .Example output
@@ -66,10 +66,10 @@ $ aws s3 ls s3://<cluster-name>-infra/
 +
 [NOTE]
 ====
-The bootstrap Ignition config file does contain secrets, such as X.509 keys. The following steps provide basic security for the S3 bucket. To provide additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket contains. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
+The bootstrap Ignition config file does have secrets, such as X.509 keys. The following steps give basic security for the S3 bucket. To give additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket has. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
 ====
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -129,25 +129,25 @@ The bootstrap Ignition config file does contain secrets, such as X.509 keys. The
 where:
 +
 --
-`InfrastructureName`:: Specifies the name for your cluster infrastructure that is encoded in your Ignition config files for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster-name>-<random-string>`.
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
 `RhcosAmi`:: Specifies the current {op-system-first} AMI to use for the bootstrap node based on your selected architecture. Specify a valid `AWS::EC2::Image::Id` value.
 `AllowedBootstrapSshCidr`:: Specifies the CIDR block to allow SSH access to the bootstrap node. Specify a CIDR block in the format `x.x.x.x/16-24`.
-`PublicSubnet`:: Specifies the public subnet that is associated with your VPC to launch the bootstrap node into. Specify the `PublicSubnetIds` value from the output of the CloudFormation template for the VPC.
-`MasterSecurityGroupId`:: Specifies the control plane security group ID for registering temporary rules. Specify the `MasterSecurityGroupId` value from the output of the CloudFormation template for the security group and roles.
-`VpcId`:: Specifies the VPC that the created resources will belong to. Specify the `VpcId` value from the output of the CloudFormation template for the VPC.
+`PublicSubnet`:: Specifies the public subnet in your VPC to launch the bootstrap node into. Specify the `PublicSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`MasterSecurityGroupId`:: Specifies the control plane security group ID for registering temporary rules. Specify the `MasterSecurityGroupId` value from the output of the `CloudFormation` template for the security group and roles.
+`VpcId`:: Specifies the VPC that the created resources will belong to. Specify the `VpcId` value from the output of the `CloudFormation` template for the VPC.
 `BootstrapIgnitionLocation`:: Specifies the location to fetch the bootstrap Ignition config file from. Specify the S3 bucket and file name in the form `s3://<bucket_name>/bootstrap.ign`.
-`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda Amazon Resource Name (ARN) value.
-`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
+`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must give a Lambda Amazon Resource Name (ARN) value.
+`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
 --
 
-. Copy the template from the *CloudFormation template for the bootstrap machine* section of this topic and save it as a YAML file on your computer. This template describes the bootstrap machine that your cluster requires.
+. Copy the template from the *`CloudFormation` template for the bootstrap machine* section and save it as a YAML file on your computer. This template describes the bootstrap machine that your cluster requires.
 
 . Optional: If you are deploying the cluster with a proxy, you must update the ignition in the template to add the  `ignition.config.proxy` fields. Additionally, If you have added the Amazon EC2, Elastic Load Balancing, and S3 VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
 
-. Launch the CloudFormation template to create a stack of {aws-short} resources that represent the bootstrap node:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the bootstrap node:
 +
 [IMPORTANT]
 ====
@@ -165,9 +165,9 @@ $ aws cloudformation create-stack --stack-name <name> \
 where:
 +
 --
-`<name>`:: Specifies the name for the CloudFormation stack, such as `cluster-bootstrap`. You need the name of this stack if you remove the cluster.
-`<template>`:: Specifies the relative path to and name of the CloudFormation template YAML file that you saved.
-`<parameters>`:: Specifies the relative path to and name of the CloudFormation parameters JSON file.
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-bootstrap`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
 `CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
 --
 +
@@ -184,7 +184,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-bootstrap/12944486-2
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must provide these parameter values to the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `BootstrapInstanceId`:: The bootstrap Instance ID.
 `BootstrapPublicIp`:: The bootstrap node public IP address.

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -8,16 +8,16 @@
 = Creating the control plane machines in AWS
 
 [role="_abstract"]
-To run the {product-title} control plane, create the three control plane machines in {aws-first} by using the provided CloudFormation template and a custom parameter file.
+To run the {product-title} control plane, create the three control plane machines in {aws-first} by using the provided `CloudFormation` template and a custom parameter file.
 
 [IMPORTANT]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your control plane nodes, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your control plane nodes, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
@@ -26,7 +26,7 @@ If you do not use the provided CloudFormation template to create your control pl
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -109,32 +109,32 @@ If you do not use the provided CloudFormation template to create your control pl
 where:
 +
 --
-`InfrastructureName`:: Specifies the name for your cluster infrastructure that is encoded in your Ignition config files for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster-name>-<random-string>`.
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
 `RhcosAmi`:: Specifies the current {op-system-first} AMI to use for the control plane machines based on your selected architecture. Specify an `AWS::EC2::Image::Id` value.
-`AutoRegisterDNS`:: Specifies whether to perform DNS etcd registration. Specify `yes` or `no`. If you specify `yes`, you must provide hosted zone information.
-`PrivateHostedZoneId`:: Specifies the Route 53 private zone ID to register the etcd targets with. Specify the `PrivateHostedZoneId` value from the output of the CloudFormation template for DNS and load balancing.
+`AutoRegisterDNS`:: Specifies whether to perform DNS etcd registration. Specify `yes` or `no`. If you specify `yes`, you must give hosted zone information.
+`PrivateHostedZoneId`:: Specifies the Route 53 private zone ID to register the etcd targets with. Specify the `PrivateHostedZoneId` value from the output of the `CloudFormation` template for DNS and load balancing.
 `PrivateHostedZoneName`:: Specifies the Route 53 zone to register the targets with. Specify `<cluster_name>.<domain_name>` where `<domain_name>` is the Route 53 base domain that you used when you generated the `install-config.yaml` file for the cluster. Do not include the trailing period (.) that is displayed in the {aws-short} console.
-`Master0Subnet`, `Master1Subnet`, `Master2Subnet`:: Specifies a subnet, preferably private, to launch the control plane machines on. Specify a subnet from the `PrivateSubnets` value from the output of the CloudFormation template for DNS and load balancing.
-`MasterSecurityGroupId`:: Specifies the control plane security group ID to associate with control plane nodes. Specify the `MasterSecurityGroupId` value from the output of the CloudFormation template for the security group and roles.
+`Master0Subnet`, `Master1Subnet`, `Master2Subnet`:: Specifies a subnet, preferably private, to launch the control plane machines on. Specify a subnet from the `PrivateSubnets` value from the output of the `CloudFormation` template for DNS and load balancing.
+`MasterSecurityGroupId`:: Specifies the control plane security group ID to associate with control plane nodes. Specify the `MasterSecurityGroupId` value from the output of the `CloudFormation` template for the security group and roles.
 `IgnitionLocation`:: Specifies the location to fetch the control plane Ignition config file from. Specify the generated Ignition config file location, `https://api-int.<cluster_name>.<domain_name>:22623/config/master`.
 `CertificateAuthorities`:: Specifies the base64 encoded certificate authority string to use. Specify the value from the `master.ign` file that is in the installation directory. This value is the long string with the format `data:text/plain;charset=utf-8;base64,ABC...xYz==`.
-`MasterInstanceProfileName`:: Specifies the IAM profile to associate with control plane nodes. Specify the `MasterInstanceProfile` parameter value from the output of the CloudFormation template for the security group and roles.
+`MasterInstanceProfileName`:: Specifies the IAM profile to associate with control plane nodes. Specify the `MasterInstanceProfile` parameter value from the output of the `CloudFormation` template for the security group and roles.
 `MasterInstanceType`:: Specifies the type of {aws-short} instance to use for the control plane machines based on your selected architecture. The instance type value corresponds to the minimum resource requirements for control plane machines. For example `m6i.xlarge` is a type for AMD64
 ifndef::openshift-origin[]
 and `m6g.xlarge` is a type for ARM64.
 endif::openshift-origin[]
-`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda Amazon Resource Name (ARN) value.
-`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
-`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} GovCloud region.
+`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must give a Lambda Amazon Resource Name (ARN) value.
+`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
 --
 
-. Copy the template from the *CloudFormation template for control plane machines* section of this topic and save it as a YAML file on your computer. This template describes the control plane machines that your cluster requires.
+. Copy the template from the *`CloudFormation` template for control plane machines* section and save it as a YAML file on your computer. This template describes the control plane machines that your cluster requires.
 
-. If you specified an `m5` instance type as the value for `MasterInstanceType`, add that instance type to the `MasterInstanceType.AllowedValues` parameter in the CloudFormation template.
+. If you specified an `m5` instance type as the value for `MasterInstanceType`, add that instance type to the `MasterInstanceType.AllowedValues` parameter in the `CloudFormation` template.
 
-. Launch the CloudFormation template to create a stack of {aws-short} resources that represent the control plane nodes:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the control plane nodes:
 +
 [IMPORTANT]
 ====
@@ -151,9 +151,9 @@ $ aws cloudformation create-stack --stack-name <name> \
 where:
 +
 --
-`<name>`:: Specifies the name for the CloudFormation stack, such as `cluster-control-plane`. You need the name of this stack if you remove the cluster.
-`<template>`:: Specifies the relative path to and name of the CloudFormation template YAML file that you saved.
-`<parameters>`:: Specifies the relative path to and name of the CloudFormation parameters JSON file.
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-control-plane`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
 --
 +
 .Example output
@@ -164,7 +164,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-control-plane/21c7e2
 +
 [NOTE]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 . Confirm that the template components exist:

--- a/modules/installation-creating-aws-dns.adoc
+++ b/modules/installation-creating-aws-dns.adoc
@@ -8,15 +8,15 @@
 = Creating networking and load balancing components in AWS
 
 [role="_abstract"]
-To route traffic to your {product-title} cluster, configure the networking and load balancing components in {aws-first} by using the provided CloudFormation template.
+To route traffic to your {product-title} cluster, configure the networking and load balancing components in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
 
-You can run the template multiple times within a single Virtual Private Cloud (VPC).
+You can run the template many times within a single Virtual Private Cloud (VPC).
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
@@ -43,7 +43,7 @@ HOSTEDZONES	65F8F38E-2268-B835-E15C-AB55336FCBFA	/hostedzone/Z21IXYZABCZ2A4	mycl
 +
 In the example output, the hosted zone ID is `Z21IXYZABCZ2A4`.
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -83,22 +83,22 @@ where:
 +
 --
 `ClusterName`:: Specifies a short, representative cluster name to use for hostnames, and so on. Set the value to the cluster name that you used when you generated the `install-config.yaml` file for the cluster.
-`InfrastructureName`:: Specifies the name for your cluster infrastructure that is encoded in your Ignition config files for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster-name>-<random-string>`.
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
 `HostedZoneId`:: Specifies the Route 53 public zone ID to register the targets with. Set the value to the Route 53 public zone ID, which has a format similar to `Z21IXYZABCZ2A4`. You can obtain this value from the {aws-short} console.
 `HostedZoneName`:: Specifies the Route 53 zone to register the targets with. Set the value to the Route 53 base domain that you used when you generated the `install-config.yaml` file for the cluster. Do not include the trailing period (.) that is displayed in the {aws-short} console.
-`PublicSubnets`:: Specifies the public subnets that you created for your VPC. Set the value to the `PublicSubnetIds` value from the output of the CloudFormation template for the VPC.
-`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the CloudFormation template for the VPC.
-`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the CloudFormation template for the VPC.
+`PublicSubnets`:: Specifies the public subnets that you created for your VPC. Set the value to the `PublicSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the `CloudFormation` template for the VPC.
 --
 
-. Copy the template from the *CloudFormation template for the network and load balancers* section of this topic and save it as a YAML file on your computer. This template describes the networking and load balancing objects that your cluster requires.
+. Copy the template from the *`CloudFormation` template for the network and load balancers* section and save it as a YAML file on your computer. This template describes the networking and load balancing objects that your cluster requires.
 +
 [IMPORTANT]
 ====
-If you are deploying your cluster to an AWS government or secret region, you must update the `InternalApiServerRecord` in the CloudFormation template to use `CNAME` records. Records of type `ALIAS` are not supported for AWS government regions.
+If you are deploying your cluster to an {aws-short} government or secret region, you must update the `InternalApiServerRecord` in the `CloudFormation` template to use `CNAME` records. Records of type `ALIAS` are not supported for {aws-short} government regions.
 ====
 
-. Launch the CloudFormation template to create a stack of {aws-short} resources that provide the networking and load balancing components:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources for the networking and load balancing components:
 +
 [IMPORTANT]
 ====
@@ -116,9 +116,9 @@ $ aws cloudformation create-stack --stack-name <name> \
 where:
 +
 --
-`<name>`:: Specifies the name for the CloudFormation stack, such as `cluster-dns`. You need the name of this stack if you remove the cluster.
-`<template>`:: Specifies the relative path to and name of the CloudFormation template YAML file that you saved.
-`<parameters>`:: Specifies the relative path to and name of the CloudFormation parameters JSON file.
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-dns`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
 `CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` resources.
 --
 +
@@ -135,7 +135,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-dns/cd3e5de0-2fd4-11
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must provide these parameter values to the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `PrivateHostedZoneId`:: Hosted zone ID for the private DNS.
 `ExternalApiLoadBalancerName`:: Full name of the external API load balancer.

--- a/modules/installation-creating-aws-security.adoc
+++ b/modules/installation-creating-aws-security.adoc
@@ -8,18 +8,18 @@
 = Creating security group and roles in AWS
 
 [role="_abstract"]
-To control access to your {product-title} cluster resources, create the required security groups and IAM roles in {aws-first} by using the provided CloudFormation template.
+To control access to your {product-title} cluster resources, create the required security groups and IAM roles in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the security groups and roles that your {product-title} cluster requires.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the security groups and roles that your {product-title} cluster requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -46,15 +46,15 @@ If you do not use the provided CloudFormation template to create your {aws-short
 where:
 +
 --
-`InfrastructureName`:: Specifies the name for your cluster infrastructure that is encoded in your Ignition config files for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster-name>-<random-string>`.
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
 `VpcCidr`:: Specifies the CIDR block for the VPC. Set the value to the CIDR block parameter that you used for the VPC that you defined in the form `x.x.x.x/16-24`.
-`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the CloudFormation template for the VPC.
-`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the CloudFormation template for the VPC.
+`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the `CloudFormation` template for the VPC.
 --
 
-. Copy the template from the *CloudFormation template for security objects* section of this topic and save it as a YAML file on your computer. This template describes the security groups and roles that your cluster requires.
+. Copy the template from the *`CloudFormation` template for security objects* section and save it as a YAML file on your computer. This template describes the security groups and roles that your cluster requires.
 
-. Launch the CloudFormation template to create a stack of {aws-short} resources that represent the security groups and roles:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the security groups and roles:
 +
 [IMPORTANT]
 ====
@@ -72,9 +72,9 @@ $ aws cloudformation create-stack --stack-name <name> \
 where:
 +
 --
-`<name>`:: Specifies the name for the CloudFormation stack, such as `cluster-sec`. You need the name of this stack if you remove the cluster.
-`<template>`:: Specifies the relative path to and name of the CloudFormation template YAML file that you saved.
-`<parameters>`:: Specifies the relative path to and name of the CloudFormation parameters JSON file.
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-sec`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
 `CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
 --
 +
@@ -91,7 +91,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-sec/03bd4210-2ed7-11
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must provide these parameter values to the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `MasterSecurityGroupId`:: Control plane security group ID
 `WorkerSecurityGroupId`:: Worker security group ID


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:

[Configuring the cluster-wide proxy during installation](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-configure-proxy_installing-aws-user-infra)

[Creating the Ingress DNS records](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-create-ingress-dns-records_installing-aws-user-infra)

[Creating the bootstrap node in AWS](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-bootstrap_installing-aws-user-infra)

[Creating the control plane machines in AWS](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-control-plane_installing-aws-user-infra)

[Creating networking and load balancing components in AWS](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-dns_installing-aws-user-infra)

[Creating security group and roles in AWS](https://118505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-security_installing-aws-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->