### PR TITLE
RHDEVDOCS-7931: Content creation for the GitOps 1.19.7 z-stream release

### DIFF
--- a/modules/gitops-release-notes-1-19-7.adoc
+++ b/modules/gitops-release-notes-1-19-7.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="gitops-release-notes-1-19-7_{context}"]
+= Release notes for {gitops-title} 1.19.7
+
+[role="_abstract"]
+
+{gitops-title} 1.19.7 is available on {OCP} 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, and 4.21.
+
+[id="errata-updates-1-19-7_{context}"]
+== Errata updates
+
+RHSA-2026:63139 - {gitops-title} 1.19.7 enhancement update advisory::
+Issued: 2026-09-03
++
+The list of enhancements that are included in this release is documented in the following advisory:
++
+* link:https://access.redhat.com/errata/RHSA-2026:63139[RHSA-2026:63139]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal,subs="+quotes"]
+----
+$ oc describe deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="fixed-issues-1-19-7_{context}"]
+== Fixed issues
+
+Redis container image updated to the latest version::
+Before this update, {gitops-title} used an outdated Redis container image that contained multiple known issues. With this update, the Operator uses the latest Redis container image, which includes security patches and dependency updates.
++
+link:https://redhat.atlassian.net/browse/GITOPS-10464[GITOPS-10464]

--- a/release_notes/gitops-release-notes-1-19.adoc
+++ b/release_notes/gitops-release-notes-1-19.adoc
@@ -29,6 +29,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.19.7
+include::modules/gitops-release-notes-1-19-7.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.19.6
 include::modules/gitops-release-notes-1-19-6.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Version(s):**

none for CP

**Issue:**

https://redhat.atlassian.net/browse/RHDEVDOCS-7931

**Link to docs preview:**

[Release notes for Red Hat OpenShift GitOps 1.19.7](https://119188--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-19.html#gitops-release-notes-1-19-7_gitops-release-notes)

**QE review: @svghadi 
Peer review:**