### PR TITLE
[enterprise-4.19][OCPBUGS-112344]: Clarifying IBM Z and IBM Power info in HCP support matrix

### DIFF
--- a/modules/hcp-support-matrix.adoc
+++ b/modules/hcp-support-matrix.adoc
@@ -125,7 +125,7 @@ The following table indicates which {product-title} versions are supported for e
 
 [IMPORTANT]
 ====
-For {ibm-power-title} and {ibm-z-title}, you must run the control plane on machine types based on 64-bit x86 architecture, and node pools on {ibm-power-title} or {ibm-z-title}.
+For {hcp} on {ibm-power-title} or {ibm-z-title}, the control plane must run on 64_bit x86 architecture. Node pools must run on either {ibm-power-title} or {ibm-z-title}. No other combinations are supported.
 ====
 
 In the following table, the management cluster version is the {product-title} version where the {mce-short} is enabled:
@@ -167,185 +167,62 @@ In the following table, the management cluster version is the {product-title} ve
 [id="hcp-matrix-multiarch_{context}"]
 == Multi-architecture support
 
-The following tables indicate the support status for {hcp} on multiple architectures, organized by platform.
+The following table indicates the supported architectures for {hcp}, organized by platform. If an architecture is not listed, it is not yet fully supported.
 
-.Multi-architecture support for {hcp} on {aws-short}
-[cols="3",options="header"]
+.Multi-architecture support for {hcp}
+[cols="4",options="header"]
 |===
-|{product-title} version |ARM64 control planes |ARM64 compute nodes
+|Platform |Control planes |Compute nodes |{product-title} version
 
+|{aws-short}
+|64-bit x86
+|64-bit x86
+|4.14 - 4.19
+
+|{aws-short}
+|64-bit x86
+|ARM64
+|4.17 - 4.19
+
+|{aws-short}
+|ARM64
+|ARM64
+|4.17 - 4.19
+
+|{aws-short}
+|ARM64
+|64-bit x86
+|4.17 - 4.19
+
+|Bare metal (Agent platform)
+|64-bit x86
+|64-bit x86
+|4.14 - 4.19
+
+|{ibm-power-title}
+|64-bit x86
+|ppc64le
+|4.17 - 4.19
+
+|{ibm-z-title}
+|64-bit x86
+|s390x
+|4.17 - 4.19
+
+|Non-bare metal Agent machines (Technology Preview)
+|64-bit x86
+|64-bit x86
+|4.16 - 4.19
+
+|{VirtProductName}
+|64-bit x86
+|64-bit x86
+|4.14 - 4.19
+
+|{rh-openstack-first} (Technology Preview)
+|64-bit x86
+|64-bit x86
 |4.19
-|General Availability
-|General Availability
-
-|4.18
-|General Availability
-|General Availability
-
-|4.17
-|General Availability
-|General Availability
-
-|4.16
-|Technology Preview
-|General Availability
-
-|4.15
-|Technology Preview
-|General Availability
-
-|4.14
-|Technology Preview
-|General Availability
-|===
-
-.Multi-architecture support for {hcp} on bare metal
-[cols="3",options="header"]
-|===
-|{product-title} version |ARM64 control planes |ARM64 compute nodes
-
-|4.19
-|Not available
-|Technology Preview
-
-|4.18
-|Not available
-|Technology Preview
-
-|4.17
-|Not available
-|Technology Preview
-
-|4.16
-|Not available
-|Technology Preview
-
-|4.15
-|Not available
-|Technology Preview
-
-|4.14
-|Not available
-|Technology Preview
-|===
-
-.Multi-architecture support for {hcp} on non-bare-metal agent machines
-[cols="3",options="header"]
-|===
-|{product-title} version |ARM64 control planes |ARM64 compute nodes
-
-|4.19
-|Not available
-|Not available
-
-|4.18
-|Not available
-|Not available
-
-|4.17
-|Not available
-|Not available
-|===
-
-.Multi-architecture support for {hcp} on {ibm-power-title}
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
-
-|4.19
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
-
-|4.18
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: Not available
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
-
-|4.17
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: Not available
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: General Availability
-|===
-
-.Multi-architecture support for {hcp} on {ibm-z-title}
-[cols="3",options="header"]
-|===
-|{product-title} version |Control planes |Compute nodes
-
-|4.19
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-
-|4.18
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-* ppc64le: Not available
-
-|4.17
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: Not available
-* ppc64le: Not available
-a|* 64-bit x86: General Availability
-* ARM64: Not available
-* s390x: General Availability
-* ppc64le: Not available
-|===
-
-.Multi-architecture support for {hcp} on {VirtProductName}
-[cols="3",options="header"]
-|===
-|{product-title} version |ARM64 control planes |ARM64 compute nodes
-
-|4.19
-|Not available
-|Not available
-
-|4.18
-|Not available
-|Not available
-
-|4.17
-|Not available
-|Not available
-
-|4.16
-|Not available
-|Not available
-
-|4.15
-|Not available
-|Not available
-
-|4.14
-|Not available
-|Not available
 
 |===
 


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/118821
