### PR TITLE
[OSDOCS#20676]: Added new content for Automatic tainting in TNF

### DIFF
--- a/installing/installing_two_node_cluster/installing_tnf/operating-a-degraded-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/operating-a-degraded-tnf.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="operating-a-degraded-tnf"]
 = Operating a degraded two-node OpenShift cluster with fencing
+include::_attributes/common-attributes.adoc[]
 :context: operating-a-degraded-tnf
 
 toc::[]
 
 [role="_abstract"]
-A two-node OpenShift cluster with fencing (TNF) enters a `degraded` state when one of its two control plane nodes becomes unavailable. The remaining node continues to host the active control plane; however, the cluster loses its high-availability (HA) redundancy until the failed node recovers.
+A two-node {product-title} cluster with fencing (TNF) enters a `degraded` state when one of its two control plane nodes becomes unavailable. The remaining node continues to host the active control plane. However, the cluster loses its high-availability (HA) redundancy until the failed node recovers.
 
 Degraded operation is an intentional design state rather than a system failure. In this state, the cluster remains functional and core services continue to operate. Only specific capabilities that strictly require two-node redundancy are temporarily unavailable.
 
@@ -20,6 +21,8 @@ include::modules/tnf-cluster-degradation-causes.adoc[leveloffset=+1]
 include::modules/node-failure-sequence-in-a-tnf-cluster.adoc[leveloffset=+1]
 
 include::modules/pacemaker-and-fencing-behavior-during-degraded-operation.adoc[leveloffset=+1]
+
+include::modules/automatic-node-tainting-tnf.adoc[leveloffset=+1]
 
 include::modules/cluster-operator-stability-during-degraded-operation.adoc[leveloffset=+1]
 

--- a/modules/automatic-node-tainting-tnf.adoc
+++ b/modules/automatic-node-tainting-tnf.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+// * installing_tnf/operating-a-degraded-tnf.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="automatic-node-tainting-tnf_{context}"]
+= Automatic node tainting in a two-node OpenShift cluster with fencing
+
+[role="_abstract"]
+In a two-node {product-title} cluster with fencing (TNF) your applications recover quickly from node failures without manual intervention by using the automatic node tainting mechanism. 
+
+When a node fails, the automatic tainting mechanism immediately evicts workloads to the surviving node, reducing failover time significantly. 
+
+This mechanism is built into the deployment, requires no configuration, cannot be disabled, and applies exclusively to control plane nodes in a two-node topology.
+
+You do not need to take any action for this automation to run. However, you can observe its activity during a fencing event. You can view the applied taint and annotation immediately after a node is fenced by running the following command:
+
+[source,terminal]
+----
+$ oc get node <node_name>
+----
+
+Persistent volumes and Deployment pods become eligible for rescheduling much sooner than they would normally. 
+
+You can inspect the local logs on each control plane node by using the `journalctl` tool by filtering for the following tags:
+
+* `taint-fenced-node`
+* `untaint-fenced-node`
+* `tnf-taint-alert`
+* `tnf-untaint-alert`.  


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20676

Link to docs preview:
https://118922--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/operating-a-degraded-tnf#automatic-node-tainting-tnf_operating-a-degraded-tnf

QE review:
- [x] QE has approved this change.


Additional information:

