### PR TITLE
[RHDEVDOCS-7242] Document CEL expression evaluation for PAC template …

### DIFF
--- a/modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc
@@ -70,3 +70,58 @@ On GitHub Apps, the generated installation token is available for 8 hours and sc
 .Additional resources
 
 * link:https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app[GitHub App authentication]
+
+
+[id="pac-cel-template-expressions_{context}"]
+== Evaluating Common Expression Language expressions in template variables
+
+You can evaluate Common Expression Language (CEL) expressions directly inside {pac} templates by using the `cel:` prefix in template variables (for example, `{{ cel: ... }}`). With this capability, you can perform conditional logic, string operations, and presence checks directly within template definitions without creating custom parameters.
+
+.Supported namespaces in CEL template evaluation
+[cols="1,2",options="header"]
+|===
+| Namespace | Description
+
+| `body`
+| The webhook JSON payload. If no payload body is present, `body` evaluates to an empty object (`{}`).
+
+| `headers`
+| The HTTP request headers from the incoming webhook.
+
+| `files`
+| Data for changed files in the pull request or commit.
+
+| `pac`
+| Standard {pac} parameters, such as `pac.target_branch` or `pac.revision`.
+|===
+
+.Examples of CEL template expressions
+* **Branch-based condition:**
++
+[source,yaml]
+----
+spec:
+  params:
+    - name: environment
+      value: "{{ cel: pac.target_branch == 'main' ? 'production' : 'staging' }}"
+----
+
+* **Safe access to optional payload fields:**
++
+[source,yaml]
+----
+spec:
+  params:
+    - name: pull-request-id
+      value: "{{ cel: has(body.pull_request) ? body.pull_request.number : '' }}"
+----
+
+* **Accessing PAC variables directly:**
++
+[source,yaml]
+----
+spec:
+  params:
+    - name: commit-sha
+      value: "{{ cel: pac.revision }}"
+----


### PR DESCRIPTION
**Jira Ticket:**
https://redhat.atlassian.net/browse/RHDEVDOCS-7242 

**Upstream Dev PR:**
[[](https://github.com/openshift-pipelines/pipelines-as-code/pull/2363
)](https://github.com/tektoncd/pipelines-as-code/pull/2363)

**Preview Link**
https://119273--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/creating-pipeline-runs-pac.html 

**QE Review**
- [x]  @chmouel 

**Peer Review**

**Summary of Changes:**
- Documented inline Common Expression Language (CEL) template variable evaluation using the cel: prefix ({{ cel: ... }}) in Pipelines as Code templates.
- Added a reference table mapping supported namespaces: body, headers, files, and pac.
- Clarified edge-case handling for missing or null webhook payload bodies, which resolve body to an empty object {}.
- Added practical YAML configuration examples demonstrating branch-based environment selection, safe field access using has(), and direct PAC variable references.

**Modified File:**
modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc