### PR TITLE
OSDOCS-18754_2: Add Google Cloud Dedicated installation procedure and configuration reference (Part 2 of 2)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -333,6 +333,8 @@ Topics:
     File: installing-gcp-vpc
   - Name: Installing a cluster on Google Cloud into a shared VPC
     File: installing-gcp-shared-vpc
+  - Name: Installing a cluster on Google Cloud Dedicated
+    File: installing-gcp-dedicated
   - Name: Installing a private cluster on Google Cloud
     File: installing-gcp-private
   - Name: Installing a cluster on Google Cloud using Infrastructure Manager templates

--- a/installing/installing_gcp/installing-gcp-dedicated.adoc
+++ b/installing/installing_gcp/installing-gcp-dedicated.adoc
@@ -1,0 +1,40 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-gcp-dedicated"]
+= Installing a cluster on Google Cloud Dedicated
+include::_attributes/common-attributes.adoc[]
+:context: installing-gcp-dedicated
+
+toc::[]
+
+[role="_abstract"]
+You can install {product-title} on Google Cloud Dedicated, Google's sovereign cloud offering that provides isolated infrastructure operated by trusted local partners to meet data residency, administrative access control, and national compliance requirements.
+
+Google Cloud Dedicated operates within a distinct universe domain and requires configuration of custom API endpoints. This installation process uses the same installer workflow as standard GCP installations but with specific configuration parameters for the sovereign cloud environment.
+
+[IMPORTANT]
+====
+This installation method is supported for Google Cloud Dedicated environments only.
+====
+
+// Part 1 modules (from PR #117698)
+include::modules/installation-gcp-dedicated-about.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-dedicated-limitations.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-dedicated-manual-modes.adoc[leveloffset=+1]
+
+include::modules/prereqs-installing-gcp-dedicated.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-dedicated-preparing.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-dedicated-installing.adoc[leveloffset=+1]
+
+include::modules/installation-gcp-dedicated-config-params.adoc[leveloffset=+1]
+
+[id="additional-resources_installing-gcp-dedicated"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a customized cluster on GCP]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[Removing cloud provider credentials]

--- a/modules/installation-gcp-dedicated-about.adoc
+++ b/modules/installation-gcp-dedicated-about.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-dedicated-about_{context}"]
+= About Google Cloud Dedicated
+
+[role="_abstract"]
+Google Cloud Dedicated is Google's sovereign cloud offering that provides isolated infrastructure to meet data residency and compliance requirements.
+
+Google Cloud Dedicated provides a fully isolated cloud environment operated by trusted local partners. This sovereign cloud infrastructure addresses requirements for data residency, administrative access control, and national compliance while maintaining compatibility with standard Google Cloud Platform services.

--- a/modules/installation-gcp-dedicated-config-params.adoc
+++ b/modules/installation-gcp-dedicated-config-params.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-gcp-dedicated-config-params_{context}"]
+= Google Cloud Dedicated installation configuration parameters
+
+[role="_abstract"]
+The `install-config.yaml` file requires specific configuration parameters for deploying {product-title} on Google Cloud Dedicated, including the sovereign cloud section, custom API endpoints, and networking configuration.
+
+== Required Google Cloud Dedicated parameters
+
+The following parameters are required when installing on Google Cloud Dedicated:
+
+`platform.gcp.sovereignCloud.region`:: Specify the Google Cloud Dedicated region name provided by your local operating partner. This must match the value in `platform.gcp.region`.
+
+`platform.gcp.sovereignCloud.apiEndpoints.compute`:: Specify the custom Compute Engine API endpoint URL for your Google Cloud Dedicated environment. The URL format is `https://compute.<universe_domain>/compute/v1/`, where `<universe_domain>` is the universe domain provided by your local operating partner.
+
+`platform.gcp.sovereignCloud.apiEndpoints.cloudResourceManager`:: Specify the custom Cloud Resource Manager API endpoint URL for your Google Cloud Dedicated environment. The URL format is `https://cloudresourcemanager.<universe_domain>/`, where `<universe_domain>` is the universe domain provided by your local operating partner.
+
+`publish`:: Must be set to `Internal` for Google Cloud Dedicated. Public clusters are not supported.
+
+== Optional Google Cloud Dedicated parameters
+
+The following parameters are optional for Google Cloud Dedicated installations:
+
+`platform.gcp.defaultMachinePlatform.osImage.project`:: Specify the Google Cloud project ID where your custom {op-system-first} image is stored. If not specified, the installation program creates an image in your Google Cloud Dedicated project during installation.
+
+`platform.gcp.defaultMachinePlatform.osImage.name`:: Specify the name of your custom {op-system} image.
+
+`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey`:: Specify Customer-Managed Encryption Key (CMEK) settings for disk encryption. When using CMEK with Google Cloud Dedicated, you must use regional keys. This parameter includes the following subfields:
++
+--
+* `name`: The name of the KMS key.
+* `keyRing`: The name of the key ring containing the KMS key.
+* `location`: The region where the KMS key is located. Must be a regional location.
+* `projectID`: The Google Cloud project ID containing the KMS key.
+--
+
+`platform.gcp.defaultMachinePlatform.osDisk.diskType`:: Specify the disk type for machine storage. Google Cloud Dedicated supports only `hyperdisk-balanced`. Other disk types such as `pd-standard` or `pd-ssd` are not available.
+
+== Sample install-config.yaml file for Google Cloud Dedicated
+
+The following example shows a complete `install-config.yaml` file configured for a Google Cloud Dedicated deployment:
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: gcd-cluster
+platform:
+  gcp:
+    projectID: my-gcd-project
+    region: europe-west9-a
+    sovereignCloud:
+      region: europe-west9-a
+      apiEndpoints:
+        compute: "https://compute.sovereign.cloud.google.com/compute/v1/"
+        cloudResourceManager: "https://cloudresourcemanager.sovereign.cloud.google.com/"
+    defaultMachinePlatform:
+      osDisk:
+        diskType: hyperdisk-balanced
+        encryptionKey:
+          kmsKey:
+            name: my-regional-key
+            keyRing: my-key-ring
+            location: europe-west9
+            projectID: my-gcd-project
+      osImage:
+        project: my-gcd-project
+        name: my-rhcos-image
+publish: Internal
+pullSecret: '{"auths": ...}'
+sshKey: 'ssh-rsa AAAA...'
+----
+
+The following list describes notable parameters in this sample configuration:
+
+`baseDomain`:: The base domain for your cluster. Specify a domain that you control.
+`metadata.name`:: The name of your cluster. This value is used as part of the cluster's DNS records.
+`platform.gcp.projectID`:: The Google Cloud project ID for your Google Cloud Dedicated environment.
+`platform.gcp.region`:: The Google Cloud Dedicated region name provided by your local operating partner.
+`platform.gcp.sovereignCloud.region`:: The Google Cloud Dedicated region name in the `sovereignCloud.region` field. This must match the value in `platform.gcp.region`.
+`platform.gcp.sovereignCloud.apiEndpoints.compute`:: The custom Compute Engine API endpoint URL for your Google Cloud Dedicated environment. Replace the example domain with the universe domain provided by your local operating partner.
+`platform.gcp.sovereignCloud.apiEndpoints.cloudResourceManager`:: The custom Cloud Resource Manager API endpoint URL for your Google Cloud Dedicated environment. Replace the example domain with the universe domain provided by your local operating partner.
+`platform.gcp.defaultMachinePlatform.osDisk.diskType`:: The disk type for machine storage. Must be `hyperdisk-balanced` for Google Cloud Dedicated.
+`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`:: The name of your regional KMS key. Global keys are not supported in Google Cloud Dedicated.
+`platform.gcp.defaultMachinePlatform.osImage.project`:: Optional: The Google Cloud project ID where your custom {op-system} image is stored. If omitted, the installation program creates an image during installation.
+`publish`:: The cluster publishing strategy. Must be `Internal` for Google Cloud Dedicated.
+`pullSecret`:: Your Red Hat pull secret.
+`sshKey`:: Your SSH public key for accessing cluster nodes.
+
+[NOTE]
+====
+Before using a custom {op-system} image, verify that it is compatible with your {product-title} version and has been properly imported into your Google Cloud Dedicated project.
+====
+
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters_installing-gcp-customizations[Installation configuration parameters]
+* link:https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-obtaining-pull-secret_installing-gcp-account[Obtaining an installation pull secret]

--- a/modules/installation-gcp-dedicated-installing.adoc
+++ b/modules/installation-gcp-dedicated-installing.adoc
@@ -1,0 +1,188 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-gcp-dedicated-installing_{context}"]
+= Installing the cluster
+
+[role="_abstract"]
+Install an {product-title} cluster on Google Cloud Dedicated by creating an installation configuration file and running the {product-title} installer.
+
+.Prerequisites
+
+* You prepared your Google Cloud Dedicated environment.
+* You obtained the {product-title} installation program.
+* You obtained the pull secret for your cluster.
+* You obtained your Google Cloud Dedicated region name and custom API endpoints from your local operating partner, such as S3NS.
+
+.Procedure
+
+. Optional: Create an install-config.yaml file:
++
+[source,terminal]
+----
+$ ./openshift-install create install-config --dir <installation_directory>
+----
++
+Replace `<installation_directory>` with the name of the directory that contains the installation files for your cluster.
++
+Provide the following values when prompted:
++
+--
+** Select `gcp` as the platform to target.
+** Specify the Google Cloud project ID.
+** Select the region where your Google Cloud Dedicated environment is located.
+** Specify the base domain for your cluster.
+** Enter a descriptive name for your cluster.
+--
+
+. Edit the `install-config.yaml` file to configure it for your Google Cloud Dedicated environment:
+
+.. Add the `sovereignCloud` section under `platform.gcp` to specify your Google Cloud Dedicated region and custom API endpoints:
++
+[source,yaml]
+----
+platform:
+  gcp:
+    region: <gcd_region_name>
+    sovereignCloud:
+      region: <gcd_region_name>
+      apiEndpoints:
+        compute: "https://compute.<universe_domain>/compute/v1/"
+        cloudResourceManager: "https://cloudresourcemanager.<universe_domain>/"
+----
++
+where:
++
+`platform.gcp.region`:: Specifies the Google Cloud Dedicated region name provided by your local operating partner.
+`platform.gcp.sovereignCloud.region`:: Specifies the same Google Cloud Dedicated region name in the `sovereignCloud.region` field.
+`platform.gcp.sovereignCloud.apiEndpoints.compute`:: Specifies the custom Compute Engine API endpoint URL for your Google Cloud Dedicated environment. Replace `<universe_domain>` with the universe domain provided by your local operating partner.
+`platform.gcp.sovereignCloud.apiEndpoints.cloudResourceManager`:: Specifies the custom Cloud Resource Manager API endpoint URL for your Google Cloud Dedicated environment. Replace `<universe_domain>` with the universe domain provided by your local operating partner.
+
+.. Configure the cluster for private networking:
++
+[source,yaml]
+----
+publish: Internal
+----
++
+where:
++
+`publish`:: Specifies to set the cluster to private networking. Google Cloud Dedicated supports only private clusters. Public clusters are not supported.
+
+.. Optional: If you need to provide a custom {op-system-first} image, add the compute platform image field:
++
+[source,yaml]
+----
+platform:
+  gcp:
+    defaultMachinePlatform:
+      osImage:
+        project: <project_id>
+        name: <image_name>
+----
++
+where:
++
+`platform.gcp.defaultMachinePlatform.osImage.project`:: Specifies the Google Cloud project ID where your custom {op-system} image is stored.
+`platform.gcp.defaultMachinePlatform.osImage.name`:: Specifies the name of your custom {op-system} image.
++
+[NOTE]
+====
+If you do not specify a custom {op-system} image, the installation program creates an image in your Google Cloud Dedicated project during installation.
+====
+
+.. Optional: Configure Customer-Managed Encryption Keys (CMEK) if required for regulatory compliance:
++
+[IMPORTANT]
+====
+When using CMEK with Google Cloud Dedicated, you must use regional keys. Global keys are not supported.
+====
++
+[source,yaml]
+----
+platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            name: <regional_key_name>
+            keyRing: <key_ring_name>
+            location: <region_name>
+            projectID: <project_id>
+----
++
+where:
++
+`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`:: Specifies a regional KMS key, not a global key.
+
+.. Configure storage to use hyperdisk-balanced:
++
+[source,yaml]
+----
+platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        diskType: hyperdisk-balanced
+----
++
+where:
++
+`platform.gcp.defaultMachinePlatform.osDisk.diskType`:: Specifies the disk type for machine storage. Google Cloud Dedicated supports only `hyperdisk-balanced` storage. Other disk types are not available.
+
+. Back up the `install-config.yaml` file:
++
+[source,terminal]
+----
+$ cp <installation_directory>/install-config.yaml <installation_directory>/install-config.yaml.backup
+----
++
+[IMPORTANT]
+====
+The `install-config.yaml` file is consumed during the installation process. If you want to reuse the file, you must back it up.
+====
+
+. Generate the Kubernetes manifests for the cluster:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir <installation_directory>
+----
+
+. Deploy the {product-title} cluster:
++
+[source,terminal]
+----
+$ ./openshift-install create cluster --dir <installation_directory> --log-level=info
+----
++
+[NOTE]
+====
+If you provided correct configuration values, the cluster creation process should complete successfully. However, the installation program might fail if it cannot validate your custom API endpoints or if there are connectivity issues with your Google Cloud Dedicated environment.
+====
+
+.Verification
+
+* When the cluster deployment is complete, the installation program displays information about accessing your cluster, including a link to the web console and credentials for the `kubeadmin` user.
+
+* Verify that the cluster operators are running:
++
+[source,terminal]
+----
+$ export KUBECONFIG=<installation_directory>/auth/kubeconfig
+----
++
+[source,terminal]
+----
+$ oc get clusteroperators
+----
++
+All cluster operators should report `AVAILABLE` as `True` and `PROGRESSING` and `DEGRADED` as `False`.
+
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-obtaining-installer_installing-gcp-account[Obtaining the installation program]
+* link:https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-obtaining-pull-secret_installing-gcp-account[Obtaining an installation pull secret]

--- a/modules/installation-gcp-dedicated-limitations.adoc
+++ b/modules/installation-gcp-dedicated-limitations.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installation-gcp-dedicated-limitations_{context}"]
+= Google Cloud Dedicated limitations
+
+[role="_abstract"]
+Google Cloud Dedicated has specific limitations compared to standard Google Cloud Platform deployments.
+
+The following limitations apply when installing {product-title} on Google Cloud Dedicated:
+
+* Only private clusters are supported. Public clusters are not available.
+* Only `hyperdisk-balanced` storage is supported.
+* Global KMS keys are not supported. You must use regional KMS keys for encryption.

--- a/modules/installation-gcp-dedicated-manual-modes.adoc
+++ b/modules/installation-gcp-dedicated-manual-modes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-dedicated-manual-modes_{context}"]
+= Installation methods for Google Cloud Dedicated
+
+[role="_abstract"]
+You can install {product-title} on Google Cloud Dedicated using installer-provisioned infrastructure.
+
+With installer-provisioned infrastructure, the installation program deploys and configures the infrastructure that the cluster runs on, creating the necessary Google Cloud Dedicated resources based on the provided configuration.

--- a/modules/installation-gcp-dedicated-preparing.adoc
+++ b/modules/installation-gcp-dedicated-preparing.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-gcp-dedicated-preparing_{context}"]
+= Preparing your Google Cloud Dedicated environment
+
+[role="_abstract"]
+Prepare your Google Cloud Dedicated environment by gathering the required configuration information and setting up your local system.
+
+.Prerequisites
+
+* You have access to your Google Cloud Dedicated environment.
+* You obtained the universe domain and custom API endpoints from your local operating partner.
+
+.Procedure
+
+. Obtain the {product-title} installation program for your operating system and architecture.
+
+. Extract the installation program.
+
+. Obtain your installation pull secret from {cluster-manager-url-pull}.
+
+.Verification
+
+* Verify that you can run the installation program:
++
+[source,terminal]
+----
+$ ./openshift-install version
+----

--- a/modules/prereqs-installing-gcp-dedicated.adoc
+++ b/modules/prereqs-installing-gcp-dedicated.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-dedicated.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="prereqs-installing-gcp-dedicated_{context}"]
+= Prerequisites for installing on Google Cloud Dedicated
+
+[role="_abstract"]
+Before you install {product-title} on Google Cloud Dedicated, you must have the necessary access and configuration information.
+
+* You have access to a Google Cloud Dedicated environment.
+* You obtained the universe domain and custom API endpoints from your local operating partner.
+* You have the necessary permissions to create resources in your Google Cloud Dedicated project.
+* You have a Red Hat account and pull secret.


### PR DESCRIPTION
Versions:
4.22 (backport), 5.0+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18754

Link to docs preview:
- [Installing the cluster](https://118735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-dedicated.html#installation-gcp-dedicated-installing_installing-gcp-dedicated)
- [Google Cloud Dedicated installation configuration parameters](https://118735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-dedicated.html#installation-gcp-dedicated-config-params_installing-gcp-dedicated)


QE review:
- [ ] QE has approved this change.

Additional information:
This is the second of two PRs to document GCD (part 1: https://github.com/openshift/openshift-docs/pull/117698).
