### PR TITLE
OSDOCS-20054: Remove invalid amd_iommu=on kernel argument

### DIFF
--- a/modules/virt-adding-kernel-arguments-enable-iommu.adoc
+++ b/modules/virt-adding-kernel-arguments-enable-iommu.adoc
@@ -44,8 +44,15 @@ spec:
 # ...
 ----
 ** `metadata.labels.machineconfiguration.openshift.io/role` specifies that the new kernel argument is applied only to worker nodes.
-** `metadata.name` specifies the ranking of this kernel argument (100) among the machine configs and its purpose. If you have an AMD CPU, specify the kernel argument as `amd_iommu=on`.
-** `spec.kernelArguments` specifies the kernel argument as `intel_iommu` for an Intel CPU.
+** `metadata.name` specifies the ranking of this kernel argument (100) among the machine configs and its purpose.
+** `spec.kernelArguments` specifies the kernel argument as `intel_iommu=on` for an Intel CPU.
++
+[NOTE]
+====
+Do not specify `amd_iommu=on`. That value is not valid for the AMD IOMMU driver. The kernel ignores it and logs `AMD-Vi: Unknown option - 'on'`.
+On AMD CPUs, IOMMU is enabled by default when AMD-Vi is enabled in the BIOS. You do not need an `amd_iommu=` kernel argument unless you require a supported option such as `off` or `force_enable`.
+For PCI passthrough, you can optionally add `iommu=pt` to reduce DMA overhead.
+====
 
 . Create the new `MachineConfig` object:
 +


### PR DESCRIPTION
## Summary
- Removes the incorrect instruction to set `amd_iommu=on` in the IOMMU MachineConfig procedure.
- Clarifies that AMD IOMMU is enabled by default when AMD-Vi is enabled in BIOS; `intel_iommu=on` remains valid for Intel.
- Updates `modules/virt-adding-kernel-arguments-enable-iommu.adoc` (used by PCI passthrough and vGPU).
Jira: https://issues.redhat.com/browse/OSDOCS-20054
## Cherry-picks
Please cherry-pick to: enterprise-4.16, enterprise-4.17, enterprise-4.18, enterprise-4.19, enterprise-4.20, enterprise-4.21, enterprise-4.22
## Test plan
- [ ] Preview the PCI passthrough and vGPU assemblies
- [ ] Confirm the Intel example still uses `intel_iommu=on`
- [ ] Confirm this module no longer recommends `amd_iommu=on`
- [ ] SME review of optional `iommu=pt` wording