### PR TITLE
ROX-36523: Release notes for 4.9.11

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -75,6 +75,7 @@ endif::[]
 :ga-date-498: 18 June 2026
 :ga-date-499: 7 July 2026
 :ga-date-4910: 30 July 2026
+:ga-date-4911: 25 August 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -26,6 +26,7 @@ toc::[]
 |`4.9.8` | {ga-date-498}
 |`4.9.9` | {ga-date-499}
 |`4.9.10` | {ga-date-4910}
+|`4.9.11` | {ga-date-4911}
 
 |====
 
@@ -820,5 +821,25 @@ This release addresses the following security vulnerabilities:
 * `github.com/jackc/pgx`: SQL injection via specific SQL query conditions (link:https://access.redhat.com/security/cve/CVE-2026-41889[CVE-2026-41889])
 //ROX-35998
 * `github.com/sigstore/fulcio`: Server-side request forgery (SSRF) and Kubernetes ServiceAccount token leakage (link:https://access.redhat.com/security/cve/CVE-2026-49478[CVE-2026-49478])
+
+[id="about-this-release-4911_{context}"]
+== About release 4.9.11
+
+*Release date*: {ga-date-4911}
+
+This release provides the following bug fixes:
+
+//ROX-35910
+* Before this update, compliance scans that used CEL-scanner profiles, such as the {ocp-virt-first} profiles, ran successfully but showed no results in the {product-title-short} *Coverage* page. The scan results existed in the database but were not displayed because {product-title-short} could not connect the results to the profile. With this release, CEL-scanner profile results now appear correctly in the *Coverage* view.
+
+This release addresses the following security vulnerabilities:
+
+* Go and golang.org:
+//ROX-35671
+** Go os.Root: Symlink following vulnerability allows directory traversal (link:https://access.redhat.com/security/cve/CVE-2026-39822[CVE-2026-39822])
+//ROX-35437, ROX-36052
+** Golang MIME: Denial of service via maliciously-crafted MIME header (link:https://access.redhat.com/security/cve/CVE-2026-42504[CVE-2026-42504])
+//ROX-36098
+* brace-expansion: Denial of service via unbounded intermediate arrays (link:https://access.redhat.com/security/cve/CVE-2026-69152[CVE-2026-69152])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.9.11


Issue: https://redhat.atlassian.net/browse/ROX-36523


Link to docs preview: https://118830--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/49-release-notes


QE review: **RHACS has no formal QE process, approved by SME**
- [x] QE has approved this change.


Additional information:

