### PR TITLE
[OSDOCS#16167]: Follow-up PR of the PR#112469 to fix hyperlink

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -35,8 +35,7 @@ include::modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc[le
 
 .Next steps
 
-* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#mounting-secrets-external-secrets-store[Mounting secrets from an external secrets store to a CSI volume]
-
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#mounting-secrets-external-secrets-store_nodes-pods-secrets-store[Mounting secrets from an external secrets store to a CSI volume]
 
 include::modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc[leveloffset=+1]
 


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16167

Link to docs preview:
https://118581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store.html#persistent-storage-csi-secrets-store-driver-install-cli_persistent-storage-csi-secrets-store

Corrected hyperlink: https://118581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store#mounting-secrets-external-secrets-store_nodes-pods-secrets-store

QE review:
N/A

Additional information:
This is the follow-up PR of https://github.com/openshift/openshift-docs/pull/112469. @stevsmit has suggested just to update the  hyperlink. 
