### PR TITLE
OSDOCS-21723: Add 4.21.30 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-30.adoc
+++ b/modules/zstream-4-21-30.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-30_{context}"]
+= RHSA-2026:57801 - {product-title} {product-version}.30 bug fix and security update
+
+Issued: 25 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.30 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:57801[RHSA-2026:57801] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:57456[RHSA-2026:57456] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.30 --pullspecs
+----
+
+[id="zstream-4-21-30-enhancements_{context}"]
+== Enhancements
+
+* Clusters that report telemetry will now report the number and the kind of `UserDefinedNetwork` and `ClusterUserDefinedNetwork` resources in use. (link:https://redhat.atlassian.net/browse/OCPBUGS-54806[OCPBUGS-54806])
+
+[id="zstream-4-21-30-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when you viewed Quick Start `{{execute}}` code snippets in the {product-title} web console, leading whitespace in the code block could render as an empty line before the command text. As a consequence, execute snippets across Quick Starts could display an extra blank line above the command, making the content harder to read. With this release, leading whitespace rendering in Quick Start execute code snippets is corrected. As a result, execute code blocks display the command text without a spurious empty line above it. (link:https://redhat.atlassian.net/browse/OCPBUGS-105864[OCPBUGS-105864])
+
+[id="zstream-4-21-30-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -47,6 +47,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.30 RNs and updating
+include::modules/zstream-4-21-30.adoc[leveloffset=+2]
+
 // 4.21.29 RNs and updating
 include::modules/zstream-4-21-29.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21723

Link to docs preview:
https://118736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-30_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/757
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:57801 / RHSA-2026:57456
