### PR TITLE
[enterprise-4.16] [TELCODOCS#2936]: Stop documenting unused PreCachingConfig override fields

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="talm-prechache-user-specified-images-preparing-crs_{context}"]
@@ -18,7 +19,7 @@ metadata:
   name: exampleconfig
   namespace: default <1>
 spec:
-[...]
+# ...
   spaceRequired: 30Gi <2>
   additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
@@ -78,7 +79,7 @@ All sites are pre-cached concurrently.
 
 .Verification
 
-. Check the pre-caching status on the hub cluster where the `ClusterUpgradeGroup` CR is applied by running the following command:
+. Check the pre-caching status on the hub cluster where the `ClusterGroupUpgrade` CR is applied by running the following command:
 +
 [source,terminal]
 ----
@@ -86,7 +87,10 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-.Example output
+The following example shows the derived pre-caching specification.
+The `platformImage` and `operatorsIndexes` values come from the managed policies, not from `PreCachingConfig` overrides.
++
+
 [source,yaml]
 ----
   precaching:

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
@@ -114,7 +114,8 @@ Example output:
 }
 ----
 +
-Displays the list of identified clusters.
+The output lists the identified clusters.
+The `platformImage` value in `status.precaching.spec` is derived by {cgu-operator} from the `ClusterVersion` object in the managed policies.
 
 . Check the status of the pre-caching job by running the following command on the spoke cluster:
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="talm-prechache-user-specified-images-concept_{context}"]
@@ -12,6 +13,9 @@ You can specify the configuration options for the pre-caching jobs using the fol
 
 * `PreCachingConfig` CR
 * `ClusterGroupUpgrade` CR
+
+{cgu-operator} derives the platform image from the `ClusterVersion` object in the managed policies.
+{cgu-operator} derives Operator index images from `CatalogSource` objects that the managed policies reference.
 
 [NOTE]
 ====
@@ -28,9 +32,6 @@ metadata:
   namespace: exampleconfig-ns
 spec:
   overrides: <1>
-    platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-    operatorsIndexes:
-      - registry.example.com:5000/custom-redhat-operators:1.0.0
     operatorsPackagesAndChannels:
       - local-storage-operator: stable
       - ptp-operator: stable
@@ -44,7 +45,7 @@ spec:
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1>  By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
+<1> Specifies Operator packages and channels to pre-cache instead of the values that {cgu-operator} derives from the managed policies. The only supported override is `operatorsPackagesAndChannels`. {cgu-operator} ignores the deprecated `platformImage` and `operatorsIndexes` override fields if they are present.
 <2> Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
 <3> Specifies the images to exclude from pre-caching based on image name matching.
 <4> Specifies the list of additional images to pre-cache.


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2936

Link to docs preview:
<!--- Add after Netlify preview is available --->

QE review:
- [x] QE has approved this change.

Additional information:
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/118337 to `enterprise-4.16`. The `/cherrypick enterprise-4.16` command failed because this branch still uses AsciiDoc callouts in the TALM `PreCachingConfig` example, while `main` uses bullet field lists.

This PR keeps the 4.16 callout structure and applies the same content change: drop unused `overrides.platformImage` and `overrides.operatorsIndexes` from the example, keep `operatorsPackagesAndChannels` as the supported override, and clarify that status `platformImage` and `operatorsIndexes` values are derived from managed policies.

TALM operator backport for 4.16 is already merged: https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/10588