### PR TITLE
OSDOCS-20557: adds release note mcp version support update

### DIFF
--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -10,7 +10,12 @@
 You can use the new features and enhancements that are available with {product-title} {version}.
 
 Disconnected installation is now Generally Available::
-Installing {prodname} in a disconnected environment in now Generally Available. You can apply cloud-like traffic management within your private, secure network. For more information, see xref:../install_rhcl/rhcl-install-disconnected.adoc#rhcl-install-disconnected[Install {prodname} in a disconnected environment].
+Installing {prodname} in a disconnected environment is now Generally Available. You can apply cloud-like traffic management within your private, secure network. For more information, see xref:../install_rhcl/rhcl-install-disconnected.adoc#rhcl-install-disconnected[Install {prodname} in a disconnected environment].
+
+*{mcpg}*: {mcpg} adds new protocol support::
+With this release, the {mcpg} adds support for the `2026-07-28` stateless Model Context Protocol (MCP) protocol version. This enhancement means that MCP servers can operate like standard HTTP services in cloud-native environments. Every request is now self-describing and independent, meaning that you can scale your MCP servers while reducing costs.
+
+//For more information, see xref:../mcp_gateway_config/modules/con-mcp-gateway-multi-protocol-support_mcp-gateway-multi-protocol-support.adoc#mcp-gateway-multi-protocol-support[Multi-protocol support for the {mcpg}]
 
 {rhdh} plugin is Generally Available::
 The {rhdh} plugin for {rhcl} is Generally Available. With a {rhdh} subscription, you can create a self-service API catalog that makes API consumption easier and enables teams to work together more effectively. For more information, see xref:../develop/rhdh_plugin/rhdh-plugin-installation.adoc#rhdh-plugin-installation[Manage APIs through Red Hat Developer Hub].


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5

Issue:
[OSDOCS-20557](https://redhat.atlassian.net/browse/OSDOCS-20557)

Link to docs preview:
https://118615--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-features-enhancements_rhcl-release-notes

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature PR, https://github.com/openshift/openshift-docs/pull/118534

