### PR TITLE
[enterprise-4.17] [NETOBSERV] 1.12.2 release

### DIFF
--- a/modules/network-observability-create-cluster-role-bindings-custom-namespace.adoc
+++ b/modules/network-observability-create-cluster-role-bindings-custom-namespace.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/configuring-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-create-cluster-role-bindings-custom-namespace_{context}"]
+= Create cluster role bindings for a custom namespace
+
+[role="_abstract"]
+Create cluster role bindings for the Network Observability Operator service accounts when you deploy in a namespace other than the default `netobserv` namespace.
+
+[IMPORTANT]
+====
+Do not modify the existing default bindings. They are overwritten during Operator upgrades. Create new bindings as shown.
+====
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* You have `cluster-admin` privileges.
+* You configured `spec.namespace` in the `FlowCollector` resource to a namespace other than `netobserv`.
+
+.Procedure
+
+. Replace `<namespace>` with the namespace you configured in `spec.namespace` of the `FlowCollector` resource.
+
+.. Create the `netobserv-informers-custom` cluster role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create clusterrolebinding netobserv-informers-custom \
+  --clusterrole=netobserv-informers \
+  --serviceaccount=<namespace>:flowlogs-pipeline \
+  --serviceaccount=<namespace>:flowlogs-pipeline-transformer
+----
+
+.. Create the `netobserv-lokiwriter-custom` cluster role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create clusterrolebinding netobserv-lokiwriter-custom \
+  --clusterrole=netobserv-loki-writer \
+  --serviceaccount=<namespace>:flowlogs-pipeline \
+  --serviceaccount=<namespace>:flowlogs-pipeline-transformer
+----
+
+.. Create the `netobserv-hostnetwork-custom` cluster role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create clusterrolebinding netobserv-hostnetwork-custom \
+  --clusterrole=netobserv-hostnetwork \
+  --serviceaccount=<namespace>:flowlogs-pipeline
+----
+
+.. Create the token review cluster role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create clusterrolebinding netobserv-tokenreview-custom \
+  --clusterrole=netobserv-token-review \
+  --serviceaccount=<namespace>:netobserv-plugin
+----
+
+.Verification
+
+. Check the `FlowCollector` status for errors by running the following command:
++
+[source,terminal]
+----
+$ oc get flowcollector cluster -o jsonpath='{.status.conditions}'
+----
+
+. Verify that no conditions report permission-related errors.
++
+[NOTE]
+====
+If the `FlowCollector` status continues to show permission errors after you grant the required permissions, restart the Network Observability Operator pod for faster reconciliation:
+
+[source,terminal]
+----
+$ oc delete pods -n openshift-netobserv-operator -l app=netobserv-operator
+----
+====

--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -123,6 +123,9 @@ Kafka can provide better scalability, resiliency, and high availability (for mor
 | `namespace`
 | `string`
 | Namespace where Network Observability pods are deployed.
+Those pods require various cluster role bindings in order to operate. Those bindings are preinstalled for service accounts located in the default namespace.
+If you configured a different namespace, you must update (or recreate) the cluster role bindings accordingly.
+You can see the list of preinstalled bindings here: https://github.com/openshift/network-observability-operator/blob/release-1.12/helm/templates/component_role_bindings.yaml
 
 | `networkPolicy`
 | `object`
@@ -1239,6 +1242,9 @@ Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
 | `object`
 | TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
 We recommend the use of mTLS for higher security standards.
+When configuring TLS, the operator watches the certificate secret and copies it to both the netobserv and netobserv-privileged namespaces.
+In order to do so, you must grant it permissions to the `netobserv-secret-watcher` and `netobserv-secret-creator` roles in the corresponding namespaces.
+Refer to the Kafka configuration documentation for more information.
 
 | `topic`
 | `string`
@@ -1351,6 +1357,9 @@ Description::
 --
 TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
 We recommend the use of mTLS for higher security standards.
+When configuring TLS, the operator watches the certificate secret and copies it to both the netobserv and netobserv-privileged namespaces.
+In order to do so, you must grant it permissions to the `netobserv-secret-watcher` and `netobserv-secret-creator` roles in the corresponding namespaces.
+Refer to the Kafka configuration documentation for more information.
 --
 
 Type::
@@ -1757,6 +1766,9 @@ Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
 | `object`
 | TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
 We recommend the use of mTLS for higher security standards.
+When configuring TLS, the operator watches the certificate secret and copies it to both the netobserv and netobserv-privileged namespaces.
+In order to do so, you must grant it permissions to the `netobserv-secret-watcher` and `netobserv-secret-creator` roles in the corresponding namespaces.
+Refer to the Kafka configuration documentation for more information.
 
 | `topic`
 | `string`
@@ -1869,6 +1881,9 @@ Description::
 --
 TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
 We recommend the use of mTLS for higher security standards.
+When configuring TLS, the operator watches the certificate secret and copies it to both the netobserv and netobserv-privileged namespaces.
+In order to do so, you must grant it permissions to the `netobserv-secret-watcher` and `netobserv-secret-creator` roles in the corresponding namespaces.
+Refer to the Kafka configuration documentation for more information.
 --
 
 Type::
@@ -2130,6 +2145,9 @@ Required::
 | `namespace`
 | `string`
 | Namespace where this `LokiStack` resource is located. If omitted, it is assumed to be the same as `spec.namespace`.
+When configuring a different namespace, the operator watches certificate secret and copies it to the netobserv main namespaces.
+In order to do so, you must grant it permissions to the `netobserv-secret-watcher` and `netobserv-secret-creator` roles in the corresponding namespaces.
+Refer to the Loki configuration documentation for more information.
 
 |===
 == .spec.loki.manual

--- a/modules/network-observability-grant-access-kafka-secrets.adoc
+++ b/modules/network-observability-grant-access-kafka-secrets.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/configuring-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-grant-access-kafka-secrets_{context}"]
+= Grant access to Kafka secrets
+
+[role="_abstract"]
+Grant the Network Observability Operator permission to access Kafka secrets when you use the Kafka deployment model with TLS or mTLS enabled.
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* You have `cluster-admin` privileges.
+* You configured the `FlowCollector` resource with `spec.deploymentModel: Kafka` and TLS or mTLS enabled.
+
+.Procedure
+
+. Replace `<namespace>` with the namespace configured in `spec.namespace` of the `FlowCollector` resource. The default value is `netobserv`.
+
+.. If Kafka is installed in the same namespace as the Network Observability components, create the secret watcher role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-watcher \
+  -n <namespace> \
+  --clusterrole=netobserv-secret-watcher \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
++
+.. Create the secret creator role binding in the privileged namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-creator \
+  -n <namespace>-privileged \
+  --clusterrole=netobserv-secret-creator \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
+
+. If Kafka is installed in a different namespace, create the secret watcher role binding in the Kafka namespace.
+
+.. Replace `<kafka_namespace>` with the namespace where Kafka is installed by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-watcher \
+  -n <kafka_namespace> \
+  --clusterrole=netobserv-secret-watcher \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
++
+.. Create the secret creator role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-creator \
+  -n <namespace> \
+  --clusterrole=netobserv-secret-creator \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
++
+.. Create the secret creator role binding in the privileged namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-creator \
+  -n <namespace>-privileged \
+  --clusterrole=netobserv-secret-creator \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
+
+.Verification
+
+. Check the `FlowCollector` status for errors by running the following command:
++
+[source,terminal]
+----
+$ oc get flowcollector cluster -o jsonpath='{.status.conditions}'
+----
+
+. Verify that no conditions report permission-related errors.
++
+[NOTE]
+====
+If the `FlowCollector` status continues to show permission errors after you grant the required permissions, restart the Network Observability Operator pod for faster reconciliation:
+
+[source,terminal]
+----
+$ oc delete pods -n openshift-netobserv-operator -l app=netobserv-operator
+----
+====

--- a/modules/network-observability-grant-access-lokistack-secrets.adoc
+++ b/modules/network-observability-grant-access-lokistack-secrets.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/configuring-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-grant-access-lokistack-secrets_{context}"]
+= Grant access to LokiStack secrets
+
+[role="_abstract"]
+Grant the Network Observability Operator permission to access the `LokiStack` secret when `LokiStack` is installed in a namespace other than `netobserv`.
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* You have `cluster-admin` privileges.
+* You use the {loki-op} with `LokiStack` installed in a namespace other than `netobserv`.
+
+.Procedure
+
+. Replace `<lokistack_namespace>` with the namespace where `LokiStack` is installed and `<namespace>` with the namespace configured in `spec.namespace` of the `FlowCollector` resource.
+
+.. Create the `secret-watcher` role binding in the LokiStack namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-watcher \
+  -n <lokistack_namespace> \
+  --clusterrole=netobserv-secret-watcher \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
+
+.. Create the `secret-creator` role binding by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-creator \
+  -n <namespace> \
+  --clusterrole=netobserv-secret-creator \
+  --serviceaccount=openshift-netobserv-operator:netobserv-controller-manager
+----
+
+.Verification
+
+. Check the `FlowCollector` status for errors by running the following command:
++
+[source,terminal]
+----
+$ oc get flowcollector cluster -o jsonpath='{.status.conditions}'
+----
+
+. Verify that no conditions report permission-related errors.
++
+[NOTE]
+====
+If the `FlowCollector` status continues to show permission errors after you grant the required permissions, restart the Network Observability Operator pod for faster reconciliation:
+
+[source,terminal]
+----
+$ oc delete pods -n openshift-netobserv-operator -l app=netobserv-operator
+----
+====

--- a/modules/network-observability-grant-permissions-custom-namespace-and-secret-access.adoc
+++ b/modules/network-observability-grant-permissions-custom-namespace-and-secret-access.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/configuring-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-grant-permissions-custom-namespace-and-secret-access_{context}"]
+= Grant permissions for custom namespace and secret access
+
+[role="_abstract"]
+Grant RBAC permissions to allow the Network Observability Operator to access secrets across custom or non-default namespaces.
+
+For security, the Network Observability Operator does not have cluster-wide permissions to read secrets. You must explicitly grant the required permissions when any of the following conditions apply:
+
+* You configured `spec.namespace` in the `FlowCollector` resource to a namespace other than `netobserv`.
+* You configured the `FlowCollector` resource with `spec.deploymentModel: Kafka` and TLS or mTLS enabled.
+* You use the {loki-op} with `LokiStack` installed in a namespace other than `netobserv`.
+
+Complete only the procedures that apply to your configuration. If you do not meet any of these conditions, no additional permissions are required.

--- a/modules/network-observability-operator-release-notes-1-12-2-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-2-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-2-advisory_{context}"]
+= Network Observability Operator 1.12.2 advisory
+
+[role="_abstract"]
+Network Observability Operator 1.12.2 includes a product enhancement advisory.
+
+* link:https://access.redhat.com/errata/RHEA-2026:56870[RHEA-2026:56870 Network Observability Operator 1.12.2]

--- a/modules/network-observability-operator-release-notes-1-12-2-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-2-fixed-issues.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-2-fixed-issues_{context}"]
+= Network Observability Operator 1.12.2 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.12.2 release contains several fixed issues that improve system status reporting and user experience.
+
+Narrowed Operator ClusterRole to least-privilege RBAC permissions::
+Before this update, the Network Observability Operator's generated `ClusterRole` granted cluster-wide write access to core resources such as secrets and namespaces, and allowed creating `SecurityContextConstraints` and `ClusterRoleBindings` without resource-name scoping. As a consequence, the Network Observability Operator service account held broader permissions than required to manage its operands.
++
+With this release, the Network Observability Operator's RBAC permissions are scoped to only the namespaces it manages, the `securitycontextconstraints` rule is restricted by resource name, and `ClusterRoleBinding` permissions are constrained to the specific bindings the Operator creates. As a result, the Operator follows the principle of least privilege and reduces the attack surface of the service account.
++
+After upgrading to Network Observability Operator 1.12.2, you must manually grant RBAC permissions if any of the following conditions apply:
++
+* You configured `spec.namespace` in the `FlowCollector` resource to a namespace other than `netobserv`.
+* You configured the `FlowCollector` resource with `spec.deploymentModel: Kafka` and TLS or mTLS enabled.
+* You use the {loki-op} with `LokiStack` installed in a namespace other than `netobserv`.
++
+For instructions, see "Granting permissions for custom namespace and secret access".
+
+Inherited scheduling configuration for the console plugin static deployment::
+Before this update, the `netobserv-plugin-static` deployment in the `openshift-netobserv-operator` namespace did not inherit `nodeSelector` and `tolerations` settings from the Operator Subscription. As a consequence, you could not schedule the static console plugin pod onto infrastructure nodes alongside the controller manager.
++
+With this release, the `netobserv-plugin-static` deployment inherits the scheduling configuration set on the Operator Subscription. As a result, node placement for the static console plugin is consistent with the controller manager.
++
+link:https://redhat.atlassian.net/browse/NETOBSERV-2575[NETOBSERV-2575]
+
+Resolved Operator startup failure with custom console logos::
+Before this update, the Network Observability Operator failed to start when the `Console.operator.openshift.io` resource had the `spec.customization.logos` field configured. The Operator incorrectly reported a validation conflict between `logos` and the deprecated `customLogoFile` field, even when only `logos` was set.
++
+With this release, the Network Observability Operator correctly handles web console configurations that use the `spec.customization.logos` field. As a result, the Operator starts successfully on clusters with custom console branding.
++
+link:https://redhat.atlassian.net/browse/NETOBSERV-2767[NETOBSERV-2767]
+
+Fixed controller crash when FlowCollector is on hold and ServiceAccount is absent::
+Before this update, the Operator controller panicked with a nil pointer dereference when the `FlowCollector` resource was in `OnHold` mode and the eBPF agent `ServiceAccount` did not exist. As a consequence, the controller manager pod entered a `CrashLoopBackOff` state and all reconciliation stopped.
++
+With this release, the Network Observability Operator gracefully skips the deletion step when the `ServiceAccount` is absent during an `OnHold` reconciliation. As a result, the controller manager no longer crashes in this scenario.
++
+link:https://redhat.atlassian.net/browse/NETOBSERV-2839[NETOBSERV-2839]

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -20,6 +20,14 @@ include::modules/network-observability-flowcollector-example.adoc[leveloffset=+2
 * xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[FlowCollector API reference]
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversation tracking]
 
+include::modules/network-observability-grant-permissions-custom-namespace-and-secret-access.adoc[leveloffset=+1]
+
+include::modules/network-observability-create-cluster-role-bindings-custom-namespace.adoc[leveloffset=+2]
+
+include::modules/network-observability-grant-access-kafka-secrets.adoc[leveloffset=+2]
+
+include::modules/network-observability-grant-access-lokistack-secrets.adoc[leveloffset=+2]
+
 include::modules/network-observability-flowcollector-kafka-config.adoc[leveloffset=+1]
 
 include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -14,6 +14,12 @@ The Network Observability Operator enables administrators to observe and analyze
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
+Some referenced tickets are not linked. This means that the ticket is not accessible without Red Hat credentials.
+
+include::modules/network-observability-operator-release-notes-1-12-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-12-2-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-12-1-advisory.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-12-advisory.adoc[leveloffset=+1]
@@ -26,3 +32,8 @@ include::modules/network-observability-operator-release-notes-1-12-new-features-
 include::modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-12-known-issues.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-grant-permissions-custom-namespace-and-secret-access_network_observability[Grant permissions for custom namespace and secret access]


### PR DESCRIPTION
Manual cherry-pick

Original PR: https://github.com/openshift/openshift-docs/pull/117094
Original commit: 5321f63a720495450ce9b8e8af11bc39dd6398b8

Version(s):
4.17

QE review:
QE is not required for this PR>

Additional information:
* 9 files. Same as original PR.
