### PR TITLE
OSDOCS MCO Implement bootimage updates for AWS marketplace

### DIFF
--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -28,6 +28,6 @@ The following table lists the platforms on which boot image management is availa
 
 |===
 
-For all other platforms, the MCO does not automatically update the boot image with each cluster update. Images from the Google Cloud Marketplace or AWS Marketplace are not automatically updated.
+For all other platforms, the MCO does not automatically update the boot image with each cluster update. Images from the Google Cloud Marketplace are not automatically updated.
 
 For clusters where automatic updates are disabled or not supported, you can manually update the boot image on your cluster. See "Manually updating the boot image" for information. The method to update or specify the image varies by platform.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-19897

Preview:
MCO -> [Boot image management](https://118580--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html) -- Removed _or AWS Marketplace_ from sentence after the table.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
