### PR TITLE
OCPBUGS-120680: Fix invalid channels YAML in oc-mirror operator catalog filtering examples

### DIFF
--- a/modules/oc-mirror-operator-catalog-filtering.adoc
+++ b/modules/oc-mirror-operator-catalog-filtering.adoc
@@ -115,7 +115,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
 ----
 |The head bundle for the selected channel of that package. You must use the `defaultChannel` field in case the filtered channels are not the default.
@@ -145,7 +145,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
           - name: stable-5.5
 ----
@@ -160,7 +160,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
             minVersion: 5.6.0
 ----
@@ -175,7 +175,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
             maxVersion: 6.0.0
 ----
@@ -192,7 +192,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-       channels
+       channels:
           - name: stable
             minVersion: 5.6.0
             maxVersion: 6.0.0
@@ -209,7 +209,7 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
         minVersion: 5.6.0
         maxVersion: 6.0.0
@@ -225,7 +225,7 @@ mirror:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
         minVersion: 5.6.0
         maxVersion: 6.0.0
@@ -242,7 +242,7 @@ mirror:
       full: true
     packages:
     - name: compliance-operator
-        channels
+        channels:
           - name: stable
             minVersion: 5.6.0
             maxVersion: 6.0.0


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-120680

Link to docs preview:

QE review:
- [ ] QE has approved this change.

N/A — YAML syntax fix in examples only; does not change procedure meaning.

Additional information:

The oc-mirror v2 operator catalog filtering reference documents ImageSetConfiguration channel filtering examples (scenarios 8–16) with invalid YAML where `channels` is missing the trailing colon. Admins copying these examples for disconnected install mirroring get parse failures.

Fix: `modules/oc-mirror-operator-catalog-filtering.adoc` — add missing `:` after `channels` in scenarios 8–16.