### PR TITLE
RHDEVDOCS-7925: Content creation for the GitOps 1.21.4 z-stream release

### DIFF
--- a/modules/gitops-release-notes-1-21-4.adoc
+++ b/modules/gitops-release-notes-1-21-4.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-21.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-21-4_{context}"]
+= Release notes for Red Hat OpenShift GitOps 1.21.4
+
+[role="_abstract"]
+
+{gitops-title} 1.21.4 is now available on {OCP} 4.18, 4.19, 4.20, 4.21, and 4.22.
+
+[id="errata-updates-1-21-4_{context}"]
+== Errata updates
+
+RHSA-2026:63142 - {gitops-title} 1.21.4 enhancement update advisory::
+Issued: 2026-09-03
++
+The list of enhancements that are included in this release is documented in the following advisory:
++
+* link:https://access.redhat.com/errata/RHSA-2026:63142[RHSA-2026:63142]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="fixed-issues-1-21-4_{context}"]
+== Fixed issues
+
+OpenShift login succeeds when NamespaceManagement CR targets an unauthorized namespace::
+Before this update, OpenShift login to Argo CD failed with an `unauthorized_client` error when a `NamespaceManagement` custom resource (CR) existed for a namespace that Argo CD was not configured to manage. With this update, OpenShift login succeeds even when a `NamespaceManagement` CR targets a namespace that Argo CD is not allowed to manage.
++
+link:https://redhat.atlassian.net/browse/GITOPS-10477[GITOPS-10477]
+
+

--- a/release_notes/gitops-release-notes-1-21.adoc
+++ b/release_notes/gitops-release-notes-1-21.adoc
@@ -30,6 +30,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.21.4
+include::modules/gitops-release-notes-1-21-4.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.21.3
 include::modules/gitops-release-notes-1-21-3.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Version(s):**
gitops-docs-1.21

**Issue**:
https://redhat.atlassian.net/browse/RHDEVDOCS-7925

**QE review:**
@varshab1210 @svghadi

**Peer review:**

**Additional information:**
Replaces PR #119186 to incorporate peer review feedback on behalf of Dhruv (OOO) for the GitOps 1.21.4 z-stream release.