### PR TITLE
Moving networking jobs to new networking map

### DIFF
--- a/maps/microshift/configure.adoc
+++ b/maps/microshift/configure.adoc
@@ -2,25 +2,13 @@
 
 = Configure
 
-include::jobs/understand-default-networking.adoc[leveloffset=+1]
-
-include::jobs/customize-networking-configuration.adoc[leveloffset=+1]
-
 include::jobs/optimize-low-latency-performance.adoc[leveloffset=+1]
-
-include::jobs/optimize-network-performance.adoc[leveloffset=+1]
-
-include::jobs/extend-with-multiple-networks.adoc[leveloffset=+1]
-
-include::jobs/provide-external-access.adoc[leveloffset=+1]
 
 include::jobs/secure-api-and-control-plane.adoc[leveloffset=+1]
 
 include::jobs/configure-audit-logging.adoc[leveloffset=+1]
 
 include::jobs/verify-trusted-container-images.adoc[leveloffset=+1]
-
-include::jobs/secure-and-control-traffic.adoc[leveloffset=+1]
 
 include::jobs/configure-access-to-host-devices.adoc[leveloffset=+1]
 
@@ -31,11 +19,3 @@ include::jobs/maintain-system-health-greenboot.adoc[leveloffset=+1]
 include::jobs/test-new-kubernetes-features.adoc[leveloffset=+1]
 
 include::jobs/configure-with-config-file.adoc[leveloffset=+1]
-
-include::jobs/configure-disconnected-networking.adoc[leveloffset=+1]
-
-include::jobs/expose-app-with-loadbalancer.adoc[leveloffset=+1]
-
-include::jobs/restrict-nodeport-access.adoc[leveloffset=+1]
-
-include::jobs/configure-crio-proxy.adoc[leveloffset=+1]

--- a/maps/microshift/navigation.adoc
+++ b/maps/microshift/navigation.adoc
@@ -33,6 +33,8 @@ include::integrate.adoc[leveloffset=+1]
 
 include::reference.adoc[leveloffset=+1]
 
+include::networking.adoc[leveloffset=+1]
+
 include::storage.adoc[leveloffset=+1]
 
 include::cli.adoc[leveloffset=+1]

--- a/maps/microshift/networking.adoc
+++ b/maps/microshift/networking.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: MAP
+
+= Networking
+
+include::jobs/understand-default-networking.adoc[leveloffset=+1]
+
+include::jobs/customize-networking-configuration.adoc[leveloffset=+1]
+
+include::jobs/optimize-network-performance.adoc[leveloffset=+1]
+
+include::jobs/extend-with-multiple-networks.adoc[leveloffset=+1]
+
+include::jobs/provide-external-access.adoc[leveloffset=+1]
+
+include::jobs/secure-and-control-traffic.adoc[leveloffset=+1]
+
+include::jobs/configure-disconnected-networking.adoc[leveloffset=+1]
+
+include::jobs/expose-app-with-loadbalancer.adoc[leveloffset=+1]
+
+include::jobs/restrict-nodeport-access.adoc[leveloffset=+1]
+
+include::jobs/configure-crio-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Link to docs preview:
https://bscott-rh.github.io/openshift-docs/move-networking-jobs/microshift/navigation.html

