### PR TITLE
RHDEVDOCS-7899: Fix Pipelines JTBD AsciiDoc markup issues

### DIFF
--- a/modules/con-working-with-pipelines-web-console.adoc
+++ b/modules/con-working-with-pipelines-web-console.adoc
@@ -5,4 +5,4 @@
 [role="_abstract"]
 You can use the *Administrator* or *Developer* perspective to create and change `Pipeline`, `PipelineRun`, and `Repository` objects from the *Pipelines* page in the {OCP} web console.
 
-You can also use the *+Add* page in the *Developer* perspective of the web console to create CI/CD pipelines for your software delivery process.
+You can also use the *Add* page in the *Developer* perspective of the web console to create CI/CD pipelines for your software delivery process.

--- a/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
@@ -115,9 +115,9 @@ spec:
         printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
         printf "%s" "$(params.url)" > "$(results.url.path)"
 ----
-+
+
 `-R`:: The script copies the content of the secret (in the form of a folder) to `${HOME}/.ssh`, which is the standard folder where `ssh` searches for credentials.
-+
+
 .Example command for running the task
 [source, terminal]
 ----

--- a/modules/op-constructing-pipelines-using-pipeline-builder.adoc
+++ b/modules/op-constructing-pipelines-using-pipeline-builder.adoc
@@ -6,7 +6,7 @@
 = Construct pipelines using the pipeline builder
 
 [role="_abstract"]
-In the *Developer* perspective of the console, you can use the *+Add* -> *Pipeline* -> *Pipeline builder* option to:
+In the *Developer* perspective of the console, you can use the *Add* -> *Pipeline* -> *Pipeline builder* option to:
 
 * Configure pipelines using either the *Pipeline builder* or the *YAML view*.
 * Construct a pipeline flow by using existing tasks. When you install the {pipelines-shortname} Operator, it adds reusable pipeline tasks to your cluster that you can use with the cluster resolver.
@@ -24,7 +24,7 @@ If you do not deploy any local {tekton-hub} instance, by default, you can only a
 
 .Procedure
 
-. In the *+Add* view of the *Developer* perspective, click the *Pipeline* tile to see the *Pipeline builder* page.
+. In the *Add* view of the *Developer* perspective, click the *Pipeline* tile to see the *Pipeline builder* page.
 . Configure the pipeline by using either the *Pipeline builder* view or the *YAML view*.
 +
 [NOTE]

--- a/modules/op-creating-pipelines-along-with-applications.adoc
+++ b/modules/op-creating-pipelines-along-with-applications.adoc
@@ -6,9 +6,9 @@
 = Create pipelines along with applications
 
 [role="_abstract"]
-To create pipelines along with applications, use the *From Git* option in the *Add+* view of the *Developer* perspective. You can view all of your available pipelines and select the pipelines you want to use to create applications while importing your code or deploying an image.
+To create pipelines along with applications, use the *From Git* option in the *Add* view of the *Developer* perspective. You can view all of your available pipelines and select the pipelines you want to use to create applications while importing your code or deploying an image.
 
-The installation program enables {tekton-hub} Integration by default. You can see the tasks your cluster supports in the {tekton-hub}. Administrators can opt out of the {tekton-hub} Integration and the {tekton-hub} will no longer display the tasks. You can also check whether a webhook URL exists for a generated pipeline. {pipelines-title} adds default webhooks for the pipelines that you create by using the *+Add* flow and the URL is visible in the side panel of the selected resources in the Topology view.
+The installation program enables {tekton-hub} Integration by default. You can see the tasks your cluster supports in the {tekton-hub}. Administrators can opt out of the {tekton-hub} Integration and the {tekton-hub} will no longer display the tasks. You can also check whether a webhook URL exists for a generated pipeline. {pipelines-title} adds default webhooks for the pipelines that you create by using the *Add* flow and the URL is visible in the side panel of the selected resources in the Topology view.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/op-odc-pipelines-abstract.adoc
+++ b/modules/op-odc-pipelines-abstract.adoc
@@ -7,14 +7,9 @@
 = Work with Pipelines in the developer perspective
 
 [role="_abstract"]
-In the *Developer* perspective, you can access the following options for creating pipelines from the *+Add* page:
+In the *Developer* perspective, you can access the following options for creating pipelines from the *Add* page:
 
-* Use the *+Add* -> *Pipelines* -> *Pipeline builder* option to create customized pipelines for your application.
-* Use the *+Add* -> *From Git* option to create pipelines by using pipeline templates and resources while creating an application.
+* Use the *Add* -> *Pipelines* -> *Pipeline builder* option to create customized pipelines for your application.
+* Use the *Add* -> *From Git* option to create pipelines by using pipeline templates and resources while creating an application.
 
 After you create the pipelines for your application, you can view and visually interact with the deployed pipelines in the *Pipelines* view. You can also use the *Topology* view to interact with the pipelines created using the *From Git* option. You must apply custom labels to pipelines created using the *Pipeline builder* to see them in the *Topology* view.
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../administer/manage-pipeline-lifecycles-and-resources.adoc#use-tekton-hub-with-openshift-pipelines_manage-pipeline-lifecycles-and-resources[Manage {tekton-hub}]

--- a/modules/op-starting-pipelines-from-topology-view.adoc
+++ b/modules/op-starting-pipelines-from-topology-view.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 For pipelines created using the *From Git* option, you can use the *Topology* view to interact with pipelines after you start them.
-+
+
 [NOTE]
 ====
 To see the pipelines created using *Pipeline builder* in the *Topology* view, customize the pipeline labels to link the pipeline with the application workload.

--- a/modules/op-supported-parameters-tekton-chains-configuration.adoc
+++ b/modules/op-supported-parameters-tekton-chains-configuration.adoc
@@ -185,7 +185,7 @@ To create occurrences, {pipelines-title} must first create notes that link occur
 
 
 {pipelines-title} uses the configurable `noteid` as the prefix of the note name. It appends the suffix `-simplesigning` for the `ATTESTATION` note and the suffix `-intoto` for the `BUILD` note. If the `noteid` field is not configured, {pipelines-title} uses `tekton-<NAMESPACE>` as the prefix.
-+
+
 .Chains configuration: Supported parameters for Grafeas storage
 [options="header"]
 |===

--- a/modules/op-types-annotation-secrets.adoc
+++ b/modules/op-types-annotation-secrets.adoc
@@ -35,7 +35,7 @@ stringData:
   username: <username>
   password: <password>
 ----
-+
+
 `<username>`:: Username for the repository
 `<password>`:: Password or personal access token for the repository
 
@@ -54,7 +54,7 @@ type: kubernetes.io/ssh-auth
 stringData:
   ssh-privatekey:
 ----
-+
+
 `ssh-privatekey`:: The content of the SSH private key file.
 
 [id="op-types-annotation-secrets-container_{context}"]
@@ -87,7 +87,7 @@ stringData:
   username: <username>
   password: <password>
 ----
-+
+
 `<username>`:: Username for the registry
 `<password>`:: Password or personal access token for the registry
 
@@ -112,7 +112,7 @@ $ oc create secret docker-registry docker-secret-config \
   --docker-password=<password> \
   --docker-server=my-registry.example.com:5000
 ----
-+
+
 `<email>`:: Email address for the registry
 `<username>`:: Username for the registry
 `<password>`:: Password or personal access token for the registry


### PR DESCRIPTION
**Tracking JIRA:** 
https://redhat.atlassian.net/browse/CCSTOOLS-2645
https://redhat.atlassian.net/browse/RHDEVDOCS-7899

**Changes:**
The Pipelines documentation preview showed standalone plus (+) characters rendering as literal text instead of being parsed as AsciiDoc list continuation markers. This was breaking the rendering of description lists in several modules.

**Doc previews:** 
- https://118876--ocpdocs-pr.netlify.app/openshift-pipelines/latest/develop/develop-and-extend-pipelines.html
- https://118876--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/control-pipeline-access-and-security.html
- https://118876--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/secure-software-supply-chains.html
