### PR TITLE
OCPBUGS-114406: Fix disable typo in etcd restore

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -65,7 +65,7 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 If you do not complete this step, you cannot access the control plane hosts to complete the restore procedure, and you cannot recover your cluster from this state.
 ====
 
-. Using SSH, connect to each control plane node to disbale etcd by running the following command:
+. Using SSH, connect to each control plane node to disable etcd by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-114406

Link to docs preview:

QE review:
- [ ] QE has approved this change.

N/A — spelling only; does not change the meaning of the procedure.

Additional information:

CQA rewrite in openshift-docs#117133 misspelled "disable" as "disbale" in the multi-node etcd restore procedure. The command on the next line is already `$ sudo -E /usr/local/bin/disable-etcd.sh`. This PR only corrects that one word.

Fix: `modules/dr-restoring-cluster-state.adoc` — correct typo.