### PR TITLE
OCPBUGS-114406: Fixed typo in Restoring to an earlier cluster state f…

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -65,7 +65,7 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 If you do not complete this step, you cannot access the control plane hosts to complete the restore procedure, and you cannot recover your cluster from this state.
 ====
 
-. Using SSH, connect to each control plane node to disbale etcd by running the following command:
+. Using SSH, connect to each control plane node to disable etcd by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OCPBUGS-114406](https://redhat.atlassian.net/browse/OCPBUGS-114406)

Link to docs preview:

* https://118948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.html
* https://118948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html
* https://118948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html
* https://118948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html


