### PR TITLE
[enterprise-5.0] CNV-71659: DataVolume retains stale ownerReference after disk is moved to another VM, resulting in PVC deletion after Owner VM deletion

### DIFF
--- a/virt/release_notes/virt-5-0-release-notes.adoc
+++ b/virt/release_notes/virt-5-0-release-notes.adoc
@@ -115,6 +115,13 @@ link:https://redhat.atlassian.net/browse/CNV-73392[CNV-73392]
 [role="_abstract"]
 Some linked Jira tickets are accessible only with Red Hat credentials.
 
+Detaching a disk from a virtual machine does not remove the owner reference from the data volume::
+When you detach a disk from a virtual machine (VM), the `DataVolume` object retains a stale owner reference to the original VM. If you then delete the original VM, garbage collection deletes the `DataVolume` object and its underlying persistent volume claim (PVC), even if the disk is attached to a different VM. As a consequence, data loss can occur.
++
+To work around this problem, after detaching a disk from a VM, manually remove the `ownerReference` entry from the `DataVolume` object before deleting the original VM. As a result, the disk is not deleted when the original VM is removed.
++
+link:https://redhat.atlassian.net/browse/CNV-71659[CNV-71659]
+
 //CNV-78892
 Non-versioned HyperConverged commands default to v1 API::
 In this release, the v1 API for the `HyperConverged` custom resource (CR) is introduced, in preparation for a future migration from v1beta1 to v1. Due to the way Kubernetes selects default API versions, non-versioned commands such as `oc get hco`, `oc edit hyperconverged`, and `oc patch hyperconverged` now default to the v1 API. As a consequence, these commands can behave unexpectedly or fail because the v1 API is not yet ready for production use.


### PR DESCRIPTION
Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/CNV-71659

Link to docs preview:
https://119131--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-5-0-release-notes.html#virt-5-0-known-issues_virt-5-0-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
