### PR TITLE
OSSM-15021: Document preserving XFCC headers with ALWAYS_FORWARD_ONLY

### DIFF
--- a/modules/ossm-configuring-xfcc-headers.adoc
+++ b/modules/ossm-configuring-xfcc-headers.adoc
@@ -6,36 +6,27 @@
 [id="ossm-configuring-xfcc-headers_{context}"]
 = Configuring X-Forwarded-Client-Cert headers
 
-Applications sometimes need the original client certificate details after {SMProductName} terminates TLS at the ingress gateway. Envoy can forward that information in the `X-Forwarded-Client-Cert` (XFCC) header. You configure this behavior in the `ServiceMeshControlPlane` resource by setting `spec.techPreview.meshConfig.defaultConfig.gatewayTopology.forwardClientCertDetails`.
+If an application behind the mesh needs the original client certificate, Envoy can pass that information in the `X-Forwarded-Client-Cert` (XFCC) header. You set this on the `ServiceMeshControlPlane` with `spec.techPreview.meshConfig.defaultConfig.gatewayTopology.forwardClientCertDetails`.
 
 :FeatureName: Configuring X-Forwarded-Client-Cert headers
 include::snippets/technology-preview.adoc[]
 
-The `forwardClientCertDetails` value applies to gateway workloads. The following values are commonly used:
+This setting applies to the ingress gateway. A few values matter in practice:
 
-`SANITIZE`:: Do not send the XFCC header to the next hop. Use this value to strip a client-provided XFCC header.
+* `SANITIZE` drops the XFCC header. If a client sends one, the gateway strips it.
+* `APPEND_FORWARD` and `FORWARD_ONLY` keep the header only when the connection into the gateway is mTLS.
+* `ALWAYS_FORWARD_ONLY` forwards the header even when the request reaches the gateway over plain HTTP.
 
-`FORWARD_ONLY`:: Forward the XFCC header only when the downstream connection uses mutual TLS (mTLS).
-
-`APPEND_FORWARD`:: When the downstream connection uses mTLS, append the client certificate information to the XFCC header and forward it.
-
-`SANITIZE_SET`:: When the downstream connection uses mTLS, replace the XFCC header with the client certificate information. This is the default value for a gateway.
-
-`ALWAYS_FORWARD_ONLY`:: Always forward the XFCC header, whether or not the downstream connection uses mTLS.
-
-[IMPORTANT]
-====
-When ingress traffic reaches the mesh over plain HTTP, for example through an edge-terminated OpenShift route, `SANITIZE`, `FORWARD_ONLY`, and `APPEND_FORWARD` strip a client-provided XFCC header. To preserve a client-provided XFCC header in that topology, set `forwardClientCertDetails` to `ALWAYS_FORWARD_ONLY`.
-====
+That last point is the usual catch. If TLS is terminated on an OpenShift route (edge termination), the gateway sees HTTP, not mTLS. In that case `SANITIZE`, `APPEND_FORWARD`, and `FORWARD_ONLY` all strip a client-provided XFCC header. Use `ALWAYS_FORWARD_ONLY` if you need that header to reach the application.
 
 .Prerequisites
 
-* You have deployed a `ServiceMeshControlPlane` resource.
-* You have installed the OpenShift CLI (`oc`).
+* You have a `ServiceMeshControlPlane` already deployed.
+* You can use the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Set `forwardClientCertDetails` to `ALWAYS_FORWARD_ONLY` on your `ServiceMeshControlPlane` resource. In this example, `basic` is the name of the resource and `istio-system` is the control plane namespace.
+. Change `forwardClientCertDetails` to `ALWAYS_FORWARD_ONLY`. This example uses an SMCP named `basic` in the `istio-system` namespace:
 +
 [source,terminal]
 ----
@@ -43,7 +34,7 @@ $ oc patch smcp basic -n istio-system --type=merge --patch \
 '{"spec":{"techPreview":{"meshConfig":{"defaultConfig":{"gatewayTopology":{"forwardClientCertDetails":"ALWAYS_FORWARD_ONLY"}}}}}}'
 ----
 +
-The following example shows the equivalent YAML:
+Or set the same value in the SMCP YAML:
 +
 [source,yaml]
 ----
@@ -60,14 +51,14 @@ spec:
           forwardClientCertDetails: ALWAYS_FORWARD_ONLY
 ----
 
-. Restart the ingress gateway so that Envoy loads the updated configuration:
+. Restart the ingress gateway so Envoy picks up the change:
 +
 [source,terminal]
 ----
 $ oc rollout restart deployment/istio-ingressgateway -n istio-system
 ----
 
-. Wait until the rollout is complete:
+. Wait for the rollout to finish:
 +
 [source,terminal]
 ----
@@ -76,17 +67,13 @@ $ oc rollout status deployment/istio-ingressgateway -n istio-system
 
 .Verification
 
-. Confirm that the `ServiceMeshControlPlane` resource contains `ALWAYS_FORWARD_ONLY`:
+. Check that the SMCP now has `ALWAYS_FORWARD_ONLY`:
 +
 [source,terminal]
 ----
 $ oc get smcp basic -n istio-system -o jsonpath='{.spec.techPreview.meshConfig.defaultConfig.gatewayTopology.forwardClientCertDetails}{"\n"}'
 ----
 
+. Send the same request you used before, with the XFCC header set, and confirm the application still sees it.
 
-. Send a request that includes a client-provided XFCC header and confirm that the backend application receives the original header value.
-
-[NOTE]
-====
-`ALWAYS_FORWARD_ONLY` preserves the client-provided XFCC header. If the gateway-to-sidecar connection uses mTLS, Envoy can also append the mesh identity to the XFCC chain.
-====
+If mesh mTLS is enabled between the gateway and the sidecar, the mesh identity may also be appended to the XFCC chain. The original client-provided value should still be there.

--- a/modules/ossm-configuring-xfcc-headers.adoc
+++ b/modules/ossm-configuring-xfcc-headers.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-traffic-manage.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-configuring-xfcc-headers_{context}"]
+= Configuring X-Forwarded-Client-Cert headers
+
+Applications sometimes need the original client certificate details after {SMProductName} terminates TLS at the ingress gateway. Envoy can forward that information in the `X-Forwarded-Client-Cert` (XFCC) header. You configure this behavior in the `ServiceMeshControlPlane` resource by setting `spec.techPreview.meshConfig.defaultConfig.gatewayTopology.forwardClientCertDetails`.
+
+:FeatureName: Configuring X-Forwarded-Client-Cert headers
+include::snippets/technology-preview.adoc[]
+
+The `forwardClientCertDetails` value applies to gateway workloads. The following values are commonly used:
+
+`SANITIZE`:: Do not send the XFCC header to the next hop. Use this value to strip a client-provided XFCC header.
+
+`FORWARD_ONLY`:: Forward the XFCC header only when the downstream connection uses mutual TLS (mTLS).
+
+`APPEND_FORWARD`:: When the downstream connection uses mTLS, append the client certificate information to the XFCC header and forward it.
+
+`SANITIZE_SET`:: When the downstream connection uses mTLS, replace the XFCC header with the client certificate information. This is the default value for a gateway.
+
+`ALWAYS_FORWARD_ONLY`:: Always forward the XFCC header, whether or not the downstream connection uses mTLS.
+
+[IMPORTANT]
+====
+When ingress traffic reaches the mesh over plain HTTP, for example through an edge-terminated OpenShift route, `SANITIZE`, `FORWARD_ONLY`, and `APPEND_FORWARD` strip a client-provided XFCC header. To preserve a client-provided XFCC header in that topology, set `forwardClientCertDetails` to `ALWAYS_FORWARD_ONLY`.
+====
+
+.Prerequisites
+
+* You have deployed a `ServiceMeshControlPlane` resource.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Set `forwardClientCertDetails` to `ALWAYS_FORWARD_ONLY` on your `ServiceMeshControlPlane` resource. In this example, `basic` is the name of the resource and `istio-system` is the control plane namespace.
++
+[source,terminal]
+----
+$ oc patch smcp basic -n istio-system --type=merge --patch \
+'{"spec":{"techPreview":{"meshConfig":{"defaultConfig":{"gatewayTopology":{"forwardClientCertDetails":"ALWAYS_FORWARD_ONLY"}}}}}}'
+----
++
+The following example shows the equivalent YAML:
++
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+  techPreview:
+    meshConfig:
+      defaultConfig:
+        gatewayTopology:
+          forwardClientCertDetails: ALWAYS_FORWARD_ONLY
+----
+
+. Restart the ingress gateway so that Envoy loads the updated configuration:
++
+[source,terminal]
+----
+$ oc rollout restart deployment/istio-ingressgateway -n istio-system
+----
+
+. Wait until the rollout is complete:
++
+[source,terminal]
+----
+$ oc rollout status deployment/istio-ingressgateway -n istio-system
+----
+
+.Verification
+
+. Confirm that the `ServiceMeshControlPlane` resource contains `ALWAYS_FORWARD_ONLY`:
++
+[source,terminal]
+----
+$ oc get smcp basic -n istio-system -o jsonpath='{.spec.techPreview.meshConfig.defaultConfig.gatewayTopology.forwardClientCertDetails}{"\n"}'
+----
+
+
+. Send a request that includes a client-provided XFCC header and confirm that the backend application receives the original header value.
+
+[NOTE]
+====
+`ALWAYS_FORWARD_ONLY` preserves the client-provided XFCC header. If the gateway-to-sidecar connection uses mTLS, Envoy can also append the mesh identity to the XFCC chain.
+====

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -29,6 +29,8 @@ endif::[]
 
 include::modules/ossm-routing-gateways.adoc[leveloffset=+2]
 
+include::modules/ossm-configuring-xfcc-headers.adoc[leveloffset=+2]
+
 [id="ossm-auto-route_{context}"]
 == Understanding automatic routes
 


### PR DESCRIPTION
Documents how to keep a client-provided XFCC header when the Service Mesh ingress gateway is sitting behind an edge-terminated OpenShift route.

SANITIZE (and APPEND_FORWARD / FORWARD_ONLY over plain HTTP) drop that header at the gateway. ALWAYS_FORWARD_ONLY is the setting that forwards it through to the app.

Jira: https://issues.redhat.com/browse/OSSM-15021

This is a docs change only. No product code change.