### PR TITLE
OSDOCS-21986: Add 4.12.97 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-97-about.adoc
+++ b/modules/zstream-4-12-97-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-97-about_{context}"]
+= RHSA-2026:59833 - {product-title} {product-version}.97 bug fix and security update
+
+[role="_abstract"]
+Issued: 03 September 2026
+
+{product-title} release {product-version}.97, which includes security updates, is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:59833[RHSA-2026:59833] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:59830[RHSA-2026:59830] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.97 --pullspecs
+----

--- a/modules/zstream-4-12-97-fixed-issues.adoc
+++ b/modules/zstream-4-12-97-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-97-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-97-updating.adoc
+++ b/modules/zstream-4-12-97-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-97-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5467,3 +5467,12 @@ include::modules/zstream-4-12-96-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.96 updating
 include::modules/zstream-4-12-96-updating.adoc[leveloffset=+3]
+
+// 4.12.97 about
+include::modules/zstream-4-12-97-about.adoc[leveloffset=+2]
+
+// 4.12.97 fixes
+include::modules/zstream-4-12-97-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.97 updating
+include::modules/zstream-4-12-97-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version
4.12

Issue
https://redhat.atlassian.net/browse/OSDOCS-21986

Doc preview link
https://119190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-97-about_release-notes

QE review
N/A

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/765
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12
- Errata: RHSA-2026:59833 (primary) / RHSA-2026:59830 (RPM companion)


