### PR TITLE
OSDOCS-16991: Add short descriptions to CloudFormation template modules

### DIFF
--- a/modules/installation-cloudformation-bootstrap.adoc
+++ b/modules/installation-cloudformation-bootstrap.adoc
@@ -7,7 +7,8 @@
 [id="installation-cloudformation-bootstrap_{context}"]
 = CloudFormation template for the bootstrap machine
 
-You can use the following CloudFormation template to deploy the bootstrap machine that you need for your {product-title} cluster.
+[role="_abstract"]
+The bootstrap machine `CloudFormation` template creates the temporary {aws-first} resources that the {product-title} bootstrap process requires to initialize the control plane.
 
 .CloudFormation template for the bootstrap machine
 [%collapsible]

--- a/modules/installation-cloudformation-control-plane.adoc
+++ b/modules/installation-cloudformation-control-plane.adoc
@@ -7,8 +7,8 @@
 [id="installation-cloudformation-control-plane_{context}"]
 = CloudFormation template for control plane machines
 
-You can use the following CloudFormation template to deploy the control plane
-machines that you need for your {product-title} cluster.
+[role="_abstract"]
+The control plane `CloudFormation` template creates the {aws-first} resources for the three control plane machines that manage your {product-title} cluster.
 
 .CloudFormation template for control plane machines
 [%collapsible]

--- a/modules/installation-cloudformation-dns.adoc
+++ b/modules/installation-cloudformation-dns.adoc
@@ -7,8 +7,8 @@
 [id="installation-cloudformation-dns_{context}"]
 = CloudFormation template for the network and load balancers
 
-You can use the following CloudFormation template to deploy the networking
-objects and load balancers that you need for your {product-title} cluster.
+[role="_abstract"]
+The networking `CloudFormation` template creates the Route 53 DNS entries and load balancers on {aws-first} that route traffic to your {product-title} control plane and applications.
 
 .CloudFormation template for the network and load balancers
 [%collapsible]

--- a/modules/installation-cloudformation-security.adoc
+++ b/modules/installation-cloudformation-security.adoc
@@ -7,8 +7,8 @@
 [id="installation-cloudformation-security_{context}"]
 = CloudFormation template for security objects
 
-You can use the following CloudFormation template to deploy the security objects
-that you need for your {product-title} cluster.
+[role="_abstract"]
+The security `CloudFormation` template creates the IAM roles and security groups on {aws-first} that control access to your {product-title} cluster resources.
 
 .CloudFormation template for security objects
 [%collapsible]

--- a/modules/installation-cloudformation-vpc.adoc
+++ b/modules/installation-cloudformation-vpc.adoc
@@ -7,8 +7,8 @@
 [id="installation-cloudformation-vpc_{context}"]
 = CloudFormation template for the VPC
 
-You can use the following CloudFormation template to deploy the VPC that
-you need for your {product-title} cluster.
+[role="_abstract"]
+The VPC `CloudFormation` template creates the {aws-first} networking infrastructure, including the public and private subnets, that your {product-title} cluster requires.
 
 .CloudFormation template for the VPC
 [%collapsible]

--- a/modules/installation-cloudformation-worker.adoc
+++ b/modules/installation-cloudformation-worker.adoc
@@ -7,7 +7,8 @@
 [id="installation-cloudformation-worker_{context}"]
 = CloudFormation template for compute machines
 
-You can deploy the compute machines that you need for your {product-title} cluster by using the following CloudFormation template.
+[role="_abstract"]
+The compute machine `CloudFormation` template creates the {aws-first} resources for the worker nodes that run your {product-title} application workloads.
 
 .CloudFormation template for compute machines
 [%collapsible]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20 +

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:
[CloudFormation template for the bootstrap machine](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-bootstrap_installing-aws-user-infra)

[CloudFormation template for control plane machines](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-control-plane_installing-aws-user-infra)

[CloudFormation template for the network and load balancers](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-dns_installing-aws-user-infra)

[CloudFormation template for security objects](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-security_installing-aws-user-infra)

[CloudFormation template for the VPC](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-vpc_installing-aws-user-infra)

[CloudFormation template for compute machines](https://118709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-cloudformation-worker_installing-aws-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->