### PR TITLE
ROX-35962: Clarify certificate authority in custom TLS setup

### DIFF
--- a/configuration/add-custom-certificates.adoc
+++ b/configuration/add-custom-certificates.adoc
@@ -11,7 +11,7 @@ Learn how to use a custom TLS certificate with {product-title}. After you set up
 
 [NOTE]
 ====
-On {osp}, the `central-ocp` service exposes the Central API with an OpenShift-signed certificate. If you already trust the {osp} root certificate authority (CA), you can use this service without adding a custom certificate.
+On {osp}, the `central-ocp` service exposes the Central API with an OpenShift-signed certificate. If you already trust the {osp} internal service certificate authority (Service CA), you can use this service without adding a custom certificate.
 ====
 
 [id="add-custom-security-cert"]


### PR DESCRIPTION
Updated note regarding the use of the internal service certificate authority instead of the root certificate authority.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 5.0+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://119211--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/add-custom-certificates.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
