### PR TITLE
TELCODOCS-2912 : add T-GM field-tunable parameters for Intel GNR-D

### DIFF
--- a/modules/nw-ptp-clock-class-state-transitions-concept.adoc
+++ b/modules/nw-ptp-clock-class-state-transitions-concept.adoc
@@ -1,0 +1,102 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ptp-clock-class-state-transitions-concept_{context}"]
+= Clock Class state transitions during holdover
+
+[role="_abstract"]
+The Precision Time Protocol (PTP) Clock Class attribute indicates the quality and traceability of the time source in Telecom Grandmaster (T-GM) deployments.
+Clock Class transitions occur automatically during GNSS signal loss and recovery scenarios, enabling downstream devices to select the best available timing source.
+
+== Clock Class overview
+
+The Clock Class is a PTP attribute that categorizes clocks based on their accuracy and traceability to a Primary Reference Time Clock (PRTC).
+Downstream PTP devices use the Clock Class value to determine which master clock provides the best timing source.
+Telecom Grandmaster deployments on Intel Granite Rapids-D hardware use three Clock Class values: 6 (locked), 7 (holdover), and 248 (freerun).
+
+== Normal operation with Clock Class 6
+
+During normal operation, the T-GM maintains Clock Class 6 when the following conditions are met:
+
+* GNSS signal is present and locked
+* DPLL is synchronized to the GNSS time source
+* Timing is traceable to a Primary Reference Time Clock (PRTC)
+* Timing accuracy is ±40 nanoseconds relative to UTC (ITU-T G.8272 PRTC-B)
+
+Clock Class 6 is the expected steady-state condition for Telecom Grandmaster deployments.
+Downstream devices prioritize Clock Class 6 masters over Clock Class 7 or Clock Class 248 masters when selecting the best available timing source.
+
+== GNSS loss scenario and transition to Clock Class 7
+
+When the GNSS signal is lost, the T-GM transitions to holdover mode and the Clock Class changes from 6 to 7.
+GNSS signal loss can occur due to antenna disconnection, signal blocking, satellite outage, or electromagnetic interference.
+
+During holdover, the digital phase-locked loop (DPLL) maintains timing using the internal oscillator based on the last known good frequency from the GNSS signal.
+The T-GM continues distributing PTP messages with Clock Class 7, indicating that timing is within the ITU-T G.8273.2 Class-B holdover specification (≤1.5 microseconds time error for ≥4 hours).
+
+Timing accuracy degrades gradually during holdover based on the oscillator quality and environmental conditions.
+The rate of timing degradation is determined by the slope calculation (`localMaxHoldoverOffset / localHoldoverTimeout`).
+
+Downstream devices continue receiving PTP messages with Clock Class 7.
+Downstream devices can continue using the T-GM as their timing source during holdover if no higher-quality Clock Class 6 master is available.
+
+== Holdover timeout and transition to Clock Class 248
+
+When the holdover duration exceeds the configured timeout or when the timing offset exceeds the maximum in-spec threshold, the T-GM transitions from Clock Class 7 to Clock Class 248.
+The default holdover timeout is 14400 seconds (4 hours), which aligns with ITU-T G.8273.2 Class-B holdover duration requirements.
+
+Clock Class 248 indicates that the T-GM is in FREERUN mode and timing is no longer traceable to a PRTC.
+The DPLL enters FREERUN when one of the following conditions occurs:
+
+* Holdover duration exceeds the `localHoldoverTimeout` parameter (default 14400 seconds)
+* Timing offset exceeds the `maxInSpecOffset` threshold (default 14400 seconds)
+
+Downstream devices should select an alternate timing source if available when the T-GM Clock Class changes to 248.
+If no alternate timing source is available, downstream devices continue receiving PTP messages from the T-GM but timing accuracy is no longer guaranteed.
+
+== GNSS recovery and transition back to Clock Class 6
+
+When the GNSS signal is restored, the T-GM resynchronizes to the GNSS time source and the Clock Class transitions back to 6.
+The transition from Clock Class 248 or Clock Class 7 to Clock Class 6 requires multiple components to reach stable LOCKED state:
+
+* `ts2phc` offset stabilizes below 100 nanoseconds
+* DPLL phase offset stabilizes
+* GNSS receiver achieves good fix (4 or more satellites with signal-to-noise ratio greater than 30 dB)
+
+Recovery time depends on GNSS signal quality and the initial timing offset magnitude.
+Typical recovery time is 1-5 minutes for GNSS restoration scenarios.
+
+== State transition timing requirements
+
+State-change events are published within 1 second of Clock Class transitions to enable fast downstream response.
+PTP Announce messages containing the updated Clock Class value are transmitted every 125 milliseconds (`logAnnounceInterval -3`).
+Downstream devices receive Clock Class updates within approximately 1 second of the state transition.
+
+== Operational implications
+
+The following operational implications apply to Clock Class state transitions:
+
+Clock Class 7 (holdover):: Acceptable for short-duration GNSS outages.
+Timing is maintained within ITU-T G.8273.2 Class-B specification (≤1.5 microseconds) for the configured holdover duration (typically 4 hours).
+
+Clock Class 248 (freerun):: Not acceptable for production telco workloads.
+Downstream devices should switch to an alternate timing source if available.
+
+Frequent 6 to 7 transitions:: Frequent transitions between Clock Class 6 and Clock Class 7 indicate intermittent GNSS signal reception.
+Investigate antenna cabling, antenna placement, or electromagnetic interference sources.
+
+== Configuration impact on state transitions
+
+Field-tunable timing parameters affect Clock Class state transition behavior:
+
+`maxInSpecOffset`:: Lower values trigger FREERUN faster during holdover.
+Higher values allow longer holdover duration before transitioning to Clock Class 248.
+
+`localHoldoverTimeout`:: Shorter values limit holdover duration before FREERUN.
+Longer values extend the holdover period, allowing more time for GNSS signal recovery.
+
+Holdover slope:: Determined by `localMaxHoldoverOffset / localHoldoverTimeout`.
+Controls the rate of timing degradation during holdover.
+A lower slope provides slower timing degradation during holdover.

--- a/modules/nw-ptp-configuring-field-tunable-timing-parameters-gnrd.adoc
+++ b/modules/nw-ptp-configuring-field-tunable-timing-parameters-gnrd.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ptp-configuring-field-tunable-timing-parameters-gnrd_{context}"]
+= Configure field-tunable timing parameters on Intel Granite Rapids-D
+
+[role="_abstract"]
+You can configure field-tunable precision timing parameters on Intel Granite Rapids-D (GNR-D) Telecom Grandmaster (T-GM) deployments without requiring kernel or firmware upgrades.
+Field-tunable parameters include holdover thresholds, GNSS source settings, and DPLL parameters.
+
+.Prerequisites
+
+* You have installed the {product-title} CLI (`oc`).
+* You have logged in as a user with `cluster-admin` privileges.
+* You have installed the PTP Operator.
+* You have applied a `PtpConfig` custom resource (CR) for Telecom Grandmaster configuration on Intel Granite Rapids-D hardware.
+* You have Dell PowerEdge XR8720t hardware with NAC adapter and 2 Carter Flat NICs installed.
+* You have connected a GNSS antenna to the NAC adapter with clear sky view.
+* You understand the Technology Preview limitations for Telecom Grandmaster on Intel Granite Rapids-D hardware.
+
+.Procedure
+
+. Create a `HardwareConfig` custom resource (CR) YAML file named `hardwareconfig-tgm-field-tuning.yaml` with the following content:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: tgm-gnrd-field-tuning
+  namespace: openshift-ptp
+spec:
+  profile:
+    - name: gnrd-tgm-profile
+      clockType: T-GM
+      clockChain:
+        structure: |
+          hardwareSpecificDefinitions: dell/XR8720t
+      holdover:
+        maxInSpecOffset: 14400
+        localMaxHoldoverOffset: 1500
+        localHoldoverTimeout: 1500
+      gnss:
+        antennaVoltage: 5
+        constellation: GPS
+        surveyMode:
+          observationTime: 600
+          accuracyThreshold: 50000
+        serialDevice: /dev/gnss0
+  relatedPtpProfileName: gnrd-tgm-profile
+----
++
+where:
++
+--
+`maxInSpecOffset`:: Specifies the maximum allowed offset in seconds before DPLL enters FREERUN. The default value is `14400`.
+`localMaxHoldoverOffset`:: Specifies the maximum offset during holdover in nanoseconds. The default value is `1500`.
+`localHoldoverTimeout`:: Specifies the holdover timeout duration in seconds. The default value is `1500`.
+`antennaVoltage`:: Specifies the antenna voltage in volts. Use `3.3` or `5` based on your antenna specification.
+`constellation`:: Specifies the GNSS constellation support. Valid values are `GPS`, `GLONASS`, `Galileo`, and `BeiDou`.
+`observationTime`:: Specifies the survey mode observation time in seconds. The default value is `600`.
+`accuracyThreshold`:: Specifies the survey mode accuracy threshold. The default value is `50000`.
+`serialDevice`:: Specifies the serial port device path for the GNSS receiver.
+`relatedPtpProfileName`:: Specifies the profile name that must match the profile name in your `PtpConfig` CR.
+--
+
+. Apply the `HardwareConfig` CR:
++
+[source,terminal]
+----
+$ oc apply -f hardwareconfig-tgm-field-tuning.yaml
+----
++
+.Example output
+[source,terminal]
+----
+hardwareconfig.ptp.openshift.io/tgm-gnrd-field-tuning created
+----
+
+. Verify that the `HardwareConfig` CR is created:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp
+----
++
+.Example output
+[source,terminal]
+----
+NAME                      AGE
+tgm-gnrd-field-tuning     10s
+----
+
+.Verification
+
+. Check the `linuxptp-daemon` pod logs to verify that the `HardwareConfig` CR is processed:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp -l app=linuxptp-daemon -c linuxptp-daemon-container | grep -i hardware
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+I0904 12:34:56.789012    1234 hwconfig.go:123] Processing HardwareConfig: tgm-gnrd-field-tuning
+I0904 12:34:56.789123    1234 hwconfig.go:456] Applied field-tunable parameters to NAC adapter
+----
+
+. Verify that the NAC adapter shows updated field-tunable parameters:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-ptp -c linuxptp-daemon-container <linuxptp-daemon-pod-name>
+sh-4.4# cat /sys/class/ptp/ptp0/device/holdover_config
+----
++
+Replace `<linuxptp-daemon-pod-name>` with the name of the `linuxptp-daemon` pod running on your T-GM node.
+
+. Monitor DPLL synchronization status to verify that the configuration is applied successfully:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp -l app=linuxptp-daemon -c linuxptp-daemon-container | grep -i dpll
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+I0904 12:35:01.123456    1234 dpll.go:789] DPLL operational state: LOCKED
+----

--- a/modules/nw-ptp-dpll-loss-detection-concept.adoc
+++ b/modules/nw-ptp-dpll-loss-detection-concept.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ptp-dpll-loss-detection-concept_{context}"]
+= DPLL loss detection mechanism for Carter Flat NICs
+
+[role="_abstract"]
+Digital phase-locked loop (DPLL) loss detection on Carter Flat network interface cards (NICs) enables automatic fault detection and Clock Class state transitions when timing reference signals are lost.
+The Linux kernel DPLL subsystem reports pin operational state changes to the PTP Operator, enabling automated Clock Class transitions without manual intervention.
+
+== DPLL loss detection overview
+
+DPLL loss detection provides automatic detection of timing reference loss on follower DPLLs in Carter Flat (Intel E830) NICs synchronized to the NAC DPLL.
+When the timing reference from the NAC DPLL is lost, the Linux kernel DPLL subsystem detects the pin operational state change and reports it to the PTP Operator.
+The PTP Operator triggers automatic Clock Class state transitions based on the DPLL state, improving fault response time and reducing manual intervention requirements.
+
+Benefits of DPLL loss detection for Far Edge RAN DU deployments:
+
+* Automated fault detection for timing outages
+* Faster Clock Class signaling to downstream devices (within 1 second)
+* Reduced manual monitoring and intervention requirements
+* Improved reliability for mission-critical 5G timing infrastructure
+
+== Linux kernel DPLL subsystem
+
+The Linux kernel DPLL subsystem provides a standardized interface for monitoring DPLL pin operational states.
+The kernel feature reports DPLL pin state changes to userspace applications through a kernel API, enabling the PTP Operator to monitor follower DPLL health on Carter Flat NICs.
+
+DPLL pin operational state monitoring requires kernel support that is backported from upstream Linux to RHEL kernels.
+If the required RHEL kernel version is not available, DPLL loss detection relies on timing offset thresholds only.
+
+== DPLL architecture on Intel Granite Rapids-D platforms
+
+Intel Granite Rapids-D Telecom Grandmaster deployments use a hierarchical DPLL architecture:
+
+Primary DPLL:: Microchip ZL80032 on the NAC adapter, synchronized to GNSS time source
++
+The primary DPLL receives GNSS timing input and locks to UTC-traceable time.
+
+Follower DPLLs:: Intel E830 DPLLs on Carter Flat NICs, synchronized to NAC DPLL via eSync/SDP timing traces
++
+Follower DPLLs receive timing reference from the primary DPLL through proprietary PCIe wiring (eSync/SDP traces) rather than external jumper cables.
+
+Timing distribution path:: GNSS → NAC DPLL → eSync/SDP traces → Carter Flat DPLLs → PHC → PTP ports
++
+Time flows from the GNSS receiver to the NAC DPLL, then to Carter Flat follower DPLLs, and finally to the PTP hardware clock (PHC) and PTP ports for distribution to downstream devices.
+
+== DPLL pin operational states
+
+The Linux kernel DPLL subsystem reports the following pin operational states:
+
+`DPLL_PIN_OPERSTATE_LOCKED`:: Pin is receiving valid timing signal, DPLL is synchronized
++
+Normal operation state. The follower DPLL is locked to the timing reference from the NAC DPLL.
+
+`DPLL_PIN_OPERSTATE_NO_SIGNAL`:: Pin is not receiving timing signal from reference source
++
+Timing reference from NAC DPLL is lost or degraded. The follower DPLL enters holdover or freerun mode.
+
+`DPLL_PIN_OPERSTATE_QUAL_FAILED`:: Pin is receiving timing signal but quality is insufficient for synchronization
++
+Signal is present but does not meet quality requirements for DPLL synchronization.
+
+State transitions trigger automatic Clock Class updates based on the current timing health and holdover timeout configuration.
+
+== Detection mechanism workflow
+
+The following workflow describes DPLL loss detection during GNSS signal loss:
+
+. NAC DPLL is locked to GNSS time source and provides timing reference to Carter Flat DPLLs via eSync/SDP traces.
+. Carter Flat DPLL pin operational state is `LOCKED` (normal operation).
+. GNSS signal is lost, and NAC DPLL enters HOLDOVER mode.
+. Timing reference to Carter Flat follower DPLLs degrades as NAC DPLL maintains timing using internal oscillator.
+. Linux kernel DPLL subsystem detects Carter Flat DPLL pin state change: `LOCKED` → `NO_SIGNAL`.
+. Kernel reports pin state change to PTP Operator via DPLL subsystem API.
+. PTP Operator triggers Clock Class state transition:
++
+* Clock Class 6 → 7 (if within holdover specification)
+* Clock Class 6 → 248 (if holdover timeout exceeded)
+. PTP Announce messages with updated Clock Class are transmitted to downstream devices.
+
+== Relationship to Clock Class state machine
+
+DPLL pin operational state changes drive automatic Clock Class state transitions:
+
+* DPLL pin state `LOCKED` → Clock Class 6 (synchronized to PRTC)
+* DPLL pin state `NO_SIGNAL` + within holdover timeout → Clock Class 7 (holdover within spec)
+* DPLL pin state `NO_SIGNAL` + holdover timeout expired → Clock Class 248 (out of sync)
+* DPLL pin state `QUAL_FAILED` → Clock Class 248 (signal quality insufficient)
+
+Automatic state transitions reduce manual intervention and improve fault response time.
+State-change events are published within 1 second of Clock Class transitions.
+
+== Follower DPLL visibility limitations
+
+Intel NIC driver limitations affect the visibility of follower DPLL behavior:
+
+High-level lock state only:: The Intel NIC driver exposes high-level follower DPLL lock state (locked or not locked) through the Linux kernel DPLL subsystem.
+
+No detailed accuracy metrics:: Intel does not plan to expose further follower DPLL lock accuracy metrics in software or firmware.
+Detailed DPLL accuracy information is not available through driver interfaces.
+
+PTP Operator capabilities:: The PTP Operator can surface follower DPLL lock state when the Intel NIC driver exposes it, but it cannot report additional follower DPLL accuracy metrics or diagnose complex follower DPLL problems on add-on NICs beyond that driver data.
+
+Complex follower DPLL problems:: Resolution of complex follower DPLL problems might require on-site hardware access and coordination with Intel rather than diagnosis inside {product-title}.

--- a/modules/nw-ptp-field-tunable-timing-parameters-reference.adoc
+++ b/modules/nw-ptp-field-tunable-timing-parameters-reference.adoc
@@ -1,0 +1,157 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ptp-field-tunable-timing-parameters-reference_{context}"]
+= Field-tunable timing parameters reference for Intel Granite Rapids-D
+
+[role="_abstract"]
+The following field-tunable precision timing parameters are available for Telecom Grandmaster (T-GM) deployments on Intel Granite Rapids-D (GNR-D) hardware.
+These parameters can be configured via the `HardwareConfig` custom resource (CR) without requiring kernel or firmware upgrades.
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-holdover_{context}"]
+== Holdover parameters
+
+The following table describes holdover parameters for controlling digital phase-locked loop (DPLL) behavior during GNSS signal loss:
+
+.Holdover parameters
+[cols="2,1,1,3",options="header"]
+|====
+|Parameter
+|Range
+|Default
+|Description
+
+|`maxInSpecOffset`
+|`0`-`86400` seconds
+|`14400` seconds (4 hours)
+|Maximum allowed offset before the DPLL enters FREERUN state.
+When the timing offset exceeds this threshold, the DPLL transitions from HOLDOVER to FREERUN and the Clock Class changes from 7 to 248.
+
+|`localMaxHoldoverOffset`
+|`0`-`10000` nanoseconds
+|`1500` nanoseconds
+|Maximum offset during holdover within ITU-T G.8273.2 Class-B specification.
+When the timing offset exceeds this threshold during holdover, the Clock Class transitions to 248 (FREERUN).
+
+|`localHoldoverTimeout`
+|`0`-`86400` seconds
+|`1500` seconds
+|Holdover duration before FREERUN state.
+After the GNSS signal is lost for this duration, the DPLL enters FREERUN and the Clock Class transitions from 7 to 248.
+|====
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-gnss_{context}"]
+== GNSS source parameters
+
+The following table describes GNSS source parameters for configuring the GNSS receiver on the NAC adapter:
+
+.GNSS source parameters
+[cols="2,2,1,3",options="header"]
+|====
+|Parameter
+|Supported values
+|Default
+|Description
+
+|`antennaVoltage`
+|`3.3`, `5`
+|Depends on antenna specification
+|Antenna voltage in volts.
+Configure this value to match your GNSS antenna power requirements.
+Active GNSS antennas typically require 3.3V or 5V power.
+
+|`constellation`
+|`GPS`, `GLONASS`, `Galileo`, `BeiDou`
+|`GPS`
+|GNSS constellation support.
+Select the satellite constellation to use for timing synchronization.
+GPS is the most widely supported constellation.
+
+|`observationTime`
+|`0`-`3600` seconds
+|`600` seconds
+|Survey mode observation time.
+The GNSS receiver observes satellite signals for this duration during initial calibration to determine the antenna position.
+
+|`accuracyThreshold`
+|`0`-`100000`
+|`50000`
+|Survey mode accuracy threshold.
+The survey mode completes when the calculated position accuracy meets this threshold.
+Lower values require higher accuracy.
+
+|`serialDevice`
+|Device path
+|`/dev/gnss0`
+|Serial port device path for the GNSS receiver.
+The NAC adapter typically exposes the GNSS receiver as `/dev/gnss0`.
+|====
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-clock-chain_{context}"]
+== Clock chain architecture parameters
+
+The following table describes clock chain architecture parameters for platform-specific DPLL behavior:
+
+.Clock chain architecture parameters
+[cols="2,2,3",options="header"]
+|====
+|Parameter
+|Supported values
+|Description
+
+|`hardwareSpecificDefinitions`
+|`dell/XR8720t`, `hpe/EL140-Gen12`
+|Platform-specific DPLL behavior configuration.
+Use `dell/XR8720t` for Dell PowerEdge XR8720t platforms in {product-title} {product-version}.
+HPE platforms are not supported in {product-title} {product-version}.
+
+|`clockType`
+|`T-GM`, `T-BC`
+|Clock role in the timing hierarchy.
+Use `T-GM` for Telecom Grandmaster deployments.
+T-BC (Telecom Boundary Clock) is not supported on Intel Granite Rapids-D hardware in {product-title} {product-version}.
+|====
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-interactions_{context}"]
+== Parameter interactions and dependencies
+
+The following parameter interactions affect Telecom Grandmaster timing behavior:
+
+`maxInSpecOffset` versus `localMaxHoldoverOffset`:: If `maxInSpecOffset` is less than `localMaxHoldoverOffset`, the DPLL enters FREERUN before reaching the maximum holdover offset.
++
+Configure `maxInSpecOffset` to be greater than or equal to `localMaxHoldoverOffset` to ensure holdover behavior is determined by the holdover timeout rather than the offset threshold.
+
+Slope calculation:: The rate of timing degradation during holdover is determined by `localMaxHoldoverOffset / localHoldoverTimeout` in nanoseconds per second.
++
+For example, with `localMaxHoldoverOffset = 1500` nanoseconds and `localHoldoverTimeout = 1500` seconds, the slope is 1 nanosecond per second.
+
+Recommended value combinations:: For ITU-T G.8273.2 Class-B compliance, use the following recommended values:
++
+* `maxInSpecOffset: 14400` seconds (4 hours)
+* `localMaxHoldoverOffset: 1500` nanoseconds
+* `localHoldoverTimeout: 1500` seconds
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-limitations_{context}"]
+== Technology Preview limitations
+
+The following limitations apply to field-tunable timing parameters in {product-title} {product-version}:
+
+Field tuning capability is Technology Preview:: The ability to configure field-tunable precision timing parameters is a Technology Preview feature and is not fully supported under Red Hat production service level agreements (SLAs).
+
+Some parameters might require DPLL firmware support:: Certain field-tunable parameters might require specific DPLL firmware versions to function correctly.
+Verify that your Dell PowerEdge XR8720t platform has the latest DPLL firmware installed.
+
+Certain parameter combinations might not be validated:: Not all possible combinations of field-tunable parameters are validated in the Technology Preview release.
+Use the recommended value combinations for ITU-T G.8273.2 Class-B compliance.
+
+[id="nw-ptp-field-tunable-timing-parameters-reference-constraints_{context}"]
+== Valid value ranges and constraints
+
+The following constraints apply to field-tunable timing parameters:
+
+* Parameters must be positive integers or valid enumeration values.
+* Timeout values are specified in seconds.
+* Offset values are specified in nanoseconds.
+* Platform-specific constraints for Dell PowerEdge XR8720t apply to all parameters.

--- a/modules/nw-ptp-gnrd-supported-hardware-reference.adoc
+++ b/modules/nw-ptp-gnrd-supported-hardware-reference.adoc
@@ -1,0 +1,124 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ptp-gnrd-supported-hardware-reference_{context}"]
+= Supported hardware for Telecom Grandmaster on Intel Granite Rapids-D
+
+[role="_abstract"]
+The following hardware configurations are qualified for Telecom Grandmaster (T-GM) deployments on Intel Granite Rapids-D (GNR-D) platforms.
+Verify that your hardware, bill of materials, and Red Hat Ecosystem Catalog certification status align with your deployment requirements.
+
+[id="nw-ptp-gnrd-supported-hardware-reference-dell_{context}"]
+== Dell PowerEdge XR8720t specifications
+
+The Dell PowerEdge XR8720t server platform is the qualified hardware configuration for Telecom Grandmaster deployments in {product-title} {product-version}.
+
+.Hardware components for Telecom Grandmaster on Dell PowerEdge XR8720t
+[cols="1,2,3",options="header"]
+|===
+|Component
+|Description
+|Function
+
+|Intel Granite Rapids-D (GNR-D) processor
+|Intel Xeon processor with integrated timing capabilities
+|Provides onboard Network Acceleration Complex (NAC) ports for timing distribution.
+
+|NAC (Network adapter) adapter
+|Onboard timing adapter with 7 time transmitter ports
+|Receives GNSS timing input and serves as the primary timing source for the T-GM deployment.
+
+|Carter Flat NIC specifications
+|Two Intel E830 network interface cards (NICs), each providing 8 time transmitter ports
+|Synchronized to the NAC adapter via eSync/SDP timing traces routed through the server platform.
+
+|GNSS antenna
+|Active GNSS antenna with clear sky view for satellite signal reception
+|Connects to the NAC adapter and provides the primary timing reference traceable to UTC.
+
+|Microchip DPLL
+|ZL80032 or zl3073x digital phase-locked loop for holdover capability
+|Maintains timing accuracy during GNSS signal loss, enabling holdover performance compliant with ITU-T G.8273.2 Class-B specifications.
+|===
+
+Environmental specifications:: The Dell XR8720t platform meets telco environmental requirements for temperature, humidity, and vibration tolerance suitable for Far Edge Radio Access Network (RAN) deployments.
+
+[id="nw-ptp-gnrd-supported-hardware-reference-bom_{context}"]
+== Bill of materials and part numbers
+
+Contact Dell for specific SKUs and part numbers for the following components:
+
+* Dell PowerEdge XR8720t server platform
+* NAC adapter (integrated with GNR-D processor)
+* Carter Flat NIC part numbers (quantity: 2)
+* GNSS antenna compatible with NAC adapter
+* Microchip DPLL (EPMB-1050 module)
+
+Verify that all components are certified in the Red Hat Ecosystem Catalog before deployment.
+
+[id="nw-ptp-gnrd-supported-hardware-reference-certification_{context}"]
+== Red Hat Ecosystem Catalog certification
+
+Verify the certification status of your hardware platform in the Red Hat Ecosystem Catalog at link:https://catalog.redhat.com/[catalog.redhat.com].
+Search for "Dell PowerEdge XR8720t" to confirm that your specific hardware configuration is certified for {product-title} {product-version}.
+
+[id="nw-ptp-gnrd-supported-hardware-reference-configuration_{context}"]
+== Platform configuration and restrictions
+
+The following table describes platform restrictions, port configuration, and interface naming requirements for Telecom Grandmaster deployments on Intel Granite Rapids-D hardware.
+
+.Platform restrictions and configuration requirements
+[cols="2,2,3",options="header"]
+|===
+|Category
+|Item
+|Details
+
+3+^|*Platform restrictions for {product-title} {product-version} Technology Preview*
+
+|Hardware variant
+|XCC variant only
+|Only the Dell PowerEdge XR8720t XCC (eXtreme Compute Cluster) variant is supported in this Technology Preview release. The HCC (High Core Count) variant is not supported.
+
+|Clock configuration
+|No T-BC support
+|Telecom Boundary Clock (T-BC) configurations are not supported on Intel Granite Rapids-D hardware in {product-title} {product-version}. T-BC support is deferred to a future release.
+
+|High availability
+|No dual TR port HA
+|Dual time receiver (TR) port high availability configurations are not supported in {product-title} {product-version}. Dual TR port HA is deferred to a future release.
+
+|Platform support
+|Dell-only support
+|Only Dell hardware platforms are supported in {product-title} {product-version}. HPE platform support (EL140 and DL110 models) is planned for {product-title} 5.2.
+
+3+^|*Port configuration and time transmitter capacity*
+
+|NAC adapter
+|7 ports
+|Time transmitter ports on onboard NAC adapter.
+
+|Carter Flat NIC 1
+|8 ports
+|Time transmitter ports on first Intel E830 NIC.
+
+|Carter Flat NIC 2
+|8 ports
+|Time transmitter ports on second Intel E830 NIC.
+
+|Total capacity
+|24 ports
+|Combined time transmitter (TT) port capacity. This configuration enables Radio Units (RUs) to connect directly to the Distributed Unit (DU) server, eliminating the fronthaul switch from the timing path and reducing timing distribution complexity in Far Edge RAN deployments.
+
+3+^|*Interface naming requirements*
+
+|Namespace collision
+|NAC and Carter Flat ports
+|Onboard NAC ports and Carter Flat ports can appear in the same kernel namespace, which makes Precision Time Protocol (PTP) metrics ambiguous unless interfaces are renamed with distinct prefixes.
+
+|Configuration requirement
+|Path-based naming via `MachineConfig`
+|Apply a `MachineConfig` resource to configure path-based interface naming so that each card presents a unique interface prefix before you apply a Telecom Grandmaster `PtpConfig` custom resource (CR). For more information, see "Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware".
+|===

--- a/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
+++ b/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
@@ -8,6 +8,7 @@
 
 [role="_abstract"]
 Intel Granite Rapids-D (GNR-D) server platforms support Telecom Grandmaster (T-GM) clock deployments that use onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs) to share timing across a single GNSS feed.
+You can configure field-tunable precision timing parameters on GNR-D T-GM deployments without requiring kernel or firmware upgrades.
 Before you configure a T-GM profile on GNR-D hardware, verify that your qualified hardware layout, cabling, port counts, and interface naming align with your deployment requirements.
 The associated procedure provides an example `PtpConfig` CR, `linuxptp` plugin expectations, and verification steps for Granite Rapids-D nodes.
 

--- a/modules/nw-ptp-tgm-operational-metrics-reference.adoc
+++ b/modules/nw-ptp-tgm-operational-metrics-reference.adoc
@@ -1,0 +1,184 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ptp-tgm-operational-metrics-reference_{context}"]
+= Operational metrics reference for Telecom Grandmaster on Intel Granite Rapids-D
+
+[role="_abstract"]
+The following operational metrics and performance specifications apply to Telecom Grandmaster (T-GM) deployments on Intel Granite Rapids-D (GNR-D) hardware.
+Monitor these metrics to verify timing health and detect synchronization degradation.
+
+[id="nw-ptp-tgm-operational-metrics-reference-thresholds_{context}"]
+== Synchronization threshold values
+
+The following table describes synchronization threshold values for Telecom Grandmaster timing health:
+
+.Synchronization thresholds
+[cols="1,1,1,2",options="header"]
+|====
+|Metric
+|Threshold
+|Measurement interval
+|Health indicator
+
+|`ts2phc` offset
+|< 100 nanoseconds
+|Continuous
+|Offset within threshold indicates healthy synchronization between the NAC adapter PHC and GNSS time source
+
+|`ptp4l` offset
+|< 100 nanoseconds
+|Continuous
+|Offset within threshold indicates healthy PTP message distribution to downstream devices
+
+|`phc2sys` offset
+|< 100 nanoseconds
+|Continuous
+|Offset within threshold indicates healthy synchronization between system clock and NAC adapter PHC
+|====
+
+[id="nw-ptp-tgm-operational-metrics-reference-clock-class_{context}"]
+== Clock Class values and meanings
+
+The following table describes Clock Class values for Telecom Grandmaster synchronization states:
+
+.Clock Class values
+[cols="1,1,1,2",options="header"]
+|====
+|Clock Class
+|State
+|Meaning
+|Expected behavior
+
+|`6`
+|LOCKED
+|Connected to PRTC, GNSS signal present
+|Normal operation.
+T-GM is locked to GNSS time source and provides timing traceable to UTC within ±40 nanoseconds.
+
+|`7`
+|HOLDOVER
+|Within holdover specification
+|GNSS signal lost.
+DPLL maintains timing using internal oscillator.
+Timing accuracy degrades gradually but remains within ITU-T G.8273.2 Class-B specification (≤1.5 microseconds for ≥4 hours).
+
+|`248`
+|FREERUN
+|Out of synchronization
+|Holdover timeout expired or maximum offset exceeded.
+Timing is no longer traceable to PRTC.
+Downstream devices should select an alternate master if available.
+|====
+
+For more information about Clock Class state transitions, see "Clock Class state transitions during holdover".
+
+[id="nw-ptp-tgm-operational-metrics-reference-cpu_{context}"]
+== CPU utilization expectations
+
+The following table describes expected CPU utilization for PTP processes on Telecom Grandmaster nodes:
+
+.CPU utilization
+[cols="1,2,2",options="header"]
+|====
+|Process
+|Expected CPU usage
+|Notes
+
+|`ptp4l`
+|< 20 millicpus during steady state
+|CPU confinement with FIFO scheduling priority is required for deterministic timing performance
+
+|`phc2sys`
+|< 5 millicpus during steady state
+|Minimal CPU usage for system clock synchronization
+
+|`ts2phc`
+|< 10 millicpus during steady state
+|GNSS time synchronization to NAC adapter PHC
+|====
+
+For more information about CPU confinement configuration, see "Configuring FIFO priority scheduling for PTP hardware".
+
+[id="nw-ptp-tgm-operational-metrics-reference-holdover_{context}"]
+== Holdover performance specifications
+
+The following table describes holdover performance specifications for Telecom Grandmaster deployments:
+
+.Holdover performance
+[cols="1,2,2",options="header"]
+|====
+|Specification
+|Value
+|Description
+
+|Holdover duration
+|Minimum 4 hours
+|ITU-T G.8273.2 Class-B requires minimum 4 hours holdover duration during GNSS signal loss
+
+|Time error during holdover
+|Maximum 1.5 microseconds
+|ITU-T G.8273.2 Class-B requires time error to remain within ±1.5 microseconds during the holdover period
+
+|Holdover timeout configuration
+|Default 14400 seconds (4 hours)
+|Configurable via `HardwareConfig` `maxInSpecOffset` parameter.
+After this timeout, the DPLL enters FREERUN and Clock Class transitions to 248.
+
+|Holdover slope
+|`localMaxHoldoverOffset / localHoldoverTimeout`
+|Determines the rate of timing degradation during holdover.
+For example, with `localMaxHoldoverOffset = 1500` nanoseconds and `localHoldoverTimeout = 1500` seconds, the slope is 1 nanosecond per second.
+
+|Recovery behavior
+|Automatic return to LOCKED
+|When GNSS signal is restored, the DPLL automatically resynchronizes and Clock Class transitions back to 6.
+Recovery time is typically 1-5 minutes.
+|====
+
+[id="nw-ptp-tgm-operational-metrics-reference-health_{context}"]
+== Health monitoring metrics
+
+The following table describes health monitoring metrics for Telecom Grandmaster deployments:
+
+.Health monitoring
+[cols="1,1,1,1",options="header"]
+|====
+|Metric
+|Healthy value
+|Degraded value
+|Failed value
+
+|GNSS connectivity
+|Signal present
+|N/A
+|Signal lost
+
+|DPLL synchronization status
+|LOCKED
+|HOLDOVER
+|FREERUN
+
+|Timing offset metrics
+|< 100 nanoseconds
+|100-500 nanoseconds
+|> 500 nanoseconds
+
+|Clock Class value
+|`6`
+|`7`
+|`248`
+|====
+
+[id="nw-ptp-tgm-operational-metrics-reference-soak_{context}"]
+== Soak test validation criteria
+
+The following soak test validation criteria apply to Telecom Grandmaster deployments during 1-week continuous operation testing:
+
+* No `clockcheck` violations detected
+* No unexpected clock jumps observed
+* No `ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES` events occur
+* Offset metrics remain within < 100 nanosecond thresholds continuously
+* Successful holdover transitions during GNSS loss scenarios with return to Clock Class 6 after GNSS recovery

--- a/modules/nw-ptp-troubleshooting-dpll-synchronization-failures.adoc
+++ b/modules/nw-ptp-troubleshooting-dpll-synchronization-failures.adoc
@@ -1,0 +1,184 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ptp-troubleshooting-dpll-synchronization-failures_{context}"]
+= Troubleshoot DPLL synchronization failures on Intel Granite Rapids-D
+
+[role="_abstract"]
+You can diagnose and resolve digital phase-locked loop (DPLL) synchronization failures on Telecom Grandmaster (T-GM) deployments using Intel Granite Rapids-D hardware.
+Common failure scenarios include DPLL stuck in FREERUN state, inability to achieve LOCKED state, and frequent transitions between LOCKED and HOLDOVER states.
+
+.Prerequisites
+
+* You have configured a Telecom Grandmaster on Intel Granite Rapids-D hardware.
+* The T-GM is operational but experiencing DPLL synchronization issues.
+* You have access to the `linuxptp-daemon` container on the T-GM node.
+* You understand the expected DPLL operational states (LOCKED, HOLDOVER, FREERUN).
+
+.Procedure
+
+. Verify the current DPLL operational state:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-ptp -c linuxptp-daemon-container <linuxptp-daemon-pod-name>
+sh-4.4# cat /sys/class/ptp/ptp0/device/dpll_0/state
+----
++
+Replace `<linuxptp-daemon-pod-name>` with the name of your `linuxptp-daemon` pod.
++
+Expected states:
++
+* `LOCKED`: Normal operation, DPLL synchronized to GNSS time source
+* `HOLDOVER`: GNSS signal lost but timing maintained within specification
+* `FREERUN`: DPLL not synchronized, no valid reference source
+
+. Verify the GNSS reference source status:
++
+[source,terminal]
+----
+sh-4.4# cat /dev/gnss0
+----
++
+.Example output showing GNSS NMEA sentences
+[source,terminal]
+----
+$GNRMC,123456.00,A,4012.1234,N,07357.5678,W,0.0,0.0,040926,,,A*6A
+$GNVTG,0.0,T,,M,0.0,N,0.0,K,A*3D
+$GNGGA,123456.00,4012.1234,N,07357.5678,W,1,08,1.2,100.0,M,-34.0,M,,*5E
+----
++
+If no output appears or the file is empty, the GNSS signal is not present.
+Proceed to "Troubleshoot GNSS connectivity issues on Intel Granite Rapids-D" for GNSS-specific troubleshooting.
+
+. Check the `ts2phc` process for GNSS time input synchronization:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container | grep ts2phc | tail -20
+----
++
+.Example output showing ts2phc synchronization
+[source,terminal]
+----
+ts2phc[1234.567]: [ptp0] master offset         -12 s2 freq  +34567
+ts2phc[1235.568]: [ptp0] master offset          +8 s2 freq  +34571
+----
++
+If the `ts2phc` output shows large offsets (> 1000 nanoseconds) or frequent state changes, the GNSS signal quality is poor or intermittent.
+
+. Diagnose common DPLL synchronization failure scenarios:
++
+.. *Scenario 1: DPLL stuck in FREERUN state*
++
+*Symptom*: Clock Class 248, DPLL state shows FREERUN.
++
+*Cause*: No valid reference source, GNSS signal lost for extended period.
++
+*Resolution*:
++
+... Verify GNSS antenna connection to NAC adapter.
+... Check GNSS signal quality (satellite count and SNR values).
+... Verify `ts2phc` configuration in the `PtpConfig` CR.
+... Restart the `linuxptp-daemon` pod if the GNSS signal is restored:
++
+[source,terminal]
+----
+$ oc delete pod -n openshift-ptp <linuxptp-daemon-pod-name>
+----
+
+.. *Scenario 2: DPLL cannot achieve LOCKED state*
++
+*Symptom*: DPLL cycles between FREERUN and HOLDOVER, never reaches LOCKED.
++
+*Cause*: Poor GNSS signal quality, incorrect antenna placement, `ts2phc` configuration error.
++
+*Resolution*:
++
+... Check GNSS signal-to-noise ratio (SNR) values. Healthy SNR is > 30 dB.
+... Verify antenna placement has clear sky view with no obstructions.
+... Review `ts2phc` configuration parameters in the `PtpConfig` CR.
+... Check for electromagnetic interference sources near the GNSS antenna.
+
+.. *Scenario 3: Frequent LOCKED to HOLDOVER transitions*
++
+*Symptom*: DPLL frequently transitions between LOCKED and HOLDOVER states.
++
+*Cause*: Intermittent GNSS signal, antenna cable issues, electromagnetic interference.
++
+*Resolution*:
++
+... Verify antenna cable integrity. Check for sharp bends, damage to cable jacket.
+... Check for interference sources near the antenna or cable routing.
+... Monitor GNSS signal stability over an extended period (1 hour minimum).
+... Replace the GNSS antenna or cable if intermittent connection is detected.
+
+. Verify `phc2sys` and `ts2phc` synchronization:
++
+.. Check `phc2sys` synchronization between system clock and NAC adapter PHC:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container | grep phc2sys | tail -10
+----
+
+.. Check for socket path mismatches between `ts2phc` and `ptp4l`:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container | grep -i socket
+----
++
+Socket path mismatches prevent inter-process communication and cause synchronization failures.
+
+.. Check for domain number mismatches:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container | grep -i domain
+----
++
+PTP processes must use the same domain number to communicate.
+
+. Monitor DPLL state transitions:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container -f | grep -i dpll
+----
++
+Expected transitions during GNSS loss: LOCKED → HOLDOVER → FREERUN
++
+Expected transitions during GNSS recovery: FREERUN → LOCKED
++
+Unexpected transitions indicate configuration or hardware issues.
+
+. Verify that the `HardwareConfig` CR is applied correctly:
++
+.. Check that the `HardwareConfig` resource exists:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp
+----
+
+.. Verify that `relatedPtpProfileName` matches the `PtpConfig` profile name:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep relatedPtpProfileName
+----
+
+.. Check that holdover parameters are applied to the DPLL:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep -A 5 holdover
+----
+
+.Verification
+
+. If the issue persists after troubleshooting, contact Red Hat Support.
+Technology Preview features are supported with Severity 3 (moderate impact) or Severity 4 (low impact) cases only.

--- a/modules/nw-ptp-troubleshooting-gnss-connectivity-issues.adoc
+++ b/modules/nw-ptp-troubleshooting-gnss-connectivity-issues.adoc
@@ -1,0 +1,199 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ptp-troubleshooting-gnss-connectivity-issues_{context}"]
+= Troubleshoot GNSS connectivity issues on Intel Granite Rapids-D
+
+[role="_abstract"]
+You can diagnose and resolve GNSS connectivity problems on Telecom Grandmaster (T-GM) deployments using Intel Granite Rapids-D hardware.
+Common failure scenarios include no GNSS signal detected, poor GNSS signal quality, and intermittent GNSS signal reception.
+
+.Prerequisites
+
+* You have installed a GNSS antenna.
+* You have configured the NAC adapter in the `HardwareConfig` CR.
+* You have access to the `linuxptp-daemon` container on the T-GM node.
+
+.Procedure
+
+. Verify that GNSS signal is present:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-ptp -c linuxptp-daemon-container <linuxptp-daemon-pod-name>
+sh-4.4# cat /dev/gnss0
+----
++
+Replace `<linuxptp-daemon-pod-name>` with the name of your `linuxptp-daemon` pod.
++
+.Example output showing GNSS NMEA sentences
+[source,terminal]
+----
+$GNRMC,123456.00,A,4012.1234,N,07357.5678,W,0.0,0.0,040926,,,A*6A
+$GNVTG,0.0,T,,M,0.0,N,0.0,K,A*3D
+$GNGGA,123456.00,4012.1234,N,07357.5678,W,1,08,1.2,100.0,M,-34.0,M,,*5E
+$GNGSA,A,3,01,03,04,06,09,11,14,17,,,,,2.1,1.2,1.7*3A
+$GPGSV,3,1,12,01,45,123,42,03,38,234,38,04,67,045,45,06,23,178,35*7A
+----
++
+If no output appears or the file is empty, GNSS signal is not present. Proceed to verify antenna installation.
+
+. Verify satellite count and signal quality from GPGSV NMEA sentences:
++
+.. Count visible satellites in the GPGSV sentence.
+Minimum satellites for good fix: 4 satellites.
+Optimal satellite count: 8 or more satellites.
+
+.. Check signal-to-noise ratio (SNR) values in the GPGSV sentence (last field for each satellite).
++
+* Healthy SNR: > 30 dB for most satellites
+* Poor SNR: < 25 dB indicates weak signal or interference
+
+. Check GNSS antenna installation:
++
+.. Verify antenna has clear sky view with no obstructions:
++
+* Outdoor mounting is preferred for best signal reception.
+* Window mounting is acceptable if the window has no metallic film or coating.
+* Indoor placement typically results in poor signal quality or no signal.
+
+.. Check antenna cable integrity:
++
+* Verify no sharp bends in the cable that could damage the inner conductor.
+* Check for damage to the cable jacket.
+* Verify cable length does not exceed specifications (maximum 50 meters for passive antennas, longer for active antennas).
+
+.. Verify antenna power:
++
+The NAC adapter provides power to active GNSS antennas. Check the antenna voltage configuration in the `HardwareConfig` CR:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep -A 3 gnss
+----
++
+.Example output showing antenna voltage configuration
+[source,yaml]
+----
+gnss:
+  antennaVoltage: 5
+  constellation: GPS
+----
++
+Verify that the `antennaVoltage` value matches your GNSS antenna specification (typically 3.3V or 5V).
+
+. Test GNSS antenna cable integrity:
++
+.. Perform visual inspection for physical damage.
+.. Check connector seating at both NAC adapter and antenna ends.
+.. Verify cable is not routed near high-power RF sources or electromagnetic interference.
+.. Test with a known-good antenna if available to isolate cable versus antenna faults.
+
+. Diagnose common GNSS connectivity failure scenarios:
++
+.. *Scenario 1: No GNSS signal detected*
++
+*Symptom*: `/dev/gnss0` is empty or missing.
++
+*Cause*: Antenna not connected, cable fault, NAC configuration error.
++
+*Resolution*:
++
+... Verify antenna cable connection at both ends.
+... Check NAC adapter GNSS configuration in the `HardwareConfig` CR.
+... Test antenna with a known-good cable.
+... Verify `/dev/gnss0` device file exists and has correct permissions.
+
+.. *Scenario 2: Poor GNSS signal quality*
++
+*Symptom*: Low satellite count (< 4 satellites), poor SNR (< 25 dB).
++
+*Cause*: Antenna obstructed, indoor placement, electromagnetic interference.
++
+*Resolution*:
++
+... Relocate antenna to outdoor mounting location with clear sky view.
+... Check for nearby interference sources (high-power transmitters, radar).
+... Verify antenna gain specification meets minimum requirements.
+... Test with a higher-gain antenna if poor signal persists.
+
+.. *Scenario 3: Intermittent GNSS signal*
++
+*Symptom*: GNSS signal present but frequently lost.
++
+*Cause*: Antenna cable intermittent connection, electromagnetic interference, nearby RF sources.
++
+*Resolution*:
++
+... Check cable connectors for intermittent contact.
+... Reroute cable away from interference sources.
+... Shield antenna cable if electromagnetic interference is detected.
+... Replace antenna cable if intermittent connection persists.
+
+. Verify GNSS receiver configuration in the `HardwareConfig` CR:
++
+.. Check antenna voltage setting matches antenna specification:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep antennaVoltage
+----
+
+.. Verify GPS constellation support is enabled:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep constellation
+----
+
+.. Check survey mode settings:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep -A 3 surveyMode
+----
++
+.Example output showing survey mode configuration
+[source,yaml]
+----
+surveyMode:
+  observationTime: 600
+  accuracyThreshold: 50000
+----
+
+.. Verify serial port device path is correct:
++
+[source,terminal]
+----
+$ oc get hardwareconfig -n openshift-ptp -o yaml | grep serialDevice
+----
++
+Default serial device is `/dev/gnss0` for NAC adapters.
+
+. Monitor GNSS receiver status and time-to-first-fix (TTFF):
++
+.. Check for GNSS receiver errors in `linuxptp-daemon` logs:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp <linuxptp-daemon-pod-name> -c linuxptp-daemon-container | grep -i gnss
+----
+
+.. Monitor time-to-first-fix:
++
+* Warm start: < 2 minutes (GNSS receiver has recent almanac data)
+* Hot start: < 30 seconds (GNSS receiver has recent ephemeris data)
+* Hardware restart: < 5 minutes (GNSS receiver has no prior data)
++
+If TTFF exceeds these values, GNSS signal quality is poor or antenna placement is suboptimal.
+
+.Verification
+
+. If the issue persists after troubleshooting:
++
+.. Replace the GNSS antenna with a known-good unit.
+.. Relocate antenna to optimal outdoor mounting location with clear sky view.
+.. Verify NAC adapter GNSS receiver is functional by testing with Red Hat Support.
+.. Contact Red Hat Support if the issue continues. Technology Preview features are supported with Severity 3 (moderate impact) or Severity 4 (low impact) cases only.

--- a/modules/nw-ptp-verifying-tgm-dpll-synchronization-gnrd.adoc
+++ b/modules/nw-ptp-verifying-tgm-dpll-synchronization-gnrd.adoc
@@ -1,0 +1,174 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ptp-verifying-tgm-dpll-synchronization-gnrd_{context}"]
+= Verify Telecom Grandmaster DPLL synchronization on Intel Granite Rapids-D
+
+[role="_abstract"]
+You can verify that the Telecom Grandmaster (T-GM) digital phase-locked loop (DPLL) is synchronized to the GNSS time source and that timing offsets remain within acceptable thresholds.
+Verification includes monitoring DPLL operational state, Clock Class transitions, timing offset metrics, and holdover behavior during GNSS loss scenarios.
+
+.Prerequisites
+
+* You have configured a Telecom Grandmaster on Intel Granite Rapids-D hardware.
+* You have applied `PtpConfig` and `HardwareConfig` custom resources (CRs).
+* You have connected a GNSS antenna with clear sky view to the NAC adapter.
+* The `linuxptp-daemon` pods are running on the T-GM nodes.
+
+.Procedure
+
+. Identify the `linuxptp-daemon` pod running on your T-GM node:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -l app=linuxptp-daemon
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE
+linuxptp-daemon-abcde         3/3     Running   0          5m
+----
+
+. Access the `linuxptp-daemon` container:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-ptp -c linuxptp-daemon-container linuxptp-daemon-abcde
+----
++
+Replace `linuxptp-daemon-abcde` with the name of your `linuxptp-daemon` pod.
+
+. Verify that the DPLL operational state shows LOCKED when GNSS signal is present:
++
+[source,terminal]
+----
+sh-4.4# cat /sys/class/ptp/ptp0/device/dpll_0/state
+----
++
+.Example output
+[source,terminal]
+----
+LOCKED
+----
++
+The DPLL operational state `LOCKED` indicates that the DPLL is synchronized to the GNSS time source.
+
+. Monitor Clock Class transitions by checking the `linuxptp-daemon` logs:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container | grep -i "clock class"
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+I0904 12:34:56.789012    1234 event.go:456] Clock Class transition: 6 (LOCKED to PRTC)
+----
++
+Clock Class 6 indicates that the T-GM is locked to a Primary Reference Time Clock (PRTC) traceable to GNSS.
+
+. Validate that the `ts2phc` offset remains below the 100 nanosecond threshold during normal operation:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container | grep ts2phc | tail -10
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+ts2phc[1234.567]: [ptp0] master offset         -12 s2 freq  +34567
+ts2phc[1235.568]: [ptp0] master offset          +8 s2 freq  +34571
+ts2phc[1236.569]: [ptp0] master offset         -15 s2 freq  +34565
+----
++
+The `master offset` values should remain below 100 nanoseconds during normal operation.
+
+. Validate that the `ptp4l` offset remains below the 100 nanosecond threshold during normal operation:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container | grep ptp4l | tail -10
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+ptp4l[1234.567]: [nac0p0] master offset         -18 s2 freq  +12345
+ptp4l[1235.568]: [nac0p0] master offset          +5 s2 freq  +12348
+ptp4l[1236.569]: [nac0p0] master offset         -22 s2 freq  +12342
+----
++
+The `master offset` values should remain below 100 nanoseconds during normal operation.
+
+. Test holdover behavior by disconnecting the GNSS signal:
++
+.. Physically disconnect the GNSS antenna cable or block the GNSS signal.
+.. Monitor the `linuxptp-daemon` logs for Clock Class transitions:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container -f | grep -i "clock class"
+----
++
+.Example output showing Clock Class transition from 6 to 7
+[source,terminal,subs="attributes+"]
+----
+I0904 12:45:00.123456    1234 event.go:456] Clock Class transition: 7 (HOLDOVER within specification)
+----
++
+Clock Class 7 indicates that the T-GM is in HOLDOVER mode and timing is maintained within ITU-T G.8273.2 Class-B specifications.
+
+.. Verify that timing offsets remain within the 1.5 microsecond threshold during holdover:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container | grep ts2phc | tail -10
+----
++
+Timing offsets should increase gradually during holdover but remain below 1.5 microseconds for at least 4 hours.
+
+.. Monitor for Clock Class transition to 248 when the holdover timeout expires:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container -f | grep -i "clock class"
+----
++
+.Example output showing Clock Class transition from 7 to 248
+[source,terminal,subs="attributes+"]
+----
+I0904 16:45:00.123456    1234 event.go:456] Clock Class transition: 248 (FREERUN - out of sync)
+----
++
+Clock Class 248 indicates that the holdover timeout has expired and the T-GM is no longer synchronized.
+
+.. Reconnect the GNSS antenna and verify return to Clock Class 6:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ptp linuxptp-daemon-abcde -c linuxptp-daemon-container -f | grep -i "clock class"
+----
++
+.Example output showing Clock Class transition back to 6
+[source,terminal,subs="attributes+"]
+----
+I0904 16:50:30.789012    1234 event.go:456] Clock Class transition: 6 (LOCKED to PRTC)
+----
++
+Recovery time typically takes 1-5 minutes depending on GNSS signal quality.
+
+.Verification
+
+. Verify that all timing health metrics are within acceptable thresholds:
++
+* `phc2sys` offset is less than 100 nanoseconds
+* `ts2phc` offset is less than 100 nanoseconds
+* DPLL synchronization status shows LOCKED
+* GNSS connectivity status shows signal present
+* Clock Class value is 6 during normal operation

--- a/networking/advanced_networking/ptp/configuring-ptp.adoc
+++ b/networking/advanced_networking/ptp/configuring-ptp.adoc
@@ -42,13 +42,39 @@ include::modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc[l
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc[leveloffset=+2]
 
+include::modules/nw-ptp-gnrd-supported-hardware-reference.adoc[leveloffset=+3]
+
+include::modules/nw-ptp-configuring-field-tunable-timing-parameters-gnrd.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-field-tunable-timing-parameters-reference.adoc[leveloffset=+3]
+
+include::modules/nw-ptp-verifying-tgm-dpll-synchronization-gnrd.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-tgm-operational-metrics-reference.adoc[leveloffset=+3]
+
+include::modules/nw-ptp-troubleshooting-dpll-synchronization-failures.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-troubleshooting-gnss-connectivity-issues.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-clock-class-state-transitions-concept.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-dpll-loss-detection-concept.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-gnrd-supported-hardware-reference_configuring-ptp[Supported hardware for Telecom Grandmaster on Intel Granite Rapids-D]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-field-tunable-timing-parameters-reference_configuring-ptp[Field-tunable timing parameters reference for Intel Granite Rapids-D]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-tgm-operational-metrics-reference_configuring-ptp[Operational metrics reference for Telecom Grandmaster on Intel Granite Rapids-D]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-grandmaster-clock-class-reference_configuring-ptp[Grandmaster clock class sync state reference]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-clock-class-state-transitions-concept_configuring-ptp[Clock Class state transitions during holdover]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-dpll-loss-detection-concept_configuring-ptp[DPLL loss detection mechanism for Intel Granite Rapids-D]
 * xref:../../../networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#cnf-configuring-the-ptp-fast-event-publisher-v2_ptp-consumer[Configuring the PTP fast event notifications publisher]
 * xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-boundary-clock-overview_configuring-ptp[Boundary clocks without holdover on Intel Granite Rapids-D hardware]
 * xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_configuring-ptp[Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware]
 * xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-gnrd-t-bc-holdover_configuring-ptp[Configuring GNR-D T-BC holdover on a GNR-D platform]
+* link:https://www.itu.int/rec/T-REC-G.8275.1[ITU-T Recommendation G.8275.1: Precision time protocol telecom profile for phase/time synchronization]
+* link:https://www.itu.int/rec/T-REC-G.8273.2[ITU-T Recommendation G.8273.2: Timing characteristics of telecom boundary clocks and telecom time slave clocks]
 
 include::modules/nw-ptp-grandmaster-clock-configuration-reference.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Add comprehensive documentation for Telecom Grandmaster on Intel Granite Rapids-D platforms with field-tunable timing parameters (Tech Preview in OCP 5.0).

New modules:
- Supported hardware reference (Dell XR8720t specs, BOM)
- Tech Preview limitations and platform timeline
- ITU-T standards compliance (G.8272, G.8273.2, G.8275.1)
- Configure field-tunable parameters via HardwareConfig v2alpha1
- Field-tunable parameters reference
- Verify T-GM DPLL synchronization procedure
- Operational metrics reference
- Clock Class state transitions concept
- Troubleshoot DPLL sync failures
- Troubleshoot GNSS connectivity issues
- DPLL loss detection concept

Updated modules:
- Enhanced T-GM overview with TP timeline, field tuning capabilities
- Enhanced Clock Class reference with thresholds, holdover specs

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
