### PR TITLE
[TELCODOCS#2942]: Name CPU isolation annotations in telco core RDS

### DIFF
--- a/modules/telco-core-application-workloads.adoc
+++ b/modules/telco-core-application-workloads.adoc
@@ -26,8 +26,11 @@ All workloads must now be compatible with `cgroup v2`.
 For more information, see link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads].
 * CNF applications should conform to the latest version of https://redhat-best-practices-for-k8s.github.io/guide/[Red Hat Best Practices for Kubernetes].
 * Use a mix of best-effort and burstable QoS pods as required by your applications.
-** Use guaranteed QoS pods with proper configuration of reserved or isolated CPUs in the `PerformanceProfile` CR that configures the node.
-** Guaranteed QoS Pods must include annotations for fully isolating CPUs.
+* Low latency workloads require special configuration to avoid being affected by interrupts, kernel scheduler, or other parts of the platform.
+** Use guaranteed QoS pods with proper configuration of reserved or isolated CPUs in the `PerformanceProfile` CR that configures the `MachineConfigPool` CR where the application runs.
+** Guaranteed QoS Pods must include annotations for fully isolating CPUs:
+*** `cpu-load-balancing.crio.io: "disable"`
+*** `irq-load-balancing.crio.io: "disable"`
 ** Best effort and burstable pods are not guaranteed exclusive CPU use.
 Workloads can be preempted by other workloads, operating system daemons, or kernel tasks.
 * Use exec probes sparingly and only when no other suitable option is available.

--- a/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
+++ b/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
@@ -17,7 +17,7 @@ Skylake and older CPUs can experience 40% transaction performance drops when Spe
 ** Intel Sierra Forest CPUs when supported by the {product-title}.
 ** IRQ balancing is enabled on worker nodes.
 The `PerformanceProfile` CR sets the `globallyDisableIrqLoadBalancing` parameter to a value of `false`.
-Guaranteed QoS pods are annotated to ensure isolation as described in "CPU partitioning and performance tuning".
+Guaranteed QoS pods are annotated to ensure isolation as described in "Application workloads".
 
 * All cluster nodes should have the following features:
 ** Have Hyper-Threading enabled

--- a/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
+++ b/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
@@ -26,7 +26,6 @@ Limits and requirements::
 * In a system with Hyper-Threading enabled, core sibling threads must always be in the same pool of CPUs.
 * The set of reserved and isolated cores must include all CPU cores.
 * Core 0 of each NUMA node must be included in the reserved CPU set.
-* Low latency workloads require special configuration to avoid being affected by interrupts, kernel scheduler, or other parts of the platform.
 
 For more information, see "Creating a performance profile".
 

--- a/modules/telco-core-scheduling.adoc
+++ b/modules/telco-core-scheduling.adoc
@@ -36,6 +36,6 @@ For example, all nodes are expected to have the same NUMA zone count.
 
 Engineering considerations::
 * Pods might require annotations for correct scheduling and isolation.
-For more information about annotations, see "CPU partitioning and performance tuning".
+For more information about annotations, see "Application workloads".
 * You can configure SR-IOV virtual function NUMA affinity to be ignored during scheduling by using the excludeTopology field in `SriovNetworkNodePolicy` CR.
 

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -36,7 +36,19 @@ include::modules/telco-core-zones.adoc[leveloffset=+1]
 
 include::modules/telco-core-cluster-common-use-model-engineering-considerations.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/telco-core-rds.adoc#telco-core-application-workloads_telco-core[Application workloads]
+
 include::modules/telco-core-application-workloads.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc#cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_cnf-provisioning-low-latency[Disabling CPU load balancing in a Pod]
+
+* xref:../scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc#cnf-disabling-interrupt-processing-for-individual-pods_cnf-provisioning-low-latency[Disabling interrupt processing for CPUs where pinned containers are running]
 
 include::modules/telco-core-signaling-workloads.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2942

Link to docs preview:
https://119356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html

QE review:
- [x] QE has approved this change.

Additional information:
Names the CRI-O CPU isolation annotations for guaranteed QoS pods in the 4.20 telco core RDS. Cherry-picks to 4.21, 4.22, and 5.0 to follow.