### PR TITLE
[enterprise-4.20] OSDOCS-16997-installing-gcp-vpc# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -11,10 +11,18 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You configured a {gcp-short} project to host the cluster. For more information, see "Configuring a {gcp-short} project".
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
 
 include::modules/installation-custom-gcp-vpc.adoc[leveloffset=+1]
 
@@ -78,23 +86,14 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#manually-create-iam_installing-gcp-vpc[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-with-short-term-creds_installing-gcp-vpc[Configuring a {gcp-short} cluster to use short-term credentials].
+//Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -118,17 +117,14 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/cli-installing-cli-linux.adoc
+++ b/modules/cli-installing-cli-linux.adoc
@@ -109,7 +109,7 @@ $ tar xvf <file>
 
 . Place the `oc` binary in a directory that is on your `PATH`.
 +
-To check your `PATH`, execute the following command:
+To check your `PATH`, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/cli-installing-cli-macos.adoc
+++ b/modules/cli-installing-cli-macos.adoc
@@ -102,11 +102,11 @@ ifdef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Click *Download Now* next to the *OpenShift v{product-version} macOS Clients* entry and save the file.
 
 endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-. Unpack and unzip the archive.
+. Extract the archive.
 
 . Move the `oc` binary to a directory on your `PATH` variable.
 +
-To check your `PATH` variable, open a terminal and execute the following command:
+To check your `PATH` variable, open a terminal and run the following command:
 +
 [source,terminal]
 ----

--- a/modules/cli-installing-cli-windows.adoc
+++ b/modules/cli-installing-cli-windows.adoc
@@ -99,7 +99,7 @@ endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 . Move the `oc` binary to a directory that is on your `PATH` variable.
 +
-To check your `PATH` variable, open the command prompt and execute the following command:
+To check your `PATH` variable, open the Command Prompt and run the following command:
 +
 [source,terminal]
 ----

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -113,14 +113,12 @@ ifndef::openshift-origin[]
 = Internet access for {product-title}
 
 [role="_abstract"]
-In {product-title} {product-version}, you require access to the internet to
 ifndef::restricted[]
-install
+In {product-title} {product-version}, you require access to the internet to install your cluster.
 endif::restricted[]
 ifdef::restricted[]
-obtain the images that are necessary to install
+In {product-title} {product-version}, you require access to the internet to obtain the images that are necessary to install your cluster.
 endif::restricted[]
-your cluster.
 
 You must have internet access to perform the following actions:
 

--- a/modules/installation-custom-gcp-vpc.adoc
+++ b/modules/installation-custom-gcp-vpc.adoc
@@ -6,7 +6,10 @@
 [id="installation-custom-gcp-vpc_{context}"]
 = About using a custom VPC
 
-In {product-title} {product-version}, you can deploy a cluster into existing subnets in an existing Virtual Private Cloud (VPC) in {gcp-first}. By deploying {product-title} into an existing {gcp-short} VPC, you might be able to avoid limit constraints in new accounts or more easily abide by the operational constraints that your company's guidelines set. If you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself, use this installation option. You must configure networking for the subnets.
+[role="_abstract"]
+In {product-title} {product-version}, you can deploy a cluster into existing subnets in an existing Virtual Private Cloud (VPC) in {gcp-first} to avoid limit constraints in new accounts or to comply with operational constraints set by your organization.
+
+By deploying {product-title} into an existing {gcp-short} VPC, you might be able to avoid limit constraints in new accounts or more easily abide by the operational constraints that your company's guidelines set. If you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself, use this installation option. You must configure networking for the subnets.
 
 [id="installation-custom-gcp-vpc-requirements_{context}"]
 == Requirements for using your VPC
@@ -29,12 +32,12 @@ To ensure that the subnets that you provide are suitable, the installation progr
 
 * All the subnets that you specify exist.
 * You provide one subnet for control-plane machines and one subnet for compute machines.
-* The subnet's CIDRs belong to the machine CIDR that you specified.
+* The subnet CIDRs belong to the machine CIDR that you specified.
 
 [id="installation-about-custom-gcp-permissions_{context}"]
 == Division of permissions
 
-Some individuals can create different resource in your clouds than others. For example, you might be able to create application-specific items, like instances, buckets, and load balancers, but not networking-related components such as VPCs, subnets, or ingress rules.
+Some individuals can create different resource in your clouds than others. For example, you might be able to create application-specific items, such as instances, buckets, and load balancers, but not networking-related components, such as VPCs, subnets, or ingress rules.
 
 [id="installation-custom-gcp-vpc-isolation_{context}"]
 == Isolation between clusters

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -27,7 +27,8 @@ endif::[]
 [id="installation-gcp-config-yaml_{context}"]
 = Sample customized install-config.yaml file for {gcp-short}
 
-You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
+[role="_abstract"]
+You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or to change the values of the required parameters.
 
 [IMPORTANT]
 ====
@@ -37,10 +38,10 @@ This sample YAML file is provided for reference only. You must obtain your `inst
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: example.com <1>
-credentialsMode: Mint <2>
-controlPlane: <3> <4>
-  hyperthreading: Enabled <5>
+baseDomain: example.com
+credentialsMode: Mint
+controlPlane:
+  hyperthreading: Enabled
   name: master
   platform:
     gcp:
@@ -51,21 +52,21 @@ controlPlane: <3> <4>
       osDisk:
         diskType: pd-ssd
         diskSizeGB: 1024
-        encryptionKey: <6>
+        encryptionKey:
           kmsKey:
             name: worker-key
             keyRing: test-machine-keys
             location: global
             projectID: project-id
-      tags: <7>
+      tags:
       - control-plane-tag1
       - control-plane-tag2
-      osImage: <8>
+      osImage:
         project: example-project-name
         name: example-image-name
   replicas: 3
-compute: <3> <4>
-- hyperthreading: Enabled <5>
+compute:
+- hyperthreading: Enabled
   name: worker
   platform:
     gcp:
@@ -76,99 +77,99 @@ compute: <3> <4>
       osDisk:
         diskType: pd-standard
         diskSizeGB: 128
-        encryptionKey: <6>
+        encryptionKey:
           kmsKey:
             name: worker-key
             keyRing: test-machine-keys
             location: global
             projectID: project-id
-        tags: <7>
+        tags:
         - compute-tag1
         - compute-tag2
-        osImage: <8>
+        osImage:
           project: example-project-name
           name: example-image-name
   replicas: 3
 metadata:
-  name: test-cluster <1>
+  name: test-cluster
 ifdef::without-networking[]
 networking:
 endif::[]
 ifdef::with-networking[]
-networking: <3>
+networking:
 endif::[]
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <9>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   gcp:
-    projectID: openshift-production <1>
-    region: us-central1 <1>
+    projectID: openshift-production
+    region: us-central1
     defaultMachinePlatform:
-      tags: <7>
+      tags:
       - global-tag1
       - global-tag2
-      osImage: <8>
+      osImage:
         project: example-project-name
         name: example-image-name
 ifdef::vpc,restricted[]
-    network: existing_vpc <10>
-    controlPlaneSubnet: control_plane_subnet <11>
-    computeSubnet: compute_subnet <12>
+    network: existing_vpc
+    controlPlaneSubnet: control_plane_subnet
+    computeSubnet: compute_subnet
 endif::vpc,restricted[]
 ifndef::restricted[]
-pullSecret: '{"auths": ...}' <1>
+pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}'
 endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <10>
-sshKey: ssh-ed25519 AAAA... <11>
+fips: false
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <10>
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifdef::vpc[]
 ifndef::openshift-origin[]
-fips: false <13>
-sshKey: ssh-ed25519 AAAA... <14>
+fips: false
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <13>
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 endif::vpc[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-fips: false <14>
-sshKey: ssh-ed25519 AAAA... <15>
+fips: false
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <14>
+sshKey: ssh-ed25519 AAAA...
 endif::openshift-origin[]
 endif::restricted[]
 ifdef::private[]
 ifndef::openshift-origin[]
-publish: Internal <15>
+publish: Internal
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-publish: Internal <14>
+publish: Internal
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <16>
+additionalTrustBundle: |
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <17>
+imageContentSources:
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -177,11 +178,11 @@ imageContentSources: <17>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <15>
+additionalTrustBundle: |
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <16>
+imageContentSources:
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -191,96 +192,53 @@ imageContentSources: <16>
 endif::openshift-origin[]
 endif::restricted[]
 ----
-<1> Required. The installation program prompts you for this value.
-<2> Optional: Add this parameter to force the Cloud Credential Operator (CCO) to use the specified mode. By default, the CCO uses the root credentials in the `kube-system` namespace to dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the "About the Cloud Credential Operator" section in the _Authentication and authorization_ guide.
-<3> If you do not provide these parameters and values, the installation program provides the default value.
-<4> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<5> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+where:
+
+* `baseDomain`, `metadata.name`, `platform.gcp.projectID`, `platform.gcp.region`, `pullSecret`: Specifies required values. The installation program prompts you for these values.
+* `credentialsMode`: Specifies the Cloud Credential Operator (CCO) mode. Optional. By default, the CCO uses the root credentials in the `kube-system` namespace to dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the "About the Cloud Credential Operator" section in the _Authentication and authorization_ guide.
+* `controlPlane`, `compute`, `networking`: Specifies optional parameters. If you do not provide these parameters and values, the installation program provides the default value. The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
+* `hyperthreading`: Specifies whether to enable or disable simultaneous multithreading. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<6> Optional: The custom encryption key section to encrypt both virtual machines and persistent volumes. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information about granting the correct permissions for your service account, see "Machine management" -> "Creating compute machine sets" -> "Creating a compute machine set on {gcp-short}".
-<7> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter will apply to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
-<8> Optional: A custom {op-system-first} that should be used to boot control plane and compute machines. The `project` and `name` parameters under `platform.gcp.defaultMachinePlatform.osImage` apply to both control plane and compute machines. If the `project` and `name` parameters under `controlPlane.platform.gcp.osImage` or `compute.platform.gcp.osImage` are set, they override the `platform.gcp.defaultMachinePlatform.osImage` parameters.
-<9> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+* `encryptionKey`: Specifies the custom encryption key section to encrypt both virtual machines and persistent volumes. Optional. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information about granting the correct permissions for your service account, see "Machine management" -> "Creating compute machine sets" -> "Creating a compute machine set on {gcp-short}".
+* `tags`: Specifies a set of network tags to apply to the control plane or compute machine sets. Optional. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
+* `osImage`: Specifies a custom {op-system-first} to boot control plane and compute machines. Optional. The `project` and `name` parameters under `platform.gcp.defaultMachinePlatform.osImage` apply to both control plane and compute machines. If the `project` and `name` parameters under `controlPlane.platform.gcp.osImage` or `compute.platform.gcp.osImage` are set, they override the `platform.gcp.defaultMachinePlatform.osImage` parameters.
+* `networkType`: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
 ifdef::vpc,restricted[]
-<10> Specify the name of an existing VPC.
-<11> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
-<12> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
+* `network`: Specifies the name of an existing VPC.
+* `controlPlaneSubnet`: Specifies the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
+* `computeSubnet`: Specifies the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
 endif::vpc,restricted[]
 ifdef::restricted[]
-<13> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+* `pullSecret`: Specifies the pull secret for your mirror registry. For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
-ifdef::vpc[]
 ifndef::openshift-origin[]
-<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+* `fips`: Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
---
 [IMPORTANT]
 ====
+ifdef::vpc[]
 To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
 
-When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
---
-<14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
 endif::vpc[]
-ifdef::restricted[]
-ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-+
-[IMPORTANT]
-====
 When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
-<15> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-endif::restricted[]
-ifndef::vpc,restricted[]
-ifndef::openshift-origin[]
-<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-+
-[IMPORTANT]
-====
-When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
-<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-endif::vpc,restricted[]
+* `sshKey`: Specifies the public SSH key that you use to access the machines in your cluster. Optional.
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifdef::private[]
-ifndef::openshift-origin[]
-<15> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<14> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
-endif::openshift-origin[]
+* `publish`: Specifies how to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::private[]
 ifdef::restricted[]
-ifndef::openshift-origin[]
-<16> Provide the contents of the certificate file that you used for your mirror registry.
-<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<15> Provide the contents of the certificate file that you used for your mirror registry.
-<16> Provide the `imageContentSources` section from the output of the command to mirror the repository.
-endif::openshift-origin[]
+* `additionalTrustBundle`: Specifies the contents of the certificate file that you used for your mirror registry.
+* `imageContentSources`: Specifies the image content sources from the output of the command to mirror the repository.
 endif::restricted[]
 
 ifeval::["{context}" == "installing-gcp-network-customizations"]


### PR DESCRIPTION
Manual cherry-pick of #117804 to enterprise-4.20.

The automated cherry-pick failed with a merge conflict in `installing/installing_gcp/installing-gcp-vpc.adoc`. This branch resolves the conflict manually.

## Conflict resolution

enterprise-4.20 does not include the user-managed firewall rules feature; the `installation-gcp-user-managed-firewall-rules` module and its anchor do not exist on this branch. The CQA prerequisites rewrite (inline cross-references converted to breadcrumb prose plus a separate Additional resources block) was applied, but the "Managing your own firewall rules" prerequisite bullet and its corresponding Additional resources cross-reference were omitted to avoid a broken cross-reference. All other cross-references were verified to resolve on enterprise-4.20.

## File count

This PR changes 7 files compared to 10 in the original PR. The three differences are no-ops on enterprise-4.20:

* `modules/installing-gcp-manual-modes.adoc` already exists on this branch.
* `modules/installing-gcp-short-term-creds.adoc` already exists on this branch.
* The `Operating System` to `Operating system` change in `modules/installation-minimum-resource-requirements.adoc` is already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
