### PR TITLE
[enterprise-4.16] OSDOCS MCO Add note on marketplace boot images not updated

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -16,7 +16,7 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for clusters managed by the Cluster API.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for clusters managed by the Cluster API. Images from the Google Cloud Marketplace are not automatically updated.
 
 :FeatureName: The updating boot image feature
 include::snippets/technology-preview.adoc[]

--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -17,7 +17,7 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only {gcp-first} clusters as a Technology Preview feature and is not supported for {cluster-capi-operator} managed clusters.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only {gcp-first} clusters as a Technology Preview feature and is not supported for {cluster-capi-operator} managed clusters. Images from the Google Cloud Marketplace are not automatically updated.
 
 :FeatureName: The updating boot image feature on {gcp-first} clusters
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/118362