### PR TITLE
OCPBUGS-115255: Fix garbled Azure machine type lists

### DIFF
--- a/modules/installation-azure-arm-tested-machine-types.adoc
+++ b/modules/installation-azure-arm-tested-machine-types.adoc
@@ -18,4 +18,57 @@ There are several Microsoft Azure ARM64 instance types tested with {product-titl
 
 See the following machine types based on 64-bit ARM architecture:
 
-include::https://raw.githubusercontent.com/openshift/installer/release-4.22/docs/user/azure/tested_instance_types_aarch64.md[]
+[id="general-purpose-arm64_{context}"]
+== General purpose ARM64
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|Bpsv2-series
+|`standardBpsv2Family`
+
+|Dpdsv5-series
+|`standardDPDSv5Family`
+
+|Dpldsv5-series
+|`standardDPLDSv5Family`
+
+|Dplsv5-series
+|`standardDPLSv5Family`
+
+|Dpsv5-series
+|`standardDPSv5Family`
+
+|Dpdsv6-series
+|`StandardDpdsv6Family`
+
+|Dpldsv6-series
+|`StandardDpldsv6Family`
+
+|Dplsv6-series
+|`StandardDplsv6Family`
+
+|Dpsv6-series
+|`StandardDpsv6Family`
+|====
+
+[id="memory-optimized-arm64_{context}"]
+== Memory optimized ARM64
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|Epdsv5-series
+|`standardEPDSv5Family`
+
+|Epsv5-series
+|`standardEPSv5Family`
+
+|Epdsv6-series
+|`StandardEpdsv6Family`
+
+|Epsv6-series
+|`StandardEpsv6Family`
+|====

--- a/modules/installation-azure-tested-machine-types.adoc
+++ b/modules/installation-azure-tested-machine-types.adoc
@@ -17,5 +17,347 @@ There are several Microsoft Azure instance types tested with {product-title}. Ch
 
 See the following machine types based on 64-bit x86 architecture:
 
-include::https://raw.githubusercontent.com/openshift/installer/release-4.22/docs/user/azure/tested_instance_types_x86_64.md[]
+[id="general-purpose_{context}"]
+== General purpose
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|Basv2-series
+|`standardBasv2Family`
+
+|BS-series
+|`standardBSFamily`
+
+|Bsv2-series
+|`standardBsv2Family`
+
+|Dadsv5-series
+|`standardDADSv5Family`
+
+|Dadsv6-series
+|`standardDadv6Family`
+
+|Daldsv6-series
+|`standardDaldv6Family`
+
+|Dalsv6-series
+|`standardDalv6Family`
+
+|Dasv4-series
+|`standardDASv4Family`
+
+|Dasv5-series
+|`standardDASv5Family`
+
+|Dasv6-series
+|`standardDav6Family`
+
+|DCas_cc_v5-series
+|`standardDCACCV5Family`
+
+|DCads_cc_v5-series
+|`standardDCADCCV5Family`
+
+|DCadsv5-series
+|`standardDCADSv5Family`
+
+|DCasv5-series
+|`standardDCASv5Family`
+
+|DCsv2-series
+|`standardDCSv2Family`
+
+|DCsv3-series
+|`standardDCSv3Family`
+
+|DCdsv3-series
+|`standardDDCSv3Family`
+
+|DCedsv5-series
+|`standardDCEDV5Family`
+
+|DCesv5-series
+|`standardDCEV5Family`
+
+|Ddsv4-series
+|`standardDDSv4Family`
+
+|Ddsv5-series
+|`standardDDSv5Family`
+
+|Ddsv6-series
+|`StandardDdsv6Family`
+
+|Dldsv5-series
+|`standardDLDSv5Family`
+
+|Dldsv6-series
+|`StandardDldsv6Family`
+
+|Dlsv5-series
+|`standardDLSv5Family`
+
+|Dlsv6-series
+|`StandardDlsv6Family`
+
+|DS-series
+|`standardDSFamily`
+
+|Dsv2-series
+|`standardDSv2Family`
+
+|Dsv3-series
+|`standardDSv3Family`
+
+|Dsv4-series
+|`standardDSv4Family`
+
+|Dsv5-series
+|`standardDSv5Family`
+
+|Dsv6-series
+|`StandardDsv6Family`
+|====
+
+[id="memory-optimized_{context}"]
+== Memory optimized
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|Eadsv5-series
+|`standardEADSv5Family`, `standardEIADSv5Family`
+
+|Eadsv6-series
+|`standardEadv6Family`
+
+|Easv4-series
+|`standardEASv4Family`, `standardEIASv4Family`
+
+|Easv5-series
+|`standardEASv5Family`, `standardEIASv5Family`
+
+|Easv6-series
+|`standardEav6Family`
+
+|Ebdsv5-series
+|`standardEBDSv5Family`, `standardEIBDSv5Family`
+
+|Ebsv5-series
+|`standardEBSv5Family`, `standardEIBSv5Family`
+
+|ECas_cc_v5-series
+|`standardECACCV5Family`
+
+|ECads_cc_v5-series
+|`standardECADCCV5Family`
+
+|ECadsv5-series
+|`standardECADSv5Family`
+
+|ECasv5-series
+|`standardECASv5Family`
+
+|ECedsv5-series
+|`standardECEDV5Family`
+
+|ECesv5-series
+|`standardECEV5Family`
+
+|Edsv4-series
+|`standardEDSv4Family`
+
+|Edsv5-series
+|`standardEDSv5Family`, `standardEIDSv5Family`
+
+|Edsv6-series
+|`StandardEdsv6Family`
+
+|Esv3-series
+|`standardESv3Family`, `standardEISv3Family`
+
+|Esv4-series
+|`standardESv4Family`, `standardXEISv4Family`
+
+|Esv5-series
+|`standardESv5Family`, `standardEISv5Family`
+
+|Esv6-series
+|`StandardEsv6Family`
+
+|M-series
+|`standardMSFamily`
+
+|Mbdsv3-series
+|`StandardMBDSMediumMemoryv3Family`
+
+|Mbsv3-series
+|`StandardMBSMediumMemoryv3Family`
+
+|Mdsv3 High Memory-series
+|`standardMDSHighMemoryv3Family`, `standardMIDSHighMemoryv3Family`
+
+|Mdsv2 Medium Memory-series
+|`standardMDSMediumMemoryv2Family`, `standardMIDSMediumMemoryv2Family`
+
+|Mdsv3 Medium Memory-series
+|`standardMDSMediumMemoryv3Family`
+
+|Msv3 High Memory-series
+|`standardMISHighMemoryv3Family`, `standardMSHighMemoryv3Family`
+
+|Msv2 Medium Memory-series
+|`standardMISMediumMemoryv2Family`, `standardMSMediumMemoryv2Family`
+
+|Msv3 Medium Memory-series
+|`standardMSMediumMemoryv3Family`
+|====
+
+[id="compute-optimized_{context}"]
+== Compute optimized
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|Falsv6-series
+|`StandardFalsv6Family`
+
+|Famsv6-series
+|`StandardFamsv6Family`
+
+|Fasv6-series
+|`StandardFasv6Family`
+
+|FS-series
+|`standardFSFamily`
+
+|Fsv2-series
+|`standardFSv2Family`
+
+|FXmdsv2-series
+|`StandardFXmdsv2Family`
+
+|FX-series
+|`standardFXMDVSFamily`
+
+|FXmsv2-series
+|`StandardFXmsv2Family`
+|====
+
+[id="storage-optimized_{context}"]
+== Storage optimized
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|GS-series
+|`standardGSFamily`
+
+|Laosv4-series
+|`standardLaosv4Family`
+
+|Lasv3-series
+|`standardLASv3Family`
+
+|Lasv4-series
+|`standardLasv4Family`
+
+|Ls-series
+|`standardLSFamily`
+
+|Lsv2-series
+|`standardLSv2Family`
+
+|Lsv3-series
+|`standardLSv3Family`
+
+|Lsv4-series
+|`standardLsv4Family`
+|====
+
+[id="gpu-accelerated_{context}"]
+== GPU accelerated
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|NC_A100_v4-series
+|`StandardNCADSA100v4Family`
+
+|NCads_H100_v5-series
+|`StandardNCadsH100v5Family`
+
+|NCCads_H100_v5-series
+|`StandardNCCads2023Family`
+
+|NCasT4_v3-series
+|`Standard NCASv3_T4 Family`
+
+|NCv3-series
+|`standardNCSv3Family`
+
+|NDasrA100_v4-series
+|`Standard NDASv4_A100 Family`
+
+|ND-H200-v5-series
+|`standardNDISRH200V5Family`
+
+|ND-H100-v5-series
+|`standardNDSH100v5Family`
+
+|NDv2-series
+|`standardNDSv2Family`
+
+|NGads_V620-series
+|`StandardNGADSV620v1Family`
+
+|NVadsA10_v5-series
+|`StandardNVADSA10v5Family`
+
+|NVads V710 v5-series
+|`StandardNVadsV710v5Family`
+
+|NVv3-series
+|`standardNVSv3Family`
+|====
+
+[id="fpga-accelerated_{context}"]
+== FPGA accelerated
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|NPS-series
+|`standardNPSFamily`
+|====
+
+[id="high-performance-compute_{context}"]
+== High performance compute
+
+[cols="1,1",options="header"]
+|====
+|Azure VM Series |Family Name
+
+|HBv2-series
+|`standardHBrsv2Family`
+
+|HBv4-series
+|`standardHBv4Family`
+
+|HBv5-series
+|`standardHBv5Family`
+
+|HC-series
+|`standardHCSFamily`
+
+|HX-series
+|`standardHXFamily`
+|====
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.22+ 

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-115255

Link to docs preview:

- [Tested instance types for Azure](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-azure-tested-machine-types_installing-azure-customizations) (IPI)
- [Tested instance types for Azure on 64-bit ARM infrastructures](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-azure-arm-tested-machine-types_installing-azure-customizations) (IPI)
- [Tested instance types for Azure](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-private.html#installation-azure-tested-machine-types_installing-azure-private) (Private cluster)
- [Tested instance types for Azure on 64-bit ARM infrastructures](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-private.html#installation-azure-arm-tested-machine-types_installing-azure-private) (Private cluster)
- [Tested instance types for Azure](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.html#installation-azure-tested-machine-types_installing-restricted-networks-azure-installer-provisioned) (Disconnected environment) 
- [Tested instance types for Azure on 64-bit ARM infrastructures](https://119123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.html#installation-azure-arm-tested-machine-types_installing-restricted-networks-azure-installer-provisioned) (Disconnected environment) 


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


## Summary
- Fixed garbled rendering of Azure machine type lists in the documentation
- Replaced Markdown include directives with proper AsciiDoc tables
- Applied to both x86_64 and ARM64 machine type reference modules

