### PR TITLE
OSDOCS WMCO 10.21.2 Release Notes

### DIFF
--- a/modules/windows-containers-release-notes-10-21-2.adoc
+++ b/modules/windows-containers-release-notes-10-21-2.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-21-2_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.21.2
+
+Issued: 31 August 2026
+
+The components of the Red Hat Windows Machine Config Operator (WMCO) 10.21.2 were released in https://access.redhat.com/errata/RHSA-2026:61780[RHSA-2026:61780].
+
+[id="wmco-10-21-2-bug-fixes"]
+== Bug fixes
+
+* Before this update, the SSH connection between the WMCO and a Windows node would terminate when the WMCO rebooted the node after a configuration update. As a consequence, the WMCO incorrectly treated the SSH disconnection as a reboot failure, preventing the Windows node from completing required reboots. With this release, the reboot validation process is modified to ignore SSH termination errors and instead verify a successful reboot by using explicit node reachability checks and the SSH reconnection. As a result, Windows nodes successfully reboot upon node configuration changes. (link:https://issues.redhat.com/browse/OCPBUGS-98229[OCPBUGS-98229])

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -11,4 +11,6 @@ You can review the following release notes to learn about changes in previous ve
 
 For the current {productwinc} release notes, see "Red Hat OpenShift support for Windows Containers release notes".
 
+include::modules/windows-containers-release-notes-10-21-1.adoc[leveloffset=+1]
+
 include::modules/windows-containers-release-notes-10-21-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -9,4 +9,4 @@ toc::[]
 [role="_abstract"]
 This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. 
 
-include::modules/windows-containers-release-notes-10-21-1.adoc[leveloffset=+1]
+include::modules/windows-containers-release-notes-10-21-2.adoc[leveloffset=+1]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-21763

Will update the release date and errata link when available.

Link to docs preview:
[Release notes for Red Hat Windows Machine Config Operator 10.21.2](https://118873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes#windows-containers-release-notes-10-21-2_windows-containers-release-notes)
[Release notes for past releases of the Windows Machine Config Operator](https://118873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past)

