### PR TITLE
OSDOCS-21726: Add 4.18.54 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-54.adoc
+++ b/modules/zstream-4-18-54.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-54_{context}"]
+= RHSA-2026:57487 - {product-title} {product-version}.54 bug fix and security update
+
+Issued: 26 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.54 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:57487[RHSA-2026:57487] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:57482[RHSA-2026:57482] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.54 --pullspecs
+----
+
+[id="zstream-4-18-54-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the console relied on the full name for user identification, which created potential ambiguity when users shared similar names. With this release, the display logic is updated to prioritize unique identifiers. As a result, the console now shows the user name instead of the full name as the display name. (link:https://redhat.atlassian.net/browse/OCPBUGS-81520[OCPBUGS-81520])
+
+[id="zstream-4-18-54-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.54 RNs and updating
+include::modules/zstream-4-18-54.adoc[leveloffset=+2]
+
 // 4.18.53 RNs and updating
 include::modules/zstream-4-18-53.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21726

Link to docs preview:
https://118739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-54_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/753
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:57487 / RHSA-2026:57482
