### PR TITLE
[enterprise-4.21] CNV-71659: DataVolume retains stale ownerReference after disk is moved to another VM, resulting in PVC deletion after Owner VM deletion

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -238,6 +238,13 @@ link:https://issues.redhat.com/browse/CNV-71192[CNV-71192]
 [role="_abstract"]
 Some linked Jira tickets are accessible only with Red Hat credentials.
 
+Detaching a disk from a virtual machine does not remove the owner reference from the data volume::
+When you detach a disk from a virtual machine (VM), the `DataVolume` object retains a stale owner reference to the original VM. If you then delete the original VM, garbage collection deletes the `DataVolume` object and its underlying persistent volume claim (PVC), even if the disk is attached to a different VM. As a consequence, data loss can occur.
++
+To work around this problem, after detaching a disk from a VM, manually remove the `ownerReference` entry from the `DataVolume` object before deleting the original VM. As a result, the disk is not deleted when the original VM is removed.
++
+link:https://redhat.atlassian.net/browse/CNV-71659[CNV-71659]
+
 //CNV-38746: According to Petr, this will remain relevant as long as 4.12 is available. Anyone upgrading from 4.12 could be affected. Version 4.12 is supported until January 2026
 [id="virt-4-21-ki-networking_{context}"]
 VMs using the cnv-bridge CNI fail to live migrate after updates from 4.12::


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/CNV-71659

Link to docs preview:
https://119137--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-known-issues_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
