### PR TITLE
[OSDOCS#19352]: Clarify that multiple KubeletConfig CRs are not merged

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -22,6 +22,13 @@ Consider the following guidance:
 * Create one `KubeletConfig` CR for each machine config pool with all the config changes you want for that pool.
 
 * As needed, create multiple `KubeletConfig` CRs with a limit of 10 per cluster. For the first `KubeletConfig` CR, the Machine Config Operator (MCO) creates a machine config appended with `kubelet`. With each subsequent CR, the controller creates another `kubelet` machine config with a numeric suffix. For example, if you have a `kubelet` machine config with a `-2` suffix, the next `kubelet` machine config is appended with `-3`.
++
+[IMPORTANT]
+====
+The Machine Config Operator does not merge multiple `KubeletConfig` CRs that target the same machine config pool. Each CR generates a separate machine config that writes the kubelet configuration. The most recently created `KubeletConfig` CR takes precedence and overrides the kubelet settings from earlier CRs for that pool.
+
+To apply multiple kubelet settings to the same pool, include all of the settings in a single `KubeletConfig` CR.
+====
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19352

Link to docs preview:
- https://118856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom.html
- https://118856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html

QE review:
- [x] QE has approved this change.

Additional information:
Clarifies that multiple `KubeletConfig` CRs targeting the same machine config pool are not merged. The most recently created CR takes precedence. Customers were reading the existing “multiple CRs / numeric suffix” wording as a merge.

QE approval: @ptalgulk01 commented “looks good” on 2026-09-03.

This module is included from:
- `machine_configuration/machine-configs-custom.adoc`
- `post_installation_configuration/node-tasks.adoc`