### PR TITLE
OSDOCS-21585: Docs for Enable NodeSelector on EgressIP to control whi…

### DIFF
--- a/modules/nw-egress-about-node-selectors.adoc
+++ b/modules/nw-egress-about-node-selectors.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-egress-about-node-selectors_{context}"]
+= About egress IP node selectors
+
+[role="_abstract"]
+You can use the `nodeSelector` field to restrict what nodes can host a specific `EgressIP` object.
+This configuration provides more granular control over `EgressIP` object placement when compared to the `k8s.ovn.org/egress-assignable label` method. 
+
+The `nodeSelector` field acts as a filter on an existing pool of nodes that are already have the `egress-assignable` label. 
+Also, explain the relationship between the `nodeSelector` field in the EgressIP object, which is managed by the Cluster Network Operator (CNO), and the underlying implementation in OVN-Kubernetes, noting that these must remain aligned.
+
+The Cluster Network Operator (CNO) manages the `EgressIP` Custom Resource Definition (CRD) and exposes the `spec.nodeSelector` field so that you can target specific nodes.
+The underlying OVN-Kubernetes network plugin must recognize those target nodes as valid egress hosts.
+Every node must match the `nodeSelector` field and also carry the `k8s.ovn.org/egress-assignable=""` label on its node object.
+
+The API definition of the CNO and the execution engine of the OVN-Kubernetes plugin must remain aligned.
+If a node matches the value in the `nodeSelector` field but lacks the OVN-Kubernetes assignable label, the Egress IP address assignment fails to move to an active state.
+
+You can apply the `k8s.ovn.org/egress-assignable=""` label to a node in your cluster so that {product-title} can assign one or more egress IP addresses to the node.

--- a/modules/nw-egress-ips-node-selector.adoc
+++ b/modules/nw-egress-ips-node-selector.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-egress-ips-node-selector_{context}"]
+= Configuring an EgressIP object by using a node selector
+
+[role="_abstract"]
+You can configure the `nodeSelector` field to restrict what nodes can host a specific `EgressIP` object.
+With this configuration, you can ensure traffic exits through controlled network segments to satisfy strict firewall whitelisting, security isolation, and hardware performance requirements.
+
+.Prerequisites
+
+* Your cluster uses the OVN-Kubernetes network plugin.
+* You have a set of nodes that each have the `k8s.ovn.org/egress-assignable: ""` label.
+
+.Procedure
+
+. Create an `EgressIP` object and specify your custom labels in the `nodeSelector.matchLabels` field:
++
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: egress-project1
+spec:
+  egressIPs:
+    - 192.168.127.10
+  namespaceSelector:
+    matchLabels:
+      env: production
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/egress: "true"
+# ...
+----
+`nodeSelector` restricts the `EgressIP` object allocation strictly to nodes labeled with `node-role.kubernetes.io/egress: "true"`.
+
+. To create the object, enter the following command:
++
+[source,terminal]
+----
+$ oc apply -f <egressips_name>.yaml
+----
++
+Replace `<egressips_name>` with the name of your Egress IP object.
+
+.Verification
+
+* Verify that the `EgressIP` object was created and successfully assigned to a node matching your custom label by entering the following command:
++
+[source,terminal]
+----
+$ oc get egressips egress-project1
+----
++
+.Example output
+[source,terminal]
+----
+NAME              EGRESSIPS        ASSIGNED NODE   ASSIGNED EGRESSIPS
+egress-project1   192.168.127.10   worker-0        192.168.127.10
+----
+
+* Confirm that the assigned node carries both your custom label and the required OVN-Kubernetes assignable label by entering the following command:
++
+[source,terminal]
+----
+$ oc get node <assigned_node_name> --show-labels
+----
++
+Replace `<assigned_node_name>` with the node name.
+Confirm the output includes both `node-role.kubernetes.io/egress=true` and `k8s.ovn.org/egress-assignable=`.

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -64,8 +64,14 @@ include::modules/egressip_configure_failover_task.adoc[leveloffset=+2]
 include::modules/egressip_failover_reference.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-rosa-hcp[]
 
+// About egress IP node selectors
+include::modules/nw-egress-about-node-selectors.adoc[leveloffset=+1]
+
 // Labeling a node to host egress IP addresses
 include::modules/nw-egress-ips-node.adoc[leveloffset=+1]
+
+// Configuring an EgressIP with a node selector
+include::modules/nw-egress-ips-node-selector.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa[]
 // Configuring dual-stack networking for an EgressIP object


### PR DESCRIPTION

Version(s):
4.16+

Issue:
[OSDOCS-21585](https://redhat.atlassian.net/browse/OSDOCS-21585) and [OSDOCS-22008](https://redhat.atlassian.net/browse/OSDOCS-22008)

Link to docs preview:

* https://119276--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html
* https://119276--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Waiting for Surya to provide dev and QEs. API eng change must be merged before doc update is possible.
