### PR TITLE
OSDOCS-21296: Document disableRedirect for S3 registry storage

### DIFF
--- a/modules/registry-configuring-registry-storage-s3-redirect.adoc
+++ b/modules/registry-configuring-registry-storage-s3-redirect.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-rhodf.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="registry-configuring-registry-storage-s3-redirect_{context}"]
+= Configuring Image Registry Operator redirects for S3-compatible storage
+
+[role="_abstract"]
+You can configure the Image Registry Operator `disableRedirect` parameter to control whether clients pull image data directly from S3-compatible object storage or through the registry. The default value is `false`, which redirects clients to the storage endpoint.
+
+By default, the Image Registry Operator redirects clients such as cluster nodes and external container tools to pull image layers directly from the object storage back end. Redirects reduce load on the registry. If clients cannot reach, resolve, or trust that storage endpoint, image pulls fail.
+
+[IMPORTANT]
+====
+If you set the `spec.storage.s3.regionEndpoint` field to a cluster-internal service DNS name, for example `s3.openshift-storage.svc` or `rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local`, and you leave `spec.disableRedirect` set to `false`, the registry redirects clients to that service hostname. Cluster nodes and external clients cannot resolve `.svc` hostnames, so image pulls fail with DNS errors such as `no such host`.
+
+To prevent these failures, set `spec.disableRedirect` to `true` so that the registry proxies the traffic, or configure `regionEndpoint` to a hostname that clients can resolve, such as an object storage route.
+====
+
+[NOTE]
+====
+Setting `disableRedirect` to `true` increases the network bandwidth and other resources that the image registry requires, because all image data passes through the registry.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the `oc` CLI.
+* You configured the image registry to use S3-compatible object storage.
+
+.Procedure
+
+* To configure the image registry to proxy traffic instead of redirecting clients to the S3 storage endpoint, set the `spec.disableRedirect` field in the `configs.imageregistry.operator.openshift.io` object to `true` by running the following command:
++
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"disableRedirect":true}}'
+----
+
+.Verification
+
+* Verify that `disableRedirect` is set to `true` by running the following command:
++
+[source,terminal]
+----
+$ oc get configs.imageregistry.operator.openshift.io cluster -o jsonpath='{.spec.disableRedirect}{"\n"}'
+----
++
+.Example output
+[source,terminal]
+----
+true
+----

--- a/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
@@ -27,6 +27,8 @@ include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloff
 
 include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
+include::modules/registry-configuring-registry-storage-s3-redirect.adoc[leveloffset=+1]
+
 [id="configuring-registry-storage-baremetal-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources

--- a/registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
@@ -27,6 +27,8 @@ include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloff
 
 include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
+include::modules/registry-configuring-registry-storage-s3-redirect.adoc[leveloffset=+1]
+
 [id="configuring-registry-storage-nutanix-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources

--- a/registry/configuring_registry_storage/configuring-registry-storage-rhodf.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-rhodf.adoc
@@ -15,6 +15,8 @@ include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloff
 
 include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
+include::modules/registry-configuring-registry-storage-s3-redirect.adoc[leveloffset=+1]
+
 [id="configuring-registry-storage-ocs"]
 [role="_additional-resources"]
 == Additional resources

--- a/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
@@ -27,6 +27,8 @@ include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloff
 
 include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
+include::modules/registry-configuring-registry-storage-s3-redirect.adoc[leveloffset=+1]
+
 [id="configuring-registry-storage-vsphere-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Explain DNS failures when redirects stay enabled with a cluster-internal S3 service endpoint on bare metal and related platforms.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
