### PR TITLE
Test MS mapping with map-tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ commercial_package
 .vale/
 !.vale/templates
 !.vale/config/vocabularies
+build/
+analysis/
 
 # Agent workspace
 .agent_workspace/

--- a/maps/jobs/automate-data-recovery.adoc
+++ b/maps/jobs/automate-data-recovery.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: automate-data-recovery
 
-include::modules/microshift-auto-recovery-manual-backups.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-auto-recovery-manual-backups.adoc[leveloffset=+0]
 
 include::modules/microshift-creating-backups-auto-recovery.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/automate-deployments-with-gitops.adoc
+++ b/maps/jobs/automate-deployments-with-gitops.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: automate-deployments-with-gitops
 
-include::modules/microshift-gitops-can-do.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-gitops-can-do.adoc[leveloffset=+0]
 
 include::modules/microshift-gitops-limitations.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/back-up-and-restore-microshift-data.adoc
+++ b/maps/jobs/back-up-and-restore-microshift-data.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: back-up-and-restore-microshift-data
 
-include::modules/microshift-about-data-backups.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-about-data-backups.adoc[leveloffset=+0]
 
 include::modules/microshift-service-stopping.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/check-audit-logs.adoc
+++ b/maps/jobs/check-audit-logs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: check-audit-logs
 
-include::modules/microshift-check-audit-logs.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-check-audit-logs.adoc[leveloffset=+0]
 
 include::modules/microshift-viewing-audit-logs.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/check-the-installed-version.adoc
+++ b/maps/jobs/check-the-installed-version.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: check-the-installed-version
 
-include::modules/microshift-check-the-installed-version.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-check-the-installed-version.adoc[leveloffset=+0]
 
 include::modules/microshift-version-cli.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/clean-up-data-with-support.adoc
+++ b/maps/jobs/clean-up-data-with-support.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: clean-up-data-with-support
 
-include::modules/microshift-clean-up-data-with-support.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-clean-up-data-with-support.adoc[leveloffset=+0]
 
 include::modules/microshift-data-cleaning-overview.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/deploy-with-kustomize.adoc
+++ b/maps/jobs/deploy-with-kustomize.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: deploy-with-kustomize
 
-include::modules/microshift-manifests-overview.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-manifests-overview.adoc[leveloffset=+0]
 
 include::modules/microshift-manifests-override-paths.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/embed-apps-for-edge.adoc
+++ b/maps/jobs/embed-apps-for-edge.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: embed-apps-for-edge
 
-include::modules/microshift-embed-apps-edge-overview.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-embed-apps-edge-overview.adoc[leveloffset=+0]
 
 include::modules/microshift-embed-app-rpms-tutorial.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/embed-rhel-edge-image.adoc
+++ b/maps/jobs/embed-rhel-edge-image.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Embed in a RHEL for Edge image
 

--- a/maps/jobs/embed-rhel-edge-image.adoc
+++ b/maps/jobs/embed-rhel-edge-image.adoc
@@ -1,5 +1,7 @@
 :_mod-docs-content-type: MAP
 
+= Embed in a RHEL for Edge image
+
 include::modules/microshift-install-embed-rhel-edge-image.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/embed-rhel-edge-image.adoc
+++ b/maps/jobs/embed-rhel-edge-image.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-
+= Embed in a RHEL for Edge image
 
 include::modules/microshift-install-embed-rhel-edge-image.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/embed-rhel-edge-image.adoc
+++ b/maps/jobs/embed-rhel-edge-image.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-= Embed in a RHEL for Edge image
+
 
 include::modules/microshift-install-embed-rhel-edge-image.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/embed-rhel-edge-image.adoc
+++ b/maps/jobs/embed-rhel-edge-image.adoc
@@ -2,7 +2,11 @@
 
 = Embed in a RHEL for Edge image
 
-include::modules/microshift-install-embed-rhel-edge-image.adoc[leveloffset=+0,chunk="to-content"]
+[role="_abstract"]
+You can embed {microshift-short} in a {op-system-base} for Edge image to deploy a customized, bootable edge operating system with Kubernetes pre-installed.
+
+
+//include::modules/microshift-install-embed-rhel-edge-image.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/ensure-application-reliability.adoc
+++ b/maps/jobs/ensure-application-reliability.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: ensure-application-reliability
 
-include::modules/microshift-greenboot-how-workload-health-checks-work.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-greenboot-how-workload-health-checks-work.adoc[leveloffset=+0]
 
 include::modules/microshift-greenboot-health-check-command.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/extend-capabilities-with-operators.adoc
+++ b/maps/jobs/extend-capabilities-with-operators.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: extend-capabilities-with-operators
 
-include::modules/microshift-about-using-operators.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-about-using-operators.adoc[leveloffset=+0]
 
 include::modules/microshift-operators-how-to-install-and-manage.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/get-support.adoc
+++ b/maps/jobs/get-support.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: get-support
 
-include::modules/microshift-get-support.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-get-support.adoc[leveloffset=+0]
 
 include::modules/support.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/install-from-rpm-fips.adoc
+++ b/maps/jobs/install-from-rpm-fips.adoc
@@ -1,5 +1,7 @@
 :_mod-docs-content-type: MAP
 
+= Install from an RPM package
+
 include::modules/microshift-install-from-rpm-fips.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-install-rpm-before.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/install-from-rpm-fips.adoc
+++ b/maps/jobs/install-from-rpm-fips.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: MAP
 
-= Install from an RPM package
 
 include::modules/microshift-install-from-rpm-fips.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/install-from-rpm-fips.adoc
+++ b/maps/jobs/install-from-rpm-fips.adoc
@@ -2,7 +2,11 @@
 
 = Install from an RPM package
 
-include::modules/microshift-install-from-rpm-fips.adoc[leveloffset=+0,chunk="to-content"]
+[role="_abstract"]
+You can install {microshift-short} from an RPM package on an existing {op-system-base} {op-system-version-major} system. You can also prepare for FIPS mode and add optional extensions such as GitOps or Observability.
+
+
+//include::modules/microshift-install-from-rpm-fips.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-install-rpm-before.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/install-from-rpm-fips.adoc
+++ b/maps/jobs/install-from-rpm-fips.adoc
@@ -1,5 +1,6 @@
 :_mod-docs-content-type: MAP
 
+= Install from an RPM package
 
 include::modules/microshift-install-from-rpm-fips.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/install-from-rpm-fips.adoc
+++ b/maps/jobs/install-from-rpm-fips.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Install from an RPM package
 

--- a/maps/jobs/install-with-image-mode-rhel.adoc
+++ b/maps/jobs/install-with-image-mode-rhel.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-= Install with image mode for RHEL
+
 
 include::modules/microshift-install-with-image-mode-rhel.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/install-with-image-mode-rhel.adoc
+++ b/maps/jobs/install-with-image-mode-rhel.adoc
@@ -2,7 +2,10 @@
 
 = Install with image mode for RHEL
 
-include::modules/microshift-install-with-image-mode-rhel.adoc[leveloffset=+0,chunk="to-content"]
+[role="_abstract"]
+You can install {microshift-short} with image mode for {op-system-base} to deploy and manage your edge OS and Kubernetes platform as a single container image.
+
+//include::modules/microshift-install-with-image-mode-rhel.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-install-bootc-conc.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/install-with-image-mode-rhel.adoc
+++ b/maps/jobs/install-with-image-mode-rhel.adoc
@@ -1,5 +1,7 @@
 :_mod-docs-content-type: MAP
 
+= Install with image mode for RHEL
+
 include::modules/microshift-install-with-image-mode-rhel.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-install-bootc-conc.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/install-with-image-mode-rhel.adoc
+++ b/maps/jobs/install-with-image-mode-rhel.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Install with image mode for RHEL
 

--- a/maps/jobs/install-with-image-mode-rhel.adoc
+++ b/maps/jobs/install-with-image-mode-rhel.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-
+= Install with image mode for RHEL
 
 include::modules/microshift-install-with-image-mode-rhel.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/manage-certificates.adoc
+++ b/maps/jobs/manage-certificates.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: manage-certificates
 
-include::modules/microshift-cert-manager-tasks.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-cert-manager-tasks.adoc[leveloffset=+0]
 
 include::modules/microshift-install-cert-manager.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/manage-responsive-restarts-and-security-certificates.adoc
+++ b/maps/jobs/manage-responsive-restarts-and-security-certificates.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: manage-responsive-restarts-and-security-certificates
 
-include::modules/microshift-manage-responsive-restarts-and-security-certificates.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-manage-responsive-restarts-and-security-certificates.adoc[leveloffset=+0]
 
 include::modules/microshift-ip-address-clock-changes.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/monitor-applications.adoc
+++ b/maps/jobs/monitor-applications.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: monitor-applications
 
-include::modules/microshift-observability-overview.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-observability-overview.adoc[leveloffset=+0]
 
 include::modules/microshift-otel-install.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/prepare-your-environment-mirroring.adoc
+++ b/maps/jobs/prepare-your-environment-mirroring.adoc
@@ -2,7 +2,11 @@
 
 = Prepare your environment for mirroring
 
-include::modules/microshift-install-prepare-env-mirroring.adoc[leveloffset=+0,chunk="to-content"]
+[role="_abstract"]
+If your edge nodes operate in a disconnected or restricted network, you can mirror the {microshift-short} container images into a private registry so that you can install the platform without internet access.
+
+
+//include::modules/microshift-install-prepare-env-mirroring.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-mirror-container-images.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/prepare-your-environment-mirroring.adoc
+++ b/maps/jobs/prepare-your-environment-mirroring.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: MAP
 
-= Prepare your environment for mirroring
 
 include::modules/microshift-install-prepare-env-mirroring.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/prepare-your-environment-mirroring.adoc
+++ b/maps/jobs/prepare-your-environment-mirroring.adoc
@@ -1,5 +1,7 @@
 :_mod-docs-content-type: MAP
 
+= Prepare your environment for mirroring
+
 include::modules/microshift-install-prepare-env-mirroring.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-mirror-container-images.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/prepare-your-environment-mirroring.adoc
+++ b/maps/jobs/prepare-your-environment-mirroring.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Prepare your environment for mirroring
 

--- a/maps/jobs/prepare-your-environment-mirroring.adoc
+++ b/maps/jobs/prepare-your-environment-mirroring.adoc
@@ -1,5 +1,6 @@
 :_mod-docs-content-type: MAP
 
+= Prepare your environment for mirroring
 
 include::modules/microshift-install-prepare-env-mirroring.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/secure-pod-workloads.adoc
+++ b/maps/jobs/secure-pod-workloads.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: secure-pod-workloads
 
-include::modules/microshift-security-context-constraints.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-security-context-constraints.adoc[leveloffset=+0]
 
 include::modules/microshift-viewing-security-context.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/troubleshoot-a-node.adoc
+++ b/maps/jobs/troubleshoot-a-node.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-a-node
 
-include::modules/microshift-troubleshoot-a-node.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-troubleshoot-a-node.adoc[leveloffset=+0]
 
 include::modules/microshift-check-node-status.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/troubleshoot-data-backup-and-restore.adoc
+++ b/maps/jobs/troubleshoot-data-backup-and-restore.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-data-backup-and-restore
 
-include::modules/microshift-troubleshoot-data-backup-and-restore.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-troubleshoot-data-backup-and-restore.adoc[leveloffset=+0]
 
 include::modules/microshift-backup-data-failed.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/troubleshoot-etcd.adoc
+++ b/maps/jobs/troubleshoot-etcd.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-etcd
 
-include::modules/microshift-troubleshooting-etcd.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-troubleshooting-etcd.adoc[leveloffset=+0]
 
 include::modules/microshift-observe-debug-etcd-server.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/troubleshoot-installation-issues.adoc
+++ b/maps/jobs/troubleshoot-installation-issues.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-installation-issues
 
-include::modules/microshift-troubleshoot-installation-issues.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-troubleshoot-installation-issues.adoc[leveloffset=+0]
 
 include::modules/microshift-gathering-sos-report.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/troubleshoot-updates.adoc
+++ b/maps/jobs/troubleshoot-updates.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-updates
 
-include::modules/microshift-troubleshoot-updates.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-troubleshoot-updates.adoc[leveloffset=+0]
 
 include::modules/microshift-updates-troubleshooting.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/understand-remote-health-monitoring.adoc
+++ b/maps/jobs/understand-remote-health-monitoring.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 :context: understand-remote-health-monitoring
 
-include::modules/microshift-about-remote-health-monitoring.adoc[leveloffset=+0,chunk="to-content"]
+include::modules/microshift-about-remote-health-monitoring.adoc[leveloffset=+0]
 
 include::modules/microshift-info-collected-telemetry.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/jobs/uninstall-microshift.adoc
+++ b/maps/jobs/uninstall-microshift.adoc
@@ -1,5 +1,7 @@
 :_mod-docs-content-type: MAP
 
+= Uninstall MicroShift 
+
 include::modules/microshift-install-uninstall.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-uninstall-microshift-rpms.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/uninstall-microshift.adoc
+++ b/maps/jobs/uninstall-microshift.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Uninstall MicroShift
 

--- a/maps/jobs/uninstall-microshift.adoc
+++ b/maps/jobs/uninstall-microshift.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-
+= Uninstall MicroShift
 
 include::modules/microshift-install-uninstall.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/uninstall-microshift.adoc
+++ b/maps/jobs/uninstall-microshift.adoc
@@ -2,6 +2,10 @@
 
 = Uninstall MicroShift
 
-include::modules/microshift-install-uninstall.adoc[leveloffset=+0,chunk="to-content"]
+[role="_abstract"]
+If you no longer need the cluster or need to reset the environment, you can uninstall {microshift-short} to cleanly remove the software and free up system resources.
+
+
+//include::modules/microshift-install-uninstall.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-uninstall-microshift-rpms.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/uninstall-microshift.adoc
+++ b/maps/jobs/uninstall-microshift.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-= Uninstall MicroShift 
+
 
 include::modules/microshift-install-uninstall.adoc[leveloffset=+0,chunk="to-content"]
 

--- a/maps/jobs/verify-your-installation.adoc
+++ b/maps/jobs/verify-your-installation.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: MAP
 
-= Verify your installation
 
 
 include::modules/microshift-install-verify-your-installation.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/verify-your-installation.adoc
+++ b/maps/jobs/verify-your-installation.adoc
@@ -1,5 +1,8 @@
 :_mod-docs-content-type: MAP
 
+= Verify your installation
+
+
 include::modules/microshift-install-verify-your-installation.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-accessing.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/verify-your-installation.adoc
+++ b/maps/jobs/verify-your-installation.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: MAP
+:chunk-to-content:
 
 = Verify your installation
 

--- a/maps/jobs/verify-your-installation.adoc
+++ b/maps/jobs/verify-your-installation.adoc
@@ -1,5 +1,6 @@
 :_mod-docs-content-type: MAP
 
+= Verify your installation
 
 
 include::modules/microshift-install-verify-your-installation.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/verify-your-installation.adoc
+++ b/maps/jobs/verify-your-installation.adoc
@@ -2,8 +2,10 @@
 
 = Verify your installation
 
+[role="_abstract"]
+After installation completes, you can retrieve your kubeconfig files and access the {microshift-short} node with the `oc` CLI to verify the cluster is running correctly and begin deploying workloads.
 
-include::modules/microshift-install-verify-your-installation.adoc[leveloffset=+0,chunk="to-content"]
+//include::modules/microshift-install-verify-your-installation.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-accessing.adoc[leveloffset=+1,toc="no"]
 

--- a/maps/microshift/install.adoc
+++ b/maps/microshift/install.adoc
@@ -2,14 +2,14 @@
 
 = Install
 
-include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1]
 
-include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1]
 
-include::jobs/embed-rhel-edge-image.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/embed-rhel-edge-image.adoc[leveloffset=+1]
 
-include::jobs/install-from-rpm-fips.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/install-from-rpm-fips.adoc[leveloffset=+1]
 
-include::jobs/verify-your-installation.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/verify-your-installation.adoc[leveloffset=+1]
 
-include::jobs/uninstall-microshift.adoc[leveloffset=+1,chunk="to-content"]
+include::jobs/uninstall-microshift.adoc[leveloffset=+1]

--- a/maps/microshift/install.adoc
+++ b/maps/microshift/install.adoc
@@ -2,14 +2,14 @@
 
 = Install
 
-include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1]
+include::jobs/prepare-your-environment-mirroring.adoc[leveloffset=+1,chunk="to-content"]
 
-include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1]
+include::jobs/install-with-image-mode-rhel.adoc[leveloffset=+1,chunk="to-content"]
 
-include::jobs/embed-rhel-edge-image.adoc[leveloffset=+1]
+include::jobs/embed-rhel-edge-image.adoc[leveloffset=+1,chunk="to-content"]
 
-include::jobs/install-from-rpm-fips.adoc[leveloffset=+1]
+include::jobs/install-from-rpm-fips.adoc[leveloffset=+1,chunk="to-content"]
 
-include::jobs/verify-your-installation.adoc[leveloffset=+1]
+include::jobs/verify-your-installation.adoc[leveloffset=+1,chunk="to-content"]
 
-include::jobs/uninstall-microshift.adoc[leveloffset=+1]
+include::jobs/uninstall-microshift.adoc[leveloffset=+1,chunk="to-content"]

--- a/modules/microshift-about-data-backups.adoc
+++ b/modules/microshift-about-data-backups.adoc
@@ -3,6 +3,7 @@
 // * microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-about-data-backups_{context}"]
 = About backing up and restoring {microshift-short} data
 

--- a/modules/microshift-about-remote-health-monitoring.adoc
+++ b/modules/microshift-about-remote-health-monitoring.adoc
@@ -3,6 +3,7 @@
 // microshift_support/microshift-remote-node-monitoring.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-about-remote-health-monitoring_{context}"]
 = About remote health monitoring with {microshift-short}
 

--- a/modules/microshift-about-using-operators.adoc
+++ b/modules/microshift-about-using-operators.adoc
@@ -3,6 +3,7 @@
 //* microshift_running_apps/microshift_operators/microshift-operators.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-about-using-operators_{context}"]
 = About using Operators with a {microshift-short} node
 

--- a/modules/microshift-auto-recovery-manual-backups.adoc
+++ b/modules/microshift-auto-recovery-manual-backups.adoc
@@ -3,6 +3,7 @@
 // * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-auto-recovery-manual-backups_{context}"]
 = Modify backup and restore commands to automate data recovery
 

--- a/modules/microshift-cert-manager-tasks.adoc
+++ b/modules/microshift-cert-manager-tasks.adoc
@@ -3,6 +3,7 @@
 // * microshift_running_apps/microshift-cert-manager.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-cert-manager-tasks_{context}"]
 = {microshift-short} certificate manager functions
 

--- a/modules/microshift-check-audit-logs.adoc
+++ b/modules/microshift-check-audit-logs.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/check-audit-logs.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-check-audit-logs_{context}"]
 = Check audit logs
 

--- a/modules/microshift-check-the-installed-version.adoc
+++ b/modules/microshift-check-the-installed-version.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/check-the-installed-version.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-check-the-installed-version_{context}"]
 = Check the installed version
 

--- a/modules/microshift-clean-up-data-with-support.adoc
+++ b/modules/microshift-clean-up-data-with-support.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/clean-up-data-with-support.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-clean-up-data-with-support_{context}"]
 = Clean up data with support
 

--- a/modules/microshift-embed-apps-edge-overview.adoc
+++ b/modules/microshift-embed-apps-edge-overview.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/embed-apps-for-edge.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-embed-apps-edge-overview_{context}"]
 = Embed applications in a {op-system-ostree} image
 

--- a/modules/microshift-get-support.adoc
+++ b/modules/microshift-get-support.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/get-support.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-get-support_{context}"]
 = Get support
 

--- a/modules/microshift-gitops-can-do.adoc
+++ b/modules/microshift-gitops-can-do.adoc
@@ -3,6 +3,7 @@
 // microshift_running_apps/microshift-gitops.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-gitops-can-do_{context}"]
 = What you can do with the GitOps agent
 

--- a/modules/microshift-greenboot-how-workload-health-checks-work.adoc
+++ b/modules/microshift-greenboot-how-workload-health-checks-work.adoc
@@ -3,6 +3,7 @@
 //* microshift_running_apps/microshift-greenboot-workload-health-checks.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-greenboot-how-workload-health-checks-work_{context}"]
 = How workload health checks work
 

--- a/modules/microshift-manage-responsive-restarts-and-security-certificates.adoc
+++ b/modules/microshift-manage-responsive-restarts-and-security-certificates.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/manage-responsive-restarts-and-security-certificates.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-manage-responsive-restarts-and-security-certificates_{context}"]
 = Manage responsive restarts and security certificates
 

--- a/modules/microshift-manifests-overview.adoc
+++ b/modules/microshift-manifests-overview.adoc
@@ -3,6 +3,7 @@
 // * microshift//running_applications/microshift-applications.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-manifests-overview_{context}"]
 = How Kustomize works with manifests to deploy applications
 

--- a/modules/microshift-observability-overview.adoc
+++ b/modules/microshift-observability-overview.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/monitor-applications.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-observability-overview_{context}"]
 = {microshift-short} Observability overview
 

--- a/modules/microshift-security-context-constraints.adoc
+++ b/modules/microshift-security-context-constraints.adoc
@@ -3,6 +3,7 @@
 // * microshift_running_apps/microshift-authentication.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-security-context-constraints_{context}"]
 
 = Security context constraint synchronization with pod security standards

--- a/modules/microshift-troubleshoot-a-node.adoc
+++ b/modules/microshift-troubleshoot-a-node.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/troubleshoot-a-node.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-troubleshoot-a-node_{context}"]
 = Troubleshoot a node
 

--- a/modules/microshift-troubleshoot-data-backup-and-restore.adoc
+++ b/modules/microshift-troubleshoot-data-backup-and-restore.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/troubleshoot-data-backup-and-restore.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-troubleshoot-data-backup-and-restore_{context}"]
 = Troubleshoot data backup and restore
 

--- a/modules/microshift-troubleshoot-installation-issues.adoc
+++ b/modules/microshift-troubleshoot-installation-issues.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/troubleshoot-installation-issues.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-troubleshoot-installation-issues_{context}"]
 = Troubleshoot installation issues
 

--- a/modules/microshift-troubleshoot-updates.adoc
+++ b/modules/microshift-troubleshoot-updates.adoc
@@ -3,6 +3,7 @@
 // * maps/jobs/troubleshoot-updates.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-troubleshoot-updates_{context}"]
 = Troubleshoot updates
 

--- a/modules/microshift-troubleshooting-etcd.adoc
+++ b/modules/microshift-troubleshooting-etcd.adoc
@@ -3,6 +3,7 @@
 //* microshift_support/microshift-etcd.adoc
 
 :_mod-docs-content-type: CONCEPT
+:chunk-to-content:
 [id="microshift-troubleshooting-etcd_{context}"]
 = Troubleshoot etcd
 


### PR DESCRIPTION
`map-preview` generated HTML: https://file.corp.redhat.com/avbhatt/ms-map-test/install.html
(this test for done only for the Install category, the `maptui` auto fixes any other errors it encountered; hence the modification of the files outside of the Install category scope)

The _hero_ module that was set to `leveloffset=+0` was dropped and it's `[role="_abstract"]` was moved to it's relevant MAP:

<img width="1369" height="384" alt="image" src="https://github.com/user-attachments/assets/bf40b50c-880a-4a9c-bcad-8b00cedd9b0d" />
