### PR TITLE
OSDOCS-21865: fix Broken flag syntax and missing role flags in ROSA Shared VPC creation command

### DIFF
--- a/modules/rosa-hcp-sharing-vpc-cluster-creation.adoc
+++ b/modules/rosa-hcp-sharing-vpc-cluster-creation.adoc
@@ -27,5 +27,5 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_4.png[Step four of the shared 
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name <cluster_name> --sts --operator-roles-prefix <prefix> --oidc-config-id <oidc_config_id> --region us-east-1 --subnet-ids <subnet_ids> --hcp-internal-communication-hosted-zone-id <local_hosted_zone_ID> --ingress-private-hosted-zone-id <private_hosted_zone_ID> --route53-role-arn <route_53_role_arn> vpc-endpoint-role-arn <vpc_endpoint_role_arn> --base-domain <dns-domain> --additional-allowed-principals <route53-role-arn>,<vpc-endpoint-role-arn> --hosted-cp
+$ rosa create cluster --cluster-name <cluster_name> --sts --operator-roles-prefix <prefix> --oidc-config-id <oidc_config_id> --region us-east-1 --subnet-ids <subnet_ids> --hcp-internal-communication-hosted-zone-id <local_hosted_zone_ID> --ingress-private-hosted-zone-id <private_hosted_zone_ID> --route53-role-arn <route_53_role_arn> --vpc-endpoint-role-arn <vpc_endpoint_role_arn> --base-domain <dns-domain> --additional-allowed-principals <route53-role-arn>,<vpc-endpoint-role-arn> --hosted-cp --role-arn <installer-role-arn> --support-role-arn <support-role-arn> --worker-iam-role <worker-role-arn>
 ----

--- a/modules/rosa-hcp-sharing-vpc-creation-and-sharing.adoc
+++ b/modules/rosa-hcp-sharing-vpc-creation-and-sharing.adoc
@@ -87,7 +87,7 @@ The trust policy principals (`Principal.AWS`) may be scoped down to the ingress 
 [source,terminal]
 ----
 $ aws iam create-role --role-name <role_name> \
-    --assume-role-policy-document file:///tmp/vpce-role.json
+    --assume-role-policy-document file:///tmp/shared-vpc-role.json
 ----
 +
 .. Attach the AWS managed policy `ROSASharedVPCEndpointPolicy` to allow for necessary shared VPC permissions.

--- a/modules/rosa-hcp-sharing-vpc-dns-and-roles.adoc
+++ b/modules/rosa-hcp-sharing-vpc-dns-and-roles.adoc
@@ -96,13 +96,14 @@ where:
 [NOTE]
 ====
 The Installer account role and the shared VPC roles must have a one-to-one relationship. If you want to create multiple shared VPC roles, you should create one set of account roles per shared VPC role.
+Take note of the Support role ARN and Worker role ARN, since you will use them in the cluster's creation command.
 ====
 
 . After creating the Operator roles, share the _Ingress Operator Cloud Credentials_, _Installer_, and _Control plane Operator Cloud Credentials_ role ARNs with the *VPC Owner*.
 +
 The shared information resembles these examples:
 +
-* ``my-rosa-cluster.14eo.p1.openshiftapps.com``
-* ``arn:aws:iam::111122223333:role/ManagedOpenShift-Installer-Role``
-* ``arn:aws:iam::111122223333:role/my-rosa-cluster-openshift-ingress-operator-cloud-credentials``
-* ``arn:aws:iam::111122223333:role/my-rosa-cluster-control-plane-operator``
+* ``14eo.p3.openshiftapps.com``
+* ``arn:aws:iam::111122223333:role/<PREFIX>-HCP-ROSA-Installer-Role``
+* ``arn:aws:iam::111122223333:role/<PREFIX>-openshift-ingress-operator-cloud-credentials``
+* ``arn:aws:iam::111122223333:role/<PREFIX>-kube-system-control-plane-operator``

--- a/modules/rosa-hcp-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-hcp-sharing-vpc-hosted-zones.adoc
@@ -42,9 +42,9 @@ include::snippets/rosa-long-cluster-name.adoc[]
 	  "Effect": "Allow",
 	  "Principal": {
 	  	"AWS": [
-          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-ingress-operator-cloud-credentials",
-          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-hcp-Installer-Role",
-          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-control-plane-operator"
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-openshift-ingress-operator-cloud-credentials",
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-HCP-ROSA-Installer-Role",
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-kube-system-control-plane-operator"
         ]
 	  },
 	  "Action": "sts:AssumeRole"


### PR DESCRIPTION
[OSDOCS-21865](https://redhat.atlassian.net/browse/OSDOCS-21865): fix Broken flag syntax and missing role flags in ROSA Shared VPC creation command

Version(s):
4.17, 4.18, 4.19, 4.20, 4.21, 4.22

Issue:
(https://redhat.atlassian.net/browse/OSDOCS-21865)

Link to docs preview:
https://119012--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-shared-vpc-config.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
