### PR TITLE
OSDOCS-16991#Replacing 'Amazon Web Services (AWS)' titles with 'AWS'

### DIFF
--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-upload-custom-rhcos-ami_{context}"]
-= Uploading a custom {op-system} AMI in {aws-first}
+= Uploading a custom {op-system} AMI in {aws-short}
 
 [role="_abstract"]
 If you are deploying to a custom {aws-short} region, you must

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-user-infra-bootstrap_{context}"]
-= Initializing the bootstrap sequence on {aws-first} with user-provisioned infrastructure
+= Initializing the bootstrap sequence on {aws-short} with user-provisioned infrastructure
 
 [role="_abstract"]
 After creating all required infrastructure in {aws-short}, you can start the bootstrap sequence that initializes the {product-title} control plane. Run the installation program to monitor the bootstrap process until the control plane is ready.

--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-user-infra-installation_{context}"]
-= Completing an {aws-first} installation on user-provisioned infrastructure
+= Completing an {aws-short} installation on user-provisioned infrastructure
 
 [role="_abstract"]
 To finish installing {product-title} on user-provisioned {aws-short} infrastructure, monitor the deployment until it completes successfully.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16991 

Link to docs preview:
[Uploading a custom RHCOS AMI in AWS](https://118957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-specialized-region.html#installation-aws-upload-custom-rhcos-ami_installing-aws-specialized-region)
[Initializing the bootstrap sequence on AWS with user-provisioned infrastructure](https://118957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-bootstrap_installing-aws-user-infra)
[Completing an AWS installation on user-provisioned infrastructure](https://118957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-installation_installing-aws-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Changing module titles to read 'AWS', not 'Amazon Web Services (AWS)', etc. 