### PR TITLE
OSDOCS-22026:Typo in heading

### DIFF
--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -4,8 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="external-secrets-operator-uninstall-olm_{context}"]
-= Uninstalling an Operator Lifecylce Manager installed community {external-secrets-operator-short}
-
+= Uninstalling an Operator Lifecycle Manager installed community {external-secrets-operator-short}
 
 [role="_abstract"]
 Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. This helps you free up resources and maintain a clean environment for your cluster.
@@ -14,7 +13,7 @@ Remove the community {external-secrets-operator-short} that was installed by an 
 
 * You must be logged in as a user with the `cluster-admin` role.
 
-* You must have deleted the `operatorconfig` CR.
+* You must have deleted the `operatorconfig` custom resource (CR).
 
 .Procedure
 
@@ -38,3 +37,4 @@ $ oc delete subscription <subscription_name> -n <operator_namespace>
 ----
 $ oc delete csv <csv_name> -n <operator_namespace>
 ----
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-22026
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://119288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE  approval is NOT REQUIRED for this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR fixes a typo in the heading, removes a superfluous blank line and adds the words "custom resource" for first time usage in this procedure to define the term "CR".
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
