### PR TITLE
OSDOCS-21758: Document that Service trafficDistribution is not supported by OVN-Kubernetes

### DIFF
--- a/modules/nw-ovn-kubernetes-traffic-distribution.adoc
+++ b/modules/nw-ovn-kubernetes-traffic-distribution.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-kubernetes-traffic-distribution_{context}"]
+= Service traffic distribution
+
+[role="_abstract"]
+The Kubernetes `spec.trafficDistribution` field on a `Service` object is not supported by the OVN-Kubernetes network plugin. The API server can persist the field, but OVN-Kubernetes does not use it when routing service traffic.
+
+You can set `spec.trafficDistribution` on a `Service` object to values such as `PreferClose`, `PreferSameZone`, or `PreferSameNode`. In Kubernetes, these values are hints that the service proxy should prefer endpoints in the same zone or on the same node as the client.
+
+The OVN-Kubernetes network plugin, which is the default Container Network Interface (CNI) plugin for {product-title}, does not implement these hints. If you set `spec.trafficDistribution`, the API server stores the value, but service traffic continues to be load balanced across healthy endpoints according to the default routing behavior.
+
+To restrict service traffic to endpoints on the same node as the client, set `spec.internalTrafficPolicy` to `Local`. If no local endpoints exist, that policy drops the traffic instead of sending it to endpoints on other nodes.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution[Traffic distribution in Kubernetes]

--- a/modules/nw-understanding-networking-core-layers-and-components.adoc
+++ b/modules/nw-understanding-networking-core-layers-and-components.adoc
@@ -19,4 +19,9 @@ The service network::
 
 A service is a networking object that provides a single, stable virtual IP address, called a ClusterIP, and a DNS name for a logical group of pods.
 +
-When a request is sent to a the ClusterIP of the service, {product-title} automatically load balances the traffic to one of the healthy pods backing that service. {product-title} uses Kubernetes labels and selectors to keep track of which pods belong to which service. This abstraction makes your applications resilient because individual pods can be created or destroyed without affecting the applications trying to reach them.
+When a request is sent to the ClusterIP of the service, {product-title} automatically load balances the traffic to one of the healthy pods backing that service. {product-title} uses Kubernetes labels and selectors to keep track of which pods belong to which service. This abstraction makes your applications resilient because individual pods can be created or destroyed without affecting the applications trying to reach them.
++
+[IMPORTANT]
+====
+The Kubernetes `spec.trafficDistribution` field on a `Service` object, including the `PreferClose`, `PreferSameZone`, and `PreferSameNode` values, is not supported by the OVN-Kubernetes network plugin. The API server might accept the field, but OVN-Kubernetes does not use it when routing service traffic. Traffic continues to be load balanced across healthy endpoints according to the default service routing behavior.
+====

--- a/networking/networking_overview/understanding-networking.adoc
+++ b/networking/networking_overview/understanding-networking.adoc
@@ -26,3 +26,4 @@ include::modules/nw-understanding-networking-securing-network-traffic.adoc[level
 .Additional resources
 
 * xref:../../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-traffic-distribution_about-ovn-kubernetes[Service traffic distribution]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -43,6 +43,9 @@ include::modules/nw-ovn-kubernetes-limitations.adoc[leveloffset=+1]
 // Session affinity
 include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 
+// Service traffic distribution
+include::modules/nw-ovn-kubernetes-traffic-distribution.adoc[leveloffset=+1]
+
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
## Summary
- Document that `spec.trafficDistribution` (`PreferClose`, `PreferSameZone`, `PreferSameNode`) is accepted by the Kubernetes/OpenShift API but is **not implemented** by OVN-Kubernetes, the default CNI plugin.
- Add an important note on the Networking overview service-network section, and a new "Service traffic distribution" section on About OVN-Kubernetes.
- Point users to `spec.internalTrafficPolicy: Local` as the supported way to restrict traffic to same-node endpoints (with no fallback).

Fixes https://issues.redhat.com/browse/OSDOCS-21758

Related:
- https://issues.redhat.com/browse/RFE-6928 (product RFE for topology-aware routing)
- https://issues.redhat.com/browse/CORENET-6690 (OVN-K implementation epic)
- https://issues.redhat.com/browse/OCPBUGS-99044 (closed as Won't Do; same dataplane gap)

## Test plan
- [ ] Preview *Understanding networking*: the important note appears under the service network description.
- [ ] Preview *About the OVN-Kubernetes network plugin*: the new *Service traffic distribution* section renders, including the Kubernetes extra resource link.
- [ ] Confirm the additional-resources xref from Understanding networking to the OVN-Kubernetes section resolves.
- [ ] Cherry-pick to `enterprise-4.22` (and `enterprise-4.21` / `enterprise-4.20` if docs for `PreferClose` should call this out there too). The generated `service-v1` API page is produced by `openshift-apidocs-gen` and is not edited here.


Made with [Cursor](https://cursor.com)