### PR TITLE
OSDOCS-16919: CQA fixes for dynamic plugins docs (4.20)

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -884,7 +884,7 @@ Provides a group, version, and kind for a k8s model. This returns the group, ver
 
 == `StatusPopupSection`
 
-Component that shows the status in a popup window. Helpful component for building `console.dashboards/overview/health/resource` extensions.
+Component that shows the status in a pop-up. Helpful component for building `console.dashboards/overview/health/resource` extensions.
 
 **Example**
 [source,tsx]

--- a/modules/dynamic-plugin-localization.adoc
+++ b/modules/dynamic-plugin-localization.adoc
@@ -7,7 +7,7 @@
 = Translating messages with react-i18next
 
 [role="_abstract"]
-The link:https://github.com/openshift/console-plugin-template[plugin template] demonstrates how you can translate messages with link:https://www.i18next.com/[react-i18next].
+The `console-plugin-template` plugin template demonstrates how you can translate messages with react-i18next.
 
 .Prerequisites
 * You must have the plugin template cloned locally.
@@ -81,3 +81,8 @@ spec:
 ----
 $ yarn i18n
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://www.i18next.com/[react-i18next]

--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -330,9 +330,7 @@ utilization item to be replaced.
 |`component` |`CodeRef<React.ComponentType<K8sActivityProps<T>>>` |no
 |The action component.
 
-|`isActivity` |`CodeRef<(resource: T) => boolean>` |yes |Function which
-determines if the given resource represents the action. If not defined,
-every resource represents activity.
+|`isActivity` |`CodeRef<(resource: T) => boolean>` |yes |Function that determines whether the given resource represents the action. If not defined, every resource represents activity.
 
 |`getTimestamp` |`CodeRef<(resource: T) => Date>` |yes |Time stamp for
 the given action, which will be used for ordering.
@@ -348,8 +346,7 @@ Adds a health subsystem to the status card of the *Overview* dashboard, where th
 |Name |Value Type |Optional |Description
 |`title` |`string` |no |Title of Operators section in the pop-up menu.
 
-|`resources` |`CodeRef<FirehoseResource[]>` |no |Kubernetes resources
-which will be fetched and passed to `healthHandler`.
+|`resources` |`CodeRef<FirehoseResource[]>` |no |Kubernetes resources that will be fetched and passed to `healthHandler`.
 
 |`getOperatorsWithStatuses` |`CodeRef<GetOperatorsWithStatuses<T>>` |yes
 |Resolves status for the Operators.
@@ -375,11 +372,9 @@ Adds a health subsystem to the status card of Overview dashboard where the sourc
 
 |`queries` |`string[]` |no |The Prometheus queries.
 
-|`healthHandler` |`CodeRef<PrometheusHealthHandler>` |no |Resolve the
-subsystem's health.
+|`healthHandler` |`CodeRef<PrometheusHealthHandler>` |no |Resolves the subsystem's health.
 
-|`additionalResource` |`CodeRef<FirehoseResource>` |yes |Additional
-resource which will be fetched and passed to `healthHandler`.
+|`additionalResource` |`CodeRef<FirehoseResource>` |yes |Additional resource that will be fetched and passed to `healthHandler`.
 
 |`popupComponent`
 |`CodeRef<React.ComponentType<PrometheusHealthPopupProps>>` |yes |Loader
@@ -405,8 +400,7 @@ Adds a health subsystem to the status card of Overview dashboard where the sourc
 |`resources` |`CodeRef<WatchK8sResources<T>>` |no |Kubernetes resources
 that will be fetched and passed to `healthHandler`.
 
-|`healthHandler` |`CodeRef<ResourceHealthHandler<T>>` |no |Resolve the
-subsystem's health.
+|`healthHandler` |`CodeRef<ResourceHealthHandler<T>>` |no |Resolves the subsystem's health.
 
 |`popupComponent` |`CodeRef<WatchK8sResults<T>>` |yes |Loader for pop-up menu content. If defined, a health item is represented as a link, which
 opens a pop-up menu with the given content.
@@ -427,10 +421,9 @@ Adds a health subsystem to the status card of Overview dashboard where the sourc
 |`url` |`string` |no |The URL to fetch data from. It will be prefixed
 with base Kubernetes URL.
 
-|`healthHandler`|`CodeRef<URLHealthHandler<T, K8sResourceCommon \| K8sResourceCommon[]>>`|no |Resolve the subsystem's health.
+|`healthHandler`|`CodeRef<URLHealthHandler<T, K8sResourceCommon \| K8sResourceCommon[]>>`|no |Resolves the subsystem's health.
 
-|`additionalResource` |`CodeRef<FirehoseResource>` |yes |Additional
-resource which will be fetched and passed to `healthHandler`.
+|`additionalResource` |`CodeRef<FirehoseResource>` |yes |Additional resource that will be fetched and passed to `healthHandler`.
 
 |`popupComponent`|`CodeRef<React.ComponentType<{ healthResult?: T; healthResultError?: any; k8sResult?: FirehoseResult<R>; }>>`|yes |Loader for popup content. If defined, a health item will be
 represented as a link which opens popup with given content.
@@ -1050,14 +1043,14 @@ Adds a new details item to the default resource summary on the details page.
 |`string` |no |The details item title.
 
 |`path`
-|`string` |yes |An optional, fully-qualified path to a resource property to used as the details item value. Only primitive type values, linked in Additional resources, can be rendered directly. Use the component property to handle other data types.
+|`string` |yes |An optional, fully-qualified path to a resource property to used as the details item value. You can directly render only primitive type values, linked in Additional resources. Use the component property to handle other data types.
 
 |`component`
 |`CodeRef<React.ComponentType<DetailsItem
 ComponentProps<K8sResourceCommon, any>>>` |yes |An optional React component that will render the details item value.
 
 |`sortWeight`
-|`number` |yes |An optional sort weight, relative to all other details items in the same column. Represented by any valid JavaScript Number, linked in Additional resources. Items in each column are sorted independently, lowest to highest. Items without sort weights are sorted after items with sort weights.
+|`number` |yes |An optional sort weight, relative to all other details items in the same column. You can represent it by using any valid JavaScript Number, linked in Additional resources. Items in each column are sorted independently, lowest to highest. Items without sort weights are sorted after items with sort weights.
 
 |===
 
@@ -1348,8 +1341,8 @@ Topology relationship provider connector extension
 |===
 |Name |Value Type |Optional |Description
 |`provides` |`CodeRef<RelationshipProviderProvides>` |no |Use to determine if a connection can be created between the source and target node
-|`tooltip` |`string` |no |Tooltip to show when connector operation is hovering over the drop target, for example, "Create a Visual Connector"
-|`create` |`CodeRef<RelationshipProviderCreate>` |no |Callback to execute when connector is drop over target node to create a connection
+|`tooltip` |`string` |no |A tooltip to show when connector operation is hovering over the drop target, for example, "Create a Visual Connector"
+|`create` |`CodeRef<RelationshipProviderCreate>` |no |A callback that creates a connection when a connector is dropped onto the target node
 |`priority` |`number` |no |Priority for relationship, higher will be preferred in case of multiple
 |===
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->   Cherry-pick of #117204. Addresses reviewer feedback on dynamic plugins documentation. QE approved on original PR. All changes apply cleanly to enterprise-4.20.

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16919](https://redhat.atlassian.net/browse/OSDOCS-16919)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://119059--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html
https://119059--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/overview-dynamic-plugin.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
