### PR TITLE
[OSDOCS#20002]: Document disk.EnableUUID requirement for Agent-based Installer on vSphere

### DIFF
--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -112,6 +112,10 @@ For platform `none`:
 * The `none` option requires the provision of DNS name resolution and load balancing infrastructure in your cluster. See _Requirements for a cluster using the platform "none" option_ in the "Additional resources" section for more information.
 
 * See "Deploying OpenShift 4.x on non-tested platforms using the bare metal install method" before you attempt to install an {product-title} cluster in virtualized or cloud environments.
+
+For platform `vsphere`, or for platform `baremetal` on vSphere:
+
+* You must set the `disk.EnableUUID` parameter to `TRUE` on all {product-title} nodes. If this parameter is not enabled, the Agent-based Installer validation fails.
 ====
 
 [NOTE]


### PR DESCRIPTION
Fix Agent based installation validations failure for disk.EnableUUID
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. --> 

Issue: https://issues.redhat.com/browse/OSDOCS-20002
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change (Weibin Lang).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Agent-based install on vSphere (or baremetal on vSphere) fails validation vsphere-disk-uuid-enabled unless disk.EnableUUID is TRUE. This adds that requirement to the existing Important note in Preparing to install with the Agent-based Installer.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Added QE review request in the forum-openshift-quality forum on 8th of SEP 2026.
