### PR TITLE
Renaming AI category to Integrate for MicroShift JTBD

### DIFF
--- a/maps/microshift/integrate.adoc
+++ b/maps/microshift/integrate.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: MAP
 
-= AI
+= Integrate
 
 include::jobs/install-ai-capabilities.adoc[leveloffset=+1]
 

--- a/maps/microshift/navigation.adoc
+++ b/maps/microshift/navigation.adoc
@@ -29,11 +29,11 @@ include::configure.adoc[leveloffset=+1]
 
 include::observe.adoc[leveloffset=+1]
 
+include::integrate.adoc[leveloffset=+1]
+
 include::reference.adoc[leveloffset=+1]
 
 include::storage.adoc[leveloffset=+1]
-
-include::ai.adoc[leveloffset=+1]
 
 include::cli.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Renaming the AI category to Integrate for MicroShift JTBD.

4.20+

https://bscott-rh.github.io/openshift-docs/rename-ai-to-integrate/microshift/_integrate.html