### PR TITLE
OSDOCS-21687: Fix aapiVersion typo in SpireOIDCDiscoveryProvider example

### DIFF
--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -25,7 +25,7 @@ Deploy the SPIRE OpenID Connect (OIDC) Discovery Provider by configuring the `Sp
 .Example `SpireOIDCDiscoveryProvider` YAML
 [source,yaml]
 ----
-aapiVersion: operator.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: SpireOIDCDiscoveryProvider
 metadata:
  name: cluster


### PR DESCRIPTION
Version(s):
4.19, 4.20, 4.21, 4.22, 5.0

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21687

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-oidc-config_zero-trust-manager-configuration

QE review:
- [ ] QE has approved this change.

Additional information:
This PR fixes a syntax typo in the sample manifest under the OIDC configuration guide (`zero-trust-manager-oidc-config` module):

* Corrected `aapiVersion` to `apiVersion` in `Example SpireOIDCDiscoveryProvider.yaml`.