### PR TITLE
OSDOCS-19342-2: removes TP snip from GA docs

### DIFF
--- a/mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
+++ b/mcp_gateway_install/mcp-gateway-isolated-deployment.adoc
@@ -9,10 +9,6 @@ toc::[]
 [role="_abstract"]
 You can deploy multiple {mcpg} instances within a single cluster to isolate traffic between teams. Each instance uses a single `MCPGatewayExtension` custom resource (CR) to manage associated MCP servers.
 
-:FeatureName: {mcpg}
-
-include::snippets/technology-preview.adoc[]
-
 include::modules/con-mcp-gateway-isolated-deployment.adoc[leveloffset=+1]
 
 include::modules/proc-mcp-gateway-deploy-isolated-instances.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.5

Issue:
[OSDOCS-19342](https://redhat.atlassian.net/browse/OSDOCS-19342)

Link to docs preview:
https://116421--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-isolated-deployment.html

See https://github.com/openshift/openshift-docs/pull/116421
