### PR TITLE
[OSDOCS#21750] Fix remaining MicroShift Vale errors

### DIFF
--- a/modules/microshift-4-20-0-dp.adoc
+++ b/modules/microshift-4-20-0-dp.adoc
@@ -3,7 +3,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-0-dp_{context}"]
 = RHEA-2025:10667 - {microshift-short} 4.20.0 bug fix and enhancement update
 

--- a/modules/microshift-4-20-13-dp.adoc
+++ b/modules/microshift-4-20-13-dp.adoc
@@ -3,7 +3,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-13-dp_{context}"]
 = RHBA-2026:1607 - {microshift-short} 4.20.13 bug fix and enhancement update
 

--- a/modules/microshift-4-20-20-dp.adoc
+++ b/modules/microshift-4-20-20-dp.adoc
@@ -3,7 +3,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-20-dp_{context}"]
 = RHBA-2026:13351 - {microshift-short} 4.20.20 fixed issue update
 

--- a/modules/microshift-4-20-23-dp.adoc
+++ b/modules/microshift-4-20-23-dp.adoc
@@ -3,7 +3,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-23-dp_{context}"]
 = RHBA-2026:17921 - {microshift-short} 4.20.23 fixed issue update
 

--- a/modules/microshift-4-20-26-dp.adoc
+++ b/modules/microshift-4-20-26-dp.adoc
@@ -3,7 +3,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-26-dp_{context}"]
 = RHBA-2026:27184 - {microshift-short} 4.20.26 fixed issue update
 

--- a/modules/microshift-4-20-about-this-release.adoc
+++ b/modules/microshift-4-20-about-this-release.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-about-this-release_{context}"]
 = About this release
 

--- a/modules/microshift-4-20-additional-release-notes.adoc
+++ b/modules/microshift-4-20-additional-release-notes.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-additional-release-notes_{context}"]
 = Additional release notes
 

--- a/modules/microshift-4-20-asynchronous-updates.adoc
+++ b/modules/microshift-4-20-asynchronous-updates.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-asynchronous-updates_{context}"]
 = Asynchronous updates
 

--- a/modules/microshift-4-20-doc-enhancements.adoc
+++ b/modules/microshift-4-20-doc-enhancements.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-doc-enhancements_{context}"]
 = Documentation enhancements
 

--- a/modules/microshift-4-20-known-issues.adoc
+++ b/modules/microshift-4-20-known-issues.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-known-issues_{context}"]
 = Known issues
 

--- a/modules/microshift-4-20-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-20-new-features-and-enhancements.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-new-features-and-enhancements_{context}"]
 = New features and enhancements
 

--- a/modules/microshift-4-20-tech-preview.adoc
+++ b/modules/microshift-4-20-tech-preview.adoc
@@ -2,7 +2,7 @@
 //
 //microshift_release_notes/microshift-4-20-release-notes.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-4-20-tech-preview_{context}"]
 = Technology Preview features
 

--- a/modules/microshift-audit-logs-about.adoc
+++ b/modules/microshift-audit-logs-about.adoc
@@ -6,4 +6,5 @@
 [id="microshift-audit-logs-about_{context}"]
 = About audit logs
 
+[role="_abstract"]
 Audit logs record API requests to the {microshift-short} API server and can help you identify pod security violations and investigate suspicious requests.

--- a/modules/microshift-cli-tools-available.adoc
+++ b/modules/microshift-cli-tools-available.adoc
@@ -6,6 +6,7 @@
 [id="microshift-cli-tools-available_{context}"]
 = Available CLI tools
 
+[role="_abstract"]
 You can use different command-line interface (CLI) tools to build, deploy, and manage a {microshift-short} node and workloads. With CLI tools, you can complete various administration and development operations from the terminal to manage deployments and interact with each component of the system.
 
 The following CLI tools are available to use with {microshift-short}:

--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -6,6 +6,7 @@
 [id="microshift-config-parameters-table_{context}"]
 = Parameters and values for the {microshift-short} config.yaml file
 
+[role="_abstract"]
 The following table explains {microshift-short} configuration YAML parameters and valid values for each:
 
 .{microshift-short} `config.yaml` parameters

--- a/modules/microshift-config-yaml-custom.adoc
+++ b/modules/microshift-config-yaml-custom.adoc
@@ -6,6 +6,7 @@
 [id="microshift-yaml-custom_{context}"]
 = Using custom settings
 
+[role="_abstract"]
 To create custom configurations, make a copy of the `config.yaml.default` file that is given in the `/etc/microshift/` directory, renaming it `config.yaml`. Keep this file in the `/etc/microshift/` directory, and then you can change supported settings that override the defaults before starting or restarting {microshift-short}.
 
 If you have just a few changes to make to the default settings, consider using configuration drop-in snippets as an alternative method.

--- a/modules/microshift-embed-app-manifests-offline.adoc
+++ b/modules/microshift-embed-app-manifests-offline.adoc
@@ -6,8 +6,9 @@
 [id="microshift-embed-app-manifests-offline_{context}"]
 = Adding application manifests to an image for offline use
 
+[role="_abstract"]
 If you have a simple application that includes a few files for deployment such as manifests, you can add those manifests directly to a {op-system-ostree-first} system image. This method is an alternative to building application RPMs or embedding workload container images.
 
-See the "Create a custom file blueprint customization" section of the following {op-system-ostree} documentation for an example:
-
+[role="_additional-resources"]
+.Additional resources
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[Create a custom file blueprint customization]

--- a/modules/microshift-fips-considerations.adoc
+++ b/modules/microshift-fips-considerations.adoc
@@ -6,6 +6,7 @@
 [id="microshift-fips-considerations_{context}"]
 = Considerations for enabling FIPS mode
 
+[role="_abstract"]
 You must enable FIPS mode for RPM-based installations of {microshift-short} on {op-system-base-full} {op-system-version-major} to ensure that your edge deployments comply with security mandates.
 
 The following considerations apply when enabling FIPS mode:

--- a/modules/microshift-lvms-provisioning-behavior.adoc
+++ b/modules/microshift-lvms-provisioning-behavior.adoc
@@ -6,4 +6,5 @@
 [id="microshift-lvms-provisioning-behavior_{context}"]
 = How the LVMS plugin provisions storage
 
+[role="_abstract"]
 LVMS provisions new LVM logical volumes for container workloads with appropriately configured persistent volume claims (PVCs). Each PVC references a storage class that represents an LVM Volume Group (VG) on the host node. LVs are only provisioned for scheduled pods.

--- a/modules/microshift-manifests-deletion-behavior.adoc
+++ b/modules/microshift-manifests-deletion-behavior.adoc
@@ -6,6 +6,7 @@
 [id="microshift-manifests-deletion-behavior_{context}"]
 = How manifest resource deletion works
 
+[role="_abstract"]
 When creating new manifests in {microshift-short}, you can use manifest resource deletion to remove or update old objects, ensuring there are no conflicts or issues.
 
 {microshift-short} supports the deletion of manifest resources in the following situations:

--- a/modules/microshift-manual-rpm-updates.adoc
+++ b/modules/microshift-manual-rpm-updates.adoc
@@ -11,6 +11,7 @@ You can update {microshift-short} manually on {op-system-base-full} by updating 
 
 * To complete this update type, use the subscription manager to enable the repository that has the new RPMs.
 * Use manual processes to ensure system health and complete additional system backups.
-* To begin a manual RPM update, use the procedures in the following documentation:
 
-** link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/updating/microshift-update-rpms-manually[About updating MicroShift RPMs manually]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/updating/microshift-update-rpms-manually[About updating MicroShift RPMs manually]

--- a/modules/microshift-migrate-storage-versions-about.adoc
+++ b/modules/microshift-migrate-storage-versions-about.adoc
@@ -6,6 +6,7 @@
 [id="microshift-migrate-storage-versions-about_{context}"]
 = About Kubernetes storage version migration
 
+[role="_abstract"]
 To update existing objects to their latest version without recreating them, use storage version migration in {microshift-short}. By creating a `StorageVersionMigration` custom resource (CR), you request the Kube Storage Version Migrator embedded controller to handle the transition automatically.
 
 Either you or a controller can create a `StorageVersionMigration` custom resource (CR) that requests a migration through the Migrator Controller.

--- a/modules/microshift-networking-pod-connectivity.adoc
+++ b/modules/microshift-networking-pod-connectivity.adoc
@@ -6,6 +6,7 @@
 [id="microshift-networking-pod-connectivity_{context}"]
 = About pod network connectivity
 
+[role="_abstract"]
 {microshift-short} administrators have several options for exposing applications that run inside a node to external traffic and securing network connections:
 
 * A service such as NodePort

--- a/modules/microshift-node-id-availability-note.adoc
+++ b/modules/microshift-node-id-availability-note.adoc
@@ -6,6 +6,7 @@
 [id="microshift-node-id-availability-note_{context}"]
 = When a node ID becomes available
 
+[role="_abstract"]
 A node ID is the unique identifier of your {microshift-short} node. You can retrieve the node ID manually by using the {oc-first} or by reading it from a file.
 
 [NOTE]

--- a/modules/microshift-nw-networkpolicy-edit-guidelines.adoc
+++ b/modules/microshift-nw-networkpolicy-edit-guidelines.adoc
@@ -6,6 +6,7 @@
 [id="microshift-nw-networkpolicy-edit-guidelines_{context}"]
 = Guidelines for editing network policies
 
+[role="_abstract"]
 You can edit an existing network policy for a namespace.
 
 Typical edits might include changes to the pods to which the policy applies, allowed ingress traffic, and the destination ports on which to accept traffic. The `apiVersion`, `kind`, and `name` fields must not be changed when editing `NetworkPolicy` objects, as these define the resource itself.

--- a/modules/microshift-oc-extended-features.adoc
+++ b/modules/microshift-oc-extended-features.adoc
@@ -6,6 +6,7 @@
 [id="microshift-oc-extended-features_{context}"]
 = Extended features of the oc CLI tool
 
+[role="_abstract"]
 The `oc` CLI tool offers the same capabilities as the `kubectl` CLI tool, but it extends to natively support additional {OCP} features, including:
 
 * **Route resource**

--- a/modules/microshift-oc-kubectl-version-compat.adoc
+++ b/modules/microshift-oc-kubectl-version-compat.adoc
@@ -6,6 +6,9 @@
 [id="microshift-oc-kubectl-version-compat_{context}"]
 = oc and server version compatibility
 
+[role="_abstract"]
+Version compatibility between the `oc` CLI tool and the {microshift-short} server determines which commands and features you can use.
+
 [IMPORTANT]
 ====
 If you installed an earlier version of `oc`, you might not be able use it to complete all of the commands in {microshift-short} {product-version}. If you want the latest features, you must download and install the latest version of `oc` that corresponds with your {microshift-short} version.

--- a/modules/microshift-standalone-rhel-updates.adoc
+++ b/modules/microshift-standalone-rhel-updates.adoc
@@ -9,8 +9,8 @@
 [role="_abstract"]
 You can update to any {op-system-base} type without updating {microshift-short} if the two final versions in your {op-system-bundle} are compatible. Check compatibilities before beginning an update. Use the {op-system-base} documentation specific to your use case.
 
-For example:
-
+[role="_additional-resources"]
+.Additional resources
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9[Red Hat Enterprise Linux 9]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL]

--- a/modules/microshift-workload-partitioning-about.adoc
+++ b/modules/microshift-workload-partitioning-about.adoc
@@ -6,6 +6,7 @@
 [id="microshift-workload-partitioning-about_{context}"]
 = About workload partitioning
 
+[role="_abstract"]
 Workload partitioning divides the node CPU resources into distinct CPU sets. The primary objective is to limit the amount of CPU usage for all control plane components which reserves rest of the device CPU resources for workloads of the user.
 
 Workload partitioning allocates reserved set of CPUs to {microshift-short} services, cluster management workloads, and infrastructure pods, ensuring that the remaining CPUs in the cluster deployment are untouched and available exclusively for non-platform workloads.


### PR DESCRIPTION
Clear ConceptLink and ShortDescription Vale errors in 4.20 MicroShift release notes and update modules

There should be some xref in module errors on the latest MS branches, but I'm not addressing them due to release note context. 

[OSDOCS-21750](https://redhat.atlassian.net/browse/OSDOCS-21750)