### PR TITLE
[OSDOCS#20432]: Corrected latency value from 500 to 100

### DIFF
--- a/modules/installing-ocp-agent-local-arbiter-node.adoc
+++ b/modules/installing-ocp-agent-local-arbiter-node.adoc
@@ -4,19 +4,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="installing-ocp-agent-local-arbiter-node_{context}"]
-= About a local arbiter node
+= About an arbiter node
 
 [role="_abstract"]
-You can configure an {product-title} cluster with two control plane nodes and one local arbiter node so as to retain high availability (HA) while reducing infrastructure costs for your cluster.
+You can configure an {product-title} cluster with two control plane nodes and one arbiter node so as to retain high availability (HA) while reducing infrastructure costs for your cluster.
 
-A local arbiter node is a lower-cost, co-located machine that participates in control plane quorum decisions. Unlike a standard control plane node, the arbiter node does not run the full set of control plane services. You can use this configuration to maintain HA in your cluster with only two fully provisioned control plane nodes instead of three.
+An arbiter node is a lower-cost, co-located machine that participates in control plane quorum decisions. Unlike a standard control plane node, the arbiter node does not run the full set of control plane services. You can use this configuration to maintain HA in your cluster with only two fully provisioned control plane nodes instead of three.
 
-[IMPORTANT]
-====
-You can configure a local arbiter node only. Remote arbiter nodes are not supported.
-====
-
-To deploy a cluster with two control plane nodes and one local arbiter node, you must define the following nodes in the `install-config.yaml` file:
+To deploy a cluster with two control plane nodes and one arbiter node, you must define the following nodes in the `install-config.yaml` file:
 
 * 2 control plane nodes
 * 1 arbiter node
@@ -26,8 +21,7 @@ The arbiter node must meet the following minimum system requirements:
 * 2 vCPUs
 * 8 GB of RAM
 * 50 GB of SSD or equivalent storage
-
-The arbiter node must be located in a network environment with an end-to-end latency of less than 500 milliseconds, including disk I/O. In high-latency environments, you might need to apply the `etcd` slow profile.
+* The arbiter node must be located in a network environment with an end-to-end latency of less than 100 milliseconds, including disk I/O. In high-latency environments, you might need to apply the `etcd` slow profile.
 
 The control plane nodes must meet the following minimum system requirements:
 
@@ -64,7 +58,6 @@ controlPlane:
   replicas: 2
 platform:
   baremetal:
-# ...
     hosts:
       - name: cluster-master-0
         role: master


### PR DESCRIPTION

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20432

Link to docs preview:
https://118783--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#installing-ocp-agent-local-arbiter-node_preparing-to-install-with-agent-based-installer

QE review:
- [x] QE has approved this change.
