### PR TITLE
OSDOCS-20983: Fixing minor bug in Images

### DIFF
--- a/openshift_images/image-streams-manage.adoc
+++ b/openshift_images/image-streams-manage.adoc
@@ -40,8 +40,7 @@ include::modules/images-imagestream-update-tag.adoc[leveloffset=+2]
 include::modules/images-imagestream-remove-tag.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-[id="additional-resources-remove-tag_{context}"]
-== Additional resources
+.Additional resources
 
 * xref:../openshift_images/configuring-samples-operator.adoc#images-samples-operator-deprecated-image-stream_configuring-samples-operator[Removing deprecated image stream tags from the Cluster Samples Operator]
 


### PR DESCRIPTION
**Version(s):**
4.20+
5.0

**Issue:**
https://redhat.atlassian.net/browse/OSDOCS-20983

**Link to docs preview:**

The title "Configuring periodic importing of image stream tags" should be rendered as a separate title and not be merged into 1 block with the Additional resources that go before it. See the ticket for a screenshot of the currently bugged area.

OSD: https://119156--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-streams-manage.html#images-imagestream-import_image-streams-managing
OCP: https://119156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage.html#images-imagestream-import_image-streams-managing
ROSA HCP: https://119156--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/image-streams-manage.html#images-imagestream-import_image-streams-managing
ROSA Classic: https://119156--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-streams-manage.html#images-imagestream-import_image-streams-managing

**QE review:**
N/A

**Additional information:**
A commit that introduced this bug was cherry-picked into 4.21 and 4.20, therefore we need to cheery-pick to those branches too.