### PR TITLE
[enterprise-4.21] OCPBUGS-99480: Replace from: All in Gateway enable example

### DIFF
--- a/modules/nw-ingress-gateway-api-enable.adoc
+++ b/modules/nw-ingress-gateway-api-enable.adoc
@@ -113,7 +113,10 @@ spec:
       - name: gwapi-wildcard
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            shared-gateway-access: "true"
 ----
 +
 where:
@@ -123,6 +126,7 @@ where:
 `listeners.name`:: The HTTPS listener listens for HTTPS requests that match a subdomain of the cluster domain. You use this listener to configure ingress to your applications by using Gateway API `HTTPRoute` resources.
 `listeners.hostname`::  The hostname must be a subdomain of the Ingress Operator domain. If you use a domain, the listener tries to serve all traffic in that domain.
 `tls.name`:: The name of the previously created secret.
+`listeners.allowedRoutes.namespaces`:: Allow route attachment only from namespaces that have the `shared-gateway-access: "true"` label. Do not set `namespaces.from: All`; that setting allows routes from every namespace and can enable hostname or domain hijacking.
 
 .. Apply the resource by running the following command:
 +


### PR DESCRIPTION
## Summary
- Manual backport of the OCPBUGS-99480 security guidance for the older Gateway API docs layout on `enterprise-4.21`.
- Replaces `from: All` in `modules/nw-ingress-gateway-api-enable.adoc` with a trusted namespace `Selector`, matching the shared-gateway pattern already used in topologies.
- Warns that `namespaces.from: All` can enable hostname or domain hijacking.

Parent: https://github.com/openshift/openshift-docs/pull/117235

## Why not a cherry-pick
The main PR edits post-JTBD Gateway modules that do not exist on 4.21. Those paths cause modify/delete conflicts. This ports only the insecure enable-example guidance that still ships on this branch.

## Test plan
- [ ] Confirm example YAML still builds in the Gateway API assembly
- [ ] Confirm no remaining `from: All` in `modules/nw-ingress-gateway-api-enable.adoc`
- [ ] QE review of the selector guidance


Made with [Cursor](https://cursor.com)