### PR TITLE
[OSDOCS#15582]: Add supportability disclaimer for DNS Operator managementState

### DIFF
--- a/modules/nw-dns-operator-managementState.adoc
+++ b/modules/nw-dns-operator-managementState.adoc
@@ -17,6 +17,11 @@ The following are use cases for changing the DNS Operator `managementState`:
 
 * You are a cluster administrator and have reported an issue with CoreDNS, but need to apply a workaround until the issue is fixed. You can set the `managementState` field of the DNS Operator to `Unmanaged` to apply the workaround.
 
+[WARNING]
+====
+Setting the `managementState` of the DNS Operator to `Unmanaged` renders CoreDNS and DNS-related cluster functionality unsupported. Any configuration changes that you make while the DNS Operator is `Unmanaged` are not supported by Red Hat. Revert your changes and set `managementState` back to `Managed` before reporting an issue.
+====
+
 [NOTE]
 ====
 You cannot upgrade while the `managementState` is set to `Unmanaged`.
@@ -37,3 +42,6 @@ oc patch dns.operator.openshift.io default --type merge --patch '{"spec":{"manag
 ----
 $ oc get dns.operator.openshift.io default -ojsonpath='{.spec.managementState}'
 ----
+
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators]


### PR DESCRIPTION
Version(s):
All (main)

Issue:
https://redhat.atlassian.net/browse/OSDOCS-15582

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.

Additional information:
Adds a supportability disclaimer to the "Changing the DNS Operator managementState" section clarifying that setting `managementState` to `Unmanaged`, and any configuration changes made while it is `Unmanaged`, are not supported by Red Hat, and links to the general "Support policy for unmanaged Operators" reference page.
