### PR TITLE
OSDOCS-21866: Add 4.21.31 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-31.adoc
+++ b/modules/zstream-4-21-31.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-31_{context}"]
+= RHBA-2026:60477 - {product-title} {product-version}.31 bug fix and security update
+
+Issued: 01 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.31 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:60477[RHSA-2026:60477] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:60450[RHBA-2026:60450] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.31 --pullspecs
+----
+
+[id="zstream-4-21-31-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, Image-Based Installation (IBI) with a proxy configuration wrote the user-provided `noProxy` value directly into the cluster configuration without adding the cluster, service, and machine network Classless Inter-Domain Routing (CIDR) blocks and internal host names required for in-cluster communication. As a consequence, the `noProxy` value did not match the proxy settings applied by the Machine Config Operator template, causing the Operator to detect a configuration drift and trigger an additional node reboot during installation. With this release, IBI enriches the `noProxy` setting by using the same logic as standard installations, aligning the initial proxy configuration with the Machine Config Operator template and preventing the extra reboot. (link:https://issues.redhat.com/browse/OCPBUGS-60993[OCPBUGS-60993])
+
+* Before this update, the Go OpenSSL FIPS provider could potentially overwhelm the `libcrypto` library with concurrent requests. As a consequence, processes could hit the `maxThreads` limit of 10,000 and crash. With this release, the Go OpenSSL FIPS provider is updated to limit concurrent requests to the `libcrypto` library to four times the number of CPUs, buffering requests as lightweight Go routines. As a result, processes avoid the `maxThreads` limit and do not crash. (link:https://issues.redhat.com/browse/OCPBUGS-112086[OCPBUGS-112086])
+
+[id="zstream-4-21-31-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -47,6 +47,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.31 RNs and updating
+include::modules/zstream-4-21-31.adoc[leveloffset=+2]
+
 // 4.21.30 RNs and updating
 include::modules/zstream-4-21-30.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.21

Issue
https://redhat.atlassian.net/browse/OSDOCS-21866

Doc preview link
https://119020--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-31_release-notes

QE review
N/A

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/776
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHBA-2026:60477 