### PR TITLE
OSDOCS-21804: Document that disconnected 4.22 installs require oc-mirror v2 for release image signatures

### DIFF
--- a/disconnected/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/about-installing-oc-mirror-v2.adoc
@@ -111,6 +111,13 @@ include::modules/oc-mirror-proxy-support.adoc[leveloffset=+1]
 * xref:../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[Updating a cluster in a disconnected environment using the OpenShift Update Service]
 * xref:../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-v2-procedure-garbage-collector_about-installing-oc-mirror-v2[Resolving storage cleanup issues in the distribution registry]
 
+include::modules/installing-mirroring-release-signatures-con.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-using[Manage secure signatures with sigstore]
+
 //signature mirroring
 include::modules/oc-mirror-signature-mirroring.adoc[leveloffset=+1]
 

--- a/disconnected/index.adoc
+++ b/disconnected/index.adoc
@@ -10,3 +10,11 @@ toc::[]
 As a cluster administrator, you can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content.
 
 include::modules/installing-mirroring-disconnected-con.adoc[leveloffset=+1]
+
+include::modules/installing-mirroring-release-signatures-con.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-using[Manage secure signatures with sigstore]

--- a/disconnected/installing-mirroring-installation-images.adoc
+++ b/disconnected/installing-mirroring-installation-images.adoc
@@ -16,7 +16,7 @@ By using the `oc adm` command, you can mirror release and catalog images in Open
 [IMPORTANT]
 ====
 * The `oc adm release mirror` command is deprecated as of {product-title} 4.22 and will be removed in a future release.
-As an alternative, use the oc-mirror plugin v2.
+This command does not mirror sigstore signatures for release images. Starting in {product-title} 4.22, cluster nodes require those signatures during first boot. Use the oc-mirror plugin v2, which mirrors signatures by default.
 
 * You must have access to the internet to obtain the necessary container images.
 In this procedure, you place your mirror registry on a mirror host
@@ -24,10 +24,13 @@ that has access to both your network and the internet. If you do not have access
 to a mirror host, use the "Mirroring Operator catalogs for use with disconnected clusters" procedure to copy images to a device you can move across network boundaries with.
 ====
 
-[NOTE]
-====
-When using the `oc adm release mirror` command, release image signatures are not automatically mirrored to the disconnected registry. Missing release signatures prevent cluster upgrades, as `ClusterImagePolicy` requires all release images to be verified. To ensure image signatures are correctly mirrored, it is recommended to use the oc-mirror v2 plugin.
-====
+include::modules/installing-mirroring-release-signatures-con.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-using[Manage secure signatures with sigstore]
 
 // TODO: Is this procedure going to be marked deprecated for 4.10 so that it could be removed in the future?
 // TODO: Add a link to the TP procedure?

--- a/modules/installing-mirroring-disconnected-con.adoc
+++ b/modules/installing-mirroring-disconnected-con.adoc
@@ -13,6 +13,6 @@ Consider the following options for creating and using a mirror registry:
 
 * If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you must create one.
 
-* After you establish your registry, you need mirroring tools. To mirror your {product-title} image repository to the mirror registry in your disconnected environment, you can use the oc-mirror {oc-first} plugin. The oc-mirror plugin is a single tool that mirrors all required {product-title} content and other images to your mirror registry. The oc-mirror plugin is the preferred method for mirroring.
+* After you establish your registry, you need mirroring tools. Use the oc-mirror {oc-first} plugin v2 to mirror your {product-title} image repository to the mirror registry in your disconnected environment. The oc-mirror plugin v2 mirrors all required {product-title} content, including sigstore signatures for release images. Starting in {product-title} 4.22, cluster nodes require those signatures during installation.
 
-* Alternately, you can use the `oc adm` command to mirror just release and catalog images for {product-title}.
+* The `oc adm release mirror` command is deprecated as of {product-title} 4.22. That command does not mirror sigstore signatures, so it cannot complete a disconnected installation that uses the default cluster image policy.

--- a/modules/installing-mirroring-release-signatures-con.adoc
+++ b/modules/installing-mirroring-release-signatures-con.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * disconnected/index.adoc
+// * disconnected/installing-mirroring-installation-images.adoc
+// * disconnected/about-installing-oc-mirror-v2.adoc
+// * nodes/nodes-sigstore-using.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-mirroring-release-signatures_{context}"]
+= Release image signatures for disconnected installations
+
+[role="_abstract"]
+Starting in {product-title} 4.22, cluster nodes enforce sigstore signature verification for {product-title} release images. In a disconnected environment, those signatures must exist in your mirror registry before you install the cluster. If the signatures are missing, control plane nodes boot but never pull release images, and the installation cannot complete.
+
+{product-title} applies a default `ClusterImagePolicy` object named `openshift` to cluster nodes. That policy writes `sigstoreSigned` entries into `/etc/containers/policy.json` for the following repositories:
+
+* `quay.io/openshift-release-dev/ocp-release`
+* `quay.io/openshift-release-dev/ocp-v4.0-art-dev`
+* `quay.io/openshift-release-dev/ocp-v5.0-art-dev`
+
+The bootstrap node does not receive this cluster image policy, so it can pull the same release image digest that a control plane node rejects. This difference is expected.
+
+On first boot, `machine-config-daemon-pull.service` pulls the machine-config-daemon image by using the original `quay.io` repository name, after registry mirroring in `/etc/containers/registries.conf`. The node policy is keyed on that original repository path. If the mirror does not contain sigstore signatures for the release images, the pull fails with an error similar to the following message:
+
+[source,text]
+----
+Source image rejected: A signature was required, but no signature exists
+----
+
+Until that pull succeeds, the node does not install `crio`, `kubelet`, or `crictl`, and it does not register with the API server.
+
+Use the oc-mirror plugin v2 to populate the mirror registry. In {product-title} 4.22 and later, the oc-mirror plugin v2 mirrors sigstore signatures by default. The following commands do not provide those signatures for first-boot verification:
+
+* `oc adm release mirror`. This command is deprecated as of {product-title} 4.22. It can create signature config maps for the Cluster Version Operator (CVO), but those config maps are not used by `podman` or `/etc/containers/policy.json` during first boot.
+* `oc image mirror`. This command copies image content. It does not automatically mirror the sigstore signatures that the default cluster image policy requires.
+
+There is no `install-config.yaml` parameter that disables the node `policy.json` file. Do not replace `/etc/containers/policy.json` with an `insecureAcceptAnything` policy to complete installation.
+
+You do not enable the `SigstoreImageVerification` feature gate or the `TechPreviewNoUpgrade` feature set to use the default `openshift` cluster image policy. That policy is enabled in {product-title} 4.22 and later. The feature gate applies only when you create additional custom cluster image policies.

--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -15,7 +15,7 @@ The following example shows general guidelines on how to configure a `ClusterIma
 
 [NOTE]
 ====
-The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images, which are stored in the `quay.io/openshift-release-dev/ocp-release` repository. You must not remove or modify this cluster image policy object. Cluster image policy names beginning with `openshift` are reserved for future system use.
+The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images in the `quay.io/openshift-release-dev/ocp-release`, `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, and `quay.io/openshift-release-dev/ocp-v5.0-art-dev` repositories. You must not remove or modify this cluster image policy object. Cluster image policy names beginning with `openshift` are reserved for future system use. You do not enable the `SigstoreImageVerification` feature gate to use this default policy.
 ====
 
 .Prerequisites
@@ -23,15 +23,11 @@ The default `ClusterImagePolicy` object, named `openshift`, provides sigstore su
 * You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
-* If a mirror registry is configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Otherwise, the default `openshift` cluster image policy, which enforces signature verification for the release repository, blocks the ability of the Cluster Version Operator to move the CVO pod to new nodes, preventing the node update.
+* If a mirror registry is configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release`, `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, and `quay.io/openshift-release-dev/ocp-v5.0-art-dev`, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Use the oc-mirror plugin v2, which mirrors those signatures by default. The `oc adm release mirror` and `oc image mirror` commands do not automatically mirror the signatures that the default cluster image policy requires.
 +
-You can use the `oc image mirror` command to mirror the signatures. For example:
+If the signatures are missing, first-boot image pulls on cluster nodes fail, and the Cluster Version Operator (CVO) cannot move the CVO pod to new nodes.
 +
-[source,terminal]
-----
-$ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig \
-mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
-----
+For more information, see "Release image signatures for disconnected installations" and "Mirroring images for a disconnected installation by using the oc-mirror plugin v2".
 
 .Procedure
 

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -15,7 +15,9 @@ The `ClusterImagePolicy` and `ImagePolicy` objects contain a policy that specifi
 +
 [NOTE]
 ====
-The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images in the `quay.io/openshift-release-dev/ocp-release` repository.
+The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images in the `quay.io/openshift-release-dev/ocp-release`, `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, and `quay.io/openshift-release-dev/ocp-v5.0-art-dev` repositories. Starting in {product-title} 4.22, the Machine Config Operator (MCO) applies this policy to cluster nodes, including during first boot. The bootstrap node does not receive this policy.
+
+You do not enable the `SigstoreImageVerification` feature gate or the `TechPreviewNoUpgrade` feature set to use this default policy. In a disconnected environment, you must mirror the sigstore signatures for these repositories by using the oc-mirror plugin v2. For more information, see "Release image signatures for disconnected installations".
 ====
 
 * Image policy. An image policy enables a cluster administrator or application developer to configure a sigstore signature verification policy for a specific namespace. The MCO watches an `ImagePolicy` instance in different namespaces and creates or updates the `/etc/crio/policies/<namespace>.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all nodes in the cluster.

--- a/modules/oc-mirror-signature-mirroring.adoc
+++ b/modules/oc-mirror-signature-mirroring.adoc
@@ -18,6 +18,8 @@ The oc-mirror plugin v2 manages image signature mirroring with the following beh
 
 * By default, the oc-mirror plugin v2 mirrors signatures for all images. To override this behavior, you must disable the signature mirroring.
 
+* Do not disable signature mirroring for {product-title} release images in a disconnected installation. Starting in {product-title} 4.22, cluster nodes require those signatures during first boot.
+
 * Because the certified, marketplace, and community catalogs contain third-party content, Red{nbsp}Hat does not ensure the availability or validity of their signatures. In such cases, you must disable signature mirroring.
 
 For more information on disabling signature mirroring, see "Disabling signature mirroring for oc-mirror plugin v2".

--- a/modules/pref-methods-working-discc-env.adoc
+++ b/modules/pref-methods-working-discc-env.adoc
@@ -9,13 +9,12 @@
 // Not sure about the heading above, I'm trying to find some phrasing that basically says "You should probably use these things if you don't have a strong reason to go with other options".
 [role="_abstract"]
 You can choose between multiple options for most aspects of managing a cluster in a disconnected environment.
-For example, when mirroring images you can choose between using the oc-mirror {oc-first} plugin or using the `oc adm` command.
 
 However, some options provide a simpler and more convenient user experience for disconnected environments, and are the preferred method over their alternatives.
 
 Unless your organizational needs require you to choose another option, use the following methods for mirroring images, installing your cluster, and updating your cluster:
 
-* Mirror your images using the oc-mirror plugin v2. For more information, see "Mirroring images for a disconnected installation by using the oc-mirror plugin v2".
+* Mirror your images by using the oc-mirror plugin v2. Starting in {product-title} 4.22, cluster nodes require sigstore signatures for release images during installation. The oc-mirror plugin v2 mirrors those signatures by default. The `oc adm release mirror` command does not. For more information, see "Mirroring images for a disconnected installation by using the oc-mirror plugin v2".
 
 * Install your cluster using the Agent-based Installer. For more information, see "Installing a cluster with customizations".
 

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -19,6 +19,14 @@ Sigstore is a collection of open source tools that you can use individually or t
 // Manage secure signatures with SigStore
 include::modules/nodes-sigstore-using-about.adoc[leveloffset=+1]
 
+include::modules/installing-mirroring-release-signatures-con.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+* xref:../disconnected/index.adoc#installing-mirroring-release-signatures_installing-mirroring-disconnected-about[Release image signatures for disconnected installations]
+
 include::modules/nodes-sigstore-configure.adoc[leveloffset=+1]
 
 include::modules/nodes-sigstore-configure-cluster-policy.adoc[leveloffset=+1]
@@ -33,3 +41,4 @@ include::modules/nodes-sigstore-configure-image-policy.adoc[leveloffset=+1]
 * link:https://docs.sigstore.dev/logging/overview/[Rekor verification in the Sigstore documentation]
 * link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair (Sigstore documentation)]
 * xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
+* xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]

--- a/snippets/oc-adm-release-mirror-depr.adoc
+++ b/snippets/oc-adm-release-mirror-depr.adoc
@@ -15,5 +15,5 @@
 ====
 The `oc adm release mirror` command is deprecated as of {product-title} 4.22 and will be removed in a future release.
 
-As an alternative, use the oc-mirror plugin v2.
+This command does not mirror sigstore signatures for release images. Starting in {product-title} 4.22, cluster nodes require those signatures during first boot. Use the oc-mirror plugin v2, which mirrors signatures by default.
 ====


### PR DESCRIPTION
## Summary
- Documents that OpenShift 4.22 applies a default `ClusterImagePolicy` (`openshift`) to cluster nodes (not bootstrap), which writes `sigstoreSigned` into `/etc/containers/policy.json` and is enforced at first boot by `machine-config-daemon-pull.service`.
- States that `oc adm release mirror` and `oc image mirror` do not provide those signatures for first-boot verification, so disconnected installs must use oc-mirror plugin v2 (signatures mirrored by default).
- Clarifies that CVO signature config maps, `install-config.yaml`, overwriting `policy.json`, and the `SigstoreImageVerification` TechPreview feature gate are not the supported path.

Fixes https://issues.redhat.com/browse/OSDOCS-21804
Related: https://issues.redhat.com/browse/OCPBUGS-82580

## Test plan
- [ ] Preview **About disconnected installation mirroring** and **Mirroring images for a disconnected installation by using the oc adm command** for the new first-boot signature section.
- [ ] Preview **Mirroring images for a disconnected installation by using the oc-mirror plugin v2** and **Manage secure signatures with sigstore**.
- [ ] Confirm the `oc adm release mirror` deprecation snippet now mentions missing signatures at first boot.
- [ ] Confirm the former `oc image mirror` signature example was removed from the cluster image policy procedure.


Made with [Cursor](https://cursor.com)