### PR TITLE
OBSDOCS-3880: Align 6.5 1x.extra-small/1x.small ingester tables with the operator

### DIFF
--- a/modules/loki-sizing-1x-extra-small.adoc
+++ b/modules/loki-sizing-1x-extra-small.adoc
@@ -18,12 +18,12 @@ The 1x.extra-small size supports 100 GB per day log ingestion with high availabi
 |Distributor |1 |1Gi |2 |2 |2Gi |None
 |Gateway |500m |500Mi |2 |1 |1Gi |None
 |Index Gateway |500m |1Gi |2 |1 |2Gi |50Gi
-|Ingester |1 |5.25Gi |3 |3 |15.75Gi |10Gi
+|Ingester |2 |8Gi |2 |4 |16Gi |10Gi
 |Querier |1.5 |3Gi |2 |3 |6Gi |None
 |Query front end |1 |1Gi |2 |2 |2Gi |None
-4+|*Subtotal (without ruler)* |*13 vCPUs* |*30.75Gi* |*180Gi*
+4+|*Subtotal (without ruler)* |*14 vCPUs* |*31Gi* |*180Gi*
 |Ruler |1 |2Gi |2 |2 |4Gi |10Gi
-4+|*Subtotal (with ruler)* |*15 vCPUs* |*34.75Gi* |*200Gi*
+4+|*Subtotal (with ruler)* |*16 vCPUs* |*35Gi* |*200Gi*
 |===
 
 [NOTE]

--- a/modules/loki-sizing-1x-small.adoc
+++ b/modules/loki-sizing-1x-small.adoc
@@ -18,12 +18,12 @@ The 1x.small size supports 500 GB per day log ingestion with high availability (
 |Distributor |2 |2Gi |2 |4 |4Gi |None
 |Gateway |1 |1Gi |2 |2 |2Gi |None
 |Index Gateway |1 |2Gi |2 |2 |4Gi |50Gi
-|Ingester |2.5 |13.25Gi |3 |7.5 |39.75Gi |10Gi
+|Ingester |4 |20Gi |2 |8 |40Gi |10Gi
 |Querier |4 |4Gi |2 |8 |8Gi |None
 |Query front end |4 |2.5Gi |2 |8 |5Gi |None
-4+|*Subtotal (without ruler)* |*33.5 vCPUs* |*66.75Gi* |*180Gi*
+4+|*Subtotal (without ruler)* |*34 vCPUs* |*67Gi* |*180Gi*
 |Ruler |4 |8Gi |2 |8 |16Gi |10Gi
-4+|*Subtotal (with ruler)* |*41.5 vCPUs* |*82.75Gi* |*200Gi*
+4+|*Subtotal (with ruler)* |*42 vCPUs* |*83Gi* |*200Gi*
 |===
 
 [NOTE]


### PR DESCRIPTION
Version(s):
Red Hat OpenShift Logging 6.5

Issue:
https://redhat.atlassian.net/browse/OBSDOCS-3880

Link to docs preview:
<!-- Netlify preview after CI -->

QE review:
- [ ] QE has approved this change.

Additional information:

The 6.5 `1x.extra-small` and `1x.small` per-component tables document the [LOG-9352](https://redhat.atlassian.net/browse/LOG-9352) / [grafana/loki#21717](https://github.com/grafana/loki/pull/21717) ingester requests (1 CPU / 5.25Gi / 3 replicas and 2.5 CPU / 13.25Gi / 3 replicas). That operator change is on `release-6.6` only and is called out as a 6.6 feature in the 6.6 release notes. It was not backported to `release-6.5`.

A 6.5 cluster with `spec.size: 1x.extra-small` requests **2 CPU / 8Gi** per ingester with **2** replicas, matching [`sizes.go` on `release-6.5`](https://github.com/openshift/loki/blob/release-6.5/operator/internal/manifests/internal/sizes.go).

This restores the 6.5 component tables to those operator values. Subtotals now match the existing overview table (14 vCPUs / 31Gi extra-small, 34 vCPUs / 67Gi small).

Keep the 5.25Gi / 13.25Gi / 3 replica numbers in 6.6+ only.

Same incorrect tables are also on `standalone-logging-docs-6.4`; a follow-up PR can restore that branch if wanted.
