### PR TITLE
[OCPBUGS-112344]: Clarifying IBM Z and IBM Power info in HCP support matrix

### DIFF
--- a/modules/hcp-support-matrix.adoc
+++ b/modules/hcp-support-matrix.adoc
@@ -147,10 +147,7 @@ The following table indicates which {product-title} versions are supported for e
 
 [IMPORTANT]
 ====
-For {ibm-power-title} and {ibm-z-title}:
-
-* You must run the control plane on machine types that are based on 64-bit x86 architecture or s390x architecture
-* You must run node pools on {ibm-power-title} or {ibm-z-title}
+For {hcp} on {ibm-power-title} or {ibm-z-title}, the control plane must run on either 64_bit x86 architecture or s390x architecture. Node pools must run on either {ibm-power-title} or {ibm-z-title}. No other combinations are supported.
 ====
 
 In the following table, the management cluster version is the {product-title} version where the {mce-short} is enabled:
@@ -235,17 +232,7 @@ The following tables indicate the supported architectures for {hcp}, organized b
 
 |{ibm-power-title}
 |64-bit x86
-|64-bit x86
-|4.19 - 4.22
-
-|{ibm-power-title}
-|64-bit x86
 |ppc64le
-|4.18 - 4.22
-
-|{ibm-z-title}
-|64-bit x86
-|64-bit x86
 |4.18 - 4.22
 
 |{ibm-z-title}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-112344
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Note in "Hosted cluster platform support": https://118821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-requirements.html#hcp-matrix-platform_hcp-requirements
- Multiarchitecture support table: https://118821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-requirements.html#hcp-matrix-multiarch_hcp-requirements
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
