### PR TITLE
[enterprise-4.20][OCPBUGS-112344]: Clarifying IBM Z and IBM Power info in HCP support matrix

### DIFF
--- a/modules/hcp-support-matrix.adoc
+++ b/modules/hcp-support-matrix.adoc
@@ -112,10 +112,7 @@ The following table indicates which {product-title} versions are supported for e
 
 [IMPORTANT]
 ====
-For {ibm-power-title} and {ibm-z-title}:
-
-* You must run the control plane on machine types that are based on 64-bit x86 architecture or s390x architecture
-* You must run node pools on {ibm-power-title} or {ibm-z-title}
+For {hcp} on {ibm-power-title} or {ibm-z-title}, the control plane must run on either 64_bit x86 architecture or s390x architecture. Node pools must run on either {ibm-power-title} or {ibm-z-title}. No other combinations are supported.
 ====
 
 In the following table, the management cluster version is the {product-title} version where the {mce-short} is enabled:
@@ -157,153 +154,67 @@ In the following table, the management cluster version is the {product-title} ve
 [id="hcp-matrix-multiarch_{context}"]
 == Multi-architecture support
 
-The following tables indicate the support status for {hcp} on multiple architectures, organized by platform.
+The following table indicates the supported architectures for {hcp}, organized by platform. If an architecture is not listed, it is not yet fully supported.
 
-.Multi-architecture support for {hcp} on {aws-short}
-[cols="3",options="header"]
+.Multi-architecture support for {hcp}
+[cols="4",options="header"]
 |===
-|{product-title} version |Control planes |Compute nodes
+|Platform |Control planes |Compute nodes |{product-title} version
 
-|4.17 - 4.20
-a|* 64-bit x86: General Availability
-* ARM64: General Availability
-a|* ARM64: General Availability
-* 64-bit x86: General Availability
+|{aws-short}
+|64-bit x86
+|64-bit x86
+|4.14, 4.16, 4.18 - 4.20
 
-|4.14 - 4.16
-a|* 64-bit x86: General Availability
-* ARM64: Technology Preview
-a|* 64-bit x86: General Availability
-* ARM64: General Availability
+|{aws-short}
+|64-bit x86
+|ARM64
+|4.18 - 4.20
 
-|===
+|{aws-short}
+|ARM64
+|ARM64
+|4.18 - 4.20
 
-.Multi-architecture support for {hcp} on bare metal (Agent)
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
+|{aws-short}
+|ARM64
+|64-bit x86
+|4.18 - 4.20
 
-|4.14 - 4.20
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Technology Preview
+|Bare metal (Agent platform)
+|64-bit x86
+|64-bit x86
+|4.14, 4.16, 4.18 - 4.20
 
-|===
+|{ibm-power-title}
+|64-bit x86
+|ppc64le
+|4.18 - 4.20
 
-.Multi-architecture support for {hcp} on non-bare-metal agent machines
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
+|{ibm-z-title}
+|64-bit x86
+|s390x
+|4.18 - 4.20
 
-|4.17 - 4.20
-a|* 64-bit x86: Technology Preview
-* ARM64: Not available
-a|* 64-bit x86: Technology Preview
-* ARM64: Not available
-
-|===
-
-.Multi-architecture support for {hcp} on {ibm-power-title}
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
-
+|{ibm-z-title}
+|s390x
+|s390x
 |4.20
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
 
-|4.19
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
+|Non-bare metal Agent machines (Technology Preview)
+|64-bit x86
+|64-bit x86
+|4.16, 4.18 - 4.20
 
-|4.18
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: Not available
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
+|{VirtProductName}
+|64-bit x86
+|64-bit x86
+|4.14, 4.16, 4.18 - 4.20
 
-|4.17
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: Not available
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
-|===
-
-.Multi-architecture support for {hcp} on {ibm-z-title}
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
-
-|4.20
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-
-|4.19
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-
-|4.18
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-* ppc64le: Not available
-
-|4.17
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-* ppc64le: Not available
-|===
-
-.Multi-architecture support for {hcp} on {VirtProductName}
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
-
-|4.16 - 4.20
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
+|{rh-openstack-first} (Technology Preview)
+|64-bit x86
+|64-bit x86
+|4.19 - 4.20
 
 |===
 


### PR DESCRIPTION
cherrypicked from https://github.com/openshift/openshift-docs/pull/118821