### PR TITLE
[enterprise-4.18] CNF#22213: Added a recommendation

### DIFF
--- a/modules/telco-core-networking.adoc
+++ b/modules/telco-core-networking.adoc
@@ -57,5 +57,10 @@ The following diagram illustrates how specific service IP addresses are advertis
 Services routes are defined in `BGPAdvertisement` CRs and configured with values for `IPAddressPool1` and `BGPPeer1` fields.
 --
 
+[NOTE]
+====
+Figure 3.2 shows the recommended network topology, where bonding uses ports from the same dual-port NIC. Bonding ports across different NICs is not recommended.
+====
+
 .Telco core reference design MetalLB service separation
 image::openshift-telco-core-rds-metallb-service-separation.png[Telco core reference design MetalLB service separation]


### PR DESCRIPTION
This is a manual cherry-pick of #108105

Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/CNF-22213

Link to docs preview:
- [Telco core RDS networking](https://119254--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html)

QE review:
- [x] QE has approved this change.

Additional information:
- Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/108105
- Automated cherry-pick did not apply cleanly. The NOTE from the original PR is placed before the MetalLB service-separation figure, matching enterprise-4.20.

/assign slovern