### PR TITLE
Simplify AWS terminology in section headings

### DIFF
--- a/modules/ossm-federation-across-cluster.adoc
+++ b/modules/ossm-federation-across-cluster.adoc
@@ -23,7 +23,7 @@ If the cluster does not support `LoadBalancer` services, using a `NodePort` serv
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifndef::openshift-dedicated[]
-== Exposing the federation ingress on Amazon Web Services (AWS)
+== Exposing the federation ingress on AWS
 By default, LoadBalancer services in clusters running on AWS do not support L4 load balancing. In order for {SMProductName} federation to operate correctly, the following annotation must be added to the ingress gateway service:
 
 service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -108,7 +108,7 @@ If you are using a firewall to control egress traffic from {product-title}, your
 Managed clusters require enabling telemetry to allow Red{nbsp}Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
 For more information about how remote health monitoring data is used by Red{nbsp}Hat, see _About remote health monitoring_ in the _Additional resources_ section.
 
-== Domains for Amazon Web Services (AWS) APIs
+== Domains for AWS APIs
 [cols="6,1,6",options="header"]
 |===
 |Domain | Port | Function


### PR DESCRIPTION
## Summary
This PR simplifies the terminology used in section headings by replacing the verbose "Amazon Web Services (AWS)" with the concise "AWS" abbreviation, aligning with recent documentation style improvements.

## Changes
- **modules/rosa-hcp-firewall-prerequisites.adoc**: Changed heading from "Domains for Amazon Web Services (AWS) APIs" to "Domains for AWS APIs"
- **modules/ossm-federation-across-cluster.adoc**: Changed heading from "Exposing the federation ingress on Amazon Web Services (AWS)" to "Exposing the federation ingress on AWS"

## Justification
Recent PRs have been standardizing terminology by using concise "AWS" in section headings while keeping the full "Amazon Web Services (AWS)" on first mention in body text. This change follows that established pattern for consistency across the documentation.

## Testing
- Verified AsciiDoc syntax is correct
- Changes are limited to section headings only
- No functional impact

🤖 Generated with Claude Code