### PR TITLE
Addressing 4.20 MicroShift content gaps

### DIFF
--- a/maps/jobs/access-the-node-with-kubeconfig.adoc
+++ b/maps/jobs/access-the-node-with-kubeconfig.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: MAP
+:context: access-the-node-with-kubeconfig
+
+include::modules/microshift-kubeconfig-overview.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-kubeconfig-local-access.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-accessing-node-locally.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-kubeconfig-remote-con.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-kubeconfig-generating-additional-files.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-accessing-node-open-firewall.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-accessing-node-remotely.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/choose-an-update-method.adoc
+++ b/maps/jobs/choose-an-update-method.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: MAP
+:context: choose-an-update-method
+
+include::modules/microshift-rhde-updates.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-standalone-updates.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-manual-rpm-updates.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-updates-rhde-config-rhel-repos.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-standalone-rhel-updates.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-simultaneous-microshift-rhel-updates.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/configure-lvms-storage.adoc
+++ b/maps/jobs/configure-lvms-storage.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: MAP
+:context: configure-lvms-storage
+
+include::modules/microshift-lvms-deployment.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-lvms-system-requirements.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-lvmd-yaml-creating.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-lvms-config-example-basic.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-device-classes.adoc[leveloffset=+1,toc="no"]
+
+include::modules/lvms-limitations-to-configure-size-of-devices.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-lvms-using.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-disabling-uninstalling-lvms-csi-snapshot.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-uninstalling-lvms-csi-snapshot.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-uninstalling-lvms-csi-driver.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/configure-microshift-with-the-config-file.adoc
+++ b/maps/jobs/configure-microshift-with-the-config-file.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: MAP
+:context: configure-microshift-with-the-config-file
+
+include::modules/microshift-config-yaml.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-config-rhde-con.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-config-yaml-custom.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-config-parameters-table.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-how-config-snippets-work.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-example-config-snippets-list.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-example-config-snippets-objects.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-example-mixed-config-snippets.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/configure-networking-for-disconnected-hosts.adoc
+++ b/maps/jobs/configure-networking-for-disconnected-hosts.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: configure-networking-for-disconnected-hosts
+
+include::modules/microshift-disconnected-host-con.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-disconnected-host-procedure.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-undo-network-config.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/configure-oc-cli-autocompletion.adoc
+++ b/maps/jobs/configure-oc-cli-autocompletion.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+:context: configure-oc-cli-autocompletion
+
+include::modules/cli-configuring-completion.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/cli-configuring-completion-zsh.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/deploy-a-load-balancer-service.adoc
+++ b/maps/jobs/deploy-a-load-balancer-service.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: MAP
+:context: deploy-a-load-balancer-service
+
+include::modules/microshift-about-load-balancer-service.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-deploying-a-load-balancer.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-blocking-nodeport-access.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-exposed-audit-ports.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-exposed-audit-ports-hostnetwork.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-exposed-audit-ports-hostport.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-exposed-audit-ports-loadbalancer.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/expand-persistent-volumes.adoc
+++ b/maps/jobs/expand-persistent-volumes.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: expand-persistent-volumes
+
+include::modules/storage-expanding-csi-volumes.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/storage-expanding-local-volumes.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-expanding-filesystem-pvc.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-expanding-recovering-failure.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/install-the-oc-cli.adoc
+++ b/maps/jobs/install-the-oc-cli.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+:context: install-the-oc-cli
+
+include::modules/cli-installing-cli-linux.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/cli-installing-cli-macos.adoc[leveloffset=+1,toc="no"]
+
+include::modules/cli-installing-cli-windows.adoc[leveloffset=+1,toc="no"]
+
+include::modules/cli-installing-cli-brew.adoc[leveloffset=+1,toc="no"]
+
+include::modules/cli-installing-cli-rpm.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/install-with-a-rhel-kickstart.adoc
+++ b/maps/jobs/install-with-a-rhel-kickstart.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+:context: install-with-a-rhel-kickstart
+
+include::modules/microshift-rhel-kickstarts-con.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-kickstart-prep.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-kickstart-rpm-install.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-kickstart-ostree-install.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-kickstart-bootc-install.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/list-supported-apis.adoc
+++ b/maps/jobs/list-supported-apis.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+:context: list-supported-apis
+
+include::modules/microshift-openshift-apis.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-k8s-apis.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/list-update-contents.adoc
+++ b/maps/jobs/list-update-contents.adoc
@@ -1,0 +1,4 @@
+:_mod-docs-content-type: MAP
+:context: list-update-contents
+
+include::modules/microshift-get-rpm-release-info.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/manage-ephemeral-storage.adoc
+++ b/maps/jobs/manage-ephemeral-storage.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: MAP
+:context: manage-ephemeral-storage
+
+include::modules/storage-ephemeral-storage-overview.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/storage-ephemeral-storage-types.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-storage-manage-overview.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-storage-manage-requests-and-limits.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-storage-manage-config-and-eviction.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-storage-monitoring.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/manage-networking-runtime-settings.adoc
+++ b/maps/jobs/manage-networking-runtime-settings.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+:context: manage-networking-runtime-settings
+
+include::modules/microshift-cri-o-container-runtime.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-ovs-snapshot.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/manage-volume-snapshots.adoc
+++ b/maps/jobs/manage-volume-snapshots.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: MAP
+:context: manage-volume-snapshots
+
+include::modules/microshift-storage-about-vol-snapshots.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-lvm-thin-volumes.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-classes.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-vol-snapshot-class.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-creating-vol-snapshot.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-backup-volume-snapshots.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-vol-snapshot-restore.adoc[leveloffset=+1,toc="no"]
+
+include::modules/persistent-storage-csi-snapshots-delete.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-storage-volume-cloning.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/migrate-storage-versions.adoc
+++ b/maps/jobs/migrate-storage-versions.adoc
@@ -1,0 +1,4 @@
+:_mod-docs-content-type: MAP
+:context: migrate-storage-versions
+
+include::modules/microshift-making-storage-migration-request.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/oc-command-reference.adoc
+++ b/maps/jobs/oc-command-reference.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: oc-command-reference
+
+include::modules/microshift-oc-cmd.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-oc-by-example-content.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-oc-adm-by-example-content.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/provision-persistent-storage.adoc
+++ b/maps/jobs/provision-persistent-storage.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: MAP
+:context: provision-persistent-storage
+
+include::modules/microshift-storage-persistent-storage-overview.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/storage-persistent-storage-lifecycle.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-persistent-storage-pv.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-persistent-storage-pvc.adoc[leveloffset=+1,toc="no"]
+
+include::modules/pvc-storage-class.adoc[leveloffset=+1,toc="no"]
+
+include::modules/pvc-claims-as-volumes.adoc[leveloffset=+1,toc="no"]
+
+include::modules/pvc-cli-command-usage.adoc[leveloffset=+1,toc="no"]
+
+include::modules/viewing-pvc-usage-statistics.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-persistent-storage-reclaim.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-persistent-storage-reclaim-manual.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-persistent-storage-fsGroup.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-control-permissions-security-context-constraints.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-pv-rwo-access-mode-permission.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-checking-pods-mismatch.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-updating-pods-mismatch.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-verifying-pods-mismatch.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/review-4-20-release-notes.adoc
+++ b/maps/jobs/review-4-20-release-notes.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: MAP
+:context: review-4-20-release-notes
+
+include::modules/microshift-4-20-about-this-release.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-4-20-new-features-and-enhancements.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-tech-preview.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-doc-enhancements.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-known-issues.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-asynchronous-updates.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-26-dp.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-23-dp.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-20-dp.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-13-dp.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-0-dp.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-4-20-additional-release-notes.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/start-and-stop-the-microshift-service.adoc
+++ b/maps/jobs/start-and-stop-the-microshift-service.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: MAP
+:context: start-and-stop-the-microshift-service
+
+include::modules/microshift-service-starting.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-service-stopping.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/understand-api-compatibility.adoc
+++ b/maps/jobs/understand-api-compatibility.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: understand-api-compatibility
+
+include::modules/api-compatibility-guidelines.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/api-compatibility-exceptions.adoc[leveloffset=+1,toc="no"]
+
+include::modules/api-compatibility-common-terminology.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/understand-api-support-tiers.adoc
+++ b/maps/jobs/understand-api-support-tiers.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: understand-api-support-tiers
+
+include::modules/api-support-tiers.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/api-support-tiers-mapping.adoc[leveloffset=+1,toc="no"]
+
+include::modules/api-support-deprecation-policy.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/understand-microshift-storage.adoc
+++ b/maps/jobs/understand-microshift-storage.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: understand-microshift-storage
+
+include::modules/microshift-persistent-storage.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-dynamic-storage-LVMS-plugin.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-ephemeral-storage.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-dynamic-provisioning-overview.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/understand-microshift.adoc
+++ b/maps/jobs/understand-microshift.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: understand-microshift
+
+include::modules/microshift-about.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-product-documentation.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-arch-design.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/use-generic-ephemeral-volumes.adoc
+++ b/maps/jobs/use-generic-ephemeral-volumes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+:context: use-generic-ephemeral-volumes
+
+include::modules/storage-ephemeral-vols-overview.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/storage-ephemeral-vols-lifecycle.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-vols-security.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-vols-pvc-naming.adoc[leveloffset=+1,toc="no"]
+
+include::modules/storage-ephemeral-vols-procedure.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/use-the-oc-cli.adoc
+++ b/maps/jobs/use-the-oc-cli.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: use-the-oc-cli
+
+include::modules/microshift-cli-oc-about.adoc[leveloffset=+0,chunk="to-content"]
+
+include::modules/microshift-cli-oc-logs.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-cli-oc-get-help.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-oc-apis-errors.adoc[leveloffset=+1,toc="no"]

--- a/maps/microshift/api.adoc
+++ b/maps/microshift/api.adoc
@@ -1,3 +1,9 @@
 :_mod-docs-content-type: MAP
 
 = API
+
+include::jobs/list-supported-apis.adoc[leveloffset=+1,navtitle="List Supported APIs"]
+
+include::jobs/understand-api-support-tiers.adoc[leveloffset=+1,navtitle="Understand API Support Tiers"]
+
+include::jobs/understand-api-compatibility.adoc[leveloffset=+1,navtitle="Understand API Compatibility"]

--- a/maps/microshift/cli.adoc
+++ b/maps/microshift/cli.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+= CLI tools
+
+include::jobs/install-the-oc-cli.adoc[leveloffset=+1,navtitle="Install the OpenShift CLI"]
+
+include::jobs/configure-oc-cli-autocompletion.adoc[leveloffset=+1,navtitle="Configure oc CLI Autocompletion"]
+
+include::jobs/use-the-oc-cli.adoc[leveloffset=+1,navtitle="Use the oc CLI"]
+
+include::jobs/oc-command-reference.adoc[leveloffset=+1,navtitle="oc Command Reference"]

--- a/maps/microshift/configure.adoc
+++ b/maps/microshift/configure.adoc
@@ -2,6 +2,10 @@
 
 = Configure
 
+include::jobs/configure-microshift-with-the-config-file.adoc[leveloffset=+1]
+
+include::jobs/access-the-node-with-kubeconfig.adoc[leveloffset=+1]
+
 include::jobs/understand-default-networking.adoc[leveloffset=+1]
 
 include::jobs/customize-networking-configuration.adoc[leveloffset=+1]
@@ -11,6 +15,12 @@ include::jobs/optimize-low-latency-performance.adoc[leveloffset=+1]
 include::jobs/optimize-network-performance.adoc[leveloffset=+1]
 
 include::jobs/extend-with-multiple-networks.adoc[leveloffset=+1]
+
+include::jobs/deploy-a-load-balancer-service.adoc[leveloffset=+1]
+
+include::jobs/manage-networking-runtime-settings.adoc[leveloffset=+1]
+
+include::jobs/configure-networking-for-disconnected-hosts.adoc[leveloffset=+1]
 
 include::jobs/provide-external-access.adoc[leveloffset=+1]
 

--- a/maps/microshift/install.adoc
+++ b/maps/microshift/install.adoc
@@ -10,6 +10,10 @@ include::jobs/embed-rhel-edge-image.adoc[leveloffset=+1]
 
 include::jobs/install-from-rpm-fips.adoc[leveloffset=+1]
 
+include::jobs/install-with-a-rhel-kickstart.adoc[leveloffset=+1]
+
+include::jobs/start-and-stop-the-microshift-service.adoc[leveloffset=+1]
+
 include::jobs/verify-your-installation.adoc[leveloffset=+1]
 
 include::jobs/uninstall-microshift.adoc[leveloffset=+1]

--- a/maps/microshift/navigation.adoc
+++ b/maps/microshift/navigation.adoc
@@ -24,6 +24,8 @@ include::ai.adoc[leveloffset=+1]
 
 include::develop.adoc[leveloffset=+1]
 
+include::cli.adoc[leveloffset=+1]
+
 include::upgrade.adoc[leveloffset=+1]
 
 include::plan.adoc[leveloffset=+1]

--- a/maps/microshift/navigation.adoc
+++ b/maps/microshift/navigation.adoc
@@ -18,6 +18,8 @@ include::api.adoc[leveloffset=+1]
 
 include::configure.adoc[leveloffset=+1]
 
+include::storage.adoc[leveloffset=+1]
+
 include::ai.adoc[leveloffset=+1]
 
 include::develop.adoc[leveloffset=+1]

--- a/maps/microshift/storage.adoc
+++ b/maps/microshift/storage.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: MAP
+
+= Storage
+
+include::jobs/understand-microshift-storage.adoc[leveloffset=+1,navtitle="Understand MicroShift Storage"]
+
+include::jobs/configure-lvms-storage.adoc[leveloffset=+1,navtitle="Configure the LVMS Storage Provider"]
+
+include::jobs/provision-persistent-storage.adoc[leveloffset=+1,navtitle="Provision Persistent Storage"]
+
+include::jobs/expand-persistent-volumes.adoc[leveloffset=+1,navtitle="Expand Persistent Volumes"]
+
+include::jobs/manage-volume-snapshots.adoc[leveloffset=+1,navtitle="Manage Volume Snapshots and Clones"]
+
+include::jobs/manage-ephemeral-storage.adoc[leveloffset=+1,navtitle="Manage Ephemeral Storage"]
+
+include::jobs/use-generic-ephemeral-volumes.adoc[leveloffset=+1,navtitle="Use Generic Ephemeral Volumes"]
+
+include::jobs/migrate-storage-versions.adoc[leveloffset=+1,navtitle="Migrate Storage API Versions"]

--- a/maps/microshift/upgrade.adoc
+++ b/maps/microshift/upgrade.adoc
@@ -2,6 +2,8 @@
 
 = Upgrade
 
+include::jobs/choose-an-update-method.adoc[leveloffset=+1]
+
 include::jobs/apply-updates-rhel-edge.adoc[leveloffset=+1]
 
 include::jobs/understand-automatic-rollbacks.adoc[leveloffset=+1]
@@ -17,3 +19,5 @@ include::jobs/verify-system-health.adoc[leveloffset=+1]
 include::jobs/troubleshoot-update-problems.adoc[leveloffset=+1]
 
 include::jobs/identify-potential-update-issues.adoc[leveloffset=+1]
+
+include::jobs/list-update-contents.adoc[leveloffset=+1]

--- a/maps/microshift/whats-new.adoc
+++ b/maps/microshift/whats-new.adoc
@@ -1,3 +1,7 @@
 :_mod-docs-content-type: MAP
 
 = What's New
+
+include::jobs/understand-microshift.adoc[leveloffset=+1,navtitle="Understand MicroShift"]
+
+include::jobs/review-4-20-release-notes.adoc[leveloffset=+1,navtitle="Review the 4.20 Release Notes"]


### PR DESCRIPTION
Version(s):
4.20

Issue:


Link to docs preview:
https://bscott-rh.github.io/openshift-docs/microshift-4-20-gap/microshift/navigation.html
