### PR TITLE
OCPBUGS-115185: Note that cnf-tests-rhel9 latency tests are x86_64 only

### DIFF
--- a/modules/cnf-measuring-latency.adoc
+++ b/modules/cnf-measuring-latency.adoc
@@ -9,11 +9,16 @@
 [role="_abstract"]
 To accurately measure system latency, use the `hwlatdetect`, `cyclictest`, and `oslat` tools provided in the `cnf-tests` image. Evaluating these metrics helps you identify and resolve performance delays in your environment.
 
+[IMPORTANT]
+====
+The `cnf-tests` image, `registry.redhat.io/openshift4/cnf-tests-rhel9`, is supported only on the x86_64 architecture. The image does not include an aarch64 payload. If you run the latency tests on an aarch64 cluster, the test pods fail with an `ErrImagePull` error because no image is found in the manifest list for the `arm64` architecture.
+====
+
 Each tool has a specific use. Use the tools in sequence to achieve reliable test results.
 
 hwlatdetect:: Measures the baseline that the bare-metal hardware can achieve. Before proceeding with the next latency test, ensure that the latency reported by `hwlatdetect` meets the required threshold because you cannot fix hardware latency spikes by operating system tuning.
 
-cyclictest:: Verifies the real-time kernel scheduler latency after `hwlatdetect` passes validation. The `cyclictest` tool schedules a repeated timer and measures the difference between the desired and the actual trigger times. The difference can uncover basic issues with the tuning caused by interrupts or process priorities. The tool must run on a real-time kernel.
+cyclictest:: Verifies the real-time kernel scheduler latency after `hwlatdetect` passes validation. The `cyclictest` tool schedules a repeated timer and measures the difference between the desired and the actual trigger times. The difference can uncover basic issues with the tuning caused by interrupts or process priorities. The tool must run on a real-time kernel, which is available on the x86_64 architecture. For aarch64 telco RAN DU deployments, only the 64k-pagesize non-real-time kernel is recommended, so `cyclictest` is not a supported latency validation path on aarch64.
 
 oslat:: Behaves similarly to a CPU-intensive DPDK application and measures all the interruptions and disruptions to the busy loop that simulates CPU heavy data processing.
 

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -17,6 +17,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 .Prerequisites
 
 * You have reviewed the prerequisites for running latency tests.
+* You are using the x86_64 architecture and a real-time kernel. The `cyclictest` tool is not a supported latency validation path on aarch64.
 
 .Procedure
 

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 Run the cluster latency tests to validate node tuning for your Cloud-native Network Functions (CNF) workload.
 
+[IMPORTANT]
+====
+The `cnf-tests` image is supported only on the x86_64 architecture. There is currently no supported latency test image for aarch64 clusters. For more information, see "Measuring latency".
+====
+
 [NOTE]
 ====
 When executing `podman` commands as a non-root or non-privileged user, mounting paths can fail with `permission denied` errors. Depending on your local operating system and SELinux configuration, you might also experience issues running these commands from your home directory. To make the `podman` commands work, run the commands from a folder that is not your home/<username> directory, and append `:Z` to the volumes creation. For example, `-v $(pwd)/:/kubeconfig:Z`. This allows `podman` to do the proper SELinux relabeling.

--- a/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
+++ b/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
@@ -7,7 +7,7 @@
 = Troubleshooting errors with the cnf-tests container
 
 [role="_abstract"]
-To troubleshoot errors when running latency tests, verify that your cluster is accessible from within the `cnf-tests` container. Ensuring this connectivity resolves common test execution failures.
+To troubleshoot errors when running latency tests, verify that your cluster is accessible from within the `cnf-tests` container and that you are using a supported architecture. Ensuring this connectivity and architecture support resolves common test execution failures.
 
 .Prerequisites
 
@@ -28,3 +28,5 @@ oc get nodes
 If this command does not work, an error related to spanning across DNS, MTU size, or firewall access might be occurring.
 
 * If the latency test pod is terminated with an `OOMKilled` status when you use a high `LATENCY_TEST_CPUS` value, set the `LATENCY_TEST_MEMORY` environment variable to a larger memory quantity, for example `2Gi`, and run the test again.
+
+* If the latency test pods remain in a `Pending` state with an `ErrImagePull` or `ImagePullBackOff` error that reports no image found in the manifest list for architecture `arm64`, you are running the tests on an aarch64 cluster. The `cnf-tests` image is supported only on the x86_64 architecture.


### PR DESCRIPTION
## Summary
- Document that `registry.redhat.io/openshift4/cnf-tests-rhel9` is supported only on x86_64 and has no aarch64 payload, so latency tests fail with `ErrImagePull` on ARM clusters.
- Clarify that `cyclictest` requires the real-time kernel and is not a supported latency validation path on aarch64 RAN DU (64k-pagesize non-RT kernel).
- Add troubleshooting for the `arm64` manifest-list pull failure.

Fixes https://issues.redhat.com/browse/OCPBUGS-115185
Related https://issues.redhat.com/browse/RFE-9810

Applies to: 4.22 and later (cherry-pick as needed).

## Test plan
- [ ] Preview the *Performing latency tests for platform verification* assembly.
- [ ] Confirm the x86_64-only note appears in Measuring latency and Running the latency tests.
- [ ] Confirm cyclictest prerequisites mention x86_64 and real-time kernel.
- [ ] Confirm Troubleshooting covers `ErrImagePull` / `arm64` manifest-list errors.


Made with [Cursor](https://cursor.com)