### PR TITLE
CNV-95686: list pods placed by Subscription vs HyperConverged

### DIFF
--- a/modules/virt-about-node-placement-virt-components.adoc
+++ b/modules/virt-about-node-placement-virt-components.adoc
@@ -16,6 +16,8 @@ Two objects control placement, and they do not place the same pods:
 
 Pods in the `{CNVNamespace}` namespace look similar until you inspect `ownerReferences`. Editing `nodePlacement` in the `HyperConverged` CR does not move OLM operator pods.
 
+The `Subscription` object supports `nodeSelector`, `affinity`, and `tolerations` in `spec.config`. Use `affinity` when you must override operator deployment affinity, for example the required control-plane `nodeAffinity` on `virt-operator`. A `nodeSelector` does not replace that affinity.
+
 Depending on the object, you can use one or more of the following rule types:
 
 `nodeSelector`:: Allows pods to be scheduled on nodes that are labeled with the key-value pair or pairs that you specify in this field. The node must have labels that exactly match all listed pairs.

--- a/modules/virt-about-node-placement-virt-components.adoc
+++ b/modules/virt-about-node-placement-virt-components.adoc
@@ -16,7 +16,7 @@ Two objects control placement, and they do not place the same pods:
 
 Pods in the `{CNVNamespace}` namespace look similar until you inspect `ownerReferences`. Editing `nodePlacement` in the `HyperConverged` CR does not move OLM operator pods.
 
-The `Subscription` object supports `nodeSelector`, `affinity`, and `tolerations` in `spec.config`. Use `affinity` when you must override operator deployment affinity, for example the required control-plane `nodeAffinity` on `virt-operator`. A `nodeSelector` does not replace that affinity.
+The `Subscription` object supports `nodeSelector`, `affinity`, and `tolerations` in `spec.config`. Use `affinity` when you must override operator deployment affinity, for example the required control plane `nodeAffinity` on `virt-operator`. A `nodeSelector` does not replace that affinity. Overriding that affinity has security implications because `virt-operator` has broad cluster-scoped RBAC.
 
 Depending on the object, you can use one or more of the following rule types:
 

--- a/modules/virt-about-node-placement-virt-components.adoc
+++ b/modules/virt-about-node-placement-virt-components.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 You can use node placement rules to deploy virtual machines only on nodes intended for virtualization workloads, to deploy Operators only on infrastructure nodes, or to maintain separation between workloads.
 
+Two objects control placement, and they do not place the same pods:
+
+* The `Subscription` object places Operator Lifecycle Manager (OLM) operator pods. Those pods exist after you install the {VirtProductName} Operator, even if you have not created a `HyperConverged` custom resource (CR).
+* The `HyperConverged` CR places operand pods that {VirtProductName} creates after you create the CR.
+
+Pods in the `{CNVNamespace}` namespace look similar until you inspect `ownerReferences`. Editing `nodePlacement` in the `HyperConverged` CR does not move OLM operator pods.
+
 Depending on the object, you can use one or more of the following rule types:
 
 `nodeSelector`:: Allows pods to be scheduled on nodes that are labeled with the key-value pair or pairs that you specify in this field. The node must have labels that exactly match all listed pairs.

--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -40,11 +40,18 @@ The following pods are placed by the `Subscription` object. They exist after you
 
 [IMPORTANT]
 ====
-The `virt-operator` deployment includes required node affinity for the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` labels. A `nodeSelector` on the `Subscription` object does not replace that affinity. If you set only a `nodeSelector` that excludes control plane nodes, `virt-operator` cannot be scheduled.
+The `virt-operator` deployment includes required node affinity for the `node-role.kubernetes.io/control-plane` or `node-role.kubernetes.io/master` label. A `nodeSelector` on the `Subscription` object does not replace that affinity. If you set only a `nodeSelector` that excludes control plane nodes, `virt-operator` cannot be scheduled.
 
 To place `virt-operator` on other nodes, set `spec.config.affinity.nodeAffinity` on the `Subscription` object. OLM overrides the operator deployment `nodeAffinity` with that value. You can also set `nodeSelector` and `tolerations` in the same `config` block, for example to match infrastructure node taints.
 
 The `node-role.kubevirt.io/control-plane` label is used only on hosted control planes, where the hosted cluster has no Kubernetes control plane nodes.
+====
+
+[WARNING]
+====
+Overriding the `virt-operator` control plane affinity moves a highly privileged Operator onto nodes that are not control plane nodes. The `virt-operator` deployment has broad cluster-scoped RBAC: it manages custom resource definitions (CRDs) and `ClusterRole` objects, and it creates privileged pods. The default affinity keeps `virt-operator` on control plane nodes, which are isolated from general workloads and hardened according to the link:https://kubernetes.io/blog/2021/10/05/nsa-cisa-kubernetes-hardening-guidance/[NSA/CISA Kubernetes Hardening Guidance]. That guidance recommends separating control plane components from worker nodes to limit blast radius.
+
+Override this affinity only if you understand the security impact and the target nodes are equivalently isolated and hardened.
 ====
 
 [NOTE]
@@ -76,7 +83,7 @@ OLM deploys the {VirtProductName} Operators on nodes labeled `example.io/example
 
 [NOTE]
 ====
-A `nodeSelector` is not enough to move `virt-operator` off control plane nodes. Use the following `affinity` example to override the required control-plane affinity from the ClusterServiceVersion (CSV).
+A `nodeSelector` is not enough to move `virt-operator` off control plane nodes. The following `affinity` example overrides the required control plane affinity from the ClusterServiceVersion (CSV). Review the warning about the security impact of this override before you use it.
 ====
 
 Example `Subscription` object with `affinity` rule:

--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -23,7 +23,7 @@ To specify the nodes where OLM deploys the {VirtProductName} Operators, edit the
 
 Currently, you cannot configure node placement rules for the `Subscription` object by using the web console.
 
-The `Subscription` object does not support the `affinity` node placement rule.
+You can set `nodeSelector`, `affinity`, and `tolerations` in `spec.config` on the `Subscription` object. OLM applies those fields to the operator Deployments.
 
 The following pods are placed by the `Subscription` object. They exist after you install the {VirtProductName} Operator, even if you have not created a `HyperConverged` CR:
 
@@ -40,7 +40,11 @@ The following pods are placed by the `Subscription` object. They exist after you
 
 [IMPORTANT]
 ====
-When the cluster has Kubernetes control plane nodes, the `virt-operator` pod must run on those nodes. The `virt-operator` deployment has required node affinity for the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` labels. The `Subscription` `spec.config` field can set `nodeSelector` and `tolerations`, but it cannot override that affinity. The `node-role.kubevirt.io/control-plane` label is used only on hosted control planes, where the hosted cluster has no Kubernetes control plane nodes.
+The `virt-operator` deployment includes required node affinity for the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` labels. A `nodeSelector` on the `Subscription` object does not replace that affinity. If you set only a `nodeSelector` that excludes control plane nodes, `virt-operator` cannot be scheduled.
+
+To place `virt-operator` on other nodes, set `spec.config.affinity.nodeAffinity` on the `Subscription` object. OLM overrides the operator deployment `nodeAffinity` with that value. You can also set `nodeSelector` and `tolerations` in the same `config` block, for example to match infrastructure node taints.
+
+The `node-role.kubevirt.io/control-plane` label is used only on hosted control planes, where the hosted cluster has no Kubernetes control plane nodes.
 ====
 
 [NOTE]
@@ -69,6 +73,47 @@ spec:
 ----
 
 OLM deploys the {VirtProductName} Operators on nodes labeled `example.io/example-infra-key = example-infra-value`.
+
+[NOTE]
+====
+A `nodeSelector` is not enough to move `virt-operator` off control plane nodes. Use the following `affinity` example to override the required control-plane affinity from the ClusterServiceVersion (CSV).
+====
+
+Example `Subscription` object with `affinity` rule:
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: {CNVNamespace}
+spec:
+  source: {CNVSubscriptionSpecSource}
+  sourceNamespace: openshift-marketplace
+  name: {CNVSubscriptionSpecName}
+  startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
+  channel: "stable"
+  config:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: example.io/example-infra-key
+              operator: In
+              values:
+              - example-infra-value
+    nodeSelector:
+      example.io/example-infra-key: example-infra-value
+    tolerations:
+    - key: example.io/example-infra-key
+      operator: Equal
+      value: example-infra-value
+      effect: NoSchedule
+----
+
+OLM overrides the operator deployment `nodeAffinity`, including the required control-plane affinity on `virt-operator`, so the Operators can schedule on nodes labeled `example.io/example-infra-key = example-infra-value`.
 
 Example `Subscription` object with `tolerations` rule:
 

--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -25,6 +25,29 @@ Currently, you cannot configure node placement rules for the `Subscription` obje
 
 The `Subscription` object does not support the `affinity` node placement rule.
 
+The following pods are placed by the `Subscription` object. They exist after you install the {VirtProductName} Operator, even if you have not created a `HyperConverged` CR:
+
+* `aaq-operator`
+* `cdi-operator`
+* `cluster-network-addons-operator`
+* `hco-operator`
+* `hco-webhook`
+* `hostpath-provisioner-operator`
+* `hyperconverged-cluster-cli-download`
+* `kubevirt-migration-operator`
+* `ssp-operator`
+* `virt-operator`
+
+[IMPORTANT]
+====
+When the cluster has Kubernetes control plane nodes, the `virt-operator` pod must run on those nodes. The `virt-operator` deployment has required node affinity for the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` labels. The `Subscription` `spec.config` field can set `nodeSelector` and `tolerations`, but it cannot override that affinity. The `node-role.kubevirt.io/control-plane` label is used only on hosted control planes, where the hosted cluster has no Kubernetes control plane nodes.
+====
+
+[NOTE]
+====
+Editing `spec.infra.nodePlacement` or `spec.workloads.nodePlacement` in the `HyperConverged` CR does not move these operator pods.
+====
+
 Example `Subscription` object with `nodeSelector` rule:
 
 [source,yaml,subs="attributes+"]
@@ -77,6 +100,27 @@ endif::openshift-rosa,openshift-dedicated[]
 == HyperConverged object node placement rule example
 
 To specify the nodes where {VirtProductName} deploys its components, you can edit the `nodePlacement` object in the `HyperConverged` custom resource (CR) file that you create during {VirtProductName} installation.
+
+The following pods are placed by the `HyperConverged` CR. They exist only after you create the CR:
+
+* `cdi-apiserver`
+* `cdi-deployment`
+* `cdi-uploadproxy`
+* `kubemacpool-cert-manager`
+* `kubemacpool-mac-controller-manager`
+* `kubevirt-console-proxy`
+* `kubevirt-console-plugin`
+* `kubevirt-ipam-controller-manager`
+* `kubevirt-migration-controller`
+* `virt-api`
+* `virt-controller`
+* `virt-exportproxy`
+* `virt-template-validator`
+
+[NOTE]
+====
+DaemonSets such as `virt-handler` also follow `HyperConverged` workload placement. Operator pods listed in the Subscription examples, including `virt-operator`, are not placed by the `HyperConverged` CR.
+====
 
 Example `HyperConverged` object with `nodeSelector` rule:
 


### PR DESCRIPTION
## Summary
- Clarify that the `Subscription` object and the `HyperConverged` CR do not place the same pods in `{CNVNamespace}`.
- List the operator pods that OLM deploys from the Subscription (present even before a HyperConverged CR).
- List the operand pods that the HyperConverged CR places (created only after the CR exists).
- Note that `virt-operator` is an OLM pod but has required control-plane affinity, so Subscription `spec.config` cannot move it off control plane nodes on classic OpenShift. The `node-role.kubevirt.io/control-plane` label is for hosted control planes only.

This is the product-docs counterpart of kubevirt/hyperconverged-cluster-operator#4522. That HCO PR cannot be retargeted here; PRs are per repository.

Jira: https://issues.redhat.com/browse/CNV-95686

Preview page: `virt/post_installation_configuration/virt-node-placement-virt-components.adoc`

## Test plan
- [ ] Preview the assembly and confirm the Subscription and HyperConverged sections list the pods.
- [ ] Confirm ROSA/OSD still hide the Subscription section (`ifndef::openshift-rosa,openshift-dedicated[]`).
- [ ] Cherry-pick to `main` / other supported branches if required after this 4.22 change merges.

Made with [Cursor](https://cursor.com)