### PR TITLE
OCPBUGS-114888: Updated exactly three control plane nodes must be to m…

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -94,16 +94,24 @@ ifdef::openshift-dedicated,openshift-rosa[]
 Control planes are managed with control plane machine sets.
 endif::openshift-dedicated,openshift-rosa[]
 Extra controls apply to control plane machines to prevent you from deleting all of the control plane machines and making the cluster inoperable.
-+
+ifndef::openshift-dedicated,openshift-rosa[]
+Exactly three control plane nodes must be used for all production deployments.
+
 [NOTE]
 ====
-ifndef::openshift-dedicated,openshift-rosa[]
-Exactly three control plane nodes must be used for all production deployments. However, on bare metal platforms, clusters can be scaled up to five control plane nodes.
+On a bare-metal platform, you can scale a cluster to three, four, or five control plane nodes.
+For best results, use odd size control plane nodes, such as three or five, on a cluster.
+A four-node control plane has the same etcd one failure tolerance as three nodes. 
+Only a five-node control plane can tolerate two simultaneous failures.
+
+Adding a fourth control plane node means etcd needs three healthy members instead of two.
+Until the fourth node is healthy, losing one of the original nodes breaks quorum and takes the cluster down.
+====
+
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Single availability zone clusters and multiple availability zone clusters require a minimum of three control plane nodes.
 endif::openshift-dedicated,openshift-rosa[]
-====
 +
 Services that fall under the Kubernetes category on the control plane include the Kubernetes API server, etcd, the Kubernetes controller manager, and the Kubernetes scheduler.
 +


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-114888](https://redhat.atlassian.net/browse/OCPBUGS-114888)

Link to docs preview:

* https://119021--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/control-plane.html
* https://119021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane.html
* https://119021--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/control-plane.html

- [x] Reporter has approved this change (Akanksha Gawai).
- [x] SME has approved this change (Haseeb Tariq).
- [x] QE has approved this change (Sandeep Kundu).

https://github.com/openshift/openshift-docs/pull/81631
