### PR TITLE
OSDOCS-16991: Replace callout annotations with description lists in AWS UPI modules (4.22)

### DIFF
--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -7,23 +7,21 @@
 [id="installation-creating-aws-bootstrap_{context}"]
 = Creating the bootstrap node in AWS
 
-You must create the bootstrap node in Amazon Web Services (AWS) to use during {product-title} cluster initialization. You do this by:
+[role="_abstract"]
+To initialize the {product-title} control plane, create the bootstrap node in {aws-first} by uploading the Ignition config to an S3 bucket and launching the `CloudFormation` template.
 
-* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is located in your installation directory. The provided CloudFormation Template assumes that the Ignition config files for your cluster are served from an S3 bucket. If you choose to serve the files from another location, you must modify the templates.
-* Using the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the bootstrap node that your {product-title} installation requires.
+* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is in your installation directory. The provided `CloudFormation` template assumes that you serve the Ignition config files for your cluster from an S3 bucket. If you choose to serve the files from another location, you must change the templates.
+* Using the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the bootstrap node that your {product-title} installation requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your bootstrap
-node, you must review the provided information and manually create
-the infrastructure. If your cluster does not initialize correctly, you might
-have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your bootstrap node, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
 
-* You created and configured DNS, load balancers, and listeners in AWS.
-* You created the security groups and roles required for your cluster in AWS.
+* You created and configured DNS, load balancers, and listeners in {aws-short}.
+* You created the security groups and roles required for your cluster in {aws-short}.
 
 .Procedure
 
@@ -31,28 +29,33 @@ have to contact Red Hat support with your installation logs.
 +
 [source,terminal]
 ----
-$ aws s3 mb s3://<cluster-name>-infra <1>
+$ aws s3 mb s3://<cluster_name>-infra
 ----
-<1> `<cluster-name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster-name>` with the name specified for the cluster.
 +
+where `<cluster_name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster_name>` with the name specified for the cluster.
++
+--
 You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, if you are:
-** Deploying to a region that has endpoints that differ from the AWS SDK.
-** Deploying a proxy.
-** Providing your own custom endpoints.
+
+* Deploying to a region that has endpoints that differ from the {aws-short} SDK.
+* Deploying a proxy.
+* Providing your own custom endpoints.
+--
 
 . Upload the `bootstrap.ign` Ignition config file to the bucket by running the following command:
 +
 [source,terminal]
 ----
-$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster-name>-infra/bootstrap.ign <1>
+$ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster_name>-infra/bootstrap.ign
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you stored the installation files in.
++
+where `<installation_directory>` is the path to the directory that you stored the installation files in.
 
 . Verify that the file uploaded by running the following command:
 +
 [source,terminal]
 ----
-$ aws s3 ls s3://<cluster-name>-infra/
+$ aws s3 ls s3://<cluster_name>-infra/
 ----
 +
 .Example output
@@ -63,113 +66,88 @@ $ aws s3 ls s3://<cluster-name>-infra/
 +
 [NOTE]
 ====
-The bootstrap Ignition config file does contain secrets, like X.509 keys. The following steps provide basic security for the S3 bucket. To provide additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket contains. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
+The bootstrap Ignition config file does have secrets, such as X.509 keys. The following steps give basic security for the S3 bucket. To give additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket has. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
 ====
 
-. Create a JSON file that contains the parameter values that the template requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
 [
   {
-    "ParameterKey": "InfrastructureName", <1>
-    "ParameterValue": "mycluster-<random_string>" <2>
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "mycluster-<random_string>"
   },
   {
-    "ParameterKey": "RhcosAmi", <3>
-    "ParameterValue": "ami-<random_string>" <4>
+    "ParameterKey": "RhcosAmi",
+    "ParameterValue": "ami-<random_string>"
   },
   {
-    "ParameterKey": "AllowedBootstrapSshCidr", <5>
-    "ParameterValue": "0.0.0.0/0" <6>
+    "ParameterKey": "AllowedBootstrapSshCidr",
+    "ParameterValue": "0.0.0.0/0"
   },
   {
-    "ParameterKey": "PublicSubnet", <7>
-    "ParameterValue": "subnet-<random_string>" <8>
+    "ParameterKey": "PublicSubnet",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "MasterSecurityGroupId", <9>
-    "ParameterValue": "sg-<random_string>" <10>
+    "ParameterKey": "MasterSecurityGroupId",
+    "ParameterValue": "sg-<random_string>"
   },
   {
-    "ParameterKey": "VpcId", <11>
-    "ParameterValue": "vpc-<random_string>" <12>
+    "ParameterKey": "VpcId",
+    "ParameterValue": "vpc-<random_string>"
   },
   {
-    "ParameterKey": "BootstrapIgnitionLocation", <13>
-    "ParameterValue": "s3://<bucket_name>/bootstrap.ign" <14>
+    "ParameterKey": "BootstrapIgnitionLocation",
+    "ParameterValue": "s3://<bucket_name>/bootstrap.ign"
   },
   {
-    "ParameterKey": "AutoRegisterELB", <15>
-    "ParameterValue": "yes" <16>
+    "ParameterKey": "AutoRegisterELB",
+    "ParameterValue": "yes"
   },
   {
-    "ParameterKey": "RegisterNlbIpTargetsLambdaArn", <17>
-    "ParameterValue": "arn:aws:lambda:<aws_region>:<account_number>:function:<dns_stack_name>-RegisterNlbIpTargets-<random_string>" <18>
+    "ParameterKey": "RegisterNlbIpTargetsLambdaArn",
+    "ParameterValue": "arn:aws:lambda:<aws_region>:<account_number>:function:<dns_stack_name>-RegisterNlbIpTargets-<random_string>"
   },
   {
-    "ParameterKey": "ExternalApiTargetGroupArn", <19>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Exter-<random_string>" <20>
+    "ParameterKey": "ExternalApiTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Exter-<random_string>"
   },
   {
-    "ParameterKey": "InternalApiTargetGroupArn", <21>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <22>
+    "ParameterKey": "InternalApiTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>"
   },
   {
-    "ParameterKey": "InternalServiceTargetGroupArn", <23>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <24>
+    "ParameterKey": "InternalServiceTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>"
   }
 ]
 
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
-<2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> Current {op-system-first} AMI to use for the bootstrap node based on your selected architecture.
-<4> Specify a valid `AWS::EC2::Image::Id` value.
-<5> CIDR block to allow SSH access to the bootstrap node.
-<6> Specify a CIDR block in the format `x.x.x.x/16-24`.
-<7> The public subnet that is associated with your VPC to launch the bootstrap
-node into.
-<8> Specify the `PublicSubnetIds` value from the output of the CloudFormation
-template for the VPC.
-<9> The master security group ID (for registering temporary rules)
-<10> Specify the `MasterSecurityGroupId` value from the output of the
-CloudFormation template for the security group and roles.
-<11> The VPC created resources will belong to.
-<12> Specify the `VpcId` value from the output of the CloudFormation template
-for the VPC.
-<13> Location to fetch bootstrap Ignition config file from.
-<14> Specify the S3 bucket and file name in the form
-`s3://<bucket_name>/bootstrap.ign`.
-<15> Whether or not to register a network load balancer (NLB).
-<16> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
-Amazon Resource Name (ARN) value.
-<17> The ARN for NLB IP target registration lambda group.
-<18> Specify the `RegisterNlbIpTargetsLambda` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
-<19> The ARN for external API load balancer target group.
-<20> Specify the `ExternalApiTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
-<21> The ARN for internal API load balancer target group.
-<22> Specify the `InternalApiTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
-<23> The ARN for internal service load balancer target group.
-<24> Specify the `InternalServiceTargetGroupArn` value from the output of the
-CloudFormation template for DNS and load balancing. Use `arn:aws-us-gov` if
-deploying the cluster to an AWS GovCloud region.
++
+where:
++
+--
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
+`RhcosAmi`:: Specifies the current {op-system-first} AMI to use for the bootstrap node based on your selected architecture. Specify a valid `AWS::EC2::Image::Id` value.
+`AllowedBootstrapSshCidr`:: Specifies the CIDR block to allow SSH access to the bootstrap node. Specify a CIDR block in the format `x.x.x.x/16-24`.
+`PublicSubnet`:: Specifies the public subnet in your VPC to launch the bootstrap node into. Specify the `PublicSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`MasterSecurityGroupId`:: Specifies the control plane security group ID for registering temporary rules. Specify the `MasterSecurityGroupId` value from the output of the `CloudFormation` template for the security group and roles.
+`VpcId`:: Specifies the VPC that the created resources will belong to. Specify the `VpcId` value from the output of the `CloudFormation` template for the VPC.
+`BootstrapIgnitionLocation`:: Specifies the location to fetch the bootstrap Ignition config file from. Specify the S3 bucket and file name in the form `s3://<bucket_name>/bootstrap.ign`.
+`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must give a Lambda Amazon Resource Name (ARN) value.
+`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+--
 
-. Copy the template from the *CloudFormation template for the bootstrap machine*
-section of this topic and save it as a YAML file on your computer. This template
-describes the bootstrap machine that your cluster requires.
+. Copy the template from the *`CloudFormation` template for the bootstrap machine* section and save it as a YAML file on your computer. This template describes the bootstrap machine that your cluster requires.
 
 . Optional: If you are deploying the cluster with a proxy, you must update the ignition in the template to add the  `ignition.config.proxy` fields. Additionally, If you have added the Amazon EC2, Elastic Load Balancing, and S3 VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the bootstrap node:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the bootstrap node:
 +
 [IMPORTANT]
 ====
@@ -178,18 +156,20 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> <1>
-     --template-body file://<template>.yaml <2>
-     --parameters file://<parameters>.json <3>
-     --capabilities CAPABILITY_NAMED_IAM <4>
+$ aws cloudformation create-stack --stack-name <name> \
+     --template-body file://<template>.yaml \
+     --parameters file://<parameters>.json \
+     --capabilities CAPABILITY_NAMED_IAM
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-bootstrap`.
-You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
-YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
-parameters JSON file.
-<4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
++
+where:
++
+--
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-bootstrap`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
+`CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
+--
 +
 .Example output
 [source,terminal]
@@ -204,9 +184,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-bootstrap/12944486-2
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `BootstrapInstanceId`:: The bootstrap Instance ID.
 `BootstrapPublicIp`:: The bootstrap node public IP address.

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -7,21 +7,17 @@
 [id="installation-creating-aws-control-plane_{context}"]
 = Creating the control plane machines in AWS
 
-You must create the control plane machines in Amazon Web Services (AWS) that your cluster will use.
-
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources that represent the control plane nodes.
+[role="_abstract"]
+To run the {product-title} control plane, create the three control plane machines in {aws-first} by using the provided `CloudFormation` template and a custom parameter file.
 
 [IMPORTANT]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your control plane
-nodes, you must review the provided information and manually create
-the infrastructure. If your cluster does not initialize correctly, you might
-have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your control plane nodes, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
@@ -30,154 +26,115 @@ have to contact Red Hat support with your installation logs.
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template
-requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
 [
   {
-    "ParameterKey": "InfrastructureName", <1>
-    "ParameterValue": "mycluster-<random_string>" <2>
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "mycluster-<random_string>"
   },
   {
-    "ParameterKey": "RhcosAmi", <3>
-    "ParameterValue": "ami-<random_string>" <4>
+    "ParameterKey": "RhcosAmi",
+    "ParameterValue": "ami-<random_string>"
   },
   {
-    "ParameterKey": "AutoRegisterDNS", <5>
-    "ParameterValue": "yes" <6>
+    "ParameterKey": "AutoRegisterDNS",
+    "ParameterValue": "yes"
   },
   {
-    "ParameterKey": "PrivateHostedZoneId", <7>
-    "ParameterValue": "<random_string>" <8>
+    "ParameterKey": "PrivateHostedZoneId",
+    "ParameterValue": "<random_string>"
   },
   {
-    "ParameterKey": "PrivateHostedZoneName", <9>
-    "ParameterValue": "mycluster.example.com" <10>
+    "ParameterKey": "PrivateHostedZoneName",
+    "ParameterValue": "mycluster.example.com"
   },
   {
-    "ParameterKey": "Master0Subnet", <11>
-    "ParameterValue": "subnet-<random_string>" <12>
+    "ParameterKey": "Master0Subnet",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "Master1Subnet", <11>
-    "ParameterValue": "subnet-<random_string>" <12>
+    "ParameterKey": "Master1Subnet",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "Master2Subnet", <11>
-    "ParameterValue": "subnet-<random_string>" <12>
+    "ParameterKey": "Master2Subnet",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "MasterSecurityGroupId", <13>
-    "ParameterValue": "sg-<random_string>" <14>
+    "ParameterKey": "MasterSecurityGroupId",
+    "ParameterValue": "sg-<random_string>"
   },
   {
-    "ParameterKey": "IgnitionLocation", <15>
-    "ParameterValue": "https://api-int.<cluster_name>.<domain_name>:22623/config/master" <16>
+    "ParameterKey": "IgnitionLocation",
+    "ParameterValue": "https://api-int.<cluster_name>.<domain_name>:22623/config/master"
   },
   {
-    "ParameterKey": "CertificateAuthorities", <17>
-    "ParameterValue": "data:text/plain;charset=utf-8;base64,ABC...xYz==" <18>
+    "ParameterKey": "CertificateAuthorities",
+    "ParameterValue": "data:text/plain;charset=utf-8;base64,ABC...xYz=="
   },
   {
-    "ParameterKey": "MasterInstanceProfileName", <19>
-    "ParameterValue": "<roles_stack>-MasterInstanceProfile-<random_string>" <20>
+    "ParameterKey": "MasterInstanceProfileName",
+    "ParameterValue": "<roles_stack>-MasterInstanceProfile-<random_string>"
   },
   {
-    "ParameterKey": "MasterInstanceType", <21>
-    "ParameterValue": "" <22>
+    "ParameterKey": "MasterInstanceType",
+    "ParameterValue": ""
   },
   {
-    "ParameterKey": "AutoRegisterELB", <23>
-    "ParameterValue": "yes" <24>
+    "ParameterKey": "AutoRegisterELB",
+    "ParameterValue": "yes"
   },
   {
-    "ParameterKey": "RegisterNlbIpTargetsLambdaArn", <25>
-    "ParameterValue": "arn:aws:lambda:<aws_region>:<account_number>:function:<dns_stack_name>-RegisterNlbIpTargets-<random_string>" <26>
+    "ParameterKey": "RegisterNlbIpTargetsLambdaArn",
+    "ParameterValue": "arn:aws:lambda:<aws_region>:<account_number>:function:<dns_stack_name>-RegisterNlbIpTargets-<random_string>"
   },
   {
-    "ParameterKey": "ExternalApiTargetGroupArn", <27>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Exter-<random_string>" <28>
+    "ParameterKey": "ExternalApiTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Exter-<random_string>"
   },
   {
-    "ParameterKey": "InternalApiTargetGroupArn", <29>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <30>
+    "ParameterKey": "InternalApiTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>"
   },
   {
-    "ParameterKey": "InternalServiceTargetGroupArn", <31>
-    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <32>
+    "ParameterKey": "InternalServiceTargetGroupArn",
+    "ParameterValue": "arn:aws:elasticloadbalancing:<aws_region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>"
   }
 ]
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
-<2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> Current {op-system-first} AMI to use for the control plane machines based on your selected architecture.
-<4> Specify an `AWS::EC2::Image::Id` value.
-<5> Whether or not to perform DNS etcd registration.
-<6> Specify `yes` or `no`. If you specify `yes`, you must provide hosted zone
-information.
-<7> The Route 53 private zone ID to register the etcd targets with.
-<8> Specify the `PrivateHostedZoneId` value from the output of the
-CloudFormation template for DNS and load balancing.
-<9> The Route 53 zone to register the targets with.
-<10> Specify `<cluster_name>.<domain_name>` where `<domain_name>` is the Route 53
-base domain that you used when you generated `install-config.yaml` file for the
-cluster. Do not include the trailing period (.) that is
-displayed in the AWS console.
-<11> A subnet, preferably private, to launch the control plane machines on.
-<12> Specify a subnet from the `PrivateSubnets` value from the output of the
-CloudFormation template for DNS and load balancing.
-<13> The master security group ID to associate with control plane nodes.
-<14> Specify the `MasterSecurityGroupId` value from the output of the
-CloudFormation template for the security group and roles.
-<15> The location to fetch control plane Ignition config file from.
-<16> Specify the generated Ignition config file location,
-`https://api-int.<cluster_name>.<domain_name>:22623/config/master`.
-<17> The base64 encoded certificate authority string to use.
-<18> Specify the value from the `master.ign` file that is in the installation
-directory. This value is the long string with the format
-`data:text/plain;charset=utf-8;base64,ABC...xYz==`.
-<19> The IAM profile to associate with control plane nodes.
-<20> Specify the `MasterInstanceProfile` parameter value from the output of
-the CloudFormation template for the security group and roles.
-<21> The type of AWS instance to use for the control plane machines based on your selected architecture.
-<22> The instance type value corresponds to the minimum resource requirements for
-control plane machines. For example `m6i.xlarge` is a type for AMD64
++
+where:
++
+--
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Specify the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
+`RhcosAmi`:: Specifies the current {op-system-first} AMI to use for the control plane machines based on your selected architecture. Specify an `AWS::EC2::Image::Id` value.
+`AutoRegisterDNS`:: Specifies whether to perform DNS etcd registration. Specify `yes` or `no`. If you specify `yes`, you must give hosted zone information.
+`PrivateHostedZoneId`:: Specifies the Route 53 private zone ID to register the etcd targets with. Specify the `PrivateHostedZoneId` value from the output of the `CloudFormation` template for DNS and load balancing.
+`PrivateHostedZoneName`:: Specifies the Route 53 zone to register the targets with. Specify `<cluster_name>.<domain_name>` where `<domain_name>` is the Route 53 base domain that you used when you generated the `install-config.yaml` file for the cluster. Do not include the trailing period (.) that is displayed in the {aws-short} console.
+`Master0Subnet`, `Master1Subnet`, `Master2Subnet`:: Specifies a subnet, preferably private, to launch the control plane machines on. Specify a subnet from the `PrivateSubnets` value from the output of the `CloudFormation` template for DNS and load balancing.
+`MasterSecurityGroupId`:: Specifies the control plane security group ID to associate with control plane nodes. Specify the `MasterSecurityGroupId` value from the output of the `CloudFormation` template for the security group and roles.
+`IgnitionLocation`:: Specifies the location to fetch the control plane Ignition config file from. Specify the generated Ignition config file location, `https://api-int.<cluster_name>.<domain_name>:22623/config/master`.
+`CertificateAuthorities`:: Specifies the base64 encoded certificate authority string to use. Specify the value from the `master.ign` file that is in the installation directory. This value is the long string with the format `data:text/plain;charset=utf-8;base64,ABC...xYz==`.
+`MasterInstanceProfileName`:: Specifies the IAM profile to associate with control plane nodes. Specify the `MasterInstanceProfile` parameter value from the output of the `CloudFormation` template for the security group and roles.
+`MasterInstanceType`:: Specifies the type of {aws-short} instance to use for the control plane machines based on your selected architecture. The instance type value corresponds to the minimum resource requirements for control plane machines. For example `m6i.xlarge` is a type for AMD64
 ifndef::openshift-origin[]
 and `m6g.xlarge` is a type for ARM64.
 endif::openshift-origin[]
-<23> Whether or not to register a network load balancer (NLB).
-<24> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
-Amazon Resource Name (ARN) value.
-<25> The ARN for NLB IP target registration lambda group.
-<26> Specify the `RegisterNlbIpTargetsLambda` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
-<27> The ARN for external API load balancer target group.
-<28> Specify the `ExternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
-<29> The ARN for internal API load balancer target group.
-<30> Specify the `InternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
-<31> The ARN for internal service load balancer target group.
-<32> Specify the `InternalServiceTargetGroupArn` value from the output of the CloudFormation template for DNS
-and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
-GovCloud region.
+`AutoRegisterELB`:: Specifies whether to register a network load balancer (NLB). Specify `yes` or `no`. If you specify `yes`, you must give a Lambda Amazon Resource Name (ARN) value.
+`RegisterNlbIpTargetsLambdaArn`:: Specifies the ARN for NLB IP target registration lambda group. Specify the `RegisterNlbIpTargetsLambda` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`ExternalApiTargetGroupArn`:: Specifies the ARN for external API load balancer target group. Specify the `ExternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalApiTargetGroupArn`:: Specifies the ARN for internal API load balancer target group. Specify the `InternalApiTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+`InternalServiceTargetGroupArn`:: Specifies the ARN for internal service load balancer target group. Specify the `InternalServiceTargetGroupArn` value from the output of the `CloudFormation` template for DNS and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an {aws-short} `GovCloud` region.
+--
 
-. Copy the template from the *CloudFormation template for control plane machines*
-section of this topic and save it as a YAML file on your computer. This template
-describes the control plane machines that your cluster requires.
+. Copy the template from the *`CloudFormation` template for control plane machines* section and save it as a YAML file on your computer. This template describes the control plane machines that your cluster requires.
 
-. If you specified an `m5` instance type as the value for `MasterInstanceType`,
-add that instance type to the `MasterInstanceType.AllowedValues` parameter
-in the CloudFormation template.
+. If you specified an `m5` instance type as the value for `MasterInstanceType`, add that instance type to the `MasterInstanceType.AllowedValues` parameter in the `CloudFormation` template.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the control plane nodes:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the control plane nodes:
 +
 [IMPORTANT]
 ====
@@ -186,16 +143,18 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> <1>
-     --template-body file://<template>.yaml <2>
-     --parameters file://<parameters>.json <3>
+$ aws cloudformation create-stack --stack-name <name> \
+     --template-body file://<template>.yaml \
+     --parameters file://<parameters>.json
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-control-plane`.
-You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
-YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
-parameters JSON file.
++
+where:
++
+--
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-control-plane`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
+--
 +
 .Example output
 [source,terminal]
@@ -205,7 +164,7 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-control-plane/21c7e2
 +
 [NOTE]
 ====
-The CloudFormation template creates a stack that represents three control plane nodes.
+The `CloudFormation` template creates a stack that represents three control plane nodes.
 ====
 
 . Confirm that the template components exist:

--- a/modules/installation-creating-aws-dns.adoc
+++ b/modules/installation-creating-aws-dns.adoc
@@ -7,35 +7,32 @@
 [id="installation-creating-aws-dns_{context}"]
 = Creating networking and load balancing components in AWS
 
-You must configure networking and classic or network load balancing in Amazon Web Services (AWS) that your {product-title} cluster can use.
+[role="_abstract"]
+To route traffic to your {product-title} cluster, configure the networking and load balancing components in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the networking and load balancing components that your {product-title} cluster requires. The template also creates a hosted zone and subnet tags.
 
-You can run the template multiple times within a single Virtual Private Cloud (VPC).
+You can run the template many times within a single Virtual Private Cloud (VPC).
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your AWS
-infrastructure, you must review the provided information and manually create
-the infrastructure. If your cluster does not initialize correctly, you might
-have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Prerequisites
 
-* You created and configured a VPC and associated subnets in AWS.
+* You created and configured a VPC and associated subnets in {aws-short}.
 
 .Procedure
 
-. Obtain the hosted zone ID for the Route 53 base domain that you specified in the
-`install-config.yaml` file for your cluster. You can obtain details about your hosted zone by running the following command:
+. Obtain the hosted zone ID for the Route 53 base domain that you specified in the `install-config.yaml` file for your cluster. You can obtain details about your hosted zone by running the following command:
 +
 [source,terminal]
 ----
-$ aws route53 list-hosted-zones-by-name --dns-name <route53_domain> <1>
+$ aws route53 list-hosted-zones-by-name --dns-name <route53_domain>
 ----
-<1> For the `<route53_domain>`, specify the Route 53 base domain that you used
-when you generated the `install-config.yaml` file for the cluster.
++
+where `<route53_domain>` is the Route 53 base domain that you used when you generated the `install-config.yaml` file for the cluster.
 +
 .Example output
 [source,terminal]
@@ -46,76 +43,62 @@ HOSTEDZONES	65F8F38E-2268-B835-E15C-AB55336FCBFA	/hostedzone/Z21IXYZABCZ2A4	mycl
 +
 In the example output, the hosted zone ID is `Z21IXYZABCZ2A4`.
 
-. Create a JSON file that contains the parameter values that the template
-requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
 [
   {
-    "ParameterKey": "ClusterName", <1>
-    "ParameterValue": "mycluster" <2>
+    "ParameterKey": "ClusterName",
+    "ParameterValue": "mycluster"
   },
   {
-    "ParameterKey": "InfrastructureName", <3>
-    "ParameterValue": "mycluster-<random_string>" <4>
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "mycluster-<random_string>"
   },
   {
-    "ParameterKey": "HostedZoneId", <5>
-    "ParameterValue": "<random_string>" <6>
+    "ParameterKey": "HostedZoneId",
+    "ParameterValue": "<random_string>"
   },
   {
-    "ParameterKey": "HostedZoneName", <7>
-    "ParameterValue": "example.com" <8>
+    "ParameterKey": "HostedZoneName",
+    "ParameterValue": "example.com"
   },
   {
-    "ParameterKey": "PublicSubnets", <9>
-    "ParameterValue": "subnet-<random_string>" <10>
+    "ParameterKey": "PublicSubnets",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "PrivateSubnets", <11>
-    "ParameterValue": "subnet-<random_string>" <12>
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "VpcId", <13>
-    "ParameterValue": "vpc-<random_string>" <14>
+    "ParameterKey": "VpcId",
+    "ParameterValue": "vpc-<random_string>"
   }
 ]
 ----
-<1> A short, representative cluster name to use for hostnames, etc.
-<2> Specify the cluster name that you used when you generated the
-`install-config.yaml` file for the cluster.
-<3> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
-<4> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
-<5> The Route 53 public zone ID to register the targets with.
-<6> Specify the Route 53 public zone ID, which has a format similar to
-`Z21IXYZABCZ2A4`. You can obtain this value from the AWS console.
-<7> The Route 53 zone to register the targets with.
-<8> Specify the Route 53 base domain that you used when you generated the
-`install-config.yaml` file for the cluster. Do not include the trailing period
-(.) that is displayed in the AWS console.
-<9> The public subnets that you created for your VPC.
-<10> Specify the `PublicSubnetIds` value from the output of the CloudFormation
-template for the VPC.
-<11> The private subnets that you created for your VPC.
-<12> Specify the `PrivateSubnetIds` value from the output of the CloudFormation
-template for the VPC.
-<13> The VPC that you created for the cluster.
-<14> Specify the `VpcId` value from the output of the CloudFormation template
-for the VPC.
++
+where:
++
+--
+`ClusterName`:: Specifies a short, representative cluster name to use for hostnames, and so on. Set the value to the cluster name that you used when you generated the `install-config.yaml` file for the cluster.
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
+`HostedZoneId`:: Specifies the Route 53 public zone ID to register the targets with. Set the value to the Route 53 public zone ID, which has a format similar to `Z21IXYZABCZ2A4`. You can obtain this value from the {aws-short} console.
+`HostedZoneName`:: Specifies the Route 53 zone to register the targets with. Set the value to the Route 53 base domain that you used when you generated the `install-config.yaml` file for the cluster. Do not include the trailing period (.) that is displayed in the {aws-short} console.
+`PublicSubnets`:: Specifies the public subnets that you created for your VPC. Set the value to the `PublicSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the `CloudFormation` template for the VPC.
+--
 
-. Copy the template from the *CloudFormation template for the network and load balancers*
-section of this topic and save it as a YAML file on your computer. This template
-describes the networking and load balancing objects that your cluster requires.
+. Copy the template from the *`CloudFormation` template for the network and load balancers* section and save it as a YAML file on your computer. This template describes the networking and load balancing objects that your cluster requires.
 +
 [IMPORTANT]
 ====
-If you are deploying your cluster to an AWS government or secret region, you must update the `InternalApiServerRecord` in the CloudFormation template to use `CNAME` records. Records of type `ALIAS` are not supported for AWS government regions.
+If you are deploying your cluster to an {aws-short} government or secret region, you must update the `InternalApiServerRecord` in the `CloudFormation` template to use `CNAME` records. Records of type `ALIAS` are not supported for {aws-short} government regions.
 ====
 
-. Launch the CloudFormation template to create a stack of AWS resources that provide the networking and load balancing components:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources for the networking and load balancing components:
 +
 [IMPORTANT]
 ====
@@ -124,18 +107,20 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> <1>
-     --template-body file://<template>.yaml <2>
-     --parameters file://<parameters>.json <3>
-     --capabilities CAPABILITY_NAMED_IAM <4>
+$ aws cloudformation create-stack --stack-name <name> \
+     --template-body file://<template>.yaml \
+     --parameters file://<parameters>.json \
+     --capabilities CAPABILITY_NAMED_IAM
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-dns`.
-You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
-YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
-parameters JSON file.
-<4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` resources.
++
+where:
++
+--
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-dns`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
+`CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` resources.
+--
 +
 .Example output
 [source,terminal]
@@ -150,16 +135,13 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-dns/cd3e5de0-2fd4-11
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
 `PrivateHostedZoneId`:: Hosted zone ID for the private DNS.
 `ExternalApiLoadBalancerName`:: Full name of the external API load balancer.
 `InternalApiLoadBalancerName`:: Full name of the internal API load balancer.
 `ApiServerDnsName`:: Full hostname of the API server.
-`RegisterNlbIpTargetsLambda`:: Lambda ARN useful to help register/deregister IP
-targets for these load balancers.
+`RegisterNlbIpTargetsLambda`:: Lambda ARN useful to help register and unregister IP targets for these load balancers.
 `ExternalApiTargetGroupArn`:: ARN of external API target group.
 `InternalApiTargetGroupArn`:: ARN of internal API target group.
 `InternalServiceTargetGroupArn`:: ARN of internal service target group.

--- a/modules/installation-creating-aws-security.adoc
+++ b/modules/installation-creating-aws-security.adoc
@@ -7,63 +7,54 @@
 [id="installation-creating-aws-security_{context}"]
 = Creating security group and roles in AWS
 
-You must create security groups and roles in Amazon Web Services (AWS) for your {product-title} cluster to use.
+[role="_abstract"]
+To control access to your {product-title} cluster resources, create the required security groups and IAM roles in {aws-first} by using the provided `CloudFormation` template.
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the security groups and roles that your {product-title} cluster requires.
+You can use the provided `CloudFormation` template and a custom parameter file to create a stack of {aws-short} resources. The stack represents the security groups and roles that your {product-title} cluster requires.
 
 [NOTE]
 ====
-If you do not use the provided CloudFormation template to create your AWS
-infrastructure, you must review the provided information and manually create
-the infrastructure. If your cluster does not initialize correctly, you might
-have to contact Red Hat support with your installation logs.
+If you do not use the provided `CloudFormation` template to create your {aws-short} infrastructure, you must review the provided information and manually create the infrastructure. If your cluster does not initialize correctly, you might have to contact Red Hat support with your installation logs.
 ====
 
 .Procedure
 
-. Create a JSON file that contains the parameter values that the template
-requires:
+. Create a JSON file that has the parameter values that the template requires:
 +
 [source,json]
 ----
 [
   {
-    "ParameterKey": "InfrastructureName", <1>
-    "ParameterValue": "mycluster-<random_string>" <2>
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "mycluster-<random_string>"
   },
   {
-    "ParameterKey": "VpcCidr", <3>
-    "ParameterValue": "10.0.0.0/16" <4>
+    "ParameterKey": "VpcCidr",
+    "ParameterValue": "10.0.0.0/16"
   },
   {
-    "ParameterKey": "PrivateSubnets", <5>
-    "ParameterValue": "subnet-<random_string>" <6>
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "subnet-<random_string>"
   },
   {
-    "ParameterKey": "VpcId", <7>
-    "ParameterValue": "vpc-<random_string>" <8>
+    "ParameterKey": "VpcId",
+    "ParameterValue": "vpc-<random_string>"
   }
 ]
 ----
-<1> The name for your cluster infrastructure that is encoded in your Ignition
-config files for the cluster.
-<2> Specify the infrastructure name that you extracted from the Ignition config
-file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> The CIDR block for the VPC.
-<4> Specify the CIDR block parameter that you used for the VPC that you defined
-in the form `x.x.x.x/16-24`.
-<5> The private subnets that you created for your VPC.
-<6> Specify the `PrivateSubnetIds` value from the output of the CloudFormation
-template for the VPC.
-<7> The VPC that you created for the cluster.
-<8> Specify the `VpcId` value from the output of the CloudFormation template for
-the VPC.
++
+where:
++
+--
+`InfrastructureName`:: Specifies the name for your cluster infrastructure that your Ignition config files encode for the cluster. Set the value to the infrastructure name that you extracted from the Ignition config file metadata, which has the format `<cluster_name>-<random_string>`.
+`VpcCidr`:: Specifies the CIDR block for the VPC. Set the value to the CIDR block parameter that you used for the VPC that you defined in the form `x.x.x.x/16-24`.
+`PrivateSubnets`:: Specifies the private subnets that you created for your VPC. Set the value to the `PrivateSubnetIds` value from the output of the `CloudFormation` template for the VPC.
+`VpcId`:: Specifies the VPC that you created for the cluster. Set the value to the `VpcId` value from the output of the `CloudFormation` template for the VPC.
+--
 
-. Copy the template from the *CloudFormation template for security objects*
-section of this topic and save it as a YAML file on your computer. This template
-describes the security groups and roles that your cluster requires.
+. Copy the template from the *`CloudFormation` template for security objects* section and save it as a YAML file on your computer. This template describes the security groups and roles that your cluster requires.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent the security groups and roles:
+. Launch the `CloudFormation` template to create a stack of {aws-short} resources that represent the security groups and roles:
 +
 [IMPORTANT]
 ====
@@ -72,18 +63,20 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> <1>
-     --template-body file://<template>.yaml <2>
-     --parameters file://<parameters>.json <3>
-     --capabilities CAPABILITY_NAMED_IAM <4>
+$ aws cloudformation create-stack --stack-name <name> \
+     --template-body file://<template>.yaml \
+     --parameters file://<parameters>.json \
+     --capabilities CAPABILITY_NAMED_IAM
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-sec`.
-You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
-YAML file that you saved.
-<3> `<parameters>` is the relative path to and name of the CloudFormation
-parameters JSON file.
-<4> You must explicitly declare the `CAPABILITY_NAMED_IAM` capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
++
+where:
++
+--
+`<name>`:: Specifies the name for the `CloudFormation` stack, such as `cluster-sec`. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path to and name of the `CloudFormation` template YAML file that you saved.
+`<parameters>`:: Specifies the relative path to and name of the `CloudFormation` parameters JSON file.
+`CAPABILITY_NAMED_IAM`:: You must explicitly declare this capability because the provided template creates some `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` resources.
+--
 +
 .Example output
 [source,terminal]
@@ -98,11 +91,9 @@ arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-sec/03bd4210-2ed7-11
 $ aws cloudformation describe-stacks --stack-name <name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values
-for the following parameters. You must provide these parameter values to
-the other CloudFormation templates that you run to create your cluster:
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. You must give these parameter values to the other `CloudFormation` templates that you run to create your cluster:
 [horizontal]
-`MasterSecurityGroupId`:: Master Security Group ID
-`WorkerSecurityGroupId`:: Worker Security Group ID
-`MasterInstanceProfile`:: Master IAM Instance Profile
-`WorkerInstanceProfile`:: Worker IAM Instance Profile
+`MasterSecurityGroupId`:: Control plane security group ID
+`WorkerSecurityGroupId`:: Worker security group ID
+`MasterInstanceProfile`:: Control plane IAM instance profile
+`WorkerInstanceProfile`:: Worker IAM instance profile


### PR DESCRIPTION
Version(s): 4.22

Issue:

https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:

[Installing AWS with user-provisioned infrastructure](https://ocpdocs-pr.netlify.app/openshift-enterprise/4.22/installing/installing_aws/installing-aws-user-infra.html)

Replaces callout annotations (`<1>`, `<2>`, etc.) with `where:` + description list format in the following AWS UPI modules, per https://github.com/openshift/openshift-docs/pull/102276:

- `modules/installation-creating-aws-bootstrap.adoc`
- `modules/installation-creating-aws-control-plane.adoc`
- `modules/installation-creating-aws-dns.adoc`
- `modules/installation-creating-aws-security.adoc`

Also includes CQA word fixes for these modules.

QE review: (Not needed for structural CQA changes)
- [ ] QE has approved this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)