### PR TITLE
OSDOCS#21745: Update the MicroShift RNs for 4.18.54

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -26,6 +26,8 @@ include::modules/microshift-4-18-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-18-asynch-errata-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-18-54-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-18-42-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-18-36-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-54-dp.adoc
+++ b/modules/microshift-4-18-54-dp.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-54-dp_{context}"]
+= RHSA-2026:57914 - {microshift-short} 4.18.54 fixed issue and security advisory
+
+Issued: 26 August 2026
+
+[role="_abstract"]
+{product-title} release 4.18.54 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHSA-2026:57914[RHSA-2026:57914] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:57487[RHSA-2026:57487] advisory.
+
+[IMPORTANT]
+====
+This release includes the last update to the {microshift-short} {product-version} bootc image. To continue receiving support, you must update to {microshift-short} 4.19 or later.
+====
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-18-54-bugs_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21745

Link to docs preview:
[4.18.54](https://118818--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-54-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- MicroShift errata: https://access.redhat.com/errata/RHSA-2026:57914
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:110592
- OCP packages advisory: https://access.redhat.com/errata/RHSA-2026:57482
- Microshift-bootc advisory: https://access.redhat.com/errata/RHBA-2026:111292
- Shipment MR (OCP): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/753
- Shipment MR (Microshift-bootc): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/759
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Note: open MicroShift 4.18.53 PR #118334 is not yet merged; this module is included above 4.18.42 on upstream.


Made with [Cursor](https://cursor.com)