### PR TITLE
OSDOCS-16990: AWS IPI CQA pt 13

### DIFF
--- a/modules/installation-aws-security-groups.adoc
+++ b/modules/installation-aws-security-groups.adoc
@@ -16,6 +16,7 @@ endif::[]
 [id="installation-aws-security-groups_{context}"]
 = Optional: AWS security groups
 
+[role="_abstract"]
 By default, the installation program creates and attaches security groups to control plane and compute machines. The rules associated with the default security groups cannot be modified.
 
 However, you can apply additional existing AWS security groups, which are associated with your existing VPC, to control plane and compute machines. Applying custom security groups can help you meet the security needs of your organization, in such cases where you need to control the incoming or outgoing traffic of these machines.


### PR DESCRIPTION
[OSDOCS-16990](https://redhat.atlassian.net/browse/OSDOCS-16990)

Version(s): 4.20 and 4.21 only

A single CQA fix for AWS IPI that applies only to 4.20 and 4.21

QE review: Not required for formatting changes