### PR TITLE
[OSDOCS#17270]: Document dnsName allow vs 0.0.0.0/0 deny behavior

### DIFF
--- a/modules/nw-egress-firewall-about.adoc
+++ b/modules/nw-egress-firewall-about.adoc
@@ -68,6 +68,62 @@ where:
 
 To find the IP address for your API servers, run `oc get ep kubernetes -n default`.
 
+* If your egress firewall includes a deny rule for `0.0.0.0/0`, all egress traffic is denied because traffic is sent to destination IP addresses. An `Allow` rule that uses the `dnsName` field does not permit traffic to that DNS name. After the fully qualified domain name (FQDN) is resolved, the connection uses the resolved IP address, which matches the deny-all CIDR rule, so the traffic is denied. To allow traffic to a specific destination when you use a global deny rule, specify the destination IP address range by using the `cidrSelector` field in an `Allow` rule.
++
+In the following example, no traffic is sent to the FQDN. After DNS resolution, the connection uses the resolved IP address, which the `0.0.0.0/0` deny rule matches:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  namespace: <namespace>
+spec:
+  egress:
+  - to:
+      dnsName: <dns_name>
+    ports:
+    - port: 443
+      protocol: TCP
+    type: Allow
+  - to:
+      cidrSelector: 0.0.0.0/0
+    type: Deny
+----
++
+where:
+
+<namespace>:: Specifies the namespace for the egress firewall.
+<dns_name>:: Specifies a DNS domain name. Traffic to this FQDN is denied because the connection uses the resolved IP address.
++
+The following example allows traffic to the specified IP address range and denies all other egress traffic:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  namespace: <namespace>
+spec:
+  egress:
+  - to:
+      cidrSelector: <destination_cidr>
+    ports:
+    - port: 443
+      protocol: TCP
+    type: Allow
+  - to:
+      cidrSelector: 0.0.0.0/0
+    type: Deny
+----
++
+where:
+
+<namespace>:: Specifies the namespace for the egress firewall.
+<destination_cidr>:: Specifies the IP address range of the destination that you want to allow.
+
 * A maximum of one `EgressFirewall` object with a maximum of 8,000 rules can be defined per project.
 
 * If you are using the OVN-Kubernetes network plugin with shared gateway mode in Red{nbsp}Hat OpenShift Networking, return ingress replies are affected by egress firewall rules. If the egress firewall rules drop the ingress reply destination IP, the traffic is dropped.
@@ -83,10 +139,17 @@ An `EgressFirewall` resource is created in the `kube-node-lease`, `kube-public`,
 
 OVN-Kubernetes evaluates egress firewall policy rules in the order they are defined in, from first to last. The first rule that matches an egress connection from a pod applies. Any subsequent rules are ignored for that connection.
 
+[NOTE]
+====
+A `Deny` rule with `cidrSelector: 0.0.0.0/0` denies all egress traffic because connections are sent to IP addresses. After a DNS name is resolved, the traffic uses the resolved IP address and matches the deny-all rule. An `Allow` rule that uses the `dnsName` field does not permit that traffic, even when the allow rule is listed first. To allow specific egress traffic, use an `Allow` rule with the `cidrSelector` field.
+====
+
 [id="domain-name-server-resolution-ovn-k_{context}"]
 == How Domain Name Server (DNS) resolution works
 
 If you use DNS names in any of your egress firewall policy rules, proper resolution of the domain names is subject to the following restrictions:
+
+* If your egress firewall includes a deny rule for `0.0.0.0/0`, an `Allow` rule that uses the `dnsName` field does not permit traffic to that DNS name. After the FQDN is resolved, the connection uses the resolved IP address, which the deny-all rule matches. Specify allowed destinations by using the `cidrSelector` field.
 
 * Domain name updates are polled based on a time-to-live (TTL) duration. By default, the duration is 30 minutes. When the egress firewall controller queries the local name servers for a domain name, if the response includes a TTL and the TTL is less than 30 minutes, the controller sets the duration for that DNS name to the returned value. Each DNS name is queried after the TTL for the DNS record expires.
 

--- a/modules/nw-egress-firewall-object.adoc
+++ b/modules/nw-egress-firewall-object.adoc
@@ -92,6 +92,11 @@ where:
 
 <egress>:: Specifies a collection of egress firewall policy rule objects.
 
+[IMPORTANT]
+====
+If your policy includes a `Deny` rule for `0.0.0.0/0`, all egress traffic is denied because traffic is sent to IP addresses. An `Allow` rule that uses the `dnsName` field does not permit traffic to that DNS name: after the FQDN is resolved, the connection uses the resolved IP address and is denied. To allow traffic to a specific destination, use the `cidrSelector` field in the `Allow` rule.
+====
+
 The following example defines a policy rule that denies traffic to the host at the `172.16.1.1/32` IP address, if the traffic is using either the TCP protocol and destination port `80` or any protocol and destination port `443`.
 
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
## Summary
- Documents that an IPv4 `cidrSelector: 0.0.0.0/0` deny rule denies all egress traffic because connections are sent to IP addresses.
- Clarifies that an `Allow` rule with `dnsName` does not permit that traffic: after FQDN resolution, the connection uses the resolved IP and matches the deny-all CIDR rule.
- Shows the working pattern: allow specific destinations with `cidrSelector`, plus a note on matching order and the example CR.

## Test plan
- [ ] Confirm the limitation, matching-order note, and DNS restriction read correctly on the configuring-egress-firewall-ovn preview.
- [ ] Confirm the IMPORTANT admonition appears next to the example `EgressFirewall` CR that uses `cidrSelector` + `0.0.0.0/0` deny.

Version(s):
main (in-development); cherry-pick to 4.18+ as needed

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17270

Link to docs preview:
(add after preview build)

QE review:
- [ ] QE has approved this change.
