### PR TITLE
CNV-83484: Remove custom ConfigMap config from vgpuDeviceManager examples

### DIFF
--- a/modules/about-using-gpu-operator.adoc
+++ b/modules/about-using-gpu-operator.adoc
@@ -65,9 +65,6 @@ spec:
   vfioManager:
     enabled: true
   vgpuDeviceManager:
-    config:
-      default: default
-      name: vgpu-devices-config
     enabled: true
   vgpuManager:
     enabled: true

--- a/modules/rdma-configuring-the-gpu-operator.adoc
+++ b/modules/rdma-configuring-the-gpu-operator.adoc
@@ -39,8 +39,6 @@ metadata:
   name: gpu-cluster-policy
 spec:
   vgpuDeviceManager:
-    config:
-      default: default
     enabled: true
   migManager:
     config:


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/CNV-83484

Preview link: TBA

Versions: 4.21+

### Summary
- Removes the custom `ConfigMap` `config` block from `vgpuDeviceManager` in two GPU operator YAML examples (`about-using-gpu-operator.adoc` and `rdma-configuring-the-gpu-operator.adoc`).
- The examples referenced a custom `ConfigMap` (`vgpu-devices-config`) that users were never told how to create, causing the NVIDIA GPU Operator to skip `ConfigMap` creation and leaving vGPU non-functional.
- Letting the operator manage the `ConfigMap` automatically is the correct default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)