### PR TITLE
OSDOCS#21746: Update the MicroShift RNs for 4.21.30

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-30-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-29-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-16-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-30-async.adoc
+++ b/modules/microshift-4-21-30-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-30-async_{context}"]
+= RHBA-2026:58257 - {microshift-short} 4.21.30 fixed issue update
+
+Issued: 25 August 2026
+
+[role="_abstract"]
+{product-title} release 4.21.30 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:58257[RHBA-2026:58257] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:57801[RHSA-2026:57801] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-21-30-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21746

Link to docs preview:
_Pending preview bot comment after CI builds. Update this field with the preview-bot issue comment URL or Netlify preview link once available._

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- MicroShift errata: https://access.redhat.com/errata/RHBA-2026:58257
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:57801
- OCP packages advisory: https://access.redhat.com/errata/RHSA-2026:57456
- Microshift-bootc advisory: https://access.redhat.com/errata/RHBA-2026:111261
- Shipment MR (OCP): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/757
- Shipment MR (Microshift-bootc): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/758
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21


Made with [Cursor](https://cursor.com)