### PR TITLE
OSDOCS-15775-19:Updated nw-ingress-gateway-api-manage-succession.adoc t

### DIFF
--- a/modules/nw-ingress-gateway-api-manage-succession.adoc
+++ b/modules/nw-ingress-gateway-api-manage-succession.adoc
@@ -7,15 +7,19 @@
 = Preparing for Gateway API management succession by the Ingress Operator
 
 [role="_abstract"]
-To ensure your Gateway API custom resource definitions (CRDs) conform to required {product-title} specifications, allow the Ingress Operator to manage their lifecycle. Preparing your older {product-title} environment for this automated management helps prevent resource conflicts and deployment errors.
+Prepare your cluster for Gateway API management succession by removing existing unsupported definitions and installing compliant resources.
+This ensures a seamless update to {product-title} {product-version} and prevents conflicts with the Ingress Operator.
 
-Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs). This means you cannot create, update, or delete any CRDs within the API groups under the Gateway API.
+Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs).
+This lifecycle control blocks you from creating, updating, or deleting CRDs within the `gateway.networking.k8s.io` API group.
 
 Updating from a version earlier than {product-title} 4.19 where the API CRD management was not present requires replacing or removing any Gateway API CRDs. 
 
 [WARNING]
 ====
-Updating or deleting Gateway API resources can result in downtime and loss of service or data. Be sure you understand how this impacts your cluster before performing the steps in this procedure. If necessary, back up any Gateway API objects in YAML format in order to restore it later.
+Updating or deleting Gateway API resources can result in downtime and loss of service or data.
+Understand how this impacts your cluster before performing the steps in this procedure. 
+If necessary, back up any Gateway API objects in YAML format to restore them later.
 ====
 
 The updated CRDs must conform to the specific {product-title} specification that is required by the Ingress Operator. {product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.
@@ -36,12 +40,6 @@ $ oc -n openshift-config patch configmap admin-acks --patch '{"data":{"ack-4.18-
 
 * You have installed the {oc-first}.
 * You have access to an {product-title} account with cluster administrator access.
-* Optional: You have backed up any necessary Gateway API objects.
-+
-[WARNING]
-====
-Backup and restore can fail or result in data loss for any CRD fields that were present in the old definitions but are absent in the new definitions.
-====
 
 .Procedure
 
@@ -55,46 +53,76 @@ $ oc get crd | grep -F -e gateway.networking.k8s.io -e gateway.networking.x-k8s.
 .Example output
 [source,terminal]
 ----
+backendtlspolicies.gateway.networking.k8s.io
 gatewayclasses.gateway.networking.k8s.io
 gateways.gateway.networking.k8s.io
 grpcroutes.gateway.networking.k8s.io
 httproutes.gateway.networking.k8s.io
+listenersets.gateway.networking.k8s.io
 referencegrants.gateway.networking.k8s.io
+tlsroutes.gateway.networking.k8s.io
+----
++
+If the output lists custom resource definitions (CRDs) for `gateway.networking.x-k8s.io`, retain those resources.
+Optional CRDs, such as `grpcroutes`, `listenersets`, `referencegrants`, and `tlsroutes` are shown for demonstrative purposes.
+
+. Back up the listed Gateway API CRDs by entering the following command:
++
+[source,terminal]
+----
+$ oc get backendtlspolicies -A -o yaml > backendtlspolicies-backup.yaml && \
+oc get gatewayclasses -A -o yaml > gatewayclasses-backup.yaml && \
+oc get gateways -A -o yaml > gateway-backup.yaml && \
+oc get grpcroutes -A -o yaml > grpcroutes-backup.yaml && \
+oc get httproutes -A -o yaml > httproutes-backup.yaml && \
+oc get listenersets -A -o yaml > listenersets-backup.yaml && \
+oc get referencegrants -A -o yaml > referencegrants-backup.yaml && \
+oc get tlsroutes -A -o yaml > tlsroutes-backup.yaml
+----
++
+[WARNING]
+====
+Back up and restore can fail or result in data loss.
+Fields present in old CRD definitions but absent in new definitions might be lost.
+====
+
+. Back up the `validatingadmissionpolicy` binding by entering the following command:
++
+[source,terminal]
+----
+$ oc get validatingadmissionpolicybinding openshift-ingress-operator-gatewayapi-crd-admission -o yaml > /tmp/gateway-binding.yaml
 ----
 
-. Delete the Gateway API CRDs from the previous step by running the following commands:
+. Delete the `validatingadmissionpolicy` binding by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd gatewayclasses.networking.k8s.io
+$ oc delete validatingadmissionpolicybinding openshift-ingress-operator-gatewayapi-crd-admission
 ----
+
+. Delete the Gateway API CRDs that were listed from a previous step by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd gateways.networking.k8s.io
-----
-+
-[source,terminal]
-----
-$ oc delete crd grpcroutes.gateway.networking.k8s.io
-----
-+
-[source,terminal]
-----
-$ oc delete crd httproutes.gateway.networking.k8s.io
-----
-+
-[source,terminal]
-----
-$ oc delete crd referencesgrants.gateway.networking.k8s.io
+$ oc delete crd backendtlspolicies.gateway.networking.k8s.io && \
+oc delete crd gatewayclasses.gateway.networking.k8s.io && \
+oc delete crd gateways.gateway.networking.k8s.io && \
+oc delete crd grpcroutes.gateway.networking.k8s.io && \
+oc delete crd httproutes.gateway.networking.k8s.io && \
+oc delete crd listenersets.gateway.networking.k8s.io && \
+oc delete crd referencegrants.gateway.networking.k8s.io && \
+oc delete crd tlsroutes.gateway.networking.k8s.io
 ----
 +
 [IMPORTANT]
 ====
-Deleting CRDs removes every custom resource that relies on them and can result in data loss. Back up any necessary data before deleting the Gateway API CRDs. Any controller that was previously managing the lifecycle of the Gateway API CRDs will fail to operate properly. Attempting to force its use in conjunction with the Ingress Operator to manage Gateway API CRDs might prevent the cluster update from succeeding.
+Deleting CRDs removes every custom resource that relies on them and can result in data loss.
+Back up any necessary data before deleting the Gateway API CRDs.
+Any controller that was previously managing the lifecycle of the Gateway API CRDs ceases to function correctly.
+Forcing its use with the Ingress Operator to manage Gateway API CRDs might prevent the cluster update from succeeding.
 ====
 
-. Get the supported Gateway API CRDs by running the following command:
+. Get and install the newly supported Gateway API CRDs on your cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -103,7 +131,32 @@ $ oc apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v
 +
 [WARNING]
 ====
-You can perform this step without deleting your CRDs. If your update to a CRD removes a field that is used by a custom resource, you can lose data. Updating a CRD a second time, to a version that re-adds a field, can cause any previously deleted data to reappear. Any third-party controller that depends on a specific Gateway API CRD version that is not supported in {product-title} {product-version} will break upon updating that CRD to one supported by Red{nbsp}Hat.
+You can perform this step without deleting your CRDs.
+If your update to a CRD removes a field that is used by a custom resource, you can lose data. 
+Updating a CRD a second time to a version that re-adds a field can cause any previously deleted data to reappear.
+Any third-party controller that depends on a specific Gateway API CRD version that is not supported in {product-title} {product-version} can break.
+This can occur when you update a CRD to one supported by Red{nbsp}Hat.
 
 For more information on the {product-title} implementation and the dead fields issue, see _Gateway API implementation for {product-title}_.
+====
+
+. Restore the listed Gateway API CRDs by entering the following command:
++
+[source,terminal]
+----
+$ oc apply -f backendtlspolicies-backup.yaml && \
+oc apply -f gatewayclasses-backup.yaml && \
+oc apply -f gateway-backup.yaml && \
+oc apply -f grpcroutes-backup.yaml && \
+oc apply -f httproutes-backup.yaml && \
+oc apply -f listenersets-backup.yaml && \
+oc apply -f referencegrants-backup.yaml && \
+oc apply -f tlsroutes-backup.yaml
+----
++
+[NOTE]
+====
+You might see a missing `kubectl.kubernetes.io/last-applied-configuration` annotation warning during restoring CRDs.
+This warning is expected when restoring CRDs that were not originally created with `oc apply`.
+The operation still succeeds, and {product-title} automatically patches the required annotation onto the resources.
 ====

--- a/modules/nw-ingress-gateway-api-manage-succession.adoc
+++ b/modules/nw-ingress-gateway-api-manage-succession.adoc
@@ -7,22 +7,29 @@
 = Preparing for Gateway API management succession by the Ingress Operator
 
 [role="_abstract"]
-To ensure your Gateway API custom resource definitions (CRDs) conform to required {product-title} specifications, allow the Ingress Operator to manage their lifecycle. Preparing your older {product-title} environment for this automated management helps prevent resource conflicts and deployment errors.
+Prepare your cluster for Gateway API management succession by removing existing unsupported definitions and installing compliant resources.
+This ensures a seamless update to {product-title} {product-version} and prevents conflicts with the Ingress Operator.
 
-Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs). This means you cannot create, update, or delete any CRDs within the API groups under the Gateway API.
+Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs).
+This lifecycle control is enforced by the `openshift-ingress-operator-gatewayapi-crd-admission` validating admission policy, which blocks you from creating, updating, or deleting CRDs within the `gateway.networking.k8s.io` API group.
 
 Updating from a version earlier than {product-title} 4.19 where the API CRD management was not present requires replacing or removing any Gateway API CRDs. 
 
 [WARNING]
 ====
-Updating or deleting Gateway API resources can result in downtime and loss of service or data. Be sure you understand how this impacts your cluster before performing the steps in this procedure. If necessary, back up any Gateway API objects in YAML format in order to restore it later.
+Updating or deleting Gateway API resources can result in downtime and loss of service or data.
+Understand how this impacts your cluster before performing the steps in this procedure. 
+If necessary, back up any Gateway API objects in YAML format to restore them later.
 ====
 
-The updated CRDs must conform to the specific {product-title} specification that is required by the Ingress Operator. {product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.
+The updated CRDs must conform to the specific {product-title} specification that is required by the Ingress Operator.
+{product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.
 
 [IMPORTANT]
 ====
-When upgrading your {product-title} 4.18 cluster to {product-title} 4.19, you might see a `Gateway API CRDs have been detected` message. A cluster administrator must understand the implications before applying the `ack-4.18-gateway-api-management-in-4.19` acknowledgment. {product-title} 4.19 can then manage the Gateway API CRDs during the upgrade operation.
+When upgrading your {product-title} 4.18 cluster to {product-title} 4.19, you might see a `Gateway API CRDs have been detected` message.
+A cluster administrator must understand the implications before applying the `ack-4.18-gateway-api-management-in-4.19` acknowledgment.
+{product-title} 4.19 can then manage the Gateway API CRDs during the upgrade operation.
 
 You can run the following command to apply the `ack-4.18-gateway-api-management-in-4.19` acknowledgment:
 
@@ -32,16 +39,16 @@ $ oc -n openshift-config patch configmap admin-acks --patch '{"data":{"ack-4.18-
 ----
 ====
 
+{product-title}{product-version} does not include `backendtlspolicy`, `listenersets-backup` and `tlsroutes` Gateway API CRDs by default.
+If you upgaded your cluster from 4.18 to 4.19 and these CRDs exist, ensure you include them in the procedure steps.
+
+{product-title}{product-version} runs Gateway API (GWAPI) version 1.2.1.
+If you run a newer version of the Gateway API that has newer CRDs, you cannot restore these newer CRDs as part of the procedure as these CRDS are not natively part of GWAPI 1.2.1.
+
 .Prerequisites
 
 * You have installed the {oc-first}.
 * You have access to an {product-title} account with cluster administrator access.
-* Optional: You have backed up any necessary Gateway API objects.
-+
-[WARNING]
-====
-Backup and restore can fail or result in data loss for any CRD fields that were present in the old definitions but are absent in the new definitions.
-====
 
 .Procedure
 
@@ -62,39 +69,57 @@ httproutes.gateway.networking.k8s.io
 referencegrants.gateway.networking.k8s.io
 ----
 
-. Delete the Gateway API CRDs from the previous step by running the following commands:
+. Back up the listed Gateway API CRDs by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd gatewayclasses.networking.k8s.io
+$ oc get gatewayclasses -A -o yaml > gatewayclasses-backup.yaml && \
+oc get gateways -A -o yaml > gateway-backup.yaml && \
+oc get grpcroutes -A -o yaml > grpcroutes-backup.yaml && \
+oc get httproutes -A -o yaml > httproutes-backup.yaml && \
+oc get referencegrants -A -o yaml > referencegrants-backup.yaml
 ----
++
+[WARNING]
+====
+Back up and restore can fail or result in data loss.
+Fields present in old CRD definitions but absent in new definitions might be lost.
+====
+
+. Back up the `validatingadmissionpolicy` binding by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd gateways.networking.k8s.io
+$ oc get validatingadmissionpolicybinding openshift-ingress-operator-gatewayapi-crd-admission -o yaml > /tmp/gateway-binding.yaml
 ----
+
+. Delete the `validatingadmissionpolicy` binding by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd grpcroutes.gateway.networking.k8s.io
+$ oc delete validatingadmissionpolicybinding openshift-ingress-operator-gatewayapi-crd-admission
 ----
+
+. Delete the Gateway API CRDs that were listed from a previous step by entering the following command:
 +
 [source,terminal]
 ----
-$ oc delete crd httproutes.gateway.networking.k8s.io
-----
-+
-[source,terminal]
-----
-$ oc delete crd referencesgrants.gateway.networking.k8s.io
+$ oc delete crd gatewayclasses.gateway.networking.k8s.io && \
+oc delete crd gateways.gateway.networking.k8s.io && \
+oc delete crd grpcroutes.gateway.networking.k8s.io && \
+oc delete crd httproutes.gateway.networking.k8s.io && \
+oc delete crd referencegrants.gateway.networking.k8s.io
 ----
 +
 [IMPORTANT]
 ====
-Deleting CRDs removes every custom resource that relies on them and can result in data loss. Back up any necessary data before deleting the Gateway API CRDs. Any controller that was previously managing the lifecycle of the Gateway API CRDs will fail to operate properly. Attempting to force its use in conjunction with the Ingress Operator to manage Gateway API CRDs might prevent the cluster update from succeeding.
+Deleting CRDs removes every custom resource that relies on them and can result in data loss.
+Back up any necessary data before deleting the Gateway API CRDs.
+Any controller that was previously managing the lifecycle of the Gateway API CRDs ceases to function correctly.
+Forcing its use with the Ingress Operator to manage Gateway API CRDs might prevent the cluster update from succeeding.
 ====
 
-. Get the supported Gateway API CRDs by running the following command:
+. Get and install the newly supported Gateway API CRDs on your cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -103,7 +128,28 @@ $ oc apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v
 +
 [WARNING]
 ====
-You can perform this step without deleting your CRDs. If your update to a CRD removes a field that is used by a custom resource, you can lose data. Updating a CRD a second time, to a version that re-adds a field, can cause any previously deleted data to reappear. Any third-party controller that depends on a specific Gateway API CRD version that is not supported in {product-title} {product-version} will break upon updating that CRD to one supported by Red{nbsp}Hat.
+You can perform this step without deleting your CRDs.
+If your update to a CRD removes a field that is used by a custom resource, you can lose data. 
+Updating a CRD a second time to a version that re-adds a field can cause any previously deleted data to reappear.
+Any third-party controller that depends on a specific Gateway API CRD version that is not supported in {product-title} {product-version} can break.
+This can occur when you update a CRD to one supported by Red{nbsp}Hat.
 
 For more information on the {product-title} implementation and the dead fields issue, see _Gateway API implementation for {product-title}_.
 ====
++
+[NOTE]
+====
+You might see a warning around a missing `kubectl.kubernetes.io/last-applied-configuration` annotation after you run the command.
+The operation still succeeds, so you can ignore the warning.
+====
+
+. Restore the listed Gateway API CRDs by entering the following command:
++
+[source,terminal]
+----
+$ oc apply -f gatewayclasses-backup.yaml && \
+oc apply -f gateway-backup.yaml && \
+oc apply -f grpcroutes-backup.yaml && \
+oc apply -f httproutes-backup.yaml && \
+oc apply -f referencegrants-backup.yaml
+----


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-15775](https://redhat.atlassian.net/browse/OSDOCS-15775)

Link to docs preview:
* https://118880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#nw-ingress-gateway-api-manage-succession_updating-cluster-prepare

RELEASE NOTE THAT ALREADY EXISTS:

* https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/release_notes/index#ocp-4-19-networking-gateway-api-crd-lifecycle_release-notes