### PR TITLE
[enterprise-4.20] OSDOCS-16997-installing-gcp-private# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -6,15 +6,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a private cluster into an existing VPC on {gcp-first}. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
-parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a private cluster into an existing VPC on {gcp-first} with customizations by using installer-provisioned infrastructure. A private cluster keeps its endpoints internal, preventing direct internet exposure.
+
+You customize your cluster by modifying parameters in the `install-config.yaml` file before installation.
 
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You configured a {gcp-short} project to host the cluster. For more information, see "Configuring a {gcp-short} project".
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 
@@ -82,23 +92,14 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-private.adoc#manually-create-iam_installing-gcp-private[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-with-short-term-creds_installing-gcp-private[Configuring a {gcp-short} cluster to use short-term credentials].
+//Alternatives to storing administrator-level secrets in the kube-system project
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -122,17 +123,14 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/installation-about-custom-gcp-vpc.adoc
+++ b/modules/installation-about-custom-gcp-vpc.adoc
@@ -6,9 +6,10 @@
 [id="installation-about-custom-gcp-vpc_{context}"]
 = About using a custom VPC
 
-In {product-title} {product-version}, you can deploy a cluster into an existing VPC in {gcp-first}. If you do, you must also use existing subnets within the VPC and routing rules.
+[role="_abstract"]
+In {product-title} {product-version}, you can deploy a cluster into an existing VPC and subnets in {gcp-first} to help avoid limit constraints in new accounts or to more easily abide by the operational constraints that your company's guidelines set.
 
-By deploying {product-title} into an existing {gcp-short} VPC, you might be able to avoid limit constraints in new accounts or more easily abide by the operational constraints that your company's guidelines set. This is a good option to use if you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself.
+You must also use existing routing rules. This installation option is a good choice if you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself.
 
 [id="installation-about-custom-gcp-vpcs-requirements_{context}"]
 == Requirements for using your VPC
@@ -21,7 +22,7 @@ The installation program will no longer create the following components:
 * Cloud NAT
 * NAT IP addresses
 
-If you use a custom VPC, you must correctly configure it and its subnets for the installation program and the cluster to use. The installation program cannot subdivide network ranges for the cluster to use, set route tables for the subnets, or set VPC options like DHCP, so you must do so before you install the cluster.
+If you use a custom VPC, you must correctly configure it and its subnets for the installation program and the cluster to use. The installation program cannot subdivide network ranges for the cluster to use, set route tables for the subnets, or set VPC options such as DHCP, so you must do so before you install the cluster.
 
 Your VPC and subnets must meet the following characteristics:
 
@@ -34,12 +35,12 @@ To ensure that the subnets that you provide are suitable, the installation progr
 * The subnet CIDRs belong to the machine CIDR.
 * You must provide a subnet to deploy the cluster control plane and compute machines to. You can use the same subnet for both machine types.
 
-If you destroy a cluster that uses an existing VPC, the VPC is not deleted.
+If you delete a cluster that uses an existing VPC, the VPC is not deleted.
 
 [id="installation-about-custom-gcp-permissions_{context}"]
 == Division of permissions
 
-Starting with {product-title} 4.3, you do not need all of the permissions that are required for an installation program-provisioned infrastructure cluster to deploy a cluster. This change mimics the division of permissions that you might have at your company: some individuals can create different resources in your clouds than others. For example, you might be able to create application-specific items, like instances, buckets, and load balancers, but not networking-related components such as VPCs, subnets, or Ingress rules.
+Starting with {product-title} 4.3, you do not need all of the permissions that are required for an installation program-provisioned infrastructure cluster to deploy a cluster. This change mimics the division of permissions that you might have at your company: some individuals can create different resources in your clouds than others. For example, you might be able to create application-specific items, such as instances, buckets, and load balancers, but not networking-related components, such as VPCs, subnets, or Ingress rules.
 
 The {gcp-short} credentials that you use when you create your cluster do not need the networking permissions that are required to make VPCs and core networking components within the VPC, such as subnets, routing tables, internet gateways, NAT, and VPN. You still need permission to make the application resources that the machines within the cluster require, such as load balancers, security groups, storage, and nodes.
 

--- a/modules/installation-gcp-enabling-confidential-vms.adoc
+++ b/modules/installation-gcp-enabling-confidential-vms.adoc
@@ -13,7 +13,10 @@
 [id="installation-gcp-enabling-confidential-vms_{context}"]
 = Enabling Confidential VMs
 
-You can use Confidential VMs when installing your cluster. Confidential VMs encrypt data while it is being processed. For more information, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
+[role="_abstract"]
+You can use Confidential VMs when installing your {product-title} cluster. Confidential VMs encrypt data during processing.
+
+For more information, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
 
 [NOTE]
 ====
@@ -22,7 +25,7 @@ Confidential VMs are currently not supported on 64-bit ARM architectures.
 
 .Procedure
 
-* Use a text editor to edit the `install-config.yaml` file prior to deploying your cluster and add one of the following stanzas:
+* Use a text editor to edit the `install-config.yaml` file before deploying your cluster and add one of the following stanzas:
 .. To use confidential VMs for only control plane machines:
 +
 [source,yaml]
@@ -30,15 +33,17 @@ Confidential VMs are currently not supported on 64-bit ARM architectures.
 controlPlane:
   platform:
     gcp:
-       confidentialCompute: AMDEncryptedVirtualizationNestedPaging <1>
-       type: n2d-standard-8 <2>
-       onHostMaintenance: Terminate <3>
+       confidentialCompute: AMDEncryptedVirtualizationNestedPaging
+       type: n2d-standard-8
+       onHostMaintenance: Terminate
 ----
 +
+where:
++
 --
-<1> Enable confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). For more information about available options, see "Additional {gcp-first} configuration parameters".
-<2> Specify a machine type that supports Confidential VMs. Confidential VMs require the N2D, C2D, C3D, or C3 series of machine types. For more information on supported machine types, see link:https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type[Supported operating systems and machine types].
-<3> Specify the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VMs do not support live VM migration.
+`confidentialCompute`:: Enables confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). For more information about available options, see "Additional {gcp-first} configuration parameters".
+`type`:: Specifies a machine type that supports Confidential VMs. Confidential VMs require the N2D, C2D, C3D, or C3 series of machine types. For more information on supported machine types, see link:https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type[Supported operating systems and machine types].
+`onHostMaintenance`:: Specifies the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VMs do not support live VM migration.
 --
 +
 .. To use confidential VMs for only compute machines:

--- a/modules/installation-gcp-enabling-shielded-vms.adoc
+++ b/modules/installation-gcp-enabling-shielded-vms.adoc
@@ -13,7 +13,10 @@
 [id="installation-gcp-enabling-shielded-vms_{context}"]
 = Enabling Shielded VMs
 
-You can use Shielded VMs when installing your cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection. For more information, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
+[role="_abstract"]
+You can use Shielded VMs when installing your {product-title} cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection.
+
+For more information, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 
 [NOTE]
 ====
@@ -22,7 +25,7 @@ Shielded VMs are currently not supported on clusters with 64-bit ARM infrastruct
 
 .Procedure
 
-* Use a text editor to edit the `install-config.yaml` file prior to deploying your cluster and add one of the following stanzas:
+* Use a text editor to edit the `install-config.yaml` file before deploying your cluster and add one of the following stanzas:
 .. To use shielded VMs for only control plane machines:
 +
 [source,yaml]

--- a/modules/installation-gcp-managing-dns-solution.adoc
+++ b/modules/installation-gcp-managing-dns-solution.adoc
@@ -10,6 +10,8 @@ If you enable user-managed DNS during installation, the installation program pro
 :FeatureName: User-provisioned DNS
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
+For information about provisioning your DNS records for the API server and the Ingress services, see "Provisioning your own DNS records".
+
 .Prerequisites
 
 * You installed the `jq` package.
@@ -32,4 +34,3 @@ platform:
 <1> Enable DNS management.
 
 
-For information about provisioning your DNS records for the API server and the Ingress services, see "Provisioning your own DNS records".

--- a/modules/installation-gcp-tested-machine-types-arm.adoc
+++ b/modules/installation-gcp-tested-machine-types-arm.adoc
@@ -13,7 +13,8 @@
 [id="installation-gcp-tested-machine-types-arm_{context}"]
 = Tested instance types for {gcp-short} on 64-bit ARM infrastructures
 
-The following {gcp-first} 64-bit ARM instance types have been tested with {product-title}.
+[role="_abstract"]
+{product-title} supports specific {gcp-first} 64-bit ARM instance types that have been validated for cluster deployment.
 
 See the following machine series for 64-bit ARM machines:
 

--- a/modules/installation-gcp-tested-machine-types.adoc
+++ b/modules/installation-gcp-tested-machine-types.adoc
@@ -13,7 +13,8 @@
 [id="installation-gcp-tested-machine-types_{context}"]
 = Tested instance types for {gcp-short}
 
-The following {gcp-full} instance types have been tested with {product-title}.
+[role="_abstract"]
+{product-title} supports specific {gcp-full} instance types that have been validated for cluster deployment.
 
 [NOTE]
 ====

--- a/modules/private-clusters-about-gcp.adoc
+++ b/modules/private-clusters-about-gcp.adoc
@@ -25,7 +25,7 @@ The internal load balancer relies on instance groups rather than the target pool
 
 * The cluster IP address is internal only.
 * One forwarding rule manages both the Kubernetes API and machine config server ports.
-* The backend service is comprised of each zone's instance group and, while it exists, the bootstrap instance group.
+* The backend service consists of each zone's instance group and, while it exists, the bootstrap instance group.
 * The firewall uses a single rule that is based on only internal source ranges.
 
 [id="private-clusters-limitations-gcp_{context}"]

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -57,13 +57,13 @@ You can use any machine that meets these access requirements and follows your co
 
 [NOTE]
 ====
-AWS China does not support a VPN connection between the VPC and your network. For more information about the Amazon VPC service in the Beijing and Ningxia regions, see "Amazon Virtual Private Cloud" in the AWS China documentation.
+AWS China does not support a VPN connection between the VPC and your network.
 ====
 
-[role="_additional-resource"]
+[role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.amazonaws.cn/en_us/aws/latest/userguide/vpc.html[Amazon Virtual Private Cloud]
+* link:https://docs.amazonaws.cn/en_us/aws/latest/userguide/vpc.html[Amazon Virtual Private Cloud (AWS China documentation)]
 endif::aws-specialized[]
 
 ifeval::["{context}" == "installing-aws-specialized-region"]


### PR DESCRIPTION
Manual cherry-pick of #117806 to enterprise-4.20.

The automated cherry-pick failed with a merge conflict in `modules/installation-gcp-managing-dns-solution.adoc`. This branch resolves the conflict manually.

## Conflict resolution

The user-provisioned DNS feature (`userProvisionedDNS`) is still a Technology Preview on enterprise-4.20; it is generally available on enterprise-4.21 and later. On the later branches, the CQA commit removed the Technology Preview admonition because the feature is GA there, and it moved the "Provisioning your own DNS records" cross-reference sentence from the bottom of the module to the top.

On enterprise-4.20, the Technology Preview admonition is retained because the feature is still in Technology Preview on this release. The cross-reference sentence is placed directly after the admonition. This keeps the release-accurate feature status and also applies the CQA improvement of surfacing the cross-reference near the top of the module. The cross-reference target, "Provisioning your own DNS records", exists on enterprise-4.20.

## File count

This PR changes 9 files compared to 11 in the original PR. The two differences are no-ops on enterprise-4.20:

* `modules/installing-gcp-manual-modes.adoc` already exists on this branch.
* `modules/installing-gcp-short-term-creds.adoc` already exists on this branch.

All cross-references were verified to resolve on enterprise-4.20, and the section anchors for the manual-modes and short-term-credentials includes match the anchors of the inline headings that they replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
