### PR TITLE
[SRVKP-13067] Document StatefulSet scheduling from TektonConfig spec.config

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -28,6 +28,8 @@ Distros: openshift-pipelines
 Topics:
 - Name: OpenShift Pipelines release notes
   File: op-release-notes-1-23
+- Name: OpenShift Pipelines 1.24 release notes
+  File: op-release-notes-1-24
 ---
 Name: About OpenShift Pipelines
 Dir: about

--- a/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+++ b/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
@@ -11,6 +11,7 @@ In {pipelines-title}, you can customize the following configurations by using th
 
 * Optimizing {pipelines-shortname} performance, including high-availability mode for the {pipelines-shortname} controller
 * Configuring the {pipelines-title} control plane
+* Configuring node selectors and tolerations for Operator-managed components
 * Changing the default service account
 * Disabling the service monitor
 * Configuring pipeline resolvers
@@ -26,6 +27,8 @@ include::modules/op-configuring-pipelines-control-plane.adoc[leveloffset=+1]
 include::modules/op-modifiable-fields-with-default-values.adoc[leveloffset=+2]
 
 include::modules/op-optional-configuration-fields.adoc[leveloffset=+2]
+
+include::modules/op-configuring-node-placement-for-pipelines-components.adoc[leveloffset=+1]
 
 include::modules/op-changing-default-service-account.adoc[leveloffset=+1]
 

--- a/modules/op-configuring-node-placement-for-pipelines-components.adoc
+++ b/modules/op-configuring-node-placement-for-pipelines-components.adoc
@@ -1,0 +1,93 @@
+// This module is included in the following assemblies:
+// * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-configuring-node-placement-for-pipelines-components_{context}"]
+= Configuring node selectors and tolerations for {pipelines-shortname} components
+
+[role="_abstract"]
+You can pin Operator-managed {pipelines-shortname} workloads to specific nodes, such as infrastructure nodes, by setting global scheduling fields in the `TektonConfig` custom resource (CR). The Operator applies `spec.config.nodeSelector`, `spec.config.tolerations`, and `spec.config.priorityClassName` to both `Deployment` and `StatefulSet` workloads, including the `tekton-results-postgres` StatefulSet.
+
+.Prerequisites
+
+* You have access to an {OCP} cluster as a user with the `cluster-admin` role.
+* You have installed the {pipelines-shortname} Operator.
+* The target nodes have the labels and taints that match the `nodeSelector` and `tolerations` values that you want to set.
+
+.Procedure
+
+. Edit the `TektonConfig` CR:
++
+[source,terminal]
+----
+$ oc edit TektonConfig config
+----
+
+. Set the global scheduling fields under `spec.config`:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    priorityClassName: system-cluster-critical
+----
++
+where:
++
+`spec.config.nodeSelector`:: Specifies the node labels that Operator-managed pods must match.
+`spec.config.tolerations`:: Specifies the taints that Operator-managed pods can tolerate, such as infrastructure node taints.
+`spec.config.priorityClassName`:: Specifies an optional priority class for Operator-managed pods.
+
+. Save the changes and exit the editor.
+
+.Verification
+
+. Confirm that {tekton-results} deployments received the node selector:
++
+[source,terminal]
+----
+$ oc get deploy tekton-results-api -n openshift-pipelines \
+  -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}'
+----
++
+.Example output
+[source,terminal]
+----
+{"node-role.kubernetes.io/infra":""}
+----
+
+. Confirm that the `tekton-results-postgres` StatefulSet received the same node selector:
++
+[source,terminal]
+----
+$ oc get statefulset tekton-results-postgres -n openshift-pipelines \
+  -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}'
+----
++
+.Example output
+[source,terminal]
+----
+{"node-role.kubernetes.io/infra":""}
+----
+
+. Confirm that {tekton-results} pods, including PostgreSQL, are scheduled on the intended nodes:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-pipelines -o wide | grep tekton-results
+----
+
+[NOTE]
+====
+If you configure {tekton-results} to use an external database, the Operator does not deploy the `tekton-results-postgres` StatefulSet. In that case, only the Deployment-based {tekton-results} components receive the global scheduling configuration.
+====

--- a/modules/op-configuring-results.adoc
+++ b/modules/op-configuring-results.adoc
@@ -12,3 +12,5 @@ Installing {pipelines-shortname} enables {tekton-results} by default.
 However, if you want to store and access logging information for your pipeline runs and task runs, you must configure forwarding this information to `LokiStack`. 
 
 You can optionally complete additional configuration for {tekton-results}.
+
+To pin {tekton-results} workloads, including the `tekton-results-postgres` StatefulSet, to infrastructure nodes, set `spec.config.nodeSelector` and `spec.config.tolerations` in the `TektonConfig` CR. For more information, see xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuring-node-placement-for-pipelines-components_customizing-configurations-in-the-tektonconfig-cr[Configuring node selectors and tolerations for {pipelines-shortname} components].

--- a/modules/op-release-notes-1-24-0.adoc
+++ b/modules/op-release-notes-1-24-0.adoc
@@ -1,0 +1,20 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-24.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-24-0_{context}"]
+= Release notes for {pipelines-title} 1.24
+
+[role="_abstract"]
+{pipelines-title} General Availability (GA) 1.24 is available on supported {OCP} versions.
+
+[id="pipelines-fixed-issues-1-24-0_{context}"]
+== Fixed issues
+
+*Operator*
+
+//SRVKP-13067
+Global scheduling configuration applied to StatefulSet workloads::
+Before this update, the `TektonConfig` custom resource `spec.config` fields `nodeSelector`, `tolerations`, and `priorityClassName` were applied only to `Deployment` workloads. As a consequence, the `tekton-results-postgres` StatefulSet did not inherit infrastructure node placement, and the PostgreSQL pod remained on worker nodes. With this update, the Operator also applies these fields to `StatefulSet` workloads. As a result, all {tekton-results} components, including `tekton-results-postgres`, are scheduled according to the global configuration.
++
+link:https://issues.redhat.com/browse/SRVKP-13067[SRVKP-13067]

--- a/release_notes/op-release-notes-1-24.adoc
+++ b/release_notes/op-release-notes-1-24.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+//OpenShift Pipelines Release Notes
+include::_attributes/common-attributes.adoc[]
+[id="op-release-notes-1-24"]
+= {pipelines-title} 1.24 release notes
+:context: op-release-notes-1-24
+
+toc::[]
+
+[NOTE]
+====
+For additional information about the {pipelines-shortname} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] and link:https://access.redhat.com/support/policy/updates/openshift[Red{nbsp}Hat {OCP} Life Cycle Policy].
+====
+
+[role="_abstract"]
+Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for {pipelines-shortname} 1.24 on {OCP}.
+
+{pipelines-title} is a cloud-native CI/CD experience based on the Tekton project, which provides:
+
+* Standard Kubernetes-native pipeline definitions (CRDs).
+* Serverless pipelines with no CI server management required.
+* Extensibility to build images by using any Kubernetes tool, such as S2I, Buildah, JIB, and Kaniko.
+* Portability across any Kubernetes distribution.
+* Powerful CLI for interacting with pipelines.
+* Integrated user experience with the {OCP} web console.
+
+For an overview of {pipelines-title}, see xref:../about/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding {pipelines-shortname}].
+
+// Release notes for Red Hat OpenShift Pipelines 1.24.0
+include::modules/op-release-notes-1-24-0.adoc[leveloffset=+1]
+
+//Additional resources 1.24


### PR DESCRIPTION
## Summary
- Documents that `TektonConfig.spec.config` `nodeSelector`, `tolerations`, and `priorityClassName` apply to both Deployment and StatefulSet workloads, including `tekton-results-postgres`.
- Adds a TektonConfig procedure for pinning OpenShift Pipelines / Tekton Results components to infrastructure nodes.
- Adds a 1.24 release-notes fixed-issue entry for [SRVKP-13067](https://redhat.atlassian.net/browse/SRVKP-13067).

## Why this PR
The operator code PR ([openshift-pipelines/operator#26961](https://github.com/openshift-pipelines/operator/pull/26961)) targeting `release-v1.20.x` closed when that branch was deleted. The StatefulSet scheduling fix is already present on `release-v1.24.x`. This docs PR targets `pipelines-docs-main` because `pipelines-docs-1.24` currently has stuck prowjob checks.

## Test plan
- [ ] Preview the TektonConfig customization assembly and confirm the new node-placement procedure renders.
- [ ] Preview the Tekton Results observability page and confirm the xref to the new procedure works.
- [ ] Preview the 1.24 release notes page and confirm the [SRVKP-13067](https://redhat.atlassian.net/browse/SRVKP-13067) fixed-issue entry renders.
- [ ] QE: with `spec.config.nodeSelector` / `tolerations` set, confirm `tekton-results-postgres` StatefulSet and Results Deployments receive the same scheduling fields.

Fixes: [SRVKP-13067](https://redhat.atlassian.net/browse/SRVKP-13067)


Made with [Cursor](https://cursor.com)