### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/modules/nodes-containers-dev-fuse-configuring.adoc
+++ b/modules/nodes-containers-dev-fuse-configuring.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 You can grant an unprivileged pod the capability to perform Filesystem in Userspace (FUSE) mounts by exposing the `/dev/fuse` device. With this setup, an unprivileged user within the pod can use tools such as `podman` with storage drivers such as `fuse-overlayfs` by mimicking privileged build capabilities in a secure and efficient manner without granting full privileged access to the pod.
 
-You expose the `/dev/fuse` device by adding the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation to your pod definition.
+You expose the `/dev/fuse` device by adding the `devices.crio.io: "/dev/fuse"` annotation to your pod definition.
 
 .Procedure
 
@@ -24,7 +24,7 @@ kind: Pod
 metadata:
   name: fuse-builder-pod
   annotations:
-    io.kubernetes.cri-o.Devices: "/dev/fuse"
+    devices.crio.io: "/dev/fuse"
 spec:
   containers:
   - name: build-container
@@ -37,7 +37,7 @@ spec:
 +
 where:
 +
-`metadata.annotations`:: Specifies that the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation makes the FUSE device available.
+`metadata.annotations`:: Specifies that the `devices.crio.io: "/dev/fuse"` annotation makes the FUSE device available.
 `spec.containers.image`:: Specifies a container that uses an image that includes `podman` (for example, `quay.io/podman/stable`).
 `spec.containers.args`:: Specifies a command to keep the container running so you can `exec` into it.
 `spec.containers.securityContext`:: Specifies a `securityContext` that runs the container as an unprivileged user (for example, `runAsUser: 1000`).


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-113999

Waiting on https://github.com/openshift/machine-config-operator/pull/6342 to merge.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

