### PR TITLE
[enterprise-4.20] OSDOCS-16997-installing-restricted-networks-gcp-installer-provisioned# CQA

### DIFF
--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -16,19 +16,27 @@ You can install an {product-title} cluster by using mirrored installation releas
 [id="prerequisites_installing-restricted-networks-gcp-installer-provisioned"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
-* You xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* You configured a {gcp-short} project to host the cluster. For more information, see "Configuring a {gcp-short} project".
+* You mirrored the images for a disconnected installation to your registry and obtained the `imageContentSources` data for your version of {product-title}. For more information, see "Mirroring images for a disconnected installation".
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* You have an existing VPC in {gcp-short}. While installing a cluster in a restricted network that uses installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
+* You have an existing VPC in {gcp-short}. When you install a cluster in a restricted network by using installer-provisioned infrastructure, you cannot use the VPC that the installation program creates. You must use a user-provisioned VPC that satisfies one of the following requirements:
 ** Contains the mirror registry
 ** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. You might need to grant access to more sites, but you must grant access to `*.googleapis.com` and `accounts.google.com`. For more information, see "Configuring your firewall for {product-title}".
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -89,23 +97,13 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-gcp-with-short-term-creds_installing-restricted-networks-gcp-installer-provisioned[Configuring a {gcp-short} cluster to use short-term credentials].
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -131,17 +129,14 @@ include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffse
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-[id="next-steps_installing-restricted-networks-gcp-installer-provisioned"]
-== Next steps
-
-* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
-* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configuring image streams for a disconnected cluster]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[Configuring additional trust stores]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_remote-health-reporting[Registering your disconnected cluster]

--- a/modules/cco-ccoctl-install-creating-manifests.adoc
+++ b/modules/cco-ccoctl-install-creating-manifests.adoc
@@ -67,7 +67,7 @@ endif::[]
 = Incorporating the Cloud Credential Operator utility manifests
 
 [role="_abstract"]
-To implement short-term security credentials managed outside the cluster for individual components, you must move the manifest files that the Cloud Credential Operator utility (`ccoctl`) created to the correct directories for the installation program.
+To implement short-term security credentials managed outside the cluster for individual {product-title} components, you must move the manifest files that the Cloud Credential Operator utility (`ccoctl`) created to the correct directories for the installation program.
 
 .Prerequisites
 

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -278,9 +278,7 @@ ifdef::aws[]
 +
 ... Select *AWS* as the platform to target.
 +
-... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS
-access key ID and secret access key for the user that you configured to run the
-installation program.
+... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS access key ID and secret access key for the user that you configured to run the installation program.
 +
 ... Select the AWS region to deploy the cluster to.
 +
@@ -315,17 +313,13 @@ ifdef::gcp[]
 +
 ... Select *gcp* as the platform to target.
 +
-... If you have not configured the service account key for your {gcp-short} account on
-your computer, you must obtain it from {gcp-short} and paste the contents of the file
-or enter the absolute path to the file.
+... If you have not configured the service account key for your {gcp-short} account on your computer, you must obtain it from {gcp-short} and paste the contents of the file or enter the absolute path to the file.
 +
-... Select the project ID to provision the cluster in. The default value is
-specified by the service account that you configured.
+... Select the project ID to provision the cluster in. The default value is specified by the service account that you configured.
 +
 ... Select the region to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::gcp[]
 ifdef::ibm-cloud[]
 +
@@ -333,8 +327,7 @@ ifdef::ibm-cloud[]
 +
 ... Select the region to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::ibm-cloud[]
 ifdef::ibm-power-vs[]
 +
@@ -344,8 +337,7 @@ ifdef::ibm-power-vs[]
 +
 ... Select the zone to deploy the cluster to.
 +
-... Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::ibm-power-vs[]
 ifdef::osp[]
 +
@@ -559,10 +551,7 @@ your registry:
 pullSecret: '{"auths":{"<mirror_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'
 ----
 +
-For `<mirror_host_name>`, specify the registry domain name
-that you specified in the certificate for your mirror registry, and for
-`<credentials>`, specify the base64-encoded user name and password for
-your mirror registry.
+For `<mirror_host_name>`, specify the registry domain name that you specified in the certificate for your mirror registry, and for `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 +
 .. Add the `additionalTrustBundle` parameter and value.
 +
@@ -751,8 +740,7 @@ it to install multiple clusters.
 +
 [IMPORTANT]
 ====
-The `install-config.yaml` file is consumed during the installation process. If
-you want to reuse the file, you must back it up now.
+The `install-config.yaml` file is consumed during the installation process. If you want to reuse the file, you must back it up now.
 ====
 ifdef::azure[]
 +

--- a/modules/installation-using-gcp-custom-machine-types.adoc
+++ b/modules/installation-using-gcp-custom-machine-types.adoc
@@ -25,11 +25,12 @@ ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisione
 :ipi:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="installation-custom-machine-types_{context}"]
 = Using custom machine types
 
-Using a custom machine type to install a {product-title} cluster is supported.
+[role="_abstract"]
+If the predefined {gcp-short} machine types do not meet your workload requirements, you can configure a custom machine type in the `install-config.yaml` file during {product-title} installation.
 
 Consider the following when using a custom machine type:
 
@@ -46,7 +47,6 @@ ifdef::ipi[]
 As part of the installation process, you specify the custom machine type in the `install-config.yaml` file.
 
 .Sample `install-config.yaml` file with a custom machine type
-
 [source,yaml]
 ----
 compute:

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -150,14 +150,15 @@ ifdef::cco-manual-mode[]
 endif::cco-manual-mode[]
 
 //For providers that support multiple modes of operation
-[role="_abstract"]
 ifdef::cco-multi-mode[]
-The Cloud Credential Operator (CCO) can be put into manual mode prior to installation in environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace.
+[role="_abstract"]
+You can put the Cloud Credential Operator (CCO) into manual mode before {product-title} installation if the cloud identity and access management (IAM) APIs are not reachable, or if you prefer not to store an administrator-level credential secret in the cluster `kube-system` namespace.
 endif::cco-multi-mode[]
 
 //For providers who only support manual mode
 ifdef::cco-manual-mode[]
-The Cloud Credential Operator (CCO) only supports your cloud provider in manual mode. As a result, you must specify the identity and access management (IAM) secrets for your cloud provider.
+[role="_abstract"]
+You must manually create and configure the identity and access management (IAM) secrets for your {product-title} cluster because the Cloud Credential Operator (CCO) only supports manual mode for your cloud provider.
 endif::cco-manual-mode[]
 
 .Procedure

--- a/modules/nw-gcp-installing-global-access-configuration.adoc
+++ b/modules/nw-gcp-installing-global-access-configuration.adoc
@@ -7,7 +7,8 @@
 [id="nw-gcp-global-access-configuration_{context}"]
 = Create an Ingress Controller with global access on {gcp-short}
 
-You can create an Ingress Controller that has global access to a {gcp-first} cluster. Global access is only available to Ingress Controllers using internal load balancers.
+[role="_abstract"]
+You can create an Ingress Controller that has global access to a {gcp-first} cluster, which allows clients from any region to reach your cluster's internal load balancer. Global access is available only to Ingress Controllers that use internal load balancers.
 
 .Prerequisites
 
@@ -15,28 +16,25 @@ You can create an Ingress Controller that has global access to a {gcp-first} clu
 
 .Procedure
 
-Create an Ingress Controller with global access on a new {gcp-short} cluster.
-
 . Change to the directory that contains the installation program and create a manifest file:
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir <installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the name of the directory that
-contains the `install-config.yaml` file for your cluster.
++
+For `_<installation_directory>_`, specify the name of the directory that contains the `install-config.yaml` file for your cluster.
 +
 . Create a file that is named `cluster-ingress-default-ingresscontroller.yaml` in the `<installation_directory>/manifests/` directory:
 +
 [source,terminal]
 ----
-$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml <1>
+$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml
 ----
-<1> For `<installation_directory>`, specify the directory name that contains the
-`manifests/` directory for your cluster.
 +
-After creating the file, several network configuration files are in the
-`manifests/` directory, as shown:
+For `_<installation_directory>_`, specify the directory name that contains the `manifests/` directory for your cluster.
++
+After creating the file, several network configuration files are in the `manifests/` directory, as shown:
 +
 [source,terminal]
 ----
@@ -64,10 +62,11 @@ cluster-ingress-default-ingresscontroller.yaml
       loadBalancer:
         providerParameters:
           gcp:
-            clientAccess: Global <1>
+            clientAccess: Global
           type: GCP
-        scope: Internal          <2>
+        scope: Internal
       type: LoadBalancerService
 ----
-<1> Set `gcp.clientAccess` to `Global`.
-<2> Global access is only available to Ingress Controllers using internal load balancers.
++
+* `gcp.clientAccess` is set to `Global` to provide global access for the Ingress Controller.
+* `scope` is set to `Internal` because global access is available only to Ingress Controllers that use internal load balancers.

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -205,7 +205,8 @@ endif::ibm-power-vs[]
 ----
 $ ssh-add <path>/<file_name>
 ----
-Specifies the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
++
+Specify the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
Manual cherry-pick of #117808 to enterprise-4.20.

The automated cherry-pick failed with a merge conflict in `installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc`. This branch resolves the conflict manually.

## Conflict resolution

The conflict was confined to the Prerequisites section. On enterprise-4.20, this assembly diverged from the main base in two ways: it used the top-level `#configuring-firewall` anchor for the firewall bullet, and it never included the Private Service Connect (PSC) endpoint bullet.

The resolution applies the CQA breadcrumb and Additional resources treatment while keeping the content release-accurate for enterprise-4.20:

* The firewall prerequisite is converted to the breadcrumb form, and its Additional resources cross-reference uses the `#configuring-firewall-module_configuring-firewall` anchor, which resolves on enterprise-4.20.
* The Private Service Connect (PSC) endpoint prerequisite and its two matching Additional resources entries (the `Private Service Connect` link and the "Installing a cluster on GCP into an existing VPC" cross-reference) are omitted. PSC is not documented on enterprise-4.20, so including these entries would be release-inaccurate.

All retained Additional resources cross-references were verified to resolve on enterprise-4.20.

## File count

This PR changes 7 files compared to 9 in the original PR. The two differences are no-ops on enterprise-4.20:

* `modules/installing-gcp-manual-modes.adoc` already exists on this branch with identical content.
* `modules/installing-gcp-short-term-creds.adoc` already exists on this branch with identical content.

The line-count differences are fully accounted for: the two pre-existing modules account for 43 of the insertions, the dropped PSC lines account for 3 insertions, and the absence of a PSC bullet to delete accounts for 1 deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
