### PR TITLE
OSDOCS-22061: Add MicroShift 4.19.46 z-stream release notes

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -28,6 +28,8 @@ include::modules/microshift-4-19-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-19-asynchronous-errata-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-19-46-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-19-43-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-19-42-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-19-46-dp.adoc
+++ b/modules/microshift-4-19-46-dp.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-19-46-dp_{context}"]
+= RHSA-2026:63636 - {microshift-short} 4.19.46 fixed issue update
+
+Issued: 9 September 2026
+
+[role="_abstract"]
+{product-title} release 4.19.46 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHSA-2026:63636[RHSA-2026:63636] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63047[RHSA-2026:63047] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-46-dp-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.


### PR DESCRIPTION
## Preview
[4.19.46](https://119437--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-46-dp_release-notes)

## Summary
- Adds z-stream release notes for MicroShift 4.19.46
- Jira: https://redhat.atlassian.net/browse/OSDOCS-22061
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/803
- OCP shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/794
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHBA-2026:xxxx (MicroShift RPM, not yet published) / RHSA-2026:63047 (OCP images, live)
- Bootc image advisory (live): RHBA-2026:65865

## Documented
- None (advisory-only)

## Skipped (not documented)
No OCPBUGS keys in the MicroShift bootc shipment YAML.

## Jira RN text populated (pre-step)
No issues required RN text population (0 auto-closed, 0 CCFR rewritten, 0 copied from clone, 0 CCFR written).

## Scope notes
- Shipment YAML keys (MR 803 bootc): 0
- Errata Fixes keys: n/a (MicroShift RPM advisory not published; bootc RHBA-2026:65865 Fixes: none)
- In YAML but not errata Fixes: none
- Draft until the MicroShift RPM advisory is published on access.redhat.com; then replace `RHBA-2026:xxxx` and mark ready for review.

## Test plan
- [ ] Title and issued date match access.redhat.com (pending MicroShift RPM errata)
- [ ] Primary + companion advisory links correct (OCP RHSA-2026:63047 is live; RPM still placeholder)
- [x] Vale clean on touched files (0 errors; stock boilerplate suggestions only)