### PR TITLE
OCPBUGS-113533: Added iLO7 to Firmware requirements for installing wi…

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -20,6 +20,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 [cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
+| 12th Generation | iLO7 | 1.23 or later
 | 11th Generation | iLO6 | 1.57 or later
 | 10th Generation | iLO5 | 2.63 or later
 


### PR DESCRIPTION

Version(s):
4.22+

Issue:
[OCPBUGS-113533](https://redhat.atlassian.net/browse/OCPBUGS-113533)

Link to docs preview:
* [Firmware requirements for installing with virtual media](https://118903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites)

- [x] SME has approved this change (Riccardo Pittau).
