### PR TITLE
OSDOCS-21729: Add 4.14.72 z-stream release notes

### DIFF
--- a/modules/zstream-4-14-72.adoc
+++ b/modules/zstream-4-14-72.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-72_{context}"]
+= RHSA-2026:56789 - {product-title} {product-version}.72 bug fix and security update
+
+Issued: 26 August 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.72 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:56789[RHSA-2026:56789] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:56785[RHSA-2026:56785] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.72 --pullspecs
+----
+
+[id="zstream-4-14-72-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-14-72-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.72 RNs and updating
+include::modules/zstream-4-14-72.adoc[leveloffset=+2]
+
 // 4.14.71 RNs and updating
 include::modules/zstream-4-14-71.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21729

Link to docs preview:
https://118742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-72_release-notes

QE review:
N/A

Additional information:

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/744
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14
- Errata: RHSA-2026:56789 / RHSA-2026:56785
