### PR TITLE
[enterprise-4.22] OSDOCS-16991_m#CQA fixes for AWS UPI procedure and proxy modules

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -141,13 +141,13 @@ ifndef::gcp[]
 * You have an existing `install-config.yaml` file.
 
 endif::gcp[]
-* You have reviewed the sites that your cluster requires access to and determined whether any of them need to bypass the proxy. By default, all cluster egress traffic is proxied, including calls to hosting cloud provider APIs. You added sites to the `Proxy` object's `spec.noProxy` field to bypass the proxy if necessary.
+* You have reviewed the sites that your cluster requires access to and determined whether any of them need to bypass the proxy. By default, the proxy handles all cluster egress traffic, including calls to hosting cloud provider APIs. You added sites to the `Proxy` object's `spec.noProxy` field to bypass the proxy if necessary.
 +
 [NOTE]
 ====
-The `Proxy` object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The `Proxy` object `status.noProxy` field includes the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
 
-For installations on Amazon Web Services (AWS), {gcp-first}, Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
+For installations on {aws-first}, {gcp-first}, Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field also includes the instance metadata endpoint (`169.254.169.254`).
 ====
 
 .Procedure
@@ -186,8 +186,8 @@ endif::aws[]
 ifdef::vsphere[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere[]
-`additionalTrustBundle`:: If provided, the installation program generates a config map that is named `user-ca-bundle` in the `openshift-config` namespace to hold the additional CA certificates. If you provide `additionalTrustBundle` and at least one proxy setting, the `Proxy` object is configured to reference the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
-`additionalTrustBundlePolicy`:: Specifies the policy that determines the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when `http/https` proxy is configured. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`. Optional parameter.
+`additionalTrustBundle`:: If you specify this value, the installation program generates a config map named `user-ca-bundle` in the `openshift-config` namespace to hold the additional CA certificates. If you specify `additionalTrustBundle` and at least one proxy setting, the `Proxy` object references the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter with the {op-system} trust bundle. You must set the `additionalTrustBundle` field unless an authority from the {op-system} trust bundle signs the proxy's identity certificate.
+`additionalTrustBundlePolicy`:: Specifies the policy that determines the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when you configure an `http/https` proxy. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`. Optional parameter.
 +
 [NOTE]
 ====
@@ -206,11 +206,11 @@ $ ./openshift-install wait-for install-complete --log-level debug
 
 . Save the file and reference it when installing {product-title}.
 +
-The installation program creates a cluster-wide proxy that is named `cluster` that uses the proxy settings in the provided `install-config.yaml` file. If no proxy settings are provided, a `cluster` `Proxy` object is still created, but it will have a nil `spec`.
+The installation program creates a cluster-wide proxy named `cluster` that uses the proxy settings in the `install-config.yaml` file. If you do not give proxy settings, the installation program still creates a `cluster` `Proxy` object, but it has a nil `spec`.
 +
 [NOTE]
 ====
-Only the `Proxy` object named `cluster` is supported, and no additional proxies can be created.
+Only the `Proxy` object named `cluster` is supported, and you cannot create additional proxies.
 ====
 
 ifeval::["{context}" == "installing-aws-china-region"]

--- a/modules/installation-create-ingress-dns-records.adoc
+++ b/modules/installation-create-ingress-dns-records.adoc
@@ -22,7 +22,7 @@ link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Instal
 
 .Procedure
 
-. Determine the routes to create.
+. Find the routes to create.
 ** To create a wildcard record, use `*.apps.<cluster_name>.<domain_name>`, where `<cluster_name>` is your cluster name, and `<domain_name>` is the Route 53 base domain for your {product-title} cluster.
 ** To create specific records, you must create a record for each route that your cluster uses, as shown in the output of the following command:
 +
@@ -41,7 +41,7 @@ alertmanager-main-openshift-monitoring.apps.<cluster_name>.<domain_name>
 prometheus-k8s-openshift-monitoring.apps.<cluster_name>.<domain_name>
 ----
 
-. Retrieve the Ingress Operator load balancer status and note the value of the external IP address that it uses, which is shown in the `EXTERNAL-IP` column:
+. Retrieve the Ingress Operator load balancer status and note the value of the external IP address that it uses, which the `EXTERNAL-IP` column displays:
 +
 [source,terminal]
 ----
@@ -91,7 +91,7 @@ where `<domain_name>` is the Route 53 base domain for your {product-title} clust
 /hostedzone/Z3URY6TWQ91KVV
 ----
 +
-The public hosted zone ID for your domain is shown in the command output. In this example, it is `Z3URY6TWQ91KVV`.
+The command output displays the public hosted zone ID for your domain. In this example, it is `Z3URY6TWQ91KVV`.
 
 . Add the alias records to your private zone:
 +
@@ -118,7 +118,7 @@ $ aws route53 change-resource-record-sets --hosted-zone-id "<private_hosted_zone
 where:
 +
 --
-`<private_hosted_zone_id>`:: Specifies the value from the output of the CloudFormation template for DNS and load balancing.
+`<private_hosted_zone_id>`:: Specifies the value from the output of the `CloudFormation` template for DNS and load balancing.
 `<cluster_domain>`:: Specifies the domain or subdomain that you use with your {product-title} cluster.
 `<hosted_zone_id>`:: Specifies the public hosted zone ID for the load balancer that you obtained.
 `<external_ip>`:: Specifies the value of the external IP address of the Ingress Operator load balancer. Ensure that you include the trailing period (`.`) in this parameter value.

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -7,14 +7,15 @@
 [id="installation-creating-aws-bootstrap_{context}"]
 = Creating the bootstrap node in AWS
 
-You must create the bootstrap node in Amazon Web Services (AWS) to use during {product-title} cluster initialization. You do this by:
+[role="_abstract"]
+To initialize the {product-title} control plane, create the bootstrap node in {aws-first} by uploading the Ignition config to an S3 bucket and launching the `CloudFormation` template.
 
-* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is located in your installation directory. The provided CloudFormation Template assumes that the Ignition config files for your cluster are served from an S3 bucket. If you choose to serve the files from another location, you must modify the templates.
-* Using the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the bootstrap node that your {product-title} installation requires.
+* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is in your installation directory. The provided `CloudFormation` template assumes that you serve the Ignition config files for your cluster from an S3 bucket. If you choose to serve the files from another location, you must change the templates.
+* Using the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the bootstrap node that your {product-title} installation requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your bootstrap
+If you do not use the provided `CloudFormation` template to create your bootstrap
 node, you must review the provided information and manually create
 the infrastructure. If your cluster does not initialize correctly, you might
 have to contact Red Hat support with your installation logs.
@@ -22,8 +23,8 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You created and configured DNS, load balancers, and listeners in AWS.
-* You created the security groups and roles required for your cluster in AWS.
+* You created and configured DNS, load balancers, and listeners in {aws-short}.
+* You created the security groups and roles required for your cluster in {aws-short}.
 
 .Procedure
 
@@ -31,12 +32,12 @@ have to contact Red Hat support with your installation logs.
 +
 [source,terminal]
 ----
-$ aws s3 mb s3://<cluster-name>-infra <1>
+$ aws s3 mb s3://<cluster_name>-infra <1>
 ----
-<1> `<cluster-name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster-name>` with the name specified for the cluster.
+<1> `<cluster_name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster_name>` with the name specified for the cluster.
 +
 You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, if you are:
-** Deploying to a region that has endpoints that differ from the AWS SDK.
+** Deploying to a region that has endpoints that differ from the {aws-short} SDK.
 ** Deploying a proxy.
 ** Providing your own custom endpoints.
 
@@ -44,7 +45,7 @@ You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, 
 +
 [source,terminal]
 ----
-$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster-name>-infra/bootstrap.ign <1>
+$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster_name>-infra/bootstrap.ign <1>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you stored the installation files in.
 
@@ -52,7 +53,7 @@ $ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster-name>-infra/boo
 +
 [source,terminal]
 ----
-$ aws s3 ls s3://<cluster-name>-infra/
+$ aws s3 ls s3://<cluster_name>-infra/
 ----
 +
 .Example output
@@ -63,10 +64,10 @@ $ aws s3 ls s3://<cluster-name>-infra/
 +
 [NOTE]
 ====
-The bootstrap Ignition config file does contain secrets, like X.509 keys. The following steps provide basic security for the S3 bucket. To provide additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket contains. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
+The bootstrap Ignition config file does have secrets, such as X.509 keys. The following steps give basic security for the S3 bucket. To give additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket has. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
 ====
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -122,54 +123,51 @@ The bootstrap Ignition config file does contain secrets, like X.509 keys. The fo
 ]
 
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
+<1> The name for your cluster infrastructure that your Ignition config files encode for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
+file metadata, which has the format `<cluster_name>-<random_string>`.
 <3> Current {op-system-first} AMI to use for the bootstrap node based on your selected architecture.
 <4> Specify a valid `AWS::EC2::Image::Id` value.
 <5> CIDR block to allow SSH access to the bootstrap node.
 <6> Specify a CIDR block in the format `x.x.x.x/16-24`.
-<7> The public subnet that is associated with your VPC to launch the bootstrap
-node into.
-<8> Specify the `PublicSubnetIds` value from the output of the CloudFormation
+<7> The public subnet in your VPC to launch the bootstrap node into.
+<8> Specify the `PublicSubnetIds` value from the output of the `CloudFormation`
 template for the VPC.
-<9> The master security group ID (for registering temporary rules)
+<9> The control plane security group ID for registering temporary rules.
 <10> Specify the `MasterSecurityGroupId` value from the output of the
-CloudFormation template for the security group and roles.
-<11> The VPC created resources will belong to.
-<12> Specify the `VpcId` value from the output of the CloudFormation template
+`CloudFormation` template for the security group and roles.
+<11> The VPC that the created resources will belong to.
+<12> Specify the `VpcId` value from the output of the `CloudFormation` template
 for the VPC.
 <13> Location to fetch bootstrap Ignition config file from.
 <14> Specify the S3 bucket and file name in the form
 `s3://<bucket_name>/bootstrap.ign`.
 <15> Whether or not to register a network load balancer (NLB).
-<16> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
+<16> Specify `yes` or `no`. If you specify `yes`, you must give a Lambda
 Amazon Resource Name (ARN) value.
 <17> The ARN for NLB IP target registration lambda group.
 <18> Specify the `RegisterNlbIpTargetsLambda` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
+`CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if
+deploying the cluster to an {aws-short} `GovCloud` region.
 <19> The ARN for external API load balancer target group.
 <20> Specify the `ExternalApiTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
+`CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if
+deploying the cluster to an {aws-short} `GovCloud` region.
 <21> The ARN for internal API load balancer target group.
 <22> Specify the `InternalApiTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
+`CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if
+deploying the cluster to an {aws-short} `GovCloud` region.
 <23> The ARN for internal service load balancer target group.
 <24> Specify the `InternalServiceTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
+`CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if
+deploying the cluster to an {aws-short} `GovCloud` region.
 
-. Copy the template from the *CloudFormation template for the bootstrap machine*
-section of this topic and save it as a YAML file on your computer. This template
+. Copy the template from the *`CloudFormation` template for the bootstrap machine* section and save it as a YAML file on your computer. This template
 describes the bootstrap machine that your cluster requires.
 
 . Optional: If you are deploying the cluster with a proxy, you must update the ignition in the template to add the  `ignition.config.proxy` fields. Additionally, If you have added the Amazon EC2, Elastic Load Balancing, and S3 VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the bootstrap node:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the bootstrap node:
 +
 [IMPORTANT]
 ====
@@ -183,11 +181,11 @@ $ aws cloudformation create-stack --stack-name <name> <1>
      --parameters file://<parameters>.json <3>
      --capabilities CAPABILITY_NAMED_IAM <4>
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-bootstrap`.
+<1> `<name>` is the name for the `CloudFormation` stack, such as `cluster-bootstrap`.
 You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
+<2> `<template>` is the relative path to and name of the `CloudFormation` template
 YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
+<3> `<parameters>` is the relative path to and name of the `CloudFormation`
 parameters JSON file.
 <4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
 +
@@ -205,8 +203,8 @@ $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
 After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+for the following parameters. You must give these parameter values to
+the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `BootstrapInstanceId`:: The bootstrap Instance ID.
 `BootstrapPublicIp`:: The bootstrap node public IP address.

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -7,18 +7,17 @@
 [id="installation-creating-aws-control-plane_{context}"]
 = Creating the control plane machines in AWS
 
-You must create the control plane machines in Amazon Web Services (AWS) that your cluster will use.
-
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources that represent the control plane nodes.
+[role="_abstract"]
+To run the {product-title} control plane, create the three control plane machines in {aws-first} by using the provided `CloudFormation` template and a custom parameter file.
 
 [IMPORTANT]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your control plane
+If you do not use the provided `CloudFormation` template to create your control plane
 nodes, you must review the provided information and manually create
 the infrastructure. If your cluster does not initialize correctly, you might
 have to contact Red Hat support with your installation logs.
@@ -30,7 +29,7 @@ have to contact Red Hat support with your installation logs.
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template
+. Create a JSON file that has the parameter values that the template
 requires:
 +
 [source,json]
@@ -110,29 +109,28 @@ requires:
   }
 ]
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
+<1> The name for your cluster infrastructure that your Ignition config files encode for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
+file metadata, which has the format `<cluster_name>-<random_string>`.
 <3> Current {op-system-first} AMI to use for the control plane machines based on your selected architecture.
 <4> Specify an `AWS::EC2::Image::Id` value.
 <5> Whether or not to perform DNS etcd registration.
-<6> Specify `yes` or `no`. If you specify `yes`, you must provide hosted zone
+<6> Specify `yes` or `no`. If you specify `yes`, you must give hosted zone
 information.
 <7> The Route 53 private zone ID to register the etcd targets with.
 <8> Specify the `PrivateHostedZoneId` value from the output of the
-CloudFormation template for DNS and load balancing.
+`CloudFormation` template for DNS and load balancing.
 <9> The Route 53 zone to register the targets with.
 <10> Specify `<cluster_name>.<domain_name>` where `<domain_name>` is the Route 53
 base domain that you used when you generated `install-config.yaml` file for the
 cluster. Do not include the trailing period (.) that is
-displayed in the AWS console.
+displayed in the {aws-short} console.
 <11> A subnet, preferably private, to launch the control plane machines on.
 <12> Specify a subnet from the `PrivateSubnets` value from the output of the
-CloudFormation template for DNS and load balancing.
-<13> The master security group ID to associate with control plane nodes.
+`CloudFormation` template for DNS and load balancing.
+<13> The control plane security group ID to associate with control plane nodes.
 <14> Specify the `MasterSecurityGroupId` value from the output of the
-CloudFormation template for the security group and roles.
+`CloudFormation` template for the security group and roles.
 <15> The location to fetch control plane Ignition config file from.
 <16> Specify the generated Ignition config file location,
 `https://api-int.<cluster_name>.<domain_name>:22623/config/master`.
@@ -142,42 +140,41 @@ directory. This value is the long string with the format
 `data:text/plain;charset=utf-8;base64,ABC...xYz==`.
 <19> The IAM profile to associate with control plane nodes.
 <20> Specify the `MasterInstanceProfile` parameter value from the output of
-the CloudFormation template for the security group and roles.
-<21> The type of AWS instance to use for the control plane machines based on your selected architecture.
+the `CloudFormation` template for the security group and roles.
+<21> The type of {aws-short} instance to use for the control plane machines based on your selected architecture.
 <22> The instance type value corresponds to the minimum resource requirements for
 control plane machines. For example `m6i.xlarge` is a type for AMD64
 ifndef::openshift-origin[]
 and `m6g.xlarge` is a type for ARM64.
 endif::openshift-origin[]
 <23> Whether or not to register a network load balancer (NLB).
-<24> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
+<24> Specify `yes` or `no`. If you specify `yes`, you must give a Lambda
 Amazon Resource Name (ARN) value.
 <25> The ARN for NLB IP target registration lambda group.
-<26> Specify the `RegisterNlbIpTargetsLambda` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
+<26> Specify the `RegisterNlbIpTargetsLambda` value from the output of the `CloudFormation` template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short}
+`GovCloud` region.
 <27> The ARN for external API load balancer target group.
-<28> Specify the `ExternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
+<28> Specify the `ExternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short}
+`GovCloud` region.
 <29> The ARN for internal API load balancer target group.
-<30> Specify the `InternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
+<30> Specify the `InternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short}
+`GovCloud` region.
 <31> The ARN for internal service load balancer target group.
-<32> Specify the `InternalServiceTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
+<32> Specify the `InternalServiceTargetGroupArn` value from the output of the `CloudFormation` template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short}
+`GovCloud` region.
 
-. Copy the template from the *CloudFormation template for control plane machines*
-section of this topic and save it as a YAML file on your computer. This template
+. Copy the template from the *`CloudFormation` template for control plane machines* section and save it as a YAML file on your computer. This template
 describes the control plane machines that your cluster requires.
 
 . If you specified an `m5` instance type as the value for `MasterInstanceType`,
 add that instance type to the `MasterInstanceType.AllowedValues` parameter
-in the CloudFormation template.
+in the `CloudFormation` template.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the control plane nodes:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the control plane nodes:
 +
 [IMPORTANT]
 ====
@@ -190,11 +187,11 @@ $ aws cloudformation create-stack --stack-name <name> <1>
      --template-body file://<template>.yaml <2>
      --parameters file://<parameters>.json <3>
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-control-plane`.
+<1> `<name>` is the name for the `CloudFormation` stack, such as `cluster-control-plane`.
 You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
+<2> `<template>` is the relative path to and name of the `CloudFormation` template
 YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
+<3> `<parameters>` is the relative path to and name of the `CloudFormation`
 parameters JSON file.
 +
 .Example output
@@ -205,7 +202,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-control-plane/21c7e2
 +
 [NOTE]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 . Confirm that the template components exist:

--- a/modules/installation-creating-aws-dns.adoc
+++ b/modules/installation-creating-aws-dns.adoc
@@ -7,15 +7,16 @@
 [id="installation-creating-aws-dns_{context}"]
 = Creating networking and load balancing components in AWS
 
-You must configure networking and classic or network load balancing in Amazon Web Services (AWS) that your {product-title} cluster can use.
+[role="_abstract"]
+To route traffic to your {product-title} cluster, configure the networking and load balancing components in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
 
-You can run the template multiple times within a single Virtual Private Cloud (VPC).
+You can run the template many times within a single Virtual Private Cloud (VPC).
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your AWS
+If you do not use the provided `CloudFormation` template to create your {aws-short}
 infrastructure, you must review the provided information and manually create
 the infrastructure. If your cluster does not initialize correctly, you might
 have to contact Red Hat support with your installation logs.
@@ -23,7 +24,7 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You created and configured a VPC and associated subnets in AWS.
+* You created and configured a VPC and associated subnets in {aws-short}.
 
 .Procedure
 
@@ -46,7 +47,7 @@ HOSTEDZONES	65F8F38E-2268-B835-E15C-AB55336FCBFA	/hostedzone/Z21IXYZABCZ2A4	mycl
 +
 In the example output, the hosted zone ID is `Z21IXYZABCZ2A4`.
 
-. Create a JSON file that contains the parameter values that the template
+. Create a JSON file that has the parameter values that the template
 requires:
 +
 [source,json]
@@ -85,37 +86,35 @@ requires:
 <1> A short, representative cluster name to use for hostnames, etc.
 <2> Specify the cluster name that you used when you generated the
 `install-config.yaml` file for the cluster.
-<3> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
+<3> The name for your cluster infrastructure that your Ignition config files encode for the cluster.
 <4> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
+file metadata, which has the format `<cluster_name>-<random_string>`.
 <5> The Route 53 public zone ID to register the targets with.
 <6> Specify the Route 53 public zone ID, which has a format similar to
-`Z21IXYZABCZ2A4`. You can obtain this value from the AWS console.
+`Z21IXYZABCZ2A4`. You can obtain this value from the {aws-short} console.
 <7> The Route 53 zone to register the targets with.
 <8> Specify the Route 53 base domain that you used when you generated the
 `install-config.yaml` file for the cluster. Do not include the trailing period
-(.) that is displayed in the AWS console.
+(.) that is displayed in the {aws-short} console.
 <9> The public subnets that you created for your VPC.
-<10> Specify the `PublicSubnetIds` value from the output of the CloudFormation
+<10> Specify the `PublicSubnetIds` value from the output of the `CloudFormation`
 template for the VPC.
 <11> The private subnets that you created for your VPC.
-<12> Specify the `PrivateSubnetIds` value from the output of the CloudFormation
+<12> Specify the `PrivateSubnetIds` value from the output of the `CloudFormation`
 template for the VPC.
 <13> The VPC that you created for the cluster.
-<14> Specify the `VpcId` value from the output of the CloudFormation template
+<14> Specify the `VpcId` value from the output of the `CloudFormation` template
 for the VPC.
 
-. Copy the template from the *CloudFormation template for the network and load balancers*
-section of this topic and save it as a YAML file on your computer. This template
+. Copy the template from the *`CloudFormation` template for the network and load balancers* section and save it as a YAML file on your computer. This template
 describes the networking and load balancing objects that your cluster requires.
 +
 [IMPORTANT]
 ====
-If you are deploying your cluster to an AWS government or secret region, you must update the `InternalApiServerRecord` in the CloudFormation template to use `CNAME` records. Records of type `ALIAS` are not supported for AWS government regions.
+If you are deploying your cluster to an {aws-short} government or secret region, you must update the `InternalApiServerRecord` in the `CloudFormation` template to use `CNAME` records. Records of type `ALIAS` are not supported for {aws-short} government regions.
 ====
 
-. Launch the CloudFormation template to create a stack of AWS resources that provide the networking and load balancing components:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources for the networking and load balancing components:
 +
 [IMPORTANT]
 ====
@@ -129,11 +128,11 @@ $ aws cloudformation create-stack --stack-name <name> <1>
      --parameters file://<parameters>.json <3>
      --capabilities CAPABILITY_NAMED_IAM <4>
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-dns`.
+<1> `<name>` is the name for the `CloudFormation` stack, such as `cluster-dns`.
 You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
+<2> `<template>` is the relative path to and name of the `CloudFormation` template
 YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
+<3> `<parameters>` is the relative path to and name of the `CloudFormation`
 parameters JSON file.
 <4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` resources.
 +
@@ -151,8 +150,8 @@ $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
 After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+for the following parameters. You must give these parameter values to
+the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `PrivateHostedZoneId`:: Hosted zone ID for the private DNS.
 `ExternalApiLoadBalancerName`:: Full name of the external API load balancer.

--- a/modules/installation-creating-aws-security.adoc
+++ b/modules/installation-creating-aws-security.adoc
@@ -7,13 +7,14 @@
 [id="installation-creating-aws-security_{context}"]
 = Creating security group and roles in AWS
 
-You must create security groups and roles in Amazon Web Services (AWS) for your {product-title} cluster to use.
+[role="_abstract"]
+To control access to your {product-title} cluster resources, create the required security groups and IAM roles in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the security groups and roles that your {product-title} cluster requires.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the security groups and roles that your {product-title} cluster requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your AWS
+If you do not use the provided `CloudFormation` template to create your {aws-short}
 infrastructure, you must review the provided information and manually create
 the infrastructure. If your cluster does not initialize correctly, you might
 have to contact Red Hat support with your installation logs.
@@ -21,7 +22,7 @@ have to contact Red Hat support with your installation logs.
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template
+. Create a JSON file that has the parameter values that the template
 requires:
 +
 [source,json]
@@ -45,25 +46,23 @@ requires:
   }
 ]
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
+<1> The name for your cluster infrastructure that your Ignition config files encode for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
+file metadata, which has the format `<cluster_name>-<random_string>`.
 <3> The CIDR block for the VPC.
 <4> Specify the CIDR block parameter that you used for the VPC that you defined
 in the form `x.x.x.x/16-24`.
 <5> The private subnets that you created for your VPC.
-<6> Specify the `PrivateSubnetIds` value from the output of the CloudFormation
+<6> Specify the `PrivateSubnetIds` value from the output of the `CloudFormation`
 template for the VPC.
 <7> The VPC that you created for the cluster.
-<8> Specify the `VpcId` value from the output of the CloudFormation template for
+<8> Specify the `VpcId` value from the output of the `CloudFormation` template for
 the VPC.
 
-. Copy the template from the *CloudFormation template for security objects*
-section of this topic and save it as a YAML file on your computer. This template
+. Copy the template from the *`CloudFormation` template for security objects* section and save it as a YAML file on your computer. This template
 describes the security groups and roles that your cluster requires.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the security groups and roles:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the security groups and roles:
 +
 [IMPORTANT]
 ====
@@ -77,11 +76,11 @@ $ aws cloudformation create-stack --stack-name <name> <1>
      --parameters file://<parameters>.json <3>
      --capabilities CAPABILITY_NAMED_IAM <4>
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-sec`.
+<1> `<name>` is the name for the `CloudFormation` stack, such as `cluster-sec`.
 You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
+<2> `<template>` is the relative path to and name of the `CloudFormation` template
 YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
+<3> `<parameters>` is the relative path to and name of the `CloudFormation`
 parameters JSON file.
 <4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
 +
@@ -99,10 +98,10 @@ $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
 After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+for the following parameters. You must give these parameter values to
+the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
-`MasterSecurityGroupId`:: Master Security Group ID
-`WorkerSecurityGroupId`:: Worker Security Group ID
-`MasterInstanceProfile`:: Master IAM Instance Profile
-`WorkerInstanceProfile`:: Worker IAM Instance Profile
+`MasterSecurityGroupId`:: Control plane security group ID
+`WorkerSecurityGroupId`:: Worker security group ID
+`MasterInstanceProfile`:: Control plane IAM instance profile
+`WorkerInstanceProfile`:: Worker IAM instance profile


### PR DESCRIPTION
4.22 cherrypick of 5364238cdd210585744ef14db15032ab09477ce9
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/118505

Note
The 4.21+ branches have more content in the four installation-creating-aws-* files than 4.20 does. These branches have additional CloudFormation parameters, GovCloud references, and other sections that 4.20 doesn't have — so there are more instances of the same CQA fixes to apply.