### PR TITLE
[enterprise-4.18] OCPBUGS-114888: UPdated xactly three control plane nodes must be to m…

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -77,18 +77,26 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Control planes are managed with control plane machine sets.
 endif::openshift-dedicated,openshift-rosa[]
-Extra controls apply to control plane machines to prevent you from deleting all of the control plane machines and breaking your cluster.
+Extra controls apply to control plane machines to prevent you from deleting all of the control plane machines and making the cluster inoperable.
+ifndef::openshift-dedicated,openshift-rosa[]
+Exactly three control plane nodes must be used for all production deployments.
 
 [NOTE]
 ====
-ifndef::openshift-dedicated,openshift-rosa[]
-Exactly three control plane nodes must be used for all production deployments. However, on bare metal platforms, clusters can be scaled up to five control plane nodes.
+On a bare-metal platform, you can scale a cluster to three, four, or five control plane nodes.
+For best results, use odd size control plane nodes, such as three or five, on a cluster.
+A four-node control plane has the same etcd one failure tolerance as three nodes. 
+Only a five-node control plane can tolerate two simultaneous failures.
+
+Adding a fourth control plane node means etcd needs three healthy members instead of two.
+Until the fourth node is healthy, losing one of the original nodes breaks quorum and takes the cluster down.
+====
+
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Single availability zone clusters and multiple availability zone clusters require a minimum of three control plane nodes.
 endif::openshift-dedicated,openshift-rosa[]
-====
-
++
 Services that fall under the Kubernetes category on the control plane include the Kubernetes API server, etcd, the Kubernetes controller manager, and the Kubernetes scheduler.
 
 .Kubernetes services that run on the control plane


### PR DESCRIPTION
CP of #119021 with commit ID d94a1f121a3726dc9fb18d7f5caa879dedbb2794

Version(s):
4.18

Issue:
[OCPBUGS-114888](https://redhat.atlassian.net/browse/OCPBUGS-114888)

Link to docs preview:


