### PR TITLE
OCPBUGS-114888: clarify that bare metal supports 3, 4, or 5 control plane nodes

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -20,6 +20,8 @@ If you have lost the majority of your control plane hosts, follow the steps in "
 If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
+
+This procedure applies to clusters with 3, 4, or 5 control plane nodes. Most production clusters have 3 control plane nodes. Bare-metal clusters can have 3, 4, or 5; a 4-node control plane is supported but is not the standard production design.
 ====
 
 // Identifying an unhealthy etcd member

--- a/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
+++ b/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
@@ -20,6 +20,8 @@ If you have lost the majority of your control plane hosts, follow the steps in "
 If the control plane certificates are not valid on the member being replaced, then you must follow the steps in "Recovering from expired control plane certificates" instead of this procedure.
 
 If a control plane node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
+
+This procedure applies to clusters with 3, 4, or 5 control plane nodes. Most production clusters have 3 control plane nodes. Bare-metal clusters can have 3, 4, or 5; a 4-node control plane is supported but is not the standard production design.
 ====
 
 // Identifying an unhealthy etcd member

--- a/machine_management/control_plane_machine_management/cpmso-manually-scaling-control-planes.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-manually-scaling-control-planes.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Manually scale to 4 or 5 control plane nodes on bare-metal infrastructure to recover from a degraded state, perform deep-level debugging, or ensure control plane stability in complex scenarios.
+On bare-metal infrastructure, you can manually scale a standard 3-node control plane to 4 or 5 control plane nodes to recover from a degraded state, perform deep-level debugging, or ensure control plane stability in complex scenarios. A cluster on bare metal can have 3, 4, or 5 control plane nodes.
 
 [IMPORTANT]
 ====

--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -98,7 +98,7 @@ Extra controls apply to control plane machines to prevent you from deleting all 
 [NOTE]
 ====
 ifndef::openshift-dedicated,openshift-rosa[]
-Exactly three control plane nodes must be used for all production deployments. However, on bare metal platforms, clusters can be scaled up to five control plane nodes.
+Production deployments typically use 3 control plane nodes. On bare metal platforms only, a cluster can have 3, 4, or 5 control plane nodes. 4-node and 5-node control planes are a non-standard high-availability option, not the default production design.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Single availability zone clusters and multiple availability zone clusters require a minimum of three control plane nodes.

--- a/modules/etcd-node-scaling.adoc
+++ b/modules/etcd-node-scaling.adoc
@@ -7,7 +7,9 @@
 = Node scaling for etcd
 
 [role="_abstract"]
-In general, clusters must have 3 control plane nodes. However, if your cluster is installed on a bare metal platform, it can have up to 5 control plane nodes. If your bare-metal cluster has fewer than 5 control plane nodes, you can scale up the cluster as a postinstallation task.
+In general, clusters must have 3 control plane nodes. A 3-node control plane is the standard production design.
+
+If your cluster is installed on a bare metal platform, it can have 3, 4, or 5 control plane nodes. 4-node and 5-node control planes are a supported non-standard high-availability option; they are not the default production design. If your bare-metal cluster has fewer than 5 control plane nodes, you can scale up the cluster as a postinstallation task.
 
 For example, to scale from 3 to 4 control plane nodes after installation, you can add a host and install it as a control plane node. Then, the etcd Operator scales accordingly to account for the additional control plane node.
 
@@ -43,5 +45,10 @@ The following table shows failure tolerance for clusters of different sizes:
 |3
 |2
 |===
+
+[NOTE]
+====
+A 4-node control plane has the same failure tolerance as a 3-node control plane. Only a 5-node control plane can tolerate 2 simultaneous control plane node failures.
+====
 
 For more information about recovering from quorum loss, see "Restoring to an earlier cluster state".


### PR DESCRIPTION
## Summary
Fixes OCPBUGS-114888

The etcd and architecture docs said bare-metal clusters can have "up to 5" control plane nodes. That phrasing is easy to misread as an open range, or as if 5 is the expected size.

This change states that:
- 3 control plane nodes is the standard production design
- On bare metal only, a cluster can have **3, 4, or 5** control plane nodes
- 4-node and 5-node control planes are a supported non-standard HA option
- A 4-node control plane has the same failure tolerance as 3 nodes

Also restates the 3 / 4 / 5 sizes on the replace-unhealthy-etcd-member procedure that support commonly links.

Related: [OSDOCS-11570](https://redhat.atlassian.net/browse/OSDOCS-11570) (original 4.17 4/5-node feature docs)

## Test plan
- [x] `modules/etcd-node-scaling.adoc` lead sentence lists 3, 4, or 5 (included by etcd performance / recommended practices)
- [x] Architecture control-plane note no longer says only "scaled up to five"
- [x] Replace-unhealthy-etcd-member assemblies stay in sync
- [ ] Docs preview / peer review of AsciiDoc rendering


Made with [Cursor](https://cursor.com)