### PR TITLE
OSDOCS#21970: Update the MicroShift RNs for 4.21.31

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-31-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-29-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-16-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-31-async.adoc
+++ b/modules/microshift-4-21-31-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-31-async_{context}"]
+= RHSA-2026:60668 - {microshift-short} 4.21.31 security update
+
+Issued: 1 September 2026
+
+[role="_abstract"]
+{product-title} release 4.21.31 is now available. Security updates are listed in the link:https://access.redhat.com/errata/RHSA-2026:60668[RHSA-2026:60668] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:60477[RHSA-2026:60477] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-21-31-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21970

Link to docs preview:
[4.21.31](https://119116--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-31-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- MicroShift errata: https://access.redhat.com/errata/RHSA-2026:60668
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:60477
- OCP extras advisory: https://access.redhat.com/errata/RHSA-2026:60478
- Microshift-bootc advisory: https://access.redhat.com/errata/RHBA-2026:61917
- OCP shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/776
- Microshift-bootc shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/786
- Advisory-only: CVE-2026-33814 / BZ-2467815 skipped (CVE-only). No documentable MicroShift OCPBUGS bullets.


Made with [Cursor](https://cursor.com)