### PR TITLE
[enterprise-4.19] CNV-71659: DataVolume retains stale ownerReference after disk is moved to another VM, resulting in PVC deletion after Owner VM deletion

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -272,6 +272,9 @@ In {VirtProductName} 4.19.6 and later, installing {VirtProductName} on OCI is ge
 [id="virt-4-19-ki-virtualization_{context}"]
 === Virtualization
 
+* When you detach a disk from a virtual machine (VM), the `DataVolume` object retains a stale owner reference to the original VM. If you then delete the original VM, garbage collection deletes the `DataVolume` object and its underlying persistent volume claim (PVC), even if the disk is attached to a different VM. As a consequence, data loss can occur.
+** As a workaround, after detaching a disk from a VM, manually remove the `ownerReference` entry from the `DataVolume` object before deleting the original VM. As a result, the disk is not deleted when the original VM is removed. (link:https://redhat.atlassian.net/browse/CNV-71659[*CNV-71659*])
+
 //CNV-61066
 * Live migration fails if the VM name exceeds 47 characters. (link:https://issues.redhat.com/browse/CNV-61066[*CNV-61066*])
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/CNV-71659

Link to docs preview:
https://119141--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html#virt-4-19-known-issues_virt-4-19-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
