### PR TITLE
OCPBUGS-114420: Added ec2.us-east-1.amazonaws.com to configuring-fire…

### DIFF
--- a/modules/configuring-firewall-module.adoc
+++ b/modules/configuring-firewall-module.adoc
@@ -242,6 +242,10 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must includ
 |443
 |Used to install and manage clusters in an AWS environment.
 
+|`ec2.us-east-1.amazonaws.com`
+|443
+|Used to get the list of available regions when interactively generating the `install-config.yaml` file.
+
 |`events.amazonaws.com`
 |443
 |Used to install and manage clusters in an AWS environment.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-114420](https://redhat.atlassian.net/browse/OCPBUGS-114420)

Link to docs preview:

* https://119098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html
* https://119098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-agent-based-installer.html
* https://119098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html

- [x] SME has approved this change (Thuan Vo).
- [x] QE has approved this change (Majur Deore).

