### PR TITLE
[enterprise-4.20] Remediating upgrade map to match Reorg spreadsheet

### DIFF
--- a/maps/jobs/apply-minor-version-update-rpms.adoc
+++ b/maps/jobs/apply-minor-version-update-rpms.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: apply-minor-version-update-rpms
-
-include::modules/microshift-updates-rpms-con.adoc[leveloffset=+0,chunk="to-content"]
-
-include::modules/microshift-updating-rpms-y.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/apply-patch-update-rpms.adoc
+++ b/maps/jobs/apply-patch-update-rpms.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: apply-patch-update-rpms
-
-include::modules/microshift-updates-rpms-con.adoc[leveloffset=+0,chunk="to-content"]
-
-// Sourced from microshift_updating/microshift-update-options.adoc
-include::modules/microshift-manual-rpm-updates.adoc[leveloffset=+1,toc="no"]
-
-include::modules/microshift-updating-rpms-z.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/apply-updates-rhel-edge.adoc
+++ b/maps/jobs/apply-updates-rhel-edge.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: apply-updates-rhel-edge
-
-include::modules/microshift-updates-rpms-ostree-con.adoc[leveloffset=+0,chunk="to-content"]
-
-include::modules/microshift-rpm-ostree-updates.adoc[leveloffset=+1,toc="no"]
-
-include::modules/microshift-updating-rpms-ostree.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/identify-potential-update-issues.adoc
+++ b/maps/jobs/identify-potential-update-issues.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: identify-potential-update-issues
-
-include::modules/microshift-identify-potential-update-issues-con.adoc[leveloffset=+0,chunk="to-content"]
-
-include::modules/microshift-rhde-compatibility-table.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/list-rpm-update-contents.adoc
+++ b/maps/jobs/list-rpm-update-contents.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: list-rpm-update-contents
+
+// Job 5: Listing RPM update package contents
+// Decomposed from microshift_updating/microshift-list-update-contents.adoc
+// CSV note: flagged as possibly obsolete -- confirm with Giga before removing.
+// 5.1 Listing the contents of the MicroShift RPM release package
+include::modules/microshift-get-rpm-release-info.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/manage-rhel-repositories.adoc
+++ b/maps/jobs/manage-rhel-repositories.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: manage-rhel-repositories
-
-include::modules/microshift-manage-rhel-repositories.adoc[leveloffset=+0,chunk="to-content"]
-
-// Sourced from microshift_updating/microshift-update-options.adoc
-include::modules/microshift-updates-rhde-config-rhel-repos.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/migrate-rhel-edge-to-image-mode.adoc
+++ b/maps/jobs/migrate-rhel-edge-to-image-mode.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: MAP
 :context: migrate-rhel-edge-to-image-mode
 
+// Job 4: Migrating MicroShift from RHEL for Edge to image mode for RHEL
+// Decomposed from microshift_updating/microshift-update-rhel-edge-to-image-mode.adoc
+// 4.1 Migrating MicroShift to image mode for RHEL
 include::modules/microshift-update-edge-to-image.adoc[leveloffset=+0,chunk="to-content"]
 
-include::modules/microshift-migrate-rhel-edge-to-image-mode.adoc[leveloffset=+1,toc="no"]
-
+// 4.1.1 Working around UID and GID drift when migrating to image mode for RHEL
 include::modules/microshift-updates-edge-to-image-uid-drift.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/migrate-rhel9-to-rhel10.adoc
+++ b/maps/jobs/migrate-rhel9-to-rhel10.adoc
@@ -1,6 +1,11 @@
 :_mod-docs-content-type: MAP
 :context: migrate-rhel9-to-rhel10
 
+// NOT IN CSV: retained pending review. "Upgrading the host operating system from
+// RHEL 9 to RHEL 10" (microshift_updating/microshift-update-rhel9-to-rhel-10.adoc).
+// Note this job reuses microshift-update-edge-to-image and
+// microshift-updates-edge-to-image-uid-drift, which also appear in Job 4
+// (migrate-rhel-edge-to-image-mode); confirm whether this job is still needed.
 include::modules/microshift-migrate-rhel9-to-rhel10.adoc[leveloffset=+0,chunk="to-content"]
 
 include::modules/microshift-update-edge-to-image.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/troubleshoot-update-problems.adoc
+++ b/maps/jobs/troubleshoot-update-problems.adoc
@@ -1,8 +1,17 @@
 :_mod-docs-content-type: MAP
 :context: troubleshoot-update-problems
 
+// Troubleshooting updates (CSV: section from the Troubleshooting Guide)
+// NOTE: maps/microshift/administer.adoc wires an overlapping job
+// jobs/troubleshoot-updates.adoc with the same modules; reconcile the two so this
+// content lives in one place.
 include::modules/microshift-troubleshoot-update-problems-con.adoc[leveloffset=+0,chunk="to-content"]
 
+// 5.1 Troubleshooting MicroShift updates
 include::modules/microshift-updates-troubleshooting.adoc[leveloffset=+1,toc="no"]
 
+// 5.2 Checking journal logs after updates
 include::modules/microshift-check-journal-logs-updates.adoc[leveloffset=+1,toc="no"]
+
+// 5.3 Checking the status of greenboot health checks
+include::modules/microshift-greenboot-check-status.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/understand-automatic-rollbacks.adoc
+++ b/maps/jobs/understand-automatic-rollbacks.adoc
@@ -1,4 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: understand-automatic-rollbacks
-
-include::modules/microshift-rpm-ostree-updates.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/update-kubernetes-storage.adoc
+++ b/maps/jobs/update-kubernetes-storage.adoc
@@ -1,8 +1,11 @@
 :_mod-docs-content-type: MAP
 :context: update-kubernetes-storage
 
+// Job 6: Updating existing Kubernetes storage objects
+// Decomposed from microshift_updating/microshift-storage-migration.adoc
+// CSV note: flagged as possibly not applicable to MicroShift -- confirm with Giga
+// before removing.
 include::modules/microshift-update-kubernetes-storage.adoc[leveloffset=+0,chunk="to-content"]
 
-include::modules/microshift-making-storage-migration-request.adoc[leveloffset=+1,toc="no"]
-
+// Not in the CSV Job 6 outline; retained as related troubleshooting content pending review.
 include::modules/microshift-storage-migration-failed.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/update-microshift-and-os-concurrently.adoc
+++ b/maps/jobs/update-microshift-and-os-concurrently.adoc
@@ -1,5 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: update-microshift-and-os-concurrently
-
-// Sourced from microshift_updating/microshift-update-options.adoc
-include::modules/microshift-simultaneous-microshift-rhel-updates.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/update-microshift-only.adoc
+++ b/maps/jobs/update-microshift-only.adoc
@@ -1,5 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: update-microshift-only
-
-// Sourced from microshift_updating/microshift-update-options.adoc
-include::modules/microshift-standalone-updates.adoc[leveloffset=+0,chunk="to-content"]

--- a/maps/jobs/update-options-rhde.adoc
+++ b/maps/jobs/update-options-rhde.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: MAP
+:context: update-options-rhde
+
+// Job 1: Update options for Red Hat Device Edge
+// Decomposed from microshift_updating/microshift-update-options.adoc
+// CSV note: a dedicated intro concept ("Understanding update options for Red Hat
+// Device Edge") is suggested but not yet written; using the existing
+// "{op-system-bundle} updates" concept (CSV 1.1) as the job intro for now.
+include::modules/microshift-rhde-updates.adoc[leveloffset=+0,chunk="to-content"]
+
+// JOB GAP (CSV): "Understanding potential upgrade issues" -- what might break during
+// an upgrade and how to remediate it. The release compatibility matrix below is the
+// closest existing content.
+include::modules/microshift-rhde-compatibility-table.adoc[leveloffset=+1,toc="no"]
+
+// 1.2 Standalone MicroShift updates
+include::modules/microshift-standalone-updates.adoc[leveloffset=+1,toc="no"]
+
+// 1.2.1 Updating MicroShift on RHEL for Edge (CSV: consider breaking out automatic rollback)
+include::modules/microshift-rpm-ostree-updates.adoc[leveloffset=+2,toc="no"]
+
+// 1.2.2 Manual RPM updates
+include::modules/microshift-manual-rpm-updates.adoc[leveloffset=+2,toc="no"]
+
+// 1.2.2.1 Keeping MicroShift and RHEL in a supported configuration
+include::modules/microshift-updates-rhde-config-rhel-repos.adoc[leveloffset=+3,toc="no"]
+
+// 1.3 Standalone RHEL updates
+include::modules/microshift-standalone-rhel-updates.adoc[leveloffset=+1,toc="no"]
+
+// 1.4 Simultaneous MicroShift and RHEL updates
+include::modules/microshift-simultaneous-microshift-rhel-updates.adoc[leveloffset=+1,toc="no"]
+
+// 1.5 Migrating MicroShift from RHEL for Edge to image mode for RHEL
+include::modules/microshift-migrate-rhel-edge-to-image-mode.adoc[leveloffset=+1,toc="no"]
+
+// JOB GAP (CSV): missing "RHEL image mode" update section, comparable to the Install doc.

--- a/maps/jobs/update-package-mode-deployments.adoc
+++ b/maps/jobs/update-package-mode-deployments.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: MAP
+:context: update-package-mode-deployments
+
+// Job 3: Update package mode deployments (CSV rename of "Updating RPMs manually")
+// Decomposed from microshift_updating/microshift-update-rpms-manually.adoc
+// 3.1 About updates using RPMs
+include::modules/microshift-updates-rpms-con.adoc[leveloffset=+0,chunk="to-content"]
+
+// 3.2 Applying patch updates using RPMs
+include::modules/microshift-updating-rpms-z.adoc[leveloffset=+1,toc="no"]
+
+// 3.3 Applying minor-version updates with RPMs
+include::modules/microshift-updating-rpms-y.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/update-rhel-os-only.adoc
+++ b/maps/jobs/update-rhel-os-only.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: update-rhel-os-only
-
-// Sourced from microshift_updating/microshift-update-options.adoc
-include::modules/microshift-standalone-rhel-updates.adoc[leveloffset=+0,chunk="to-content"]
-
-include::modules/microshift-rhde-updates.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/update-rpms-rhel-edge.adoc
+++ b/maps/jobs/update-rpms-rhel-edge.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: update-rpms-rhel-edge
+
+// Job 2: Update RPMs on a RHEL for Edge system
+// Decomposed from microshift_updating/microshift-update-rpms-ostree.adoc
+// 2.1 MicroShift updates on an RHEL for Edge system
+include::modules/microshift-updates-rpms-ostree-con.adoc[leveloffset=+0,chunk="to-content"]
+
+// 2.2 Applying updates on an RHEL for Edge system
+include::modules/microshift-updating-rpms-ostree.adoc[leveloffset=+1,toc="no"]

--- a/maps/jobs/verify-system-health.adoc
+++ b/maps/jobs/verify-system-health.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: MAP
-:context: verify-system-health
-
-include::modules/microshift-verify-system-health-con.adoc[leveloffset=+0,chunk="to-content"]
-
-include::modules/microshift-greenboot-check-status.adoc[leveloffset=+1,toc="no"]

--- a/maps/microshift/upgrade.adoc
+++ b/maps/microshift/upgrade.adoc
@@ -2,30 +2,37 @@
 
 = Upgrade
 
-include::jobs/apply-updates-rhel-edge.adoc[leveloffset=+1]
+// Restructured to match "Reorg- MicroShift docs - Upgrade.csv".
 
-include::jobs/understand-automatic-rollbacks.adoc[leveloffset=+1]
+// Job 1: Update options for Red Hat Device Edge
+include::jobs/update-options-rhde.adoc[leveloffset=+1]
 
-include::jobs/apply-patch-update-rpms.adoc[leveloffset=+1]
+// Job 2: Update RPMs on a RHEL for Edge system
+include::jobs/update-rpms-rhel-edge.adoc[leveloffset=+1]
 
-include::jobs/apply-minor-version-update-rpms.adoc[leveloffset=+1]
+// Job 3: Update package mode deployments (CSV rename of "Updating RPMs manually")
+include::jobs/update-package-mode-deployments.adoc[leveloffset=+1]
 
+// Job 4: Migrating MicroShift from RHEL for Edge to image mode for RHEL
 include::jobs/migrate-rhel-edge-to-image-mode.adoc[leveloffset=+1]
 
-include::jobs/verify-system-health.adoc[leveloffset=+1]
+// Job 5: Listing RPM update package contents
+// CSV note: flagged as possibly obsolete -- confirm with Giga before removing.
+include::jobs/list-rpm-update-contents.adoc[leveloffset=+1]
 
-include::jobs/troubleshoot-update-problems.adoc[leveloffset=+1]
-
-include::jobs/identify-potential-update-issues.adoc[leveloffset=+1]
-
-include::jobs/migrate-rhel9-to-rhel10.adoc[leveloffset=+1]
-
+// Job 6: Updating existing Kubernetes storage objects
+// CSV note: flagged as possibly not applicable to MicroShift -- confirm with Giga before removing.
 include::jobs/update-kubernetes-storage.adoc[leveloffset=+1]
 
-include::jobs/update-microshift-and-os-concurrently.adoc[leveloffset=+1]
+// JOB GAP (CSV): "Check update results" (Maintain system health) -- a new job merging
+// "Updates and third-party workloads" and "Checking the results of an update".
+// Suggested subsections: Access health check output in the system log; Access
+// prerollback health check output in the system log; Check updates with a health check
+// script. No modules exist yet; create the content before wiring this job in.
+// include::jobs/check-update-results.adoc[leveloffset=+1]
 
-include::jobs/update-rhel-os-only.adoc[leveloffset=+1]
+// Troubleshooting updates (CSV: section from the Troubleshooting Guide)
+include::jobs/troubleshoot-update-problems.adoc[leveloffset=+1]
 
-include::jobs/update-microshift-only.adoc[leveloffset=+1]
-
-include::jobs/manage-rhel-repositories.adoc[leveloffset=+1]
+// NOT IN CSV: retained pending review.
+include::jobs/migrate-rhel9-to-rhel10.adoc[leveloffset=+1]


### PR DESCRIPTION
4.20 CP of e17ddddf5841990a7d70180573a3cd74739d5bc8. `modules/microshift-updating-stored-data-to-latest-storage-version.adoc` does not exist in 4.20.