### PR TITLE
OSDOCS-21727: Add 4.19.44 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-44.adoc
+++ b/modules/zstream-4-19-44.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-44_{context}"]
+= RHSA-2026:57408 - {product-title} {product-version}.44 bug fix and security update
+
+Issued: 26 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.44 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:57408[RHSA-2026:57408] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:57401[RHSA-2026:57401] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.44 --pullspecs
+----
+
+[id="zstream-4-19-44-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Operator used the `reflect.DeepEqual` parameter for node label comparison which required an exact label match instead of Kubernetes label selector semantics. As a consequence, the `IngressNodeFirewallNodeState` objects were not created for nodes added after the Operator startup. With this release, the `reflect.DeepEqual` parameter is replaced with the `labels.SelectorFromSet().Matches()` parameter for correct Kubernetes label selector matching. As a result, the Operator correctly creates the `IngressNodeFirewallNodeState` object for dynamically added nodes and label changes. (link:https://redhat.atlassian.net/browse/OCPBUGS-99218[OCPBUGS-99218])
+
+[id="zstream-4-19-44-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.44 RNs and updating
+include::modules/zstream-4-19-44.adoc[leveloffset=+2]
+
 // 4.19.43 RNs and updating
 include::modules/zstream-4-19-43.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21727

Link to docs preview:
https://118740--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-44_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/752
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:57408 / RHSA-2026:57401
