### PR TITLE
CNV-95767: Add fusion access Operator deprecation note

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -186,15 +186,19 @@ link:https://issues.redhat.com/browse/CNV-69069[CNV-69069]
 == Deprecated features
 
 The `HotplugVolume` feature gate is deprecated::
-
 The `HotplugVolume` feature gate, which allows you to add storage without restarting your VM, is deprecated and will be removed in a future release. This feature gate will be replaced by `DeclarativeHotplugVolumes`.
 +
 [NOTE]
 ====
 `DeclarativeHotplugVolumes` does not support hot plugging ephemeral volumes. Ephemeral volumes are hot plugged to a VMI and do not persist in the owner VM. Existing ephemeral volumes that are hot plugged are automatically detached after you switch to the `DeclarativeHotplugVolumes` feature gate.
 ====
-
++
 link:https://issues.redhat.com/browse/CNV-73301[CNV-73301]
+
+The {FusionSAN} Operator is deprecated::
+The {FusionSAN} Operator is deprecated and will be removed in a future release. For new deployments, configure {IBMFusionFirst} in Fusion Data Foundation as an external system.
++
+For more information, see link:https://www.ibm.com/docs/en/fusion-software/2.13.x?topic=san-deploying-fusion-access[Deploying IBM Fusion Access for SAN].
 
 [id="virt-4-21-removed_{context}"]
 == Removed features

--- a/virt/storage/install-configure-fusion-access-san.adoc
+++ b/virt/storage/install-configure-fusion-access-san.adoc
@@ -7,7 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You configure SAN-based storage for virtual machines by using {IBMFusionFirst} with {VirtProductName}. You must install the {FusionSAN} Operator (Fusion Access for SAN) and set up the storage cluster and file systems.
+You can configure SAN-based storage for virtual machines by using {IBMFusionFirst} with {VirtProductName}.
+
+[IMPORTANT]
+====
+The {FusionSAN} Operator is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+For new deployments, configure {IBMFusionFirst} in Fusion Data Foundation as an external system. For more information, see "Deploying IBM Fusion Access for SAN" in the Additional resources section.
+====
 
 include::modules/virt-about-fusion-access-san.adoc[leveloffset=+1]
 
@@ -30,7 +37,4 @@ include::modules/virt-fusion-access-san-release-updates.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-
-* xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating virtual machines from instance types]
-
-* xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating virtual machines from templates]
+* link:https://www.ibm.com/docs/en/fusion-software/2.13.x?topic=san-deploying-fusion-access[Deploying IBM Fusion Access for SAN]


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/CNV-95767

Link to docs preview:
- https://119393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-deprecated_virt-4-21-release-notes
- https://119393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
