### PR TITLE
OSDOCS CMA 2.19.0-3 release notes

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-2190-3.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2190-3.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-rn-2190-3_{context}"]
+= Custom Metrics Autoscaler Operator 2.19.0-3 release notes
+
+Issued: 03 September 2026
+
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Custom Metrics Autoscaler Operator.
+
+The following advisory is available for the Custom Metrics Autoscaler Operator:
+
+* link:https://access.redhat.com/errata/RHSA-2026:62866[RHSA-2026:62866]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+Bug fixes::
+
+* Before this update, the `default` scaling strategy for scaled jobs was missing. With this fix, the `default` strategy has been added back to the `scaledjobs` custom resource. As a result, you can select the default strategy with scaled jobs. (link:https://redhat.atlassian.net/browse/OCPBUGS-98657[OCPBUGS-98657])
+
+* Before this update, the `installAdmissionWebhooks` function was incorrectly using `Operator.Volumes` and `Operator.VolumeMounts` parameters instead of the `AdmissionWebhooks.Volumes` and `AdmissionWebhooks.VolumeMounts` parameters. This caused user-configured volumes for admission webhooks to not be applied correctly, because the Operator's volumes were used instead. With the fix, the Custom Metrics Autoscaler Operator correctly configures admission webhooks, ensuring the proper deployment of user-defined volumes and volume mounts. (link:https://redhat.atlassian.net/browse/OCPBUGS-84045[OCPBUGS-84045])

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -11,6 +11,7 @@ You can review the following release notes to learn about changes in previous ve
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+include::modules/nodes-pods-autoscaling-custom-rn-2190-2.adoc[leveloffset=+1]
 include::modules/nodes-pods-autoscaling-custom-rn-2190.adoc[leveloffset=+1]
 include::modules/nodes-pods-autoscaling-custom-rn-218.adoc[leveloffset=+1]
 include::modules/nodes-pods-autoscaling-custom-rn-217.adoc[leveloffset=+1]

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 
 [role="_abstract"]
-You can review the following release notes to learn about changes in the Custom Metrics Autoscaler Operator version 2.19.0-2. The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
+You can review the following release notes to learn about changes in the Custom Metrics Autoscaler Operator version 2.19.0-3. The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
 
 The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
 
@@ -28,45 +28,45 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.21
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.20
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.19
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.18
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.17
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.16
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.15
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.14
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.13
 |General availability
 
-|2.19.0-2
+|2.19.0-3
 |4.12
 |General availability
 |===
 
-include::modules/nodes-pods-autoscaling-custom-rn-2190-2.adoc[leveloffset=+1]
+include::modules/nodes-pods-autoscaling-custom-rn-2190-3.adoc[leveloffset=+1]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-22037

Link to docs preview:
[Custom Metrics Autoscaler Operator 2.19.0-3 release notes](https://119289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2190-3_nodes-cma-autoscaling-custom-rn) -- New module. Need link to errata.
[Supported versions](https://119289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) -- Updated version
[Custom Metrics Autoscaler Operator 2.19.0-2 release notes](https://119289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2190-2_nodes-cma-autoscaling-custom-rn-past) -- Moved to past release notes, no change to text.
