### PR TITLE
OCPBUGS-114346: Document OIDC IdP naming restriction for group sync

### DIFF
--- a/modules/identity-provider-oidc-CR.adoc
+++ b/modules/identity-provider-oidc-CR.adoc
@@ -37,7 +37,7 @@ spec:
         - groups
       issuer: https://www.idp-issuer.com <6>
 ----
-<1> This provider name is prefixed to the value of the identity claim to form an identity name. It is also used to build the redirect URL.
+<1> This provider name is prefixed to the value of the identity claim to form an identity name. It is also used to build the redirect URL. If you configure the `groups` claim, this name is also written as a `Group` annotation key, so it must not contain spaces or other characters that are invalid in Kubernetes annotation keys. Use a name such as `oidcidp` or `AIF-Keycloak`.
 <2> Controls how mappings are established between this provider's identities and `User` objects.
 <3> The client ID of a client registered with the OpenID provider. The client must be allowed to redirect to `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>`.
 <4> A reference to an {product-title} `Secret` object containing the client secret.
@@ -89,4 +89,4 @@ spec:
 for this identity. The first non-empty claim is used.
 <5> The list of claims to use as the display name. The first non-empty claim is used.
 <6> The list of claims to use as the email address. The first non-empty claim is used.
-<7> The list of claims to use to synchronize groups from the OpenID Connect provider to {product-title} upon user login. The first non-empty claim is used.
+<7> The list of claims to use to synchronize groups from the OpenID Connect provider to {product-title} upon user login. The first non-empty claim is used. Group names from the claim must be valid Kubernetes object names. For Keycloak, disable *Full group path* on the Group Membership mapper so that group claims do not include `/`. When this claim is set, the identity provider `name` must not contain spaces.

--- a/modules/identity-provider-oidc-about.adoc
+++ b/modules/identity-provider-oidc-about.adoc
@@ -47,6 +47,15 @@ issuer.
 
 See the link:http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims[OpenID claims documentation] for more information.
 
+[IMPORTANT]
+====
+If you configure the `groups` claim to synchronize group membership from the OpenID Connect provider, the identity provider `name` must be valid as the name part of a Kubernetes annotation key. Use only alphanumeric characters, `-`, `_`, or `.`, and start and end the name with an alphanumeric character. Do not use spaces or other unsupported characters.
+
+{product-title} records the identity provider name on each synchronized `Group` object as the annotation `oauth.openshift.io/idp.<name>`. Kubernetes rejects annotation keys that contain spaces. As a result, names such as `AIF - Keycloak` or `Microsoft Entra ID` cause login to fail with `An authentication error occurred` when group synchronization is enabled. Login can succeed if you omit the `groups` claim.
+
+Use a name such as `AIF-Keycloak`. If you rename an existing identity provider, update the OpenID Connect client redirect URL so that it matches `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>`.
+====
+
 [NOTE]
 ====
 Unless your OpenID Connect identity provider supports the resource owner password credentials (ROPC) grant flow, users must get a token from `<namespace_route>/oauth/token/request` to use with command-line tools.


### PR DESCRIPTION
Fixes OCPBUGS-114346

When `openID.claims.groups` is configured, oauth-server annotates synchronized `Group` objects with `oauth.openshift.io/idp.<IdP name>`. Kubernetes annotation keys cannot contain spaces, so identity provider names such as `AIF - Keycloak` or `Microsoft Entra ID` fail login with `An authentication error occurred`.

This change documents that restriction on the OpenID Connect identity provider page, recommends a name such as `AIF-Keycloak`, and notes that the OIDC client redirect URL must be updated if the IdP is renamed.

The product defect is tracked in OCPBUGS-56908 ([oauth-server PR 252](https://github.com/openshift/oauth-server/pull/252)). This docs PR covers current shipped behavior (including 4.20/4.21) until that fix is available.

## Test plan
- [x] Confirm the IMPORTANT note appears in `modules/identity-provider-oidc-about.adoc` (included by Configuring an OpenID Connect identity provider)
- [x] Confirm the `name` and `groups` callouts in the sample CRs mention the restriction
- [ ] Docs preview / peer review of AsciiDoc rendering


Made with [Cursor](https://cursor.com)