### PR TITLE
OCPBUGS-120673: Fix malformed field-selector in HCP node troubleshooting

### DIFF
--- a/modules/hcp-ts-nodes-stuck.adoc
+++ b/modules/hcp-ts-nodes-stuck.adoc
@@ -22,5 +22,5 @@ $ oc get nodes -o yaml
 +
 [source,terminal]
 ----
-$ oc get pods -A --field-selector=status.phase!=Running,status,phase!=Succeeded
+$ oc get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-120673

Link to docs preview:

QE review:
- [ ] QE has approved this change.

N/A — command syntax fix only; does not change procedure meaning.

Additional information:

HCP troubleshooting runbook for stuck NotReady nodes documents a malformed field selector (`status,phase` instead of `status.phase`), causing `oc get pods` to fail during cluster provisioning failures.

Fix: `modules/hcp-ts-nodes-stuck.adoc` — correct field selector typo.