### PR TITLE
OCPBUGS-112633: Clarified values in nw-cluster-mtu-preparing.adoc

### DIFF
--- a/modules/nw-cluster-mtu-preparing.adoc
+++ b/modules/nw-cluster-mtu-preparing.adoc
@@ -55,7 +55,16 @@ ethernet.mtu=<mtu>
 --
 where:
 
-`<interface>`:: Specifies the primary network interface name.
+`<interface>`:: Specifies the primary network interface name or the bond if using bonding.
++
+[IMPORTANT]
+====
+Observe the following constraints when specifying the interface:
+
+* Do not specify subordinate interfaces of a bond, such as `eth0` or `eth1`. Subordinate interfaces automatically inherit the MTU value set on the parent bond.
+* The MTU of the VLAN interface cannot exceed the MTU of its parent physical or bonded interface. A parent interface with a larger MTU, such as `9000` for jumbo frames, can host VLANs with smaller MTUs, such as `1500`. However, raising the MTU of a VLAN interface beyond the MTU parent interface current limit requires updating the parent interface first.
+====
++
 `<mtu>`:: Specifies the new hardware MTU value.
 --
 +


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-112633](https://redhat.atlassian.net/browse/OCPBUGS-112633)

Link to docs preview:

* [Preparing your hardware MTU configuration](https://118921--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu.html#nw-cluster-mtu-preparing_changing-cluster-network-mtu)

- [x] SME has approved this change (Ben Nemec).
- [x] QE has approved this change (Ross B.).
- [X] Reporter has approved this change (Will Russell)

