### PR TITLE
OSDOCS-22031: Add 4.20.37 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-37.adoc
+++ b/modules/zstream-4-20-37.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-37_{context}"]
+= RHSA-2026:63103 - {product-title} {product-version}.37 bug fix and security update
+
+Issued: 08 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.37 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:63103[RHSA-2026:63103] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:63099[RHBA-2026:63099] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.37 --pullspecs
+----
+
+[id="zstream-4-20-37-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-20-37-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -32,6 +32,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 //z-stream release notes
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.37 RNs and updating
+include::modules/zstream-4-20-37.adoc[leveloffset=+2]
+
 // 4.20.36 RNs and updating
 include::modules/zstream-4-20-36.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-22031

Link to docs preview:
https://119281--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-37_release-notes

QE review:
N/A

Additional information:

    Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/796
    ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
    Errata: RHSA-2026:63103 / RHBA-2026:63099