### PR TITLE
OSDOCS-21311: ROSA Classic JTBD Maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ commercial_package
 .vale/
 !.vale/templates
 !.vale/config/vocabularies
+build/
 
 # Agent workspace
 .agent_workspace/

--- a/hosted_control_planes/hcp-import.adoc
+++ b/hosted_control_planes/hcp-import.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
+:chunk-to-content:
 include::_attributes/common-attributes.adoc[]
 [id="hcp-import"]
 = Manually importing a hosted cluster

--- a/maps/cluster-admin/cluster-admin.adoc
+++ b/maps/cluster-admin/cluster-admin.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Cluster Admin

--- a/maps/discover/discover.adoc
+++ b/maps/discover/discover.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Discover

--- a/maps/get-started/get-started.adoc
+++ b/maps/get-started/get-started.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Get started

--- a/maps/install/install.adoc
+++ b/maps/install/install.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Install

--- a/maps/jtbd_attributes.adoc
+++ b/maps/jtbd_attributes.adoc
@@ -1,0 +1,2 @@
+:_mod-docs-content-type: ATTRIBUTES
+:product-title: Red Hat Openshift Services on AWS (classic architecture)

--- a/maps/navigation.adoc
+++ b/maps/navigation.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: MAP
+
+For preview only:
+include::../_attributes/common-attributes.adoc[]
+include::../_attributes/attributes-openshift-dedicated.adoc[]
+//This needs to be removed. This is just to get the product title attributes to show.
+include::jtbd_attributes.adoc[]
+
+= Navigation
+
+include::whats-new/whats-new.adoc[leveloffset=+1]
+
+include::discover/discover.adoc[leveloffset=+1]
+
+include::get-started/get-started.adoc[leveloffset=+1]
+
+include::plan/plan.adoc[leveloffset=+1]
+
+include::install/install.adoc[leveloffset=+1]
+
+include::upgrade/upgrade.adoc[leveloffset=+1]
+
+include::cluster-admin/cluster-admin.adoc[leveloffset=+1]
+
+include::tutorials/tutorials.adoc[leveloffset=+1]
+

--- a/maps/plan/plan.adoc
+++ b/maps/plan/plan.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Plan

--- a/maps/tutorials/tutorials.adoc
+++ b/maps/tutorials/tutorials.adoc
@@ -1,0 +1,3 @@
+:_mod-docs-content-type: MAP
+
+= Tutorials

--- a/maps/upgrade/channels-and-cluster-update-options.adoc
+++ b/maps/upgrade/channels-and-cluster-update-options.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= Channels and cluster update options
+
+include::../../modules/rosa-upgrading-channels.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/deleting-a-cluster-upgrade-with-the-rosa-cli.adoc
+++ b/maps/upgrade/deleting-a-cluster-upgrade-with-the-rosa-cli.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= Deleting a cluster upgrade with the ROSA CLI
+
+include::../../modules/rosa-deleting-cluster-upgrade-cli.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/deleting-an-upgrade-with-the-openshift-cluster-manager-console.adoc
+++ b/maps/upgrade/deleting-an-upgrade-with-the-openshift-cluster-manager-console.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= Deleting an upgrade with the OpenShift Cluster Manager console
+
+include::../../modules/rosa-deleting-cluster-upgrade-ocm.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/how-upgrades-work.adoc
+++ b/maps/upgrade/how-upgrades-work.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= How upgrades work
+
+include::../../modules/rosa-how-upgrades-work.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/plan-cluster-upgrades.adoc
+++ b/maps/upgrade/plan-cluster-upgrades.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: MAP
+:chunk-to-content:
+
+= Plan cluster upgrades
+
+include::channels-and-cluster-update-options.adoc[leveloffset=+1,toc="no"]
+
+include::../../modules/rosa-upgrading-lifecycle-policy.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/schedule-cluster-upgrades.adoc
+++ b/maps/upgrade/schedule-cluster-upgrades.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: MAP
+:chunk-to-content:
+
+= Schedule cluster upgrades
+
+include::how-upgrades-work.adoc[leveloffset=+1,toc="no"]
+
+include::upgrading-with-rosa-cli.adoc[leveloffset=+1,toc="no"]
+
+include::upgrading-with-the-openshift-cluster-manager-console.adoc[leveloffset=+1,toc="no"]
+
+include::deleting-a-cluster-upgrade-with-the-rosa-cli.adoc[leveloffset=+1,toc="no"]
+
+include::deleting-an-upgrade-with-the-openshift-cluster-manager-console.adoc[leveloffset=+1,toc="no"]
+
+include::../../modules/rosa-sts-upgrading-a-cluster-with-sts.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/upgrade.adoc
+++ b/maps/upgrade/upgrade.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+
+= Upgrade
+
+include::plan-cluster-upgrades.adoc[leveloffset=+1]
+
+include::schedule-cluster-upgrades.adoc[leveloffset=+1]
+

--- a/maps/upgrade/upgrading-with-rosa-cli.adoc
+++ b/maps/upgrade/upgrading-with-rosa-cli.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= Upgrading with ROSA CLI
+
+include::../../modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/upgrade/upgrading-with-the-openshift-cluster-manager-console.adoc
+++ b/maps/upgrade/upgrading-with-the-openshift-cluster-manager-console.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= Upgrading with the OpenShift Cluster Manager console
+
+include::../../modules/rosa-upgrading-manual-ocm.adoc[leveloffset=+1,toc="no"]
+

--- a/maps/whats-new/whats-new.adoc
+++ b/maps/whats-new/whats-new.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+
+= What's new
+
+include::../../rosa_release_notes/rosa-release-notes.adoc[leveloffset=+1]
+

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
+:chunk-to-content:
 [id="rosa-whats-new"]
 = What's new for {product-title}
 
@@ -12,39 +13,39 @@ toc::[]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
 ifdef::openshift-rosa-hcp[]
-include::modules/rosa-release-notes-Q3-2026.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q3-2026.adoc[leveloffset=+1,toc="no"]
 endif::openshift-rosa-hcp[]
 
-include::modules/rosa-release-notes-Q2-2026.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q2-2026.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q1-2026.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q1-2026.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q4-2025.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q4-2025.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q3-2025.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q3-2025.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q2-2025.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q2-2025.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q1-2025.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q1-2025.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q4-2024.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q4-2024.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q3-2024.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q3-2024.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q2-2024.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q2-2024.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q1-2024.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q1-2024.adoc[leveloffset=+1,toc="no"]
 
 ifdef::openshift-rosa[]
-include::modules/rosa-release-notes-Q4-2023.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q4-2023.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q3-2023.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q3-2023.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q2-2023.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q2-2023.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-Q1-2023.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-Q1-2023.adoc[leveloffset=+1,toc="no"]
 endif::openshift-rosa[]
 
-include::modules/rosa-release-notes-known-issues.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-known-issues.adoc[leveloffset=+1,toc="no"]
 
-include::modules/rosa-release-notes-deprecated-removed-features.adoc[leveloffset=+1]
+include::modules/rosa-release-notes-deprecated-removed-features.adoc[leveloffset=+1,toc="no"]


### PR DESCRIPTION
Version(s):
`enterprise-4.22+`

Issue:
**[OSDOCS-21311](https://redhat.atlassian.net/browse/OSDOCS-21311)**

Link to docs preview:
Hosted preview

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR creates the core structures of the new JTBD ROSA Classic maps.

This PR uses the following map sources:
* [Upgrade](https://docs.google.com/spreadsheets/d/1H8uiD77GN_tatg4M68KXtt8px5fS8Lx80fFxuIN_9uU/edit?gid=1374357176#gid=1374357176)