### PR TITLE
[enterprise-4.17] CNF#22213: Added a recommendation

### DIFF
--- a/modules/telco-core-rds-networking.adoc
+++ b/modules/telco-core-rds-networking.adoc
@@ -15,6 +15,11 @@ Description::
 
 * The validated physical network configuration consists of two dual-port NICs.
 One NIC is shared among the primary CNI (OVN-Kubernetes) and IPVLAN and MACVLAN traffic, the second NIC is dedicated to SR-IOV VF-based Pod traffic.
++
+[NOTE]
+====
+The recommended network topology uses bonding with ports from the same dual-port NIC. Bonding ports across different NICs is not recommended.
+====
 
 * A Linux bonding interface (`bond0`) is created in an active-active LACP `IEEE 802.3ad` configuration with the two NIC ports attached.
 +


### PR DESCRIPTION
This is a manual cherry-pick of #108105

Version(s):
4.17

Issue:
https://redhat.atlassian.net/browse/CNF-22213

Link to docs preview:
- [Telco core RDS networking](https://119253--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.html)

QE review:
- [x] QE has approved this change.

Additional information:
- Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/108105
- This version does not have `modules/telco-core-networking.adoc` or the MetalLB service-separation figure. The recommendation is added in `modules/telco-core-rds-networking.adoc` next to the dual-port NIC description, without a figure-number reference.

/assign slovern