### PR TITLE
[enterprise-4.17] [OCPBUGS#67196][OCPBUGS#67195]: Add procedure for configuring cluster network MTU at install time

### DIFF
--- a/edge_computing/ztp-advanced-install-ztp.adoc
+++ b/edge_computing/ztp-advanced-install-ztp.adoc
@@ -6,9 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use `SiteConfig` custom resources (CRs) to deploy custom functionality and configurations in your managed clusters at installation time.
 
 include::modules/ztp-customizing-the-install-extra-manifests.adoc[leveloffset=+1]
+
+include::modules/ztp-configuring-cluster-network-mtu.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-advanced-install-ztp.adoc#ztp-customizing-the-install-extra-manifests_ztp-advanced-install-ztp[Customizing extra installation manifests in the {ztp} pipeline]
 
 include::modules/ztp-filtering-ai-crs-using-siteconfig.adoc[leveloffset=+1]
 

--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -74,6 +74,9 @@ include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
 
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[About disk encryption]
 
+// Configuring cluster network MTU
+include::modules/installing-ocp-agent-cluster-network-mtu.adoc[leveloffset=+2]
+
 // Creating and booting the agent image
 include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]
 

--- a/modules/installing-ocp-agent-cluster-network-mtu.adoc
+++ b/modules/installing-ocp-agent-cluster-network-mtu.adoc
@@ -1,0 +1,132 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-ocp-agent-cluster-network-mtu_{context}"]
+= Configuring cluster network MTU at installation time
+
+[role="_abstract"]
+You can explicitly set the cluster network maximum transmission unit (MTU) during installation by placing a `Network` custom resource (CR) as an additional manifest in the `openshift` directory of your Agent-based Installer configuration.
+
+Setting the cluster network MTU with additional headroom during deployment prevents the need for a Day 2 MTU update that requires at least two rolling reboots of all cluster nodes.
+
+During installation, the Cluster Network Operator (CNO) automatically calculates the cluster network MTU based on the primary network interface MTU.
+When you enable IPsec at installation time, the calculation includes both the OVN-Kubernetes overhead of 100 bytes and the IPsec overhead.
+If you plan to enable IPsec or another encapsulation technology as a Day 2 operation, the calculated MTU includes only the OVN-Kubernetes overhead and might be insufficient.
+
+By explicitly setting the cluster network MTU at installation time, you can include additional headroom for those future needs and avoid a disruptive MTU migration.
+
+[IMPORTANT]
+====
+The cluster network MTU value must be lower than the machine network MTU by at least 100 bytes to account for OVN-Kubernetes overlay overhead.
+If you plan to enable IPsec as a Day 2 operation, allow an additional 46 bytes for IPsec headroom.
+For example, with a machine network MTU of `9100` bytes, set the cluster network MTU to `8900` bytes, which accounts for the following offset:
+
+* OVN-Kubernetes overhead: 100 bytes
+* IPsec headroom: 46 bytes
+* Extra headroom: 54 bytes
+* Total offset: 200 bytes
+
+To avoid selecting an MTU value that a node cannot support, verify the maximum MTU (`maxmtu`) that the network interface accepts by running the `ip -d link` command.
+====
+
+.Prerequisites
+
+* You have created the `install-config.yaml` and `agent-config.yaml` files for your installation.
+* You have created the `openshift` subdirectory within your installation directory as described in "Creating a directory to contain additional manifests".
+
+.Procedure
+
+. In your `agent-config.yaml` file, set the machine network MTU on the network interface for each host by using NMState configuration.
++
+The following example configures an Ethernet interface with MTU `9100`:
++
+[source,yaml]
+----
+apiVersion: v1beta1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: master-0
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a5
+    networkConfig:
+      interfaces:
+        - name: eno1
+          type: ethernet
+          state: up
+          mtu: 9100
+          ipv4:
+            enabled: true
+            dhcp: false
+            address:
+              - ip: "192.168.111.80"
+                prefix-length: 24
+----
+
+. Create a `Network` CR manifest file named `set-cluster-mtu.yaml` that sets the cluster network MTU:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      mtu: 8900
+----
++
+where:
++
+`mtu`:: Specifies the cluster network MTU value. This value must be at least 100 bytes less than the machine network MTU. In this example, the value is 200 bytes less than the machine network MTU of 9100 to allow headroom for IPsec and other future requirements.
+
+. Place the `set-cluster-mtu.yaml` manifest file in the `openshift` subdirectory of your installation directory:
++
+[source,text]
+----
+<installation_directory>/
+├── install-config.yaml
+├── agent-config.yaml
+└── openshift/
+    └── set-cluster-mtu.yaml
+----
++
+[NOTE]
+====
+Manifests in the `openshift` directory cannot override default cluster manifests. This restriction does not affect the `Network` CR for cluster network MTU because MTU configuration is not part of the default manifest set.
+====
+
+. Create the agent image and boot your servers as described in "Creating and booting the agent image".
++
+During cluster installation, the installation program applies the `Network` CR as an additional manifest, and the CNO uses the specified MTU value instead of auto-calculating it.
+
+.Verification
+
+* After the cluster installation is complete, verify the cluster network MTU by running the following command:
++
+[source,terminal]
+----
+$ oc get networks.operator.openshift.io cluster -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+# ...
+spec:
+  # ...
+  defaultNetwork:
+    ovnKubernetesConfig:
+      # ...
+      mtu: 8900
+----

--- a/modules/ztp-configuring-cluster-network-mtu.adoc
+++ b/modules/ztp-configuring-cluster-network-mtu.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// * edge_computing/ztp-advanced-install-ztp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-configuring-cluster-network-mtu_{context}"]
+= Configuring cluster network MTU at installation time
+
+[role="_abstract"]
+You can explicitly set the cluster network maximum transmission unit (MTU) during installation by including a `Network` custom resource (CR) as an extra manifest in the {ztp-first} pipeline.
+
+Setting the cluster network MTU with additional headroom during deployment prevents the need for a Day 2 MTU update that requires at least two rolling reboots of all cluster nodes.
+
+During installation, the Cluster Network Operator (CNO) automatically calculates the cluster network MTU based on the primary network interface MTU.
+When you enable IPsec at installation time, the calculation includes both the OVN-Kubernetes overhead of 100 bytes and the IPsec overhead.
+If you plan to enable IPsec or another encapsulation technology as a Day 2 operation, the calculated MTU includes only the OVN-Kubernetes overhead and might be insufficient.
+
+By explicitly setting the cluster network MTU at installation time, you can include additional headroom for those future needs and avoid a disruptive MTU migration.
+
+[IMPORTANT]
+====
+The cluster network MTU value must be lower than the machine network MTU by at least 100 bytes to account for OVN-Kubernetes overlay overhead.
+If you plan to enable IPsec as a Day 2 operation, allow an additional 46 bytes for IPsec headroom.
+For example, with a machine network MTU of `9100` bytes, set the cluster network MTU to `8900` bytes, which accounts for the following offset:
+
+* OVN-Kubernetes overhead: 100 bytes
+* IPsec headroom: 46 bytes
+* Extra headroom: 54 bytes
+* Total offset: 200 bytes
+
+To avoid selecting an MTU value that a node cannot support, verify the maximum MTU (`maxmtu`) that the network interface accepts by running the `ip -d link` command.
+====
+
+.Prerequisites
+
+* You have configured the hub cluster to provision managed clusters by using the {ztp} pipeline.
+* You have a Git repository where you manage your custom site configuration data. The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+
+.Procedure
+
+. In your `SiteConfig` CR, set the machine network MTU on the network interface for all nodes.
++
+The following example configures a VLAN interface with MTU `9100`:
++
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "site1-sno-du"
+  namespace: "site1-sno-du"
+spec:
+  clusters:
+    - clusterName: "site1-sno-du"
+      nodes:
+        - hostName: "node1.example.com"
+          nodeNetwork:
+            interfaces:
+              - name: "bond0.120"
+                macAddress: "00:00:00:00:00:00"
+            config:
+              interfaces:
+                - name: bond0.120
+                  type: vlan
+                  state: up
+                  mtu: 9100
+                  ipv4:
+                    enabled: true
+                    dhcp: false
+                    address:
+                      - ip: "192.168.120.15"
+                        prefix-length: 25
+                  vlan:
+                    base-iface: bond0
+                    id: 120
+  # ...
+----
+
+. Create a `Network` CR manifest file named `set-cluster-mtu.yaml` that sets the cluster network MTU:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      mtu: 8900
+----
++
+where:
++
+`mtu`:: Specifies the cluster network MTU value. This value must be at least 100 bytes less than the machine network MTU. In this example, the value is 200 bytes less than the machine network MTU of 9100 to allow headroom for IPsec and other future requirements.
+
+. In your `siteconfig` directory, place the manifest file in a custom extra manifests subdirectory:
++
+[source,text]
+----
+siteconfig/
+├── site1-sno-du.yaml
+├── extra-manifest/
+└── custom-manifest/
+    └── set-cluster-mtu.yaml
+----
+
+. In your `SiteConfig` CR, enter the directory name in the `extraManifests.searchPaths` field:
++
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "site1-sno-du"
+  namespace: "site1-sno-du"
+spec:
+  clusters:
+    - clusterName: "site1-sno-du"
+      networkType: "OVNKubernetes"
+      extraManifests:
+        searchPaths:
+          - extra-manifest/
+          - custom-manifest/
+  # ...
+----
+
+. Commit the `SiteConfig` CR and the `set-cluster-mtu.yaml` manifest to your Git repository and push the changes.
++
+During cluster provisioning, the {ztp} pipeline applies the `Network` CR as an extra manifest, and the CNO uses the specified MTU value instead of auto-calculating it.
+
+.Verification
+
+* After the cluster installation is complete, verify the cluster network MTU by running the following command:
++
+[source,terminal]
+----
+$ oc get networks.operator.openshift.io cluster -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+# ...
+spec:
+  # ...
+  defaultNetwork:
+    ovnKubernetesConfig:
+      # ...
+      mtu: 8900
+----


### PR DESCRIPTION
This is a manual cherry-pick of #114938

Version(s):
4.17

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-67196
https://redhat.atlassian.net/browse/OCPBUGS-67195

Link to docs preview:
<!-- Add after CI -->

QE review:
- [x] QE has approved this change.

Additional information:
- Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/114938
- The ZTP procedure is adapted from `ClusterInstance` extra manifests (used on `main` and 4.21+) to `SiteConfig` `extraManifests.searchPaths`, which this version uses.
- The Agent-based Installer procedure is unchanged from the original PR.

/assign slovern

Made with [Cursor](https://cursor.com)