### PR TITLE
[RHDEVDOCS-6455] Add ClusterTriggerBinding documentation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -80,6 +80,8 @@ Topics:
   File: migrate-from-clustertask-to-cluster-resolver
 - Name: Using manual approval in OpenShift Pipelines
   File: using-manual-approval
+- Name: Using ClusterTriggerBindings with OpenShift Pipelines
+  File: using-clustertriggerbindings
 - Name: Using Red Hat entitlements in pipelines
   File: using-rh-entitlements-pipelines
 ---

--- a/create/using-clustertriggerbindings.adoc
+++ b/create/using-clustertriggerbindings.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="using-clustertriggerbindings"]
+= Using ClusterTriggerBindings with {pipelines-shortname}
+:context: using-clustertriggerbindings
+
+toc::[]
+
+[role="_abstract"]
+You can trigger pipeline runs automatically in response to Git repository events by using the `ClusterTriggerBinding` resources that {pipelines-shortname} installs. These cluster-scoped bindings extract parameters from webhook payloads for GitHub, GitLab, and Bitbucket.
+
+include::modules/op-about-cluster-trigger-bindings.adoc[leveloffset=+1]
+
+include::modules/op-triggering-pipeline-with-github-push.adoc[leveloffset=+1]
+
+include::modules/op-cluster-trigger-binding-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../create/creating-applications-with-cicd-pipelines.adoc#creating-applications-with-cicd-pipelines[Creating CI/CD solutions for applications using {pipelines-shortname}]
+* xref:../about/understanding-openshift-pipelines.adoc#about-triggers_understanding-openshift-pipelines[Triggers]
+* xref:../secure/securing-webhooks-with-event-listeners.adoc#securing-webhooks-with-event-listeners[Securing webhooks with event listeners]

--- a/modules/op-about-cluster-trigger-bindings.adoc
+++ b/modules/op-about-cluster-trigger-bindings.adoc
@@ -1,0 +1,55 @@
+// This module is included in the following assemblies:
+// * create/using-clustertriggerbindings.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-cluster-trigger-bindings_{context}"]
+= ClusterTriggerBindings overview
+
+[role="_abstract"]
+You can use `ClusterTriggerBinding` resources in {pipelines-shortname} to extract fields from webhook event payloads and pass them as parameters to your `TriggerTemplate` resources.
+
+Unlike a `TriggerBinding` resource, which is scoped to a single namespace, a `ClusterTriggerBinding` resource is cluster-scoped and reusable in all namespaces. {pipelines-shortname} installs a set of `ClusterTriggerBinding` resources for common Git hosting provider events. You can reference these preinstalled bindings in your `Trigger` or `EventListener` resources without writing custom parameter extraction logic.
+
+The following example shows the structure of a `ClusterTriggerBinding` resource that extracts fields from a GitHub push event:
+
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1beta1
+kind: ClusterTriggerBinding
+metadata:
+  name: github-push
+spec:
+  params:
+  - name: git-revision
+    value: $(body.head_commit.id)
+  - name: git-repo-url
+    value: $(body.repository.url)
+  - name: git-repo-name
+    value: $(body.repository.name)
+----
+
+To reference a `ClusterTriggerBinding` resource in a `Trigger` resource, set the `kind` field to `ClusterTriggerBinding` in the `bindings` list:
+
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1
+kind: Trigger
+metadata:
+  name: my-trigger
+spec:
+  bindings:
+  - ref: github-push
+    kind: ClusterTriggerBinding
+  template:
+    ref: my-trigger-template
+----
+
+Without the `kind: ClusterTriggerBinding` field, {tekton-triggers} looks for a namespace-scoped `TriggerBinding` resource with that name instead.
+
+You can list the `ClusterTriggerBinding` resources installed in your cluster by running the following command:
+
+[source,terminal]
+----
+$ oc get clustertriggerbindings
+----
+

--- a/modules/op-about-triggers.adoc
+++ b/modules/op-about-triggers.adoc
@@ -12,7 +12,7 @@ For example, you define a CI/CD workflow by using {pipelines-title} for your app
 
 Triggers consist of the following main resources that work together to form a reusable, decoupled, and self-sustaining CI/CD system:
 
-* The `TriggerBinding` resource extracts the fields from an event payload and stores them as parameters.
+* The `TriggerBinding` resource extracts the fields from an event payload and stores them as parameters. A `ClusterTriggerBinding` resource provides the same functionality at cluster scope, allowing reuse across all namespaces. {pipelines-title} installs a set of `ClusterTriggerBinding` resources for common Git hosting provider events, such as GitHub push and pull request events.
 +
 The following example shows a code snippet of the `TriggerBinding` resource, from which you extract the Git repository information from the received event payload:
 +
@@ -25,7 +25,7 @@ metadata:
 spec:
   params:
   - name: git-repo-url
-    value: $(body.repository.url)
+    value: $(body.repository.html_url)
   - name: git-repo-name
     value: $(body.repository.name)
   - name: git-revision

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: git-repo-url
-    value: $(body.repository.url)
+    value: $(body.repository.html_url)
   - name: git-repo-name
     value: $(body.repository.name)
   - name: git-revision

--- a/modules/op-cluster-trigger-binding-reference.adoc
+++ b/modules/op-cluster-trigger-binding-reference.adoc
@@ -1,0 +1,461 @@
+// This module is included in the following assemblies:
+// * create/using-clustertriggerbindings.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cluster-trigger-binding-reference_{context}"]
+= ClusterTriggerBinding reference
+
+[role="_abstract"]
+{pipelines-title} installs the following `ClusterTriggerBinding` resources. Each binding extracts parameters from the webhook event payload of the corresponding Git hosting provider. You can reference these bindings in a `Trigger` or `EventListener` resource by setting `kind: ClusterTriggerBinding`.
+
+[id="github-cluster-trigger-bindings_{context}"]
+== GitHub ClusterTriggerBindings
+
+.github-push
+Extracts parameters from a GitHub push event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-revision`
+| SHA of the commit that triggered the push
+| `$(body.head_commit.id)`
+
+| `git-commit-message`
+| Commit message of the pushed commit
+| `$(body.head_commit.message)`
+
+| `git-repo-url`
+| GitHub REST API URL of the repository. This is not a clone URL and cannot be used directly with `git-clone`. Use `git-repo-clone-url` instead when you need to clone the repository.
+| `$(body.repository.url)`
+
+| `git-repo-clone-url`
+| HTTPS URL of the repository, suitable for cloning. Use this parameter with `git-clone` and similar tasks.
+| `$(body.repository.html_url)`
+
+| `git-repo-name`
+| Name of the repository
+| `$(body.repository.name)`
+
+| `content-type`
+| Content type of the HTTP request
+| `$(header.Content-Type)`
+
+| `pusher-name`
+| GitHub username of the pusher
+| `$(body.pusher.name)`
+|===
+
+.github-pullreq
+Extracts parameters from a GitHub pull request event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-repo-url`
+| HTML URL of the repository
+| `$(body.repository.html_url)`
+
+| `pullreq-sha`
+| SHA of the head commit of the pull request
+| `$(body.pull_request.head.sha)`
+
+| `pullreq-action`
+| Action that triggered the event, for example `opened` or `closed`
+| `$(body.action)`
+
+| `pullreq-number`
+| Pull request number
+| `$(body.number)`
+
+| `pullreq-repo-full_name`
+| Full name of the repository, in `<owner>/<repo>` format
+| `$(body.repository.full_name)`
+
+| `pullreq-html-url`
+| HTML URL of the pull request
+| `$(body.pull_request.html_url)`
+
+| `pullreq-title`
+| Title of the pull request
+| `$(body.pull_request.title)`
+
+| `pullreq-issue-url`
+| Issue API URL associated with the pull request
+| `$(body.pull_request.issue_url)`
+
+| `organisations-url`
+| URL of the pull request author's organizations
+| `$(body.pull_request.user.organizations_url)`
+
+| `user-type`
+| Type of the pull request author, for example `User` or `Bot`
+| `$(body.pull_request.user.type)`
+|===
+
+.github-pullreq-review-comment
+Extracts parameters from a GitHub pull request review comment event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `comment`
+| Body of the review comment
+| `$(body.comment.body)`
+
+| `comment-user-login`
+| GitHub username of the comment author
+| `$(body.comment.user.login)`
+
+| `merge-commit-sha`
+| SHA of the merge commit for the pull request
+| `$(body.pull_request.merge_commit_sha)`
+|===
+
+[id="gitlab-cluster-trigger-bindings_{context}"]
+== GitLab ClusterTriggerBindings
+
+.gitlab-push
+Extracts parameters from a GitLab push event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-revision`
+| SHA of the latest commit in the push
+| `$(body.checkout_sha)`
+
+| `git-commit-message`
+| Commit message of the first commit in the push
+| `$(body.commits[0].message)`
+
+| `git-repo-url`
+| HTTP clone URL of the repository
+| `$(body.repository.git_http_url)`
+
+| `git-repo-ssh-url`
+| SSH clone URL of the repository
+| `$(body.repository.git_ssh_url)`
+
+| `git-repo-name`
+| Name of the repository
+| `$(body.repository.name)`
+
+| `pusher-name`
+| GitLab username of the pusher
+| `$(body.user_name)`
+|===
+
+.gitlab-mergereq
+Extracts parameters from a GitLab merge request event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-repo-url`
+| HTTP clone URL of the project
+| `$(body.project.git_http_url)`
+
+| `git-repo-ssh-url`
+| SSH clone URL of the repository
+| `$(body.repository.git_ssh_url)`
+
+| `mergereq-sha`
+| SHA of the last commit in the merge request
+| `$(body.object_attributes.last_commit.id)`
+
+| `mergereq-action`
+| Action that triggered the event, for example `open` or `merge`
+| `$(body.object_attributes.action)`
+
+| `mergereq-number`
+| Internal ID of the merge request
+| `$(body.object_attributes.iid)`
+
+| `mergereq-repo-name`
+| Name of the repository
+| `$(body.repository.name)`
+
+| `mergereq-url`
+| URL of the merge request
+| `$(body.object_attributes.url)`
+
+| `mergereq-title`
+| Title of the merge request
+| `$(body.object_attributes.title)`
+|===
+
+.gitlab-review-comment-on-issues
+Extracts parameters from a GitLab comment event on an issue.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `issue-url`
+| URL of the issue
+| `$(body.issue.url)`
+
+| `issue-title`
+| Title of the issue
+| `$(body.issue.title)`
+
+| `issue-comment-link`
+| URL of the comment
+| `$(body.object_attributes.url)`
+
+| `issue-owner`
+| Name of the comment author
+| `$(body.user.name)`
+|===
+
+.gitlab-review-comment-on-mergerequest
+Extracts parameters from a GitLab comment event on a merge request.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `mergereq-url`
+| URL of the merge request
+| `$(body.merge_request.url)`
+
+| `comment-description`
+| Body of the comment
+| `$(body.object_attributes.description)`
+
+| `comment-url`
+| URL of the comment
+| `$(body.object_attributes.url)`
+
+| `mr-owner`
+| Name of the comment author
+| `$(body.user.name)`
+|===
+
+.gitlab-review-comment-on-commit
+Extracts parameters from a GitLab comment event on a commit.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `commit-url`
+| URL of the commit
+| `$(body.commit.url)`
+
+| `comment-description`
+| Body of the comment
+| `$(body.object_attributes.description)`
+
+| `comment-url`
+| URL of the comment
+| `$(body.object_attributes.url)`
+
+| `commit-owner`
+| Name of the comment author
+| `$(body.user.name)`
+|===
+
+.gitlab-review-comment-on-snippet
+Extracts parameters from a GitLab comment event on a snippet.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `snippet-comment-description`
+| Body of the comment
+| `$(body.object_attributes.description)`
+
+| `snippet-comment-url`
+| URL of the comment
+| `$(body.object_attributes.url)`
+
+| `snippet-title`
+| Title of the snippet
+| `$(body.snippet.title)`
+
+| `snippet-type`
+| Type of the snippet
+| `$(body.snippet.type)`
+
+| `snippet-owner`
+| Name of the comment author
+| `$(body.user.name)`
+|===
+
+[id="bitbucket-server-cluster-trigger-bindings_{context}"]
+== Bitbucket Server ClusterTriggerBindings
+
+.bitbucket-push
+Extracts parameters from a Bitbucket Server push event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-revision`
+| Display ID of the reference that was pushed, for example a branch name
+| `$(body.changes[0].ref.displayId)`
+
+| `gitrepo-url`
+| Clone URL of the repository
+| `$(body.repository.links.clone[0].href)`
+
+| `git-repo-name`
+| Name of the repository
+| `$(body.repository.name)`
+
+| `pusher-name`
+| Username of the pusher
+| `$(body.actor.name)`
+|===
+
+.bitbucket-pullreq
+Extracts parameters from a Bitbucket Server pull request event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `gitrepo-url`
+| SSH clone URL of the source repository
+| `$(body.pullRequest.fromRef.repository.links.clone[?(@.name=="ssh")].href)`
+
+| `pullreq-sha`
+| Latest commit SHA of the source branch
+| `$(body.pullRequest.fromRef.latestCommit)`
+
+| `pullreq-state`
+| State of the pull request, for example `OPEN` or `MERGED`
+| `$(body.pullRequest.state)`
+
+| `pullreq-number`
+| ID of the pull request
+| `$(body.pullRequest.id)`
+
+| `pullreq-repo-name`
+| Name of the target repository
+| `$(body.pullRequest.toRef.repository.name)`
+
+| `pullreq-html-url`
+| Web URL of the pull request
+| `$(body.pullRequest.links.self[0].href)`
+
+| `pullreq-title`
+| Title of the pull request
+| `$(body.pullRequest.title)`
+
+| `user-type`
+| Type of the pull request author
+| `$(body.pullRequest.author.user.type)`
+|===
+
+.bitbucket-pullreq-add-comment
+Extracts parameters from a Bitbucket Server pull request comment event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `comment`
+| Text of the comment
+| `$(body.comment.text)`
+
+| `comment-user-login`
+| Username of the comment author
+| `$(body.comment.author.name)`
+|===
+
+[id="bitbucket-cloud-cluster-trigger-bindings_{context}"]
+== Bitbucket Cloud ClusterTriggerBindings
+
+.bitbucket-cloud-push
+Extracts parameters from a Bitbucket Cloud push event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `git-revision`
+| Name of the branch or tag that was pushed
+| `$(body.push.changes[0].new.name)`
+
+| `gitrepo-url`
+| HTML URL of the repository
+| `$(body.repository.links.html.href)`
+
+| `git-repo-name`
+| Name of the repository
+| `$(body.repository.name)`
+
+| `pusher-name`
+| Display name of the pusher
+| `$(body.actor.display_name)`
+|===
+
+.bitbucket-cloud-pullreq
+Extracts parameters from a Bitbucket Cloud pull request event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `gitrepo-url`
+| HTML URL of the source repository
+| `$(body.pullrequest.source.repository.links.html.href)`
+
+| `pullreq-sha`
+| Commit hash of the source branch head
+| `$(body.pullrequest.source.commit.hash)`
+
+| `pullreq-state`
+| State of the pull request, for example `OPEN` or `MERGED`
+| `$(body.pullrequest.state)`
+
+| `pullreq-number`
+| ID of the pull request
+| `$(body.pullrequest.id)`
+
+| `pullreq-repo-name`
+| Name of the destination repository
+| `$(body.pullrequest.destination.repository.name)`
+
+| `pullreq-html-url`
+| HTML URL of the pull request
+| `$(body.pullrequest.links.html.href)`
+
+| `pullreq-title`
+| Title of the pull request
+| `$(body.pullrequest.title)`
+
+| `user-type`
+| Display name of the pull request author
+| `$(body.pullrequest.author.display_name)`
+|===
+
+.bitbucket-cloud-pullreq-add-comment
+Extracts parameters from a Bitbucket Cloud pull request comment event payload.
+
+[cols="1,2,2", options="header"]
+|===
+| Parameter name | Description | Source (JSONPath)
+
+| `comment`
+| Raw text of the comment
+| `$(body.comment.content.raw)`
+
+| `comment-user-login`
+| Display name of the comment author
+| `$(body.comment.user.display_name)`
+
+| `pullreq-number`
+| ID of the pull request the comment belongs to
+| `$(body.comment.pullrequest.id)`
+|===

--- a/modules/op-triggering-pipeline-with-github-push.adoc
+++ b/modules/op-triggering-pipeline-with-github-push.adoc
@@ -1,0 +1,199 @@
+// This module is included in the following assemblies:
+// * create/using-clustertriggerbindings.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="triggering-pipeline-with-github-push_{context}"]
+= Triggering a pipeline run from a GitHub push event
+
+[role="_abstract"]
+Trigger a pipeline run automatically when code is pushed to a GitHub repository by using the preinstalled `github-push` `ClusterTriggerBinding` resource in {pipelines-shortname}.
+
+.Prerequisites
+
+* You have access to an {OCP} cluster with {pipelines-title} installed.
+* You have installed the {pipelines-shortname} CLI (`tkn`).
+* You have `cluster-admin` or equivalent permissions, or you have permission to create `EventListener`, `TriggerTemplate`, `Route`, and `Secret` resources in your namespace.
+* You have a GitHub repository to which you have admin access, so that you can configure webhooks.
+* You have a pipeline that accepts `git-url` and `git-revision` parameters, or you can adapt the `TriggerTemplate` in this procedure to match your pipeline.
+
+.Procedure
+
+. Verify that the `github-push` `ClusterTriggerBinding` resource is installed:
++
+[source,terminal]
+----
+$ oc get clustertriggerbinding github-push -o yaml
+----
++
+The output shows the binding and its parameter definitions extracted from the GitHub push event payload.
+
+. Create a webhook secret to validate incoming GitHub events. Replace `<your_secret_token>` with a secure, random string that you will also enter when configuring the GitHub webhook:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-webhook-secret
+type: Opaque
+stringData:
+  secretToken: "<your_secret_token>"
+----
++
+Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f github-webhook-secret.yaml
+----
+
+. Create a `TriggerTemplate` resource that defines how to create a `PipelineRun` from the parameters supplied by the `github-push` `ClusterTriggerBinding`. Replace `<your_pipeline_name>` with the name of your pipeline:
++
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1
+kind: TriggerTemplate
+metadata:
+  name: github-push-pipeline
+spec:
+  params:
+  - name: git-revision
+    description: The SHA of the commit that triggered the push
+  - name: git-repo-clone-url
+    description: The HTTPS clone URL of the repository
+  - name: git-repo-name
+    description: The name of the repository
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1
+    kind: PipelineRun
+    metadata:
+      generateName: github-push-run-
+    spec:
+      serviceAccountName: pipeline
+      pipelineRef:
+        name: <your_pipeline_name>
+      params:
+      - name: git-url
+        value: $(tt.params.git-repo-clone-url)
+      - name: git-revision
+        value: $(tt.params.git-revision)
+      - name: deployment-name
+        value: $(tt.params.git-repo-name)
+      workspaces:
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 500Mi
+----
++
+[IMPORTANT]
+====
+Use the `git-repo-clone-url` parameter, not `git-repo-url`, when you need the repository URL for cloning. The `git-repo-url` parameter maps to `$(body.repository.url)`, which is the GitHub REST API URL and cannot be used for cloning. The `git-repo-clone-url` parameter maps to `$(body.repository.html_url)`, which is the correct HTTPS URL for cloning the repository with `git-clone` or similar tasks.
+====
++
+Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f github-push-pipeline-template.yaml
+----
+
+. Create an `EventListener` resource that exposes an HTTP endpoint, references the `github-push` `ClusterTriggerBinding`, and uses the GitHub interceptor to validate the webhook signature and filter for push events only:
++
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1
+kind: EventListener
+metadata:
+  name: github-push-listener
+spec:
+  serviceAccountName: pipeline
+  triggers:
+  - interceptors:
+    - ref:
+        name: github
+      params:
+      - name: secretRef
+        value:
+          secretName: github-webhook-secret
+          secretKey: secretToken
+      - name: eventTypes
+        value: ["push"]
+    bindings:
+    - ref: github-push
+      kind: ClusterTriggerBinding
+    template:
+      ref: github-push-pipeline
+----
++
+The `kind: ClusterTriggerBinding` field is required to distinguish the `github-push` binding from a namespace-scoped `TriggerBinding` resource with the same name.
++
+The `eventTypes: ["push"]` interceptor parameter ensures the event listener processes only push events and ignores all other event types, such as pull requests or releases.
++
+Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f github-push-listener.yaml
+----
+
+. Expose the `EventListener` service as a publicly accessible route:
++
+[source,terminal]
+----
+$ oc expose svc el-github-push-listener
+----
++
+Get the route URL by running the following command:
++
+[source,terminal]
+----
+$ oc get route el-github-push-listener --template='http://{{.spec.host}}'
+----
++
+Save the URL displayed in the output. You provide this URL to GitHub when configuring the webhook.
++
+[NOTE]
+====
+For a production environment, create a secure HTTPS route instead. See "Securing webhooks with event listeners" in the Additional resources section.
+====
+
+. Configure a webhook on your GitHub repository to send push events to the `EventListener` route:
+
+.. Open your GitHub repository in a browser.
+.. Click *Settings* -> *Webhooks* -> *Add webhook*.
+.. On the *Add webhook* page:
+... Enter the `EventListener` route URL from the earlier step in the *Payload URL* field.
+... Select *application/json* for the *Content type*.
+... Enter the secret token you set in the `github-webhook-secret` `Secret` resource in the *Secret* field.
+... Select *Just the push event*.
+... Select *Active*.
+... Click *Add webhook*.
+
+.Verification
+
+. Push a commit to your GitHub repository by running the following commands:
++
+[source,terminal]
+----
+$ git commit --allow-empty -m "Test pipeline trigger"
+----
++
+[source,terminal]
+----
+$ git push
+----
+
+. List the pipeline runs to confirm that a new run was created:
++
+[source,terminal]
+----
+$ tkn pipelinerun list
+----
++
+A new `PipelineRun` with a name prefixed by `github-push-run-` is displayed in the output within a few seconds of the push event.
+


### PR DESCRIPTION
Version(s):
- `pipelines_docs_1.22`
- `pipelines_docs_1.23`
- `pipelines_docs_1.24`

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-6455

Link to docs preview:
- changes in [Triggers](https://118851--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/understanding-openshift-pipelines.html#about-triggers_understanding-openshift-pipelines)
- main content in [Using ClusterTriggerBindings with OpenShift Pipelines](https://118851--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/using-clustertriggerbindings.html)

QE/SME review:
- [x] QE/SME has approved this change.

