### PR TITLE
Clarify default channel behavior in ImageSetConfiguration

### DIFF
--- a/modules/oc-mirror-operator-catalog-filtering.adoc
+++ b/modules/oc-mirror-operator-catalog-filtering.adoc
@@ -51,7 +51,7 @@ mirror:
      packages:
     - name: compliance-operator
 ----
-|One bundle, corresponding to the head version for each channel of that package.
+|When no `channels` field is specified for a package, oc-mirror includes all channels of that package and mirrors one bundle corresponding to the head version for each channel. To mirror only specific channels, add a `channels` block listing the desired channel names.
 
 a|Scenario 4
 


### PR DESCRIPTION
## Summary
This PR clarifies the default channel behavior in the oc-mirror v2 operator catalog filtering documentation, making it explicit that when no `channels` field is specified, ALL channels are included in the mirroring set.

## Issue
Fixes #114629

## Problem
The current documentation for Scenario 3 states:
> "One bundle, corresponding to the head version for each channel of that package."

While technically accurate, this wording only **implies** that all channels are included. Users have to read carefully to understand this, and it's easy to misinterpret as meaning only the default channel is mirrored. This ambiguity can lead to misunderstandings about the scope of mirroring operations.

## Solution
Updated the description to explicitly state:
> "When no `channels` field is specified for a package, oc-mirror includes all channels of that package and mirrors one bundle corresponding to the head version for each channel. To mirror only specific channels, add a `channels` block listing the desired channel names."

This clarification:
- ✅ Explicitly states that ALL channels are included by default
- ✅ Explains what gets mirrored (head version for each channel)
- ✅ Provides actionable guidance on how to filter specific channels
- ✅ Helps users make informed decisions about mirroring scope

## Changes
- **modules/oc-mirror-operator-catalog-filtering.adoc**: Updated Scenario 3 description to clarify default channel behavior

## Impact
- Improves user understanding of oc-mirror v2 filtering behavior
- Reduces potential for misconfig uration due to unclear defaults
- Provides clearer guidance for users who want to limit mirror scope

## Testing
- Documentation-only change
- No functional code changes
- AsciiDoc syntax verified

## Note
I noticed there was a comment on the issue from @Khushboo1206 asking to work on it. Since no PR has been submitted yet and the issue remains unassigned, I went ahead with this fix. If there's overlap, happy to coordinate!

🤖 Generated with Claude Code