### PR TITLE
OSDOCS#22059: Update the MicroShift RNs for 4.22.13

### DIFF
--- a/microshift_release_notes/microshift-4-22-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-22-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/microshift-4-22-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-22-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-22-13-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-22-7-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-22-4-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-22-13-async.adoc
+++ b/modules/microshift-4-22-13-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-22-13-async_{context}"]
+= RHBA-2026:xxxx - {microshift-short} 4.22.13 fixed issue update
+
+Issued: 8 September 2026
+
+[role="_abstract"]
+{product-title} release 4.22.13 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:xxxx[RHBA-2026:xxxx] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63096[RHSA-2026:63096] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-22-13-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-22059

Link to docs preview:
4.22.13

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- Draft: MicroShift RPM advisory is not published yet (`RHBA-2026:xxxx` placeholder).
- OCP images advisory (shipment live_id, not live yet): https://access.redhat.com/errata/RHSA-2026:63096
- OCP packages advisory (from image YAML, not live yet): https://access.redhat.com/errata/RHSA-2026:63091
- Microshift-bootc (stage): https://access.stage.redhat.com/errata/RHBA-2026:120679
- OCP shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/795
- Microshift-bootc shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/804
- Advisory-only: no documentable MicroShift OCPBUGS bullets.


Made with [Cursor](https://cursor.com)