### PR TITLE
OSDOCS-22034: Add 4.16.70 z-stream release notes

### DIFF
--- a/modules/zstream-4-16-70.adoc
+++ b/modules/zstream-4-16-70.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-70_{context}"]
+= RHSA-2026:62550 - {product-title} {product-version}.70 bug fix and security update
+
+Issued: 10 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.70 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:62550[RHSA-2026:62550] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:62548[RHSA-2026:62548] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.70 --pullspecs
+----
+
+[id="zstream-4-16-70-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, binary data such as `JAR` or `JCEKS` keystores, was incorrectly decoded as UTF-8 text when `Secret` objects were edited through the {product-title} web console. This corrupted the binary values with replacement characters and rendered the files unusable. With this release, the web console now preserves base64-encoded binary data and passes it directly to the file input component without text conversion. Binary secret data remains intact when editing other fields in the same secret. (link:https://redhat.atlassian.net/browse/OCPBUGS-114417[OCPBUGS-114417])
+
+[id="zstream-4-16-70-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.70 RNs and updating
+include::modules/zstream-4-16-70.adoc[leveloffset=+2]
+
 // 4.16.69 RNs and updating
 include::modules/zstream-4-16-69.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-22034

Link to docs preview:
https://119284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-70_release-notes

QE review:
N/A

Additional information:

Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/790
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16
Errata: RHSA-2026:62550/RHSA-2026:62548