### PR TITLE
OSDOCS-16991: Add short descriptions to VPC and worker node procedure modules

### DIFF
--- a/modules/installation-creating-aws-vpc.adoc
+++ b/modules/installation-creating-aws-vpc.adoc
@@ -7,9 +7,8 @@
 [id="installation-creating-aws-vpc_{context}"]
 = Creating a VPC in AWS
 
-You must create a Virtual Private Cloud (VPC) in Amazon Web Services (AWS) for your {product-title}
-cluster to use. You can customize the VPC to meet your requirements, including
-VPN and route tables.
+[role="_abstract"]
+You must create a Virtual Private Cloud (VPC) in Amazon Web Services (AWS) for your {product-title} cluster to use. You can customize the VPC to meet your requirements, including VPN and route tables.
 
 You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources that represent the VPC.
 

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -11,11 +11,8 @@ endif::[]
 [id="installation-creating-aws-worker_{context}"]
 = Creating the worker nodes in AWS
 
-////
-If you do not plan to automatically create worker nodes by using a MachineSet,
-////
-
-You can create worker nodes in Amazon Web Services (AWS) for your cluster to use.
+[role="_abstract"]
+Create worker nodes in {aws-first} for your cluster by using the provided `CloudFormation` template and a custom parameter file.
 
 ifdef::three-node-cluster[]
 [NOTE]


### PR DESCRIPTION
Versions:
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:

[Creating a VPC in AWS](https://118710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-vpc_installing-aws-user-infra)

[Creating the worker nodes in AWS](https://118710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->