### PR TITLE
[OCPBUGS#48588]: SCC and PSA steps for applying SELinux profiles

### DIFF
--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -133,11 +133,57 @@ ifdef::selinux[]
 $ oc label ns nginx-deploy security.openshift.io/scc.podSecurityLabelSync=false
 ----
 
-. Apply the `privileged` label to the `nginx-deploy` namespace by running the following command:
+. Apply the `privileged` Pod Security labels to the `nginx-deploy` namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc label ns nginx-deploy --overwrite=true pod-security.kubernetes.io/enforce=privileged
+$ oc label ns nginx-deploy --overwrite \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged
+----
++
+If you set only `enforce`, `warn` and `audit` stay `restricted`. Creating a pod with a custom SELinux type then returns a Pod Security warning.
+
+. Create a service account for the workload. A custom SELinux type needs an SCC with `seLinuxContext: RunAsAny`. The `edit` role is not enough; `restricted-v2` rejects `seLinuxOptions.type`.
++
+[source,terminal]
+----
+$ oc create sa spo-deploy-test -n nginx-deploy
+----
+
+. Allow that service account to use the `privileged` SCC:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spo-nginx
+  namespace: nginx-deploy
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spo-nginx
+  namespace: nginx-deploy
+subjects:
+- kind: ServiceAccount
+  name: spo-deploy-test
+  namespace: nginx-deploy
+roleRef:
+  kind: Role
+  name: spo-nginx
+  apiGroup: rbac.authorization.k8s.io
 ----
 
 . Obtain the SELinux profile usage string by running the following command:
@@ -153,7 +199,7 @@ $ oc get selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure -ojsonp
 nginx-secure.process
 ----
 
-. Apply the output string in the workload manifest in the `.spec.containers[].securityContext.seLinuxOptions` attribute:
+. Create a pod that uses the service account and the usage string in `.spec.containers[].securityContext.seLinuxOptions`:
 +
 [source,yaml]
 ----
@@ -163,6 +209,7 @@ metadata:
   name: nginx-secure
   namespace: nginx-deploy
 spec:
+  serviceAccountName: spo-deploy-test
   securityContext:
     runAsNonRoot: true
     seccompProfile:
@@ -175,14 +222,26 @@ spec:
         capabilities:
           drop: [ALL]
         seLinuxOptions:
-          # NOTE: This uses an appropriate SELinux type
-          type: nginx-secure.process
+          type: nginx-secure.process <1>
+----
+<1> Use the value from `status.usage`. The type must exist before you create the pod.
+
+.Verification
+
+* Confirm the container is running with the profile:
++
+[source,terminal]
+----
+$ oc exec -n nginx-deploy nginx-secure -- cat /proc/self/attr/current
 ----
 +
-[IMPORTANT]
-====
-The SELinux `type` must exist before creating the workload.
-====
+.Example output
+[source,terminal]
+----
+system_u:system_r:nginx-secure.process:s0:c160,c578
+----
++
+The type in the output must match `status.usage`.
 endif::[]
 
 ifeval::["{context}" == "spo-seccomp"]

--- a/modules/spo-create-selinux-profile.adoc
+++ b/modules/spo-create-selinux-profile.adoc
@@ -24,6 +24,8 @@ The `SelinuxProfile` object has several features that allow for better security 
 ----
 $ oc new-project nginx-deploy
 ----
++
+`SelinuxProfile` objects are cluster-scoped. Do not set `metadata.namespace` on the custom resource.
 
 . Create a policy that can be used with a non-privileged workload by creating the following `SelinuxProfile` object:
 +


### PR DESCRIPTION
Version(s):
4.17 and later (reproduced on 4.19 / SPO 0.10.0). Please cherry-pick to enterprise-4.17+ if this looks ok.

Issue:
https://issues.redhat.com/browse/OCPBUGS-48588

Additional information:

Followed the applying-profiles section on 4.19 with SPO v0.10.0. SelinuxProfile is cluster-scoped (`NAMESPACED=false`).

**Profile**

```
$ oc apply -f selinuxprofile.yaml
selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure created

$ oc get selinuxprofile nginx-secure
NAME           USAGE                  STATE
nginx-secure   nginx-secure.process   InProgress

$ oc wait --for=condition=ready selinuxprofile nginx-secure --timeout=180s
selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure condition met

$ oc get selinuxprofile nginx-secure -o jsonpath='status={.status.status} usage={.status.usage}{"\n"}'
status=Installed usage=nginx-secure.process
```

**Docs steps (PSA enforce only), as cluster-admin**

```
$ oc label ns nginx-deploy security.openshift.io/scc.podSecurityLabelSync=false --overwrite
namespace/nginx-deploy labeled

$ oc label ns nginx-deploy pod-security.kubernetes.io/enforce=privileged --overwrite
namespace/nginx-deploy labeled

$ oc get ns nginx-deploy --show-labels
NAME           STATUS   AGE   LABELS
nginx-deploy   Active   11m   kubernetes.io/metadata.name=nginx-deploy,pod-security.kubernetes.io/audit-version=latest,pod-security.kubernetes.io/audit=restricted,pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/warn-version=latest,pod-security.kubernetes.io/warn=restricted,security.openshift.io/scc.podSecurityLabelSync=false
```

warn/audit stay `restricted`. Pod still creates, with a warning:

```
$ oc apply -f nginx-secure-pod.yaml
Warning: would violate PodSecurity "restricted:latest": seLinuxOptions (container "nginx" set forbidden securityContext.seLinuxOptions: type "nginx-secure.process")
pod/nginx-secure created

$ oc get pod nginx-secure -n nginx-deploy
NAME           READY   STATUS    RESTARTS   AGE
nginx-secure   1/1     Running   0          17s

$ oc get pod nginx-secure -n nginx-deploy -o jsonpath='scc={.metadata.annotations.openshift\.io/scc}{"\n"}seLinuxOptions={.spec.containers[0].securityContext.seLinuxOptions}{"\n"}'
scc=insights-runtime-extractor-scc
seLinuxOptions={"type":"nginx-secure.process"}

$ oc exec -n nginx-deploy nginx-secure -- cat /proc/self/attr/current
system_u:system_r:nginx-secure.process:s0:c160,c578
```

So as cluster-admin the type does apply. Admission used `insights-runtime-extractor-scc`, not something the docs mention.

**Same pod as a normal user (SA docs-test, edit only)**

```
$ oc create sa docs-test -n nginx-deploy
serviceaccount/docs-test created

$ oc adm policy add-role-to-user edit -z docs-test -n nginx-deploy
clusterrole.rbac.authorization.k8s.io/edit added: "docs-test"

$ oc apply --as=system:serviceaccount:nginx-deploy:docs-test -n nginx-deploy -f nginx-secure-pod.yaml
Error from server (Forbidden): error when creating "STDIN": pods "nginx-secure" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].seLinuxOptions.level: Invalid value: "": must be s0:c27,c14, provider restricted-v2: .containers[0].seLinuxOptions.type: Invalid value: "nginx-secure.process": must be , provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid-v2": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "insights-runtime-extractor-scc": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```

restricted-v2 will not allow `seLinuxOptions.type: nginx-secure.process`. The apply-to-pod procedure never grants an SCC with `seLinuxContext: RunAsAny`.

This PR adds the SA / SCC use steps, sets warn/audit to privileged, puts `serviceAccountName` on the example pod, adds a check of `/proc/self/attr/current`, and notes that SelinuxProfile is cluster-scoped.

Trushna Deokar



