### PR TITLE
CNV-96026: Fix VM Density Example

### DIFF
--- a/modules/virt-enabling-higher-vm-workload-density.adoc
+++ b/modules/virt-enabling-higher-vm-workload-density.adoc
@@ -42,6 +42,8 @@ metadata:
     machineconfiguration.openshift.io/role: worker
   name: 90-worker-swap
 spec:
+  kernelArguments:
+    - "schedstats=enable"
   config:
     ignition:
       version: 3.5.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add "schedstats=enable" to VM density MachineConfig example.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
5.0
4.22

Issue:
[CNV-96026](https://redhat.atlassian.net/browse/CNV-96026)

Link to docs preview:
[Enabling higher VM workload density](https://119323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-enabling-higher-vm-workload-density_virt-configuring-higher-vm-workload-density)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
