### PR TITLE
CNV#91132: Fix invalid MAC address pool end example in KubeMacPool docs

### DIFF
--- a/modules/virt-custom-kubemacpool-range.adoc
+++ b/modules/virt-custom-kubemacpool-range.adoc
@@ -37,7 +37,7 @@ spec:
   networking:
     kubeMacPoolConfiguration:
       rangeStart: "AA:00:00:00:00:00"
-      rangeEnd: "FD:FF:FF:FF:FF:FF"
+      rangeEnd: "FE:A8:11:22:33:44"
 # ...
 ----
 
@@ -58,7 +58,7 @@ Example output:
 ----
 {
   "rangeStart": "AA:00:00:00:00:00",
-  "rangeEnd": "FD:FF:FF:FF:FF:FF"
+  "rangeEnd": "FE:A8:11:22:33:44"
 }
 ----
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/CNV-91132

Link to docs preview:
Will add after preview build completes

QE review:
- [ ] QE has approved this change.

Additional information:
Fixed invalid example MAC address rejected by KubeMacPool.