### PR TITLE
OCPBUGS-114874: Document filtering oc adm top pod metrics by node

### DIFF
--- a/modules/nodes-pods-viewing-usage.adoc
+++ b/modules/nodes-pods-viewing-usage.adoc
@@ -39,3 +39,10 @@ downloads-594fcccf94-kv4p6   2m           15Mi
 ----
 $ oc adm top pod --selector='<pod_name>'
 ----
+
+. Optional: Add the `--field-selector` option to view usage statistics for pods on a specific node. This uses the existing field selector; there is no `--node` flag. For example:
++
+[source,terminal]
+----
+$ oc adm top pod -A --field-selector spec.nodeName=<node_name>
+----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-114874

Link to docs preview:

QE review:
- [ ] QE has approved this change.

N/A — documentation example only.

Additional information:

Documents filtering oc adm top pod metrics by node using the existing `--field-selector spec.nodeName=<node_name>` flag. Does not add a new `--node` flag.

Fix: add example to OpenShift viewing pod usage statistics docs.