### PR TITLE
OSDOCS-21724: Add 4.20.35 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-35.adoc
+++ b/modules/zstream-4-20-35.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-35_{context}"]
+= RHSA-2026:57545 - {product-title} {product-version}.35 bug fix and security update
+
+Issued: 25 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.35 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:57545[RHSA-2026:57545] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.35 --pullspecs
+----
+
+[id="zstream-4-20-35-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `nested-container` Security Context Constraint (SCC) used an incorrect specification for UID ranges, causing the UID ranges to be completely missing. As a consequence, pods using the `nested-container` SCC did not have the expected UID range constraints applied. With this release, the SCC correctly uses `uidRangeMin` and `uidRangeMax` fields to specify the UID range from `0` to `65534` so that the `nested-container` SCC properly enforces UID range constraints. (link:https://redhat.atlassian.net/browse/OCPBUGS-98555[OCPBUGS-98555])
+
+* Before this update, when you added a new {vmw-full} failure domain that used a MachineSet with a custom `providerSpec.Template` name, the Machine Config Operator (MCO) boot image controller looked up the VM template only by its own computed name and ignored the `providerSpec.Template` name. As a consequence, reconciliation for that failure domain might have failed. A customer-managed VM with the same computed name outside the MCO workspace folder might be overwritten when mistaken for the MCO template. With this release, the controller checks the `providerSpec.Template` name first. The controller falls back to the computed name only when the template is not found. The template is then created from the Open Virtual Appliance (OVA) when needed. The controller does not modify VMs whose names match but are outside the `providerSpec.Workspace.Folder` parameter. As a result, new {vmw-full} failure domains with custom template names reconcile successfully and customer-managed VMs outside the MCO workspace folder are not at risk of being overwritten. (link:https://redhat.atlassian.net/browse/OCPBUGS-105436[OCPBUGS-105436])
+
+[id="zstream-4-20-35-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -30,8 +30,10 @@ include::modules/ocp-release-notes-technology-preview-tables.adoc[leveloffset=+1
 include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 
 //z-stream release notes
-
 include::modules/rn-async-errata.adoc[leveloffset=+1]
+
+// 4.20.35 RNs and updating
+include::modules/zstream-4-20-35.adoc[leveloffset=+2]
 
 // 4.20.34 RNs and updating
 include::modules/zstream-4-20-34.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21724

Link to docs preview:
https://118737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-35_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/754
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:57545
