### PR TITLE
RHDEVDOCS-7893: Fixing the incorrect link in the Monitoring section

### DIFF
--- a/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
+++ b/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
@@ -17,7 +17,7 @@ With {gitops-title}, you can monitor the availability of Argo CD custom resource
 * {gitops-title} is installed in your cluster.
 * The monitoring stack is configured in your cluster in the `openshift-monitoring` project. In addition, the Argo CD instance is in a namespace that you can monitor through Prometheus.
 * The `kube-state-metrics` service is running on your cluster.
-* Optional: If you are enabling monitoring for an Argo CD instance already present in a user-defined project, ensure that the monitoring is link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[enabled for user-defined projects] in your cluster.
+* Optional: If you are enabling monitoring for an Argo CD instance already present in a user-defined project, ensure that the monitoring is link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.22/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#enabling-monitoring-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm[enabled for user-defined projects] in your cluster.
 +
 [NOTE]
 ====
@@ -33,4 +33,4 @@ include::modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloa
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.22/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#enabling-monitoring-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.22

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7893

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Fixing the incorrect link for Enabling monitoring for user-defined projects in the [Monitoring Argo CD custom resource workloads](https://118795--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.html) section

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: alkumari@redhat.com
QE review:
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
