### PR TITLE
[OSDOCS#21417]: Add schedstats kernel arg to memory overcommit MachineConfig

### DIFF
--- a/modules/virt-enabling-higher-vm-workload-density.adoc
+++ b/modules/virt-enabling-higher-vm-workload-density.adoc
@@ -66,9 +66,13 @@ spec:
             RequiredBy=kubelet-dependencies.target
           enabled: true
           name: swap-provision.service
+  kernelArguments:
+    - schedstats=enable
 ----
 +
 Set the `SWAP_SIZE_MB` value to the amount of swap space to provision on the node, in MB. Adjust this value by using the formula that follows.
++
+The `schedstats=enable` kernel argument enables scheduler statistics that virtualization observability dashboards use, such as vCPU wait metrics. This kernel argument adds a minor additional load to the scheduler.
 +
 Ensure that the provisioned swap space is at least equal to the overcommitted RAM. Calculate the amount of swap space to provision on a node by using the following formula:
 +


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21417

Link to docs preview:
<!--- Add after Netlify posts the preview. --->

QE review:
- [ ] QE has approved this change.

Additional information:
The example `MachineConfig` for enabling higher VM workload density did not include the `schedstats=enable` kernel argument. Without that argument, virtualization observability dashboards (vCPU wait metrics and related widgets) do not return data.

This change adds `spec.kernelArguments: [schedstats=enable]` to the example customers copy from `virt-enabling-higher-vm-workload-density`, matching the requirement already documented in the Prometheus queries topic.

This module is included from:
- `virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc`


Made with [Cursor](https://cursor.com)