### PR TITLE
OSSM-15861 [OSSM] Add mod-docs-content-type to Attributes

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // common attributes
 :toc:
 :toc-title:

--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // common attributes
 :product-short-name: OpenShift Dedicated
 :toc:

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.9".
 // {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
 // See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#product-name-and-version for more information on this topic.

--- a/_attributes/servicebinding-document-attributes.adoc
+++ b/_attributes/servicebinding-document-attributes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Standard document attributes to be used in the documentation
 //
 // The following are shared by all documents:


### PR DESCRIPTION
[OSSM-15861](https://redhat.atlassian.net/browse/OSSM-15861) [OSSM] Add mod-docs-content-type to Attributes

Version(s):
`service-mesh-JTBD`

Issue:
https://redhat.atlassian.net/browse/OSSM-15861

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
