### PR TITLE
CNV-76169 - Docs should mention vioscsi

### DIFF
--- a/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
+++ b/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc
@@ -20,7 +20,11 @@ After the drivers are installed, the `container-native-virtualization/virtio-win
 
 |*viostor*
 |VEN_1AF4&DEV_1001, VEN_1AF4&DEV_1042
-|The block driver. Sometimes labeled as an *SCSI Controller* in the *Other devices* group.
+|The block driver. Sometimes labeled as an *SCSI Controller* in the *Other devices* group. Required for virtual machines using `bus: virtio`.
+
+|*vioscsi*
+|VEN_1AF4&DEV_1004, VEN_1AF4&DEV_1048
+|The SCSI pass-through driver. Sometimes labeled as a *SCSI Controller* in the *Other devices* group. Required for virtual machines using `bus: scsi`.
 
 |*viorng*
 |VEN_1AF4&DEV_1005, VEN_1AF4&DEV_1044


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[CNV-76197](https://redhat.atlassian.net/browse/CNV-76169)

Link to docs preview:
https://119096--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.html#virt-downloading-virtio-win-iso_virt-install-virtio-drivers-on-windows-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a Bug which is to be merged for 4.20 & also be back ported to older currently supported versions as well.
