### PR TITLE
No Jira: Restore Hat in Red Hat Customer Portal for oc download

### DIFF
--- a/modules/cli-installing-cli-linux.adoc
+++ b/modules/cli-installing-cli-linux.adoc
@@ -57,7 +57,7 @@ endif::[]
 = Installing the OpenShift CLI on Linux
 
 [role="_abstract"]
-To manage your cluster and deploy applications from the command line on Linux, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp} Customer Portal.
+To manage your cluster and deploy applications from the command line on Linux, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp}Hat Customer Portal.
 
 [IMPORTANT]
 ====

--- a/modules/cli-installing-cli-macos.adoc
+++ b/modules/cli-installing-cli-macos.adoc
@@ -57,7 +57,7 @@ endif::[]
 = Installing the OpenShift CLI on macOS
 
 [role="_abstract"]
-To manage your cluster and deploy applications from the command line on macOS, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp} Customer Portal.
+To manage your cluster and deploy applications from the command line on macOS, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp}Hat Customer Portal.
 
 [IMPORTANT]
 ====

--- a/modules/cli-installing-cli-windows.adoc
+++ b/modules/cli-installing-cli-windows.adoc
@@ -57,7 +57,7 @@ endif::[]
 = Installing the OpenShift CLI on Windows
 
 [role="_abstract"]
-To manage your cluster and deploy applications from the command line on Windows, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp} Customer Portal.
+To manage your cluster and deploy applications from the command line on Windows, install the {oc-first} binary. You can download the {oc-first} from the Red{nbsp}Hat Customer Portal.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The Linux, Windows, and macOS CLI install abstracts rendered as
"Red Customer Portal" because of a space after {nbsp}.

Version(s): 4.22+

Issue: N/A

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:
Fixes the published wording "Red Customer Portal" to "Red Hat Customer Portal"
in the oc Linux, Windows, and macOS install abstracts.
