### PR TITLE
[enterprise-4.21] OSDOCS-16997-installation-config-parameters-gcp# CQA

### DIFF
--- a/installing/installing_gcp/installation-config-parameters-gcp.adoc
+++ b/installing/installing_gcp/installation-config-parameters-gcp.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you deploy an {product-title} cluster on {gcp-first}, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+[role="_abstract"]
+Before you deploy an {product-title} cluster on {gcp-first}, you create the `install-config.yaml` file and provide parameters to customize your cluster and the platform that hosts it. You can then modify the `install-config.yaml` file to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -538,7 +538,7 @@ endif::ibm-power-vs[]
 
 [NOTE]
 ====
-Set the `networking.machineNetwork` to match the CIDR that the preferred NIC resides in.
+Set the `networking.machineNetwork` to match the CIDR of the preferred NIC.
 ====
 
 |networking:


### PR DESCRIPTION
This is a manual cherry-pick of #114139 to enterprise-4.21.

The automated cherry-pick failed because of a merge conflict in `modules/installation-configuration-parameters.adoc`. I resolved it manually to apply only the change from #114139 (the `networking.machineNetwork` NOTE phrasing). The AWS dual-stack networking content in that NOTE block exists on `main` but not on this branch, so it was correctly excluded from the resolution.

/assign sslocket