### PR TITLE
OSDOCS-21870: Add 4.20.36 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-36.adoc
+++ b/modules/zstream-4-20-36.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-36_{context}"]
+= RHSA-2026:60446 - {product-title} {product-version}.36 bug fix and security update
+
+Issued: 01 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.36 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:60446[RHSA-2026:60446] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:60444[RHSA-2026:60444] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.36 --pullspecs
+----
+
+[id="zstream-4-20-36-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when you viewed `execute code` snippets on the **Quick Start** page in the {product-title} web console, leading whitespace in the code block could render as an empty line before the command text. As a consequence, `execute code` snippets across **Quick Start** could display an extra blank line above the command, making the content harder to read. With this release, leading whitespace rendering in the `execute code` snippet on the **Quick Start** page is corrected. As a result, execute code blocks display the command text without a spurious empty line above it. (link:https://issues.redhat.com/browse/OCPBUGS-109132[OCPBUGS-109132])
+
+* Before this update, the Go OpenSSL FIPS provider could overwhelm libcrypto with concurrent requests. As a consequence, processes could hit the `maxThreads` limit of 10,000 and crash. With this release, the Go OpenSSL FIPS provider is updated to limit concurrent requests to libcrypto to four times the number of CPUs, buffering requests as lightweight Go routines. As a result, processes avoid the `maxThreads` limit and do not crash. (link:https://issues.redhat.com/browse/OCPBUGS-112087[OCPBUGS-112087])
+
+[id="zstream-4-20-36-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -32,6 +32,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 //z-stream release notes
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.36 RNs and updating
+include::modules/zstream-4-20-36.adoc[leveloffset=+2]
+
 // 4.20.35 RNs and updating
 include::modules/zstream-4-20-35.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s)
4.20

Issue
https://redhat.atlassian.net/browse/OSDOCS-21870

Doc preview link
https://119035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-36_release-notes

QE Review
N/A

Additional Information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/771
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHBA-2026:60446