### PR TITLE
[enterprise-4.19] OCPBUGS-81524: Added a note about seed cluster usage

### DIFF
--- a/modules/cnf-image-based-upgrade-generate-seed-image.adoc
+++ b/modules/cnf-image-based-upgrade-generate-seed-image.adoc
@@ -141,8 +141,6 @@ The cluster reboots and loses API capabilities while the {lcao} generates the se
 Applying the `SeedGenerator` CR stops the `kubelet` and the CRI-O operations, then it starts the image generation.
 ====
 
-If you want to generate more seed images, you must provision a new seed cluster with the version that you want to generate a seed image from.
-
 .Verification
 
 * After the cluster recovers and it is available, you can check the status of the `SeedGenerator` CR by running the following command:
@@ -172,3 +170,10 @@ status:
   observedGeneration: 1
 ----
 <1> The seed image generation is complete.
+
+[IMPORTANT]
+====
+After the seed image generation completes, do not use the seed cluster. Do not continue to run `oc` commands against the seed cluster or use it to manage managed clusters.
+
+If you access the seed cluster after generating the seed image, you can meet TLS certificate validation errors because the seed cluster certificates expire during seed image generation. If you need to generate another seed image, provision a new seed cluster.
+====


### PR DESCRIPTION
This is a manual cherry-pick of #114277

Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-81524

Link to docs preview:
- [Generating a seed image for the image-based upgrade](https://119244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed.html#cnf-image-based-upgrade-generate-seed-image_generate-seed)
- [Generating a seed image with the Lifecycle Agent](https://119244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-preparing-for-image-based-install.html#cnf-image-based-upgrade-generate-seed-image_ibi-preparing-image-based-install)

QE review:
- [x] QE has approved this change.

Additional information:
- Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/114277
- Automated cherry-pick did not apply cleanly because this version still uses a callout in the verification example, and the previous "provision a new seed cluster" sentence is before the Verification section.
- The IMPORTANT note about not using the seed cluster after image generation replaces that sentence and is placed after verification, matching the original PR.

/assign slovern