### PR TITLE
[enterprise-4.21][OCPBUGS-112344]: Clarifying IBM Z and IBM Power info in HCP support matrix

### DIFF
--- a/modules/hcp-support-matrix.adoc
+++ b/modules/hcp-support-matrix.adoc
@@ -129,10 +129,7 @@ The following table indicates which {product-title} versions are supported for e
 
 [IMPORTANT]
 ====
-For {ibm-power-title} and {ibm-z-title}:
-
-* You must run the control plane on machine types that are based on 64-bit x86 architecture or s390x architecture
-* You must run node pools on {ibm-power-title} or {ibm-z-title}
+For {hcp} on {ibm-power-title} or {ibm-z-title}, the control plane must run on either 64_bit x86 architecture or s390x architecture. Node pools must run on either {ibm-power-title} or {ibm-z-title}. No other combinations are supported.
 ====
 
 In the following table, the management cluster version is the {product-title} version where the {mce-short} is enabled:
@@ -212,24 +209,9 @@ The following tables indicate the supported architectures for {hcp}, organized b
 |ARM64
 |4.21
 
-|Non-bare-metal Agent machines (Technology Preview)
-|64-bit x86
-|64-bit x86
-|4.16 - 4.21
-
-|{ibm-power-title}
-|64-bit x86
-|64-bit x86
-|4.19 - 4.21
-
 |{ibm-power-title}
 |64-bit x86
 |ppc64le
-|4.17 - 4.21
-
-|{ibm-z-title}
-|64-bit x86
-|64-bit x86
 |4.17 - 4.21
 
 |{ibm-z-title}
@@ -241,6 +223,11 @@ The following tables indicate the supported architectures for {hcp}, organized b
 |s390x
 |s390x
 |4.20 - 4.21
+
+|Non-bare-metal Agent machines (Technology Preview)
+|64-bit x86
+|64-bit x86
+|4.16 - 4.21
 
 |{VirtProductName}
 |64-bit x86


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/118821