### PR TITLE
OSDOCS-20235 - CQA fixes for ROSA Classic Tutorials

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
+++ b/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-update-component-routes"]
-= Tutorial: Updating component routes with custom domains and TLS certificates
+= Tutorial: Update component routes with custom domains and TLS certificates
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-update-component-routes
@@ -8,31 +8,31 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-This guide demonstrates how to modify the hostname and TLS certificate of the Web console, OAuth server, and Downloads component routes in {product-title} version 4.14 and above.{fn-supported-versions}
+You can modify the hostname and Transport Layer Security (TLS) certificate of the Web console, OAuth server, and Downloads component routes in {product-title} version 4.14 and later.
 
-The changes that we make to the component routes{fn-term-component-routes} in this guide are described in greater detail in the customizing the link:https://docs.openshift.com/container-platform/latest/authentication/configuring-internal-oauth.html#customizing-the-oauth-server-url_configuring-internal-oauth[internal OAuth server URL], link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-console-route_customizing-web-console[console route], and link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-download-route_customizing-web-console[download route] OpenShift Container Platform documentation. 
+The changes that you make to the component routes in this tutorial are described in greater detail in the {OCP} documentation, see resources about customizing the internal OAuth server URL, console route, and download route in __Additional resources__.
 
-[id="prerequisites_{context}"]
-== Prerequisites
-* {rosa-cli} (`rosa`) version 1.2.37 or higher
-* AWS CLI (`aws`)
-* A {product-title} cluster version 4.14 or higher
-+
-[NOTE]
-====
-{rosa-title} is not supported at this time.
-====
-+
-* {oc-first}
-* `jq` CLI
-* Access to the cluster as a user with the `cluster-admin` role.
-* OpenSSL (for generating the demonstration SSL/TLS certificates)
+include::modules/cloud-experts-update-component-routes-prerequisites.adoc[leveloffset=+1]
 
 include::modules/cloud-experts-update-component-routes-environment-setup.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-find-current-component-routes.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-create-tls-certificates.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-add-certificates-as-secrets.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-find-lb-hostname.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-add-component-routes-to-dns.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-tls-using-rosa-cli.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-update-component-routes-reset-component-routes-to-default.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/configuring-internal-oauth#customizing-the-oauth-server-url_configuring-internal-oauth[Customizing the internal OAuth server URL]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/web_console/index#customizing-the-console-route_customizing-web-console[Customizing the console route]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/web_console/index#customizing-the-download-route_customizing-web-console[Customizing the download route]

--- a/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-mobb-verify-permissions-sts-deployment"]
-= Tutorial: Verifying permissions for a {product-title} STS deployment
+= Tutorial: Verify permissions for a {product-title} STS deployment
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-mobb-verify-permissions-sts-deployment
@@ -8,97 +8,18 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-To proceed with the deployment of a {product-title} cluster, an account must support the required roles and permissions. AWS Service Control Policies (SCPs) cannot block the API calls made by the installer or Operator roles.
+Before deploying a {product-title} cluster, verify that your AWS account has the required roles and permissions. AWS Service Control Policies (SCPs) cannot block the API calls made by the installer or Operator roles.
 
-Details about the IAM resources required for an STS-enabled installation of {product-title} can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for {product-title} clusters that use STS].
+For more information about the IAM resources required for an STS-enabled installation of {product-title}, see "About IAM resources for STS clusters" in __Additional resources__.
 
 This guide is validated for {product-title} v4.11.X.
 
-== Prerequisites
 
-* link:https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[AWS CLI]
-* xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] v1.2.6
-* link:https://stedolan.github.io/jq/[jq CLI]
-* link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html[AWS role with required permissions]
+include::modules/rosa-verify-permissions-sts-deployment-about-verification.adoc[leveloffset=+1]
 
-[id="verify-ROSA-permissions_{context}"]
-== Verifying {product-title} permissions
-To verify the permissions required for {product-title}, we can run the script included in the following section without ever creating any AWS resources.
+include::modules/rosa-verify-permissions-sts-deployment-verify-permissions.adoc[leveloffset=+1]
 
-The script uses the `rosa`, `aws`, and `jq` CLI commands to create files in the working directory that will be used to verify permissions in the account connected to the current AWS configuration.
-
-The AWS Policy Simulator is used to verify the permissions of each role policy against the API calls extracted by `jq`; results are then stored in a text file appended with `.results`.
-
-This script is designed to verify the permissions for the current account and region.
-
-[id="usage-instructions_{context}"]
-== Usage Instructions
-
-. To use the script, run the following commands in a `bash` terminal (the -p option defines a prefix for the roles):
-+
-[source,terminal]
-----
-$ mkdir scratch
-$ cd scratch
-$ cat << 'EOF' > verify-permissions.sh
-#!/bin/bash
-while getopts 'p:' OPTION; do
-  case "$OPTION" in
-    p)
-      PREFIX="$OPTARG"
-      ;;
-    ?)
-      echo "script usage: $(basename \$0) [-p PREFIX]" >&2
-      exit 1
-      ;;
-  esac
-done
-shift "$(($OPTIND -1))"
-rosa create account-roles --mode manual --prefix $PREFIX
-INSTALLER_POLICY=$(cat sts_installer_permission_policy.json | jq )
-CONTROL_PLANE_POLICY=$(cat sts_instance_controlplane_permission_policy.json | jq)
-WORKER_POLICY=$(cat sts_instance_worker_permission_policy.json | jq)
-SUPPORT_POLICY=$(cat sts_support_permission_policy.json | jq)
-simulatePolicy () {
-    outputFile="${2}.results"
-    echo $2
-    aws iam simulate-custom-policy --policy-input-list "$1" --action-names $(jq '.Statement | map(select(.Effect == "Allow"))[].Action | if type == "string" then . else .[] end' "$2" -r) --output text > $outputFile
-}
-simulatePolicy "$INSTALLER_POLICY" "sts_installer_permission_policy.json"
-simulatePolicy "$CONTROL_PLANE_POLICY" "sts_instance_controlplane_permission_policy.json"
-simulatePolicy "$WORKER_POLICY" "sts_instance_worker_permission_policy.json"
-simulatePolicy "$SUPPORT_POLICY" "sts_support_permission_policy.json"
-EOF
-$ chmod +x verify-permissions.sh
-$ ./verify-permissions.sh -p SimPolTest
-----
-
-. After the script completes, review each results file to ensure that none of the required API calls are blocked:
-+
-[source,terminal]
-----
-$ for file in $(ls *.results); do echo $file; cat $file; done
-----
-+
-The output will look similar to the following:
-+
-[source,terminal]
-----
-sts_installer_permission_policy.json.results
-EVALUATIONRESULTS       autoscaling:DescribeAutoScalingGroups   allowed *
-MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
-ENDPOSITION     6       195
-STARTPOSITION   17      3
-EVALUATIONRESULTS       ec2:AllocateAddress     allowed *
-MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
-ENDPOSITION     6       195
-STARTPOSITION   17      3
-EVALUATIONRESULTS       ec2:AssociateAddress    allowed *
-MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
-...
-----
-+
-[NOTE]
-====
-If any actions are blocked, review the error provided by AWS and consult with your Administrator to determine if SCPs are blocking the required API calls.
-====
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for STS clusters]

--- a/modules/cloud-experts-update-component-routes-add-certificates-as-secrets.adoc
+++ b/modules/cloud-experts-update-component-routes-add-certificates-as-secrets.adoc
@@ -7,16 +7,24 @@
 = Add the certificates to the cluster as secrets
 
 [role="_abstract"]
-You can use the {oc-first} tool to add the certificates to your created cluster as secrets.
+Add the Transport Layer Security (TLS) certificates to your cluster as secrets by using the {oc-first} tool. Store the certificates as secrets in the `openshift-config` namespace so that you can reference them when you update the component routes later.
 
 .Procedure
-. Create three TLS secrets in the `openshift-config` namespace.
+* Create three TLS secrets in the `openshift-config` namespace.
 +
-These become your secret reference when you update the component routes later in this guide.
+These become your secret reference when you update the component routes.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create secret tls console-tls --cert=cert-console.pem --key=key-console.pem -n openshift-config
+----
++
+[source,terminal]
+----
 $ oc create secret tls downloads-tls --cert=cert-downloads.pem --key=key-downloads.pem -n openshift-config
+----
++
+[source,terminal]
+----
 $ oc create secret tls oauth-tls --cert=cert-oauth.pem --key=key-oauth.pem -n openshift-config
 ----

--- a/modules/cloud-experts-update-component-routes-add-component-routes-to-dns.adoc
+++ b/modules/cloud-experts-update-component-routes-add-component-routes-to-dns.adoc
@@ -2,12 +2,16 @@
 //
 // * cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-update-component-routes-add-component-routes-to-dns_{context}"]
 = Add component route DNS records to your hosting provider
 
 [role="_abstract"]
-In your hosting provider, add DNS records that map the `CNAME` of your new component route hostnames to the load balancer hostname we found in the previous step.
+You can add component route Domain Name System (DNS) records to your hosting provider to map the new component route hostnames to the load balancer.
+
+.Procedure
+
+* In your hosting provider, add DNS records that map the `CNAME` of your new component route hostnames to the load balancer hostname that you found in link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/tutorials/index#cloud-experts-update-component-routes-find-lb-hostname_cloud-experts-update-component-routes[Find the hostname of the load balancer in your cluster].
 
 //.Need an image for this
 //image::[Picture goes here]

--- a/modules/cloud-experts-update-component-routes-create-tls-certificates.adoc
+++ b/modules/cloud-experts-update-component-routes-create-tls-certificates.adoc
@@ -7,7 +7,7 @@
 = Create a valid TLS certificate for each component route
 
 [role="_abstract"]
-In this section, we create three separate self-signed certificate key pairs and then trust them to verify that we can access our new component routes using a real web browser.
+Create three separate self-signed Transport Layer Security (TLS) certificate key pairs and add them to your local trust store to verify that you can access the new component routes in a web browser.
 
 [WARNING]
 ====
@@ -16,18 +16,25 @@ This is for demonstration purposes only, and is not recommended as a solution fo
 
 [IMPORTANT]
 ====
-To prevent issues with HTTP/2 connection coalescing, you must use a separate individual certificate for each endpoint. Using a wildcard or SAN certificate is not supported.
+To prevent issues with HTTP/2 connection coalescing, you must use a separate individual certificate for each endpoint. Using a wildcard or Subject Alternative Name (SAN) certificate is not supported.
 ====
 
 .Procedure
-. Generate a certificate for each component route, taking care to set our certificate's subject (`-subj`) to the custom domain of the component route we want to use: 
+* Generate a certificate for each component route, taking care to set the certificate's subject (`-subj`) to the custom domain of the component route you want to use:
 +
-*Example*:
-+
-[source,bash]
+.Example
+[source,terminal]
 ----
 $ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout key-console.pem -out cert-console.pem -subj "/CN=console.my-new-domain.dev"
+----
++
+[source,terminal]
+----
 $ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout key-downloads.pem -out cert-downloads.pem -subj "/CN=downloads.my-new-domain.dev"
+----
++
+[source,terminal]
+----
 $ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout key-oauth.pem -out cert-oauth.pem -subj "/CN=oauth.my-new-domain.dev"
 ----
 +

--- a/modules/cloud-experts-update-component-routes-environment-setup.adoc
+++ b/modules/cloud-experts-update-component-routes-environment-setup.adoc
@@ -4,14 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-update-component-routes-environment-setup_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
-You can use environment variables to ensure consistency across the commands within this lab.
+Set environment variables to ensure consistency across the commands within this tutorial.
 
 .Procedure
 . Log in to your cluster using an account with `cluster-admin` privileges.
-+
+
 . Configure an environment variable for your cluster name:
 +
 [source,terminal]

--- a/modules/cloud-experts-update-component-routes-find-current-component-routes.adoc
+++ b/modules/cloud-experts-update-component-routes-find-current-component-routes.adoc
@@ -1,22 +1,26 @@
 // Module included in the following assemblies:
 //
-// * cloud_experts_osd_tutorials/cloud-experts-update-component-routes.adoc
+// * cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-update-component-routes-find-current-component-routes_{context}"]
 = Find the current routes
 
 [role="_abstract"]
-You need to use the {oc-first} tool to find the base hostname of your cluster routes.
+Find the base hostnames of your cluster routes and retrieve the ingress ID so you can update the routes with custom domains later.
 
 .Procedure
 . Verify that you can reach the component routes on their default hostnames.
 +
 You can find the hostnames by querying the lists of routes in the `openshift-console` and `openshift-authentication` projects.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get routes -n openshift-console
+----
++
+[source,terminal]
+----
 $ oc get routes -n openshift-authentication
 ----
 +
@@ -30,15 +34,15 @@ NAME              HOST/PORT                                                     
 oauth-openshift   oauth-openshift.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com ... 1 more  oauth-openshift   6443   passthrough/Redirect   None
 ----
 +
-From this output you can see that our base hostname is `z9a9.p1.openshiftapps.com`.
-+
+From this output you can see that your base hostname is `z9a9.p1.openshiftapps.com`.
+
 . Get the ID of the default ingress by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ export INGRESS_ID=$(rosa list ingress -c ${CLUSTER_NAME} -o json | jq -r '.[] | select(.default == true) | .id')
 ----
-+
+
 . Ensure all fields output correctly before moving to the next section:
 +
 [source,terminal]
@@ -52,15 +56,15 @@ $ echo "Ingress ID: ${INGRESS_ID}"
 Ingress ID: r3l6
 ----
 +
-By running these commands you can see that the default component routes for our cluster are:
+By running these commands you can see that the default component routes for your cluster are:
 +
 * `console-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for Console
 * `downloads-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for Downloads
 * `oauth-openshift.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for OAuth
 +
-We can use the `rosa edit ingress` command to change the hostname of each service and add a TLS certificate for all of our component routes. The relevant parameters are shown in this excerpt of the command-line help for the `rosa edit ingress` command:
+You can use the `rosa edit ingress` command to change the hostname of each service and add a TLS certificate for all of your component routes. The relevant parameters are shown in this excerpt of the command-line help for the `rosa edit ingress` command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ rosa edit ingress -h
 Edit a cluster ingress for a cluster. Usage:
@@ -69,7 +73,7 @@ Edit a cluster ingress for a cluster. Usage:
   --component-routes string                Component routes settings. Available keys [oauth, console, downloads]. For each key a pair of hostname and tlsSecretRef is expected to be supplied. Format should be a comma separate list 'oauth: hostname=example-hostname;tlsSecretRef=example-secret-ref,downloads:...'
 ----
 +
-For this example, we'll use the following custom component routes:
+For this example, you use the following custom component routes:
 +
 * `console.my-new-domain.dev` for Console
 * `downloads.my-new-domain.dev` for Downloads

--- a/modules/cloud-experts-update-component-routes-find-lb-hostname.adoc
+++ b/modules/cloud-experts-update-component-routes-find-lb-hostname.adoc
@@ -7,18 +7,23 @@
 = Find the hostname of the load balancer in your cluster
 
 [role="_abstract"]
-When you create a cluster, the service creates a load balancer and generates a hostname for that load balancer. We need to know the load balancer hostname in order to create DNS records for our cluster. You can find the hostname by using the {oc-first} tool.
+When you create a cluster, the service creates a load balancer and generates a hostname for that load balancer. You need to know the load balancer hostname to create Domain Name System (DNS) records for your cluster.
 
 .Procedure
-* Run the following command against the `openshift-ingress` namespace. 
+* Run the following command against the `openshift-ingress` namespace.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get svc -n openshift-ingress
+----
++
+.Example output
+[source,text]
+----
 NAME            TYPE          CLUSTER-IP     EXTERNAL-IP                                             PORT(S)                     AGE
 router-default  LoadBalancer  172.30.237.88  a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com  80:31175/TCP,443:31554/TCP  76d
 ----
 +
-The hostname of the load balancer is the `EXTERNAL-IP` associated with the `router-default` service in the `openshift-ingress` namespace. In our case, the hostname is `a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com`.
+The hostname of the load balancer is the `EXTERNAL-IP` associated with the `router-default` service in the `openshift-ingress` namespace. In this example, the hostname is `a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com`.
 +
-Save this value for later, as we will need it to configure DNS records for our new component route hostnames.
+Save this value, because you need it to configure DNS records for your new component route hostnames.

--- a/modules/cloud-experts-update-component-routes-prerequisites.adoc
+++ b/modules/cloud-experts-update-component-routes-prerequisites.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cloud-experts-update-component-routes-prerequisites_{context}"]
+= Prerequisites for updating component routes
+
+[role="_abstract"]
+Review the following prerequisites before updating component routes.
+
+* The {rosa-cli-first} version 1.2.37 or later is installed.
+* The AWS CLI (`aws`) is installed.
+* You have a {product-title} cluster version 4.14 or later.
+* The {oc-first} is installed.
+* The `jq` CLI tool is installed.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* OpenSSL is installed.

--- a/modules/cloud-experts-update-component-routes-reset-component-routes-to-default.adoc
+++ b/modules/cloud-experts-update-component-routes-reset-component-routes-to-default.adoc
@@ -7,12 +7,12 @@
 = Reset the component routes to the default using the {rosa-cli}
 
 [role="_abstract"]
-You can use the {oc-first} tool to reset the component routes to the default configuration.
+You can use the {rosa-cli-first} tool to reset the component routes to the default configuration if you no longer need your custom domain.
 
 .Procedure
-* Run the following command to reset your component routes:
+* Reset your component routes by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ rosa edit ingress -c ${CLUSTER_NAME} ${INGRESS_ID} --component-routes 'console: hostname="";tlsSecretRef="",downloads: hostname="";tlsSecretRef="", oauth: hostname="";tlsSecretRef=""'
 ----

--- a/modules/cloud-experts-update-component-routes-tls-using-rosa-cli.adoc
+++ b/modules/cloud-experts-update-component-routes-tls-using-rosa-cli.adoc
@@ -7,28 +7,26 @@
 = Update the component routes and TLS secret using the {rosa-cli}
 
 [role="_abstract"]
-When your DNS records have been updated, you can use the {rosa-cli} to change the component routes.
+When your Domain Name System (DNS) records have been updated, change the component routes and Transport Layer Security (TLS) secret references to ensure your cluster traffic is routed correctly through your custom domain and protected with updated TLS certificates.
 
 .Procedure
-. Use the `rosa edit ingress` command to update your default ingress route with the new base domain and the secret reference associated with it, taking care to update the hostnames for each component route.
+. Update your default ingress route with the new base domain and the secret reference associated with it, and update the hostnames for each component route:
 +
-[source,bash]
+[source,terminal]
 ----
 $ rosa edit ingress -c ${CLUSTER_NAME} ${INGRESS_ID} --component-routes 'console: hostname=console.my-new-domain.dev;tlsSecretRef=console-tls,downloads: hostname=downloads.my-new-domain.dev;tlsSecretRef=downloads-tls,oauth: hostname=oauth.my-new-domain.dev;tlsSecretRef=oauth-tls'
 ----
 +
-[NOTE]
-====
-You can also edit only a subset of the component routes by leaving the component routes you do not want to change set to an empty string. For example, if you only want to change the Console and OAuth server hostnames and TLS certificates, you would run the following command:
-[source,bash]
+Alternatively, you can edit only a subset of the component routes by leaving the component routes you do not want to change set to an empty string. For example, to change only the Console and OAuth server hostnames and TLS certificates, run the following command:
++
+[source,terminal]
 ----
 $ rosa edit ingress -c ${CLUSTER_NAME} ${INGRESS_ID} --component-routes 'console: hostname=console.my-new-domain.dev;tlsSecretRef=console-tls,downloads: hostname="";tlsSecretRef="", oauth: hostname=oauth.my-new-domain.dev;tlsSecretRef=oauth-tls'
 ----
-====
+
+. Verify that your changes were successfully made:
 +
-. Run the `rosa list ingress` command to verify that your changes were successfully made:
-+
-[source,bash]
+[source,terminal]
 ----
 $ rosa list ingress -c ${CLUSTER_NAME} -ojson | jq ".[] | select(.id == \"${INGRESS_ID}\") | .component_routes"
 ----
@@ -54,5 +52,7 @@ $ rosa list ingress -c ${CLUSTER_NAME} -ojson | jq ".[] | select(.id == \"${INGR
   }
 }
 ----
-+
-. Add your certificate to the truststore on your local system, then confirm that you can access your components at their new routes using your local web browser.
+
+. Add your certificate to the truststore on your local system.
+
+. Confirm that you can access your components at their new routes by using your local web browser.

--- a/modules/rosa-verify-permissions-sts-deployment-about-verification.adoc
+++ b/modules/rosa-verify-permissions-sts-deployment-about-verification.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-verify-permissions-sts-deployment-about-verification_{context}"]
+= Permission verification for STS deployments
+
+[role="_abstract"]
+You can verify the permissions required for {product-title} by running a script without creating any AWS resources. The script uses the `rosa`, `aws`, and `jq` CLI commands to create files in the working directory that are used to verify permissions in the account connected to the current AWS configuration.
+
+The AWS Policy Simulator is used to verify the permissions of each role policy against the API calls extracted by `jq`; results are then stored in a text file appended with `.results`.
+
+This script is designed to verify the permissions for the current account and region.

--- a/modules/rosa-verify-permissions-sts-deployment-verify-permissions.adoc
+++ b/modules/rosa-verify-permissions-sts-deployment-verify-permissions.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-verify-permissions-sts-deployment-verify-permissions_{context}"]
+= Verify your AWS account permissions
+
+[role="_abstract"]
+Run the permissions verification script to check whether your AWS account has the required permissions for a {product-title} STS deployment. The script verifies the permissions for the current account and region.
+
+.Prerequisites
+
+* The link:https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[AWS CLI] is installed.
+* The link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-get-started-cli[ROSA CLI] v1.2.6 or later is installed.
+* The link:https://jqlang.github.io/jq/[jq] CLI tool is installed.
+* You have an link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html[AWS role with the required permissions].
+
+.Procedure
+
+. To use the script, run the following commands in a `bash` terminal (the `-p`` option defines a prefix for the roles):
++
+[source,terminal,subs="+quotes,verbatim"]
+----
+$ mkdir scratch
+$ cd scratch
+$ cat << 'EOF' > verify-permissions.sh
+#!/bin/bash
+while getopts 'p:' OPTION; do
+  case "$OPTION" in
+    p)
+      PREFIX="$OPTARG"
+      ;;
+    ?)
+      echo "script usage: $(basename \$0) [-p PREFIX]" >&2
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+rosa create account-roles --mode manual --prefix $PREFIX
+INSTALLER_POLICY=$(cat sts_installer_permission_policy.json | jq )
+CONTROL_PLANE_POLICY=$(cat sts_instance_controlplane_permission_policy.json | jq)
+WORKER_POLICY=$(cat sts_instance_worker_permission_policy.json | jq)
+SUPPORT_POLICY=$(cat sts_support_permission_policy.json | jq)
+simulatePolicy () {
+    outputFile="${2}.results"
+    echo $2
+    aws iam simulate-custom-policy --policy-input-list "$1" --action-names $(jq '.Statement | map(select(.Effect == "Allow"))[].Action | if type == "string" then . else .[] end' "$2" -r) --output text > $outputFile
+}
+simulatePolicy "$INSTALLER_POLICY" "sts_installer_permission_policy.json"
+simulatePolicy "$CONTROL_PLANE_POLICY" "sts_instance_controlplane_permission_policy.json"
+simulatePolicy "$WORKER_POLICY" "sts_instance_worker_permission_policy.json"
+simulatePolicy "$SUPPORT_POLICY" "sts_support_permission_policy.json"
+EOF
+$ chmod +x verify-permissions.sh
+$ ./verify-permissions.sh -p SimPolTest
+----
+
+. After the script completes, review each results file to ensure that none of the required API calls are blocked:
++
+[source,terminal]
+----
+$ for file in $(ls *.results); do echo $file; cat $file; done
+----
++
+.Example output
+[source,text]
+----
+sts_installer_permission_policy.json.results
+EVALUATIONRESULTS       autoscaling:DescribeAutoScalingGroups   allowed *
+MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
+ENDPOSITION     6       195
+STARTPOSITION   17      3
+EVALUATIONRESULTS       ec2:AllocateAddress     allowed *
+MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
+ENDPOSITION     6       195
+STARTPOSITION   17      3
+EVALUATIONRESULTS       ec2:AssociateAddress    allowed *
+MATCHEDSTATEMENTS       PolicyInputList.1       IAM Policy
+...
+----
++
+[NOTE]
+====
+If any actions are blocked, review the error provided by AWS and consult with your administrator to determine if SCPs are blocking the required API calls.
+====


### PR DESCRIPTION
Version(s):
4.22+
5.0+

Issue:
Main CQA: https://redhat.atlassian.net/browse/OSDOCS-20235
CQA Jobs: [OSDOCS-21712](https://redhat.atlassian.net/browse/OSDOCS-21712), [OSDOCS-21713](https://redhat.atlassian.net/browse/OSDOCS-21713), [OSDOCS-21711](https://redhat.atlassian.net/browse/OSDOCS-21711)

Link to docs preview:
2 ROSA Classic-only tutorials:
https://118701--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-update-component-routes.html
https://118701--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.html 

QE review:
N/A

Additional information:
