### PR TITLE
OSDOCS#21749: Update the MicroShift RNs for 4.16.69

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -86,3 +86,5 @@ include::modules/microshift-4-16-47-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-16-58-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-16-63-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-16-69-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-16-69-dp.adoc
+++ b/modules/microshift-4-16-69-dp.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-69-dp_{context}"]
+= RHSA-2026:57845 - {microshift-short} 4.16.69 bug fix advisory
+
+Issued: 26 August 2026
+
+[role="_abstract"]
+{product-title} release 4.16.69 is now available. The list of fixed issues that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2026:57845[RHSA-2026:57845] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:56854[RHSA-2026:56854] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-69-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21749

Link to docs preview:
[4.16.69](https://118817--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-69-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- MicroShift errata: https://access.redhat.com/errata/RHSA-2026:57845
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:111240
- OCP packages advisory: https://access.redhat.com/errata/RHSA-2026:56852
- Shipment MR (OCP): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/745
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16


Made with [Cursor](https://cursor.com)