### PR TITLE
OCPBUGS-61396: Add NTP prerequisite note to PTP Operator

### DIFF
--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -43,4 +43,4 @@ Engineering considerations::
 ** Variations with and without HA
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
-* Cluster Node(s) must have proper NTP configuration to ensure correct time prior to PTP operator taking ownership of node timing.
+* Cluster nodes must have valid NTP configurations to establish accurate time before the PTP Operator takes ownership of node timing.


### PR DESCRIPTION
Adds an NTP prerequisite note to the PTP Operator engineering considerations in the Telco RAN DU RDS.

Cluster nodes must have correct time via NTP before the PTP Operator takes ownership of node timing.

Backport of the note already present on `main` and `enterprise-4.22`. Mirrors the upstream RDS source change (internal GitLab MRs !137, !139, !140).

Tracked by: OCPBUGS-61396 / [TELCODOCS-2562](https://redhat.atlassian.net/browse/TELCODOCS-2562)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
