### PR TITLE
OSSM-15841 [OSSM] Add mod-docs-content-type to Snippets

### DIFF
--- a/snippets/deprecated-feature.adoc
+++ b/snippets/deprecated-feature.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 

--- a/snippets/developer-preview.adoc
+++ b/snippets/developer-preview.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // DO NOT USE THIS SNIPPET. DEVELOPER PREVIEW FEATURES ARE NOT DOCUMENTED IN CORE OPENSHIFT DOCS.
 
 // When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.

--- a/snippets/technology-preview-SPIRE.adoc
+++ b/snippets/technology-preview-SPIRE.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // snippet included in the following assembly and modules:
 //
 // * service-mesh-docs-main/install/ossm-SPIRE.adoc

--- a/snippets/technology-preview-istio-ambient-mode.adoc
+++ b/snippets/technology-preview-istio-ambient-mode.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // snippet included in the following assemblies:
 //
 // * service-mesh-docs-main/install/ossm-istio-ambient-mode.adoc

--- a/snippets/technology-preview-istiocsr.adoc
+++ b/snippets/technology-preview-istiocsr.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // snippet included in the following modules:
 //
 // * service-mesh-docs-main/modules/ossm-about-cert-manager.adoc


### PR DESCRIPTION
[OSSM-15841](https://redhat.atlassian.net/browse/OSSM-15841) [OSSM] Add mod-docs-content-type to Snippets


Version(s):
`service-mesh-JTBD`

Issue:
https://redhat.atlassian.net/browse/OSSM-15841

Link to docs preview:


QE review:
QE it not required for this PR.

Additional information:
* 3 snippet files already had `_mod-docs-content-type: SNIPPET` so they did not need to be updated.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
