### PR TITLE
OSDOCS-21665: adds RHCL async release note 1.4.3

### DIFF
--- a/modules/rhcl-relnotes-1.4.3-z-stream.adoc
+++ b/modules/rhcl-relnotes-1.4.3-z-stream.adoc
@@ -1,0 +1,21 @@
+// Module used in the following assemblies
+//
+// *release_notes/rhcl-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.4.3-z-stream_{context}"]
+= {product-title} 1.4.3 bug fix and security update
+
+Issued: 8 September 2026
+
+[role="_abstract"]
+{product-title} release 1.4.3 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:65470[RHBA-2026:65470] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../update/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Update Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.4.3-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the `wasm-shim` component executed case-sensitive trie lookups on `request.host` without normalization. Consequently, requests with mixed-case or uppercase host headers, such as `Host: API.Example.COM`, failed to match lowercased or wildcard policy rules, bypassing `wasm-shim` policy enforcement. With this update the `wasm-shim` automatically lowercases all configured host names at index build time and normalizes runtime `request.host `values before lookups. As a result, hostname policy matching is now case-insensitive across exact and wildcard rules, ensuring that policies apply consistently regardless of host header casing. (link:https://redhat.atlassian.net/browse/CONNLINK-1448[CONNLINK-1448])
+
+* Previously, on Istio v1.26.x, policy `targetRef` matching selected all `Gateway` objects within a namespace due to an upstream selector issue, applying generated `EnvoyFilter` configurations globally across unrelated routes. With this update, `targetRef `is replaced with a `workloadSelector` that matches specific `Gateway` object names and namespaces. In addition, an automated migration path updates existing configurations. Now, `EnvoyFilter` resources target `Gateway` objects strictly by name and namespace, eliminating cross-gateway policy leakage. Stale references are removed. (link:https://redhat.atlassian.net/browse/CONNLINK-1510[CONNLINK-1510])
+
+* Previously, non-deterministic serialization caused the Kuadrant Operator to continually detect state drift on `wasm-shim` `EnvoyFilter` custom resources at roughly 24 updates per minute. This infinite reconciliation loop consumed memory until the Operator hit its 300Mi limit and was `OOMKilled`, causing control-plane memory pressure and intermittent `HTTP 503` errors during restarts. With this update, object-matching logic for the `EnvoyFilter` `spec` now normalizes and accurately compares required versus actual states, suppressing unnecessary mutation updates. As a result, `EnvoyFilter` resources stabilize at generation 1, resolving the memory leak and preventing service disruptions from operator restarts. (link:https://redhat.atlassian.net/browse/CONNLINK-1567[CONNLINK-1567])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
 include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+1]
 
+include::modules/rhcl-relnotes-1.4.3-z-stream.adoc[leveloffset=+2]
+
 include::modules/rhcl-relnotes-1.4.2-z-stream.adoc[leveloffset=+2]
 
 include::modules/rhcl-relnotes-1.4.1-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-21665](https://redhat.atlassian.net/browse/OSDOCS-21665)

Link to docs preview:
https://119026--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.4.3-z-stream_rhcl-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

