### PR TITLE
OSDOCS-21717: Add 4.14.72 z-stream release notes

### DIFF
--- a/modules/zstream-4-14-72.adoc
+++ b/modules/zstream-4-14-72.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-72_{context}"]
+= RHSA-2026:56789 - {product-title} {product-version}.72 bug fix and security update
+
+Issued: TBD
+
+[role="_abstract"]
+{product-title} release {product-version}.72 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:56789[RHSA-2026:56789] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:xxxxx[RHBA-2026:xxxxx] advisory.
+
+[id="zstream-4-14-72-container-images_{context}"]
+== Container images
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.72 --pullspecs
+----
+
+[id="zstream-4-14-72-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-14-72-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.72 RNs and updating
+include::modules/zstream-4-14-72.adoc[leveloffset=+2]
+
 // 4.14.71 RNs and updating
 include::modules/zstream-4-14-71.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OCP 4.14.72 (advisory-only)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-21717
- Shipment branch: prepare-shipment-4.14.72-20260819053507
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14
- Errata: RHSA-2026:56789 (primary) / RHBA-2026:xxxxx (RPM companion - TBD)

## Documented
None - advisory-only release (no notable fixed issues)

## Skipped (not documented)
All 18 issues auto-closed in Step 3a (pre-step):

| Key | Reason |
|-----|--------|
| OCPBUGS-76887 | Red Hat Employee |
| OCPBUGS-77116 | Release Note Not Required |
| OCPBUGS-79820 | Release Note Not Required |
| OCPBUGS-79821 | Release Note Not Required |
| OCPBUGS-81595 | Release Note Not Required |
| OCPBUGS-81664 | Red Hat Employee |
| OCPBUGS-83659 | Release Note Not Required |
| OCPBUGS-85463 | Red Hat Employee |
| OCPBUGS-87115 | Red Hat Employee |
| OCPBUGS-87116 | Red Hat Employee |
| OCPBUGS-88405 | Release Note Not Required |
| OCPBUGS-88588 | Release Note Not Required |
| OCPBUGS-90803 | Red Hat Employee |
| OCPBUGS-91906 | Red Hat Employee |
| OCPBUGS-92176 | Red Hat Employee |
| OCPBUGS-97816 | Red Hat Employee |
| OCPBUGS-99086 | Release Note Not Required |
| OCPBUGS-100361 | Release Note Not Required |

## Jira RN text populated (pre-step)
All 18 issues auto-closed:
- 9 issues with Security Level = "Red Hat Employee"
- 9 issues with Release Note Type = "Release Note Not Required"
- All set to RN Status = Done, RN Text = N/A

## Scope notes
- Shipment YAML keys: 18
- Errata not yet published (using live_id from shipment YAML)
- All 18 bugs auto-closed per workflow Step 3a (mandatory pre-step)
- Result: Advisory-only release

## Notes
- Errata not yet published - using placeholder issued date "TBD"
- This PR should be marked as **DRAFT** until errata is published
- Workflow Step 3a (auto-close) executed BEFORE Step 3b (filter) ✓
- Gate 1 passed: Auto-close count = 18 ✓
- Gate 2 passed: Filter complete, 0 documentable bugs ✓

## Test plan
- [x] Workflow gates passed (Step 3a before 3b)
- [x] Auto-close mandatory section included in final report
- [x] Vale clean (0 errors)
- [ ] Update issued date when errata published
- [ ] Update companion advisory ID when available