### PR TITLE
OSDOCS-21720-419 created RNs

### DIFF
--- a/modules/zero-trust-manager-release-notes-1-0-2.adoc
+++ b/modules/zero-trust-manager-release-notes-1-0-2.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-1-0-2_{context}"]
+= Zero Trust Workload Identity Manager 1.0.2
+
+
+Issued: 3 September 2026
+
+
+[role="_abstract"]
+This release fixes some Common Vulnerabilities and Exposures (CVEs).
+
+
+The following advisories are available for the {zero-trust-full}:
+
+
+* https://access.redhat.com/errata/RHBA-2026:62762[RHBA-2026:62762]
+* https://access.redhat.com/errata/RHBA-2026:62764[RHBA-2026:62764]
+* https://access.redhat.com/errata/RHBA-2026:62766[RHBA-2026:62766]
+* https://access.redhat.com/errata/RHBA-2026:62768[RHBA-2026:62768]
+* https://access.redhat.com/errata/RHBA-2026:62769[RHBA-2026:62769]
+* https://access.redhat.com/errata/RHBA-2026:62770[RHBA-2026:62770]
+* https://access.redhat.com/errata/RHBA-2026:63118[RHBA-2026:63118]
+
+
+[is="zero-trust-manager-1-0-2-cves_{context}"]
+== CVEs
+
+
+* https://access.redhat.com/security/cve/cve-2026-32283[CVE-2026-32283]
+
+
+* https://access.redhat.com/security/cve/cve-2026-33811[CVE-2026-33811]
+
+
+* https://access.redhat.com/security/cve/cve-2026-39829[CVE-2026-39829]
+
+
+* https://access.redhat.com/security/cve/cve-2026-39831[CVE-2026-39831]
+
+
+* https://access.redhat.com/security/cve/cve-2026-42502[CVE-2026-42502]
+
+
+* https://access.redhat.com/security/cve/cve-2026-46597[CVE-2026-46597]
+
+
+* https://access.redhat.com/security/cve/cve-2026-68121[CVE-2026-68121]
+
+
+* https://access.redhat.com/security/cve/cve-2026-71235[CVE-2026-71235]
+
+
+
+
+
+
+

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
@@ -10,6 +10,9 @@ The {zero-trust-full} leverages Secure Production Identity Framework for Everyon
 
 These release notes track the development of {zero-trust-full}.
 
+// RNs 1.0.2
+include::modules/zero-trust-manager-release-notes-1-0-2.adoc[leveloffset=+1]
+
 // RNs 1.0.1
 include::modules/zero-trust-manager-release-notes-1-0-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21720

Link to docs preview:
https://119307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
