### PR TITLE
CNV-94191: Document crash detection reporting metrics

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -194,6 +194,52 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes
 Memory swapping indicates that the virtual machine is under memory pressure. Increasing the memory allocation of the virtual machine can mitigate this issue.
 ====
 
+[id="virt-promql-crash-detection-metrics_{context}"]
+== Crash detection metrics
+
+You can track guest operating system panic events to identify unstable virtual machines (VMs) and problematic VM images. {VirtProductName} detects a guest operating system panic through the `pvpanic` device on Linux and Windows guests, or through the Hyper-V enlightenment mechanism on Windows guests, and records each event in the following metric.
+
+`kubevirt_vmi_guest_os_panic_total`::
+Returns the total number of guest operating system panic events detected for a VM. Type: Counter.
++
+This metric includes the following labels:
++
+* `namespace` and `name` identify the affected VM.
+* `type` identifies the panic source, for example `pvpanic` or `hyper-v`.
+* `bugcheck_code` provides the bug check code for a Windows guest. Use this code to identify the cause of a Windows stop error.
+
+Example crash frequency query:
+
+The following query returns the top 3 VMs with the most guest operating system panic events over a one-hour period. A consistently high value can indicate an unstable workload or a problematic VM image:
+
+[source,promql]
+----
+topk(3, sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[1h]))) > 0
+----
+
+Example 24-hour crash count query:
+
+The following query returns the number of guest operating system panic events for each VM over a rolling 24-hour window. Use this query for immediate awareness of crash activity across your environment:
+
+[source,promql]
+----
+sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 0
+----
+
+Example query to identify a problematic VM image:
+
+To determine whether a VM image is the source of instability, compare the guest operating system panic events of VMs that were created from the same image. If multiple VMs share the same `type` or `bugcheck_code` value, the image or its drivers are the likely cause. The following query groups panic events by panic type over a 24-hour window:
+
+[source,promql]
+----
+sum by (namespace, name, type, bugcheck_code) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 0
+----
+
+[NOTE]
+====
+The `ClusterVMPanicDetected` and `VMNonRecoverableOSPanic` alerts are based on the `kubevirt_vmi_guest_os_panic_total` metric. When a VM has a run strategy of `Always`, the VM restarts automatically after a non-recoverable panic. Repeated panic events for the same VM can indicate a crash loop that requires investigation.
+====
+
 [id="virt-promql-aaq-metrics_{context}"]
 == Monitoring AAQ operator metrics
 The following metrics are exposed by the Application Aware Quota (AAQ) controller for monitoring resource quotas:


### PR DESCRIPTION
Add a "Crash detection metrics" section to the virtualization metrics reference, documenting the kubevirt_vmi_guest_os_panic_total counter. Includes queries for crash frequency, a rolling 24-hour crash count, and identifying problematic VM images by grouping on panic type and bug check code.

CNV#94191

Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/CNV-94191

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
