### PR TITLE
[RHDEVDOCS-7883] Release notes for Pipelines 1.23.2

### DIFF
--- a/modules/op-release-notes-1-23-2.adoc
+++ b/modules/op-release-notes-1-23-2.adoc
@@ -1,0 +1,36 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-23.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-23-2_{context}"]
+= Release notes for {pipelines-title} 1.23.2
+
+[role="_abstract"]
+{pipelines-title} General Availability 1.23.2 is available on {OCP} 4.14 and later supported versions.
+
+[id="fixed-issues-1-23-2_{context}"]
+== Fixed issues
+
+.User interface
+//SRVKP-11469
+Pipeline run logs with carriage return characters no longer overlap::
+Before this update, pipeline run logs containing carriage return characters (`\r`) were not rendered correctly. As a consequence, log lines that used carriage returns for progress updates overlapped each other instead of overwriting the current line. With this update, the console plugin handles carriage return characters to replicate terminal behavior. As a result, pipeline run logs with progress bars and status updates display correctly.
++
+link:https://redhat.atlassian.net/browse/SRVKP-11469[SRVKP-11469]
+
+.Pipelines
+//SRVKP-12133
+Pipeline runs no longer stall in the `ResolvingTaskRef` state::
+Before this update, when a `ResolutionRequest` completion event was dropped, the associated pipeline run remained in the `ResolvingTaskRef` state indefinitely. As a consequence, pipeline runs stalled for minutes or longer, requiring you to manually delete the controller pods to recover. With this update, pipeline runs in the `ResolvingTaskRef` state are requeued after one second to ensure they are updated when their resolution requests complete. As a result, pipeline runs no longer stall in the `ResolvingTaskRef` state.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12133[SRVKP-12133]
+
+[id="removed-features-1-23-2_{context}"]
+== Removed features
+
+.User interface
+//SRVKP-12189
+{tekton-hub} integration is removed from the console plugin::
+The {tekton-hub} integration in the {pipelines-shortname} console plugin, which provided task catalog discovery and installation through {tekton-hub} APIs, is removed. Use {artifact-hub} as the catalog source for discovering and installing community tasks.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12189[SRVKP-12189]

--- a/release_notes/op-release-notes-1-23.adoc
+++ b/release_notes/op-release-notes-1-23.adoc
@@ -29,6 +29,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.23
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.23.2
+include::modules/op-release-notes-1-23-2.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.23.1
 include::modules/op-release-notes-1-23-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7883

Link to docs preview:
- [1.23.2 Release Notes](https://118707--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-23.html#op-release-notes-1-23-2_op-release-notes-1-23)

QE/SME review:
- [x] QE/SME has approved this change.
