### PR TITLE
OCPBUGS-112584: Update Scalability and performance TP tracker for 4.22

### DIFF
--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -3,7 +3,7 @@
 = Technology Preview features status
 
 [role="_abstract"]
-You can determine if a new feature in {product-title}{product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use. 
+You can determine if a new feature in {product-title}{product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use.
 
 Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
@@ -588,9 +588,9 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |General Availability
 
 |Configuring NUMA-aware scheduler replicas and high availability
-|Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
+|General Availability
 |====
 
 //[id="ocp-release-notes-special-hardware-tech-preview_{context}"]

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -565,32 +565,32 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |Mount namespace encapsulation
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Node Observability Operator
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Increasing the etcd database size
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing etcd size by setting the `eventTTLMinutes` property
 |Not available
 |Technology Preview
-|
+|General Availability
 
 |Pinned Image Sets
 |Technology Preview
 |Technology Preview
-|
+|General Availability
 
 |Configuring NUMA-aware scheduler replicas and high availability
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 |====
 
 //[id="ocp-release-notes-special-hardware-tech-preview_{context}"]

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -555,12 +555,12 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |{factory-prestaging-tool}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Hyperthreading-aware CPU manager policy
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Mount namespace encapsulation
 |Technology Preview

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -3,7 +3,7 @@
 = Technology Preview features status
 
 [role="_abstract"]
-You can determine if a new feature in {product-title}{product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use.
+You can determine if a new feature in {product-title} {product-version} is currently in Technology Preview before deciding to install the feature. These experimental features are not intended for production use.
 
 Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
@@ -406,7 +406,7 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |DPU Operator
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Fast IPAM for the Whereabouts IPAM CNI plugin
 |Technology Preview
@@ -555,37 +555,37 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |{factory-prestaging-tool}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Hyperthreading-aware CPU manager policy
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Mount namespace encapsulation
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Node Observability Operator
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Increasing the etcd database size
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing etcd size by setting the `eventTTLMinutes` property
 |Not available
 |Technology Preview
-|
+|General Availability
 
 |Pinned Image Sets
 |Technology Preview
 |Technology Preview
-|
+|General Availability
 
 |Configuring NUMA-aware scheduler replicas and high availability
 |General Availability


### PR DESCRIPTION
Updated Technology Preview tracker table in release notes to reflect current status of features based on documentation analysis:

- Mount namespace encapsulation: Technology Preview (modules/enabling-encapsulation.adoc has TP marker)

- Node Observability Operator: Technology Preview (scalability_and_performance/node-observability-operator.adoc has TP marker)

- Increasing the etcd database size: Technology Preview (modules/etcd-increase-db.adoc has TP marker)

- Managing etcd size via eventTTLMinutes: General Availability (modules/etcd-customize-ttl.adoc exists with no TP marker)

- Pinned Image Sets: General Availability (modules/machine-config-pin-preload-images.adoc exists with no TP marker)

- Configuring NUMA-aware scheduler replicas and HA: General Availability (modules/cnf-managing-ha-nrop-scheduler.adoc has TP marker)

Note: Factory Prestaging Tool and Hyperthreading-aware CPU manager policy remain empty pending SME verification (no documentation found).
