### PR TITLE
OCPBUGS-86706: Added IPv6 CIDR ranges note to Whereabouts doc

### DIFF
--- a/networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.adoc
+++ b/networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.adoc
@@ -9,6 +9,13 @@ toc::[]
 [role="_abstract"]
 You can configure IP address assignments for secondary networks so that pods can connect to the secondary networks.
 
+[IMPORTANT]
+====
+When using the Whereabouts IPAM plugin with an IPv6 address, do not configure wide IPv6 CIDR ranges where the intended allocation addresses require an offset larger than 64 bits from the CIDR network base. In particular, avoid IPv6 ranges with prefix length less than or equal to `/64`. Due to the current uint64-based offset calculation in Whereabouts, such ranges can result in incorrect allocation persistence or reconstruction.
+
+Use a narrower IPv6 CIDR that directly covers the intended allocation range. For example, instead of using `193:21:4::/24` with a range start of `193:21:4::2` and a range end of `193:21:4::180`, use `193:21:4::/119`.
+====
+
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 
 include::modules/nw-multus-whereabouts.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OCPBUGS-86706](https://redhat.atlassian.net/browse/OCPBUGS-86706)

Link to docs preview:

* https://118883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.html

- [x] SME has approved this change (Raphael Rosa).
- [x] QE has approved this change (Weibin Liang).
- [x] Tam has approved this change (Terry Hu)
