### PR TITLE
OSDOCS-16991#Removing monospace formatting from CloudFormation heading

### DIFF
--- a/modules/installation-aws-creating-cloudformation-stack-compute.adoc
+++ b/modules/installation-aws-creating-cloudformation-stack-compute.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-creating-cloudformation-stack_{context}"]
-= Creating the `CloudFormation` stack for compute machines
+= Creating the CloudFormation stack for compute machines
 
 [role="_abstract"]
 You can create a stack of {aws-first} resources for the compute machines by using the provided `CloudFormation` template.


### PR DESCRIPTION
Version:
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991

Link to docs preview:
- [Creating the CloudFormation stack for compute machines](https://118879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-creating-cloudformation-stack_installing-aws-user-infra)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a follow-up PR to https://github.com/openshift/openshift-docs/pull/118841. That PR kept backticks in the heading for reconciliation with enterprise branches. This PR removes them per style guidelines.