### PR TITLE
Rhdevdocs 6787 cel regex filtering

### DIFF
--- a/modules/op-matching-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-matching-pipeline-run-using-pipelines-as-code.adoc
@@ -190,6 +190,19 @@ $ git commit --amend --no-edit && git push --force-with-lease
 ----
 ====
 
+.Example: Filtering pull requests by excluding non-code file changes
+[source,yaml]
+----
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && !files.all.all(x, x.matches('^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+----
+
+In this example, {pac} triggers the pipeline run only when a pull request targeting the `main` branch includes file modifications outside of documentation (`docs/`, `.md`) or repository metadata (`OWNERS`, `PROJECT`, `LICENSE`, `.gitignore`).
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
**Jira:** 

[RHDEVDOCS-6787](https://issues.redhat.com/browse/RHDEVDOCS-6787)

**QA Review**
@zakisk 

**Peer Review**
@briandooley 

**Link**
https://118784--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/understanding-openshift-pipelines


**Summary of Changes:**
* Added a Common Expression Language (CEL) regex example to the Pipelines as Code matching module (`op-matching-pipeline-run-using-pipelines-as-code.adoc`).
* Documented how to use `!files.all.all()` with `x.matches()` to bypass `PipelineRun` execution on pull requests that update non-code files (such as `docs/`, `.md`, `OWNERS`, `LICENSE`, and `.gitignore`).
* Resolved user syntax ambiguity by providing a copy-pasteable configuration pattern for gating test pipelines.

