### PR TITLE
Add HOST_ARCH support for OKD installer downloads

### DIFF
--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -58,6 +58,17 @@ $ export HOST_ARCH=$(uname -m)
 +
 This command detects the architecture of the installation host. If the installation host architecture differs from the target cluster architecture, the downloaded binaries must match the installation host. For example, if you are installing an `aarch64` cluster from an `x86_64` bastion host, `HOST_ARCH` is `x86_64`.
 
+ifdef::openshift-origin[]
+. Set the architecture suffix for {product-title} downloads:
++
+[source,terminal]
+----
+$ export OKD_ARCH=$(if [ "$HOST_ARCH" = "aarch64" ]; then echo "-arm64"; else echo ""; fi)
+----
++
+This command sets the architecture suffix used in {product-title} GitHub release asset names.
+endif::openshift-origin[]
+
 ifndef::openshift-origin[]
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +
@@ -81,7 +92,7 @@ ifdef::openshift-origin[]
 +
 [source,terminal]
 ----
-$ curl -L https://github.com/okd-project/okd/releases/download/$OKD_VERSION/openshift-client-linux-$OKD_VERSION.tar.gz -o oc.tar.gz
+$ curl -L https://github.com/okd-project/okd/releases/download/$OKD_VERSION/openshift-client-linux$OKD_ARCH-$OKD_VERSION.tar.gz -o oc.tar.gz
 ----
 +
 [source,terminal]
@@ -108,7 +119,7 @@ ifdef::openshift-origin[]
 +
 [source,terminal]
 ----
-$ curl -L https://github.com/okd-project/okd/releases/download/$OKD_VERSION/openshift-install-linux-$OKD_VERSION.tar.gz -o openshift-install-linux.tar.gz
+$ curl -L https://github.com/okd-project/okd/releases/download/$OKD_VERSION/openshift-install-linux$OKD_ARCH-$OKD_VERSION.tar.gz -o openshift-install-linux.tar.gz
 ----
 endif::openshift-origin[]
 +


### PR DESCRIPTION
## Summary
This PR fixes the OKD single-node installer documentation to support ARM64 architecture by adding proper architecture handling for GitHub release asset downloads.

## Issue
Fixes #112917

## Problem
The OKD installer and client download commands did not include architecture specification in the URL, causing failures when trying to download ARM64 binaries on `aarch64` installer machines. While `HOST_ARCH` was defined and used for OpenShift Container Platform downloads, it was not utilized for OKD GitHub release downloads.

## Solution
Added a new `OKD_ARCH` variable that maps the system architecture (`HOST_ARCH`) to the GitHub release asset naming convention:
- `aarch64` → `-arm64` (appended to filename)
- `x86_64` → `` (empty string, default naming)

Updated both the `openshift-client` and `openshift-install` download URLs to include `$OKD_ARCH`, ensuring the correct architecture-specific binaries are downloaded.

## Changes
- **modules/install-sno-generating-the-install-iso-manually.adoc**:
  - Added step to set `OKD_ARCH` variable (OKD-specific section only)
  - Updated client download URL: `openshift-client-linux$OKD_ARCH-$OKD_VERSION.tar.gz`
  - Updated installer download URL: `openshift-install-linux$OKD_ARCH-$OKD_VERSION.tar.gz`

## Verification
Verified against actual OKD releases (e.g., 4.14.0-0.okd-2024-01-26-175629) which include:
- `openshift-install-linux-4.14.0-0.okd-2024-01-26-175629.tar.gz` (x86_64, default)
- `openshift-install-linux-arm64-4.14.0-0.okd-2024-01-26-175629.tar.gz` (ARM64)

## Testing
- Changes only affect OKD documentation (`ifdef::openshift-origin[]` sections)
- No impact on OpenShift Container Platform documentation
- AsciiDoc syntax verified

🤖 Generated with Claude Code