### PR TITLE
RHDEVDOCS-7925: Content creation for the GitOps 1.21.4 z-stream release

### DIFF
--- a/modules/gitops-release-notes-1-21-4.adoc
+++ b/modules/gitops-release-notes-1-21-4.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-21.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-21-4_{context}"]
+= Release notes for Red Hat OpenShift GitOps 1.21.4
+
+[role="_abstract"]
+
+{gitops-title} 1.21.4 is now available on {OCP} 4.18, 4.19, 4.20, 4.21, and 4.22.
+
+[id="errata-updates-1-21-4_{context}"]
+== Errata updates
+
+RHBA-XXXX:NNNN - {gitops-title} 1.21.4 enhancement update advisory::
+Issued: 2026-09-03
++
+The list of enhancements that are included in this release is documented in the following advisory:
++
+* link:https://access.redhat.com/errata/RHBA-XXXX:NNNN[RHBA-XXXX:NNNN]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="fixed-issues-1-21-4_{context}"]
+== Fixed issues
+
+OpenShift login succeeds when NamespaceManagement CR targets an unauthorized namespace::
+Before this update, OpenShift login to Argo CD failed with an `unauthorized_client` error when a `NamespaceManagement` custom resource (CR) existed for a namespace that Argo CD was not configured to manage. With this update, OpenShift login succeeds even when a `NamespaceManagement` CR targets an unauthorized namespace.
++
+link:https://redhat.atlassian.net/browse/GITOPS-10477[GITOPS-10477]
+
+

--- a/release_notes/gitops-release-notes-1-21.adoc
+++ b/release_notes/gitops-release-notes-1-21.adoc
@@ -30,6 +30,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.21.4
+include::modules/gitops-release-notes-1-21-4.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.21.3
 include::modules/gitops-release-notes-1-21-3.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

none for CP

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7925

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Release notes for Red Hat OpenShift GitOps 1.21.4](https://119186--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-21.html#gitops-release-notes-1-21-4_gitops-release-notes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
QE review:
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
