### PR TITLE
OCPBUGS-104214: Fix etcd restore intro on node recreation

### DIFF
--- a/modules/manually-restoring-cluster-etcd-backup.adoc
+++ b/modules/manually-restoring-cluster-etcd-backup.adoc
@@ -8,13 +8,12 @@
 = Restoring a cluster manually from an etcd backup
 
 [role="_abstract"]
-Manually restore your cluster from an etcd backup by starting a three-member etcd cluster on existing control plane nodes, without re-creating nodes as required by the standard restore procedure.
+Manually restore your cluster from an etcd backup by starting a three-member etcd cluster on existing control plane nodes.
 
-The restore procedure described in the section "Restoring to an earlier cluster state": 
+The restore procedure described in the section "Restoring to an earlier cluster state":
 
-* Requires the complete recreation of 2 control plane nodes, which might be a complex procedure for clusters installed with the UPI installation method, since an UPI installation does not create any `Machine` or `ControlPlaneMachineset` for the control plane nodes.
-
-* Uses the script /usr/local/bin/cluster-restore.sh, which starts a new single-member etcd cluster and then scales it to three members. 
+* Uses `disable-etcd.sh` on control plane nodes and `/usr/local/bin/cluster-restore.sh` on the recovery host. Recreating non-recovery control plane machines is optional, not required.
+* Starts a new single-member etcd cluster and then scales it to three members.
 
 In contrast, this procedure:
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-104214

Link to docs preview:

QE review:
- [ ] QE has approved this change.

N/A — removes incorrect statement; aligns intro with current 4.18+ restore procedure.

Additional information:

The manual etcd restore procedure introduction incorrectly claims the standard restore requires recreating two control plane nodes. Recreating nodes is optional since OpenShift 4.18.

Fix: `modules/manually-restoring-cluster-etcd-backup.adoc` — update intro text.