### PR TITLE
Service Mesh_v3.3.7

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.3.6
+:SMProductVersion: 3.3.7
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.17

--- a/modules/ossm-release-notes-3-3-7.adoc
+++ b/modules/ossm-release-notes-3-3-7.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assembly:
+//
+// * ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-3-7_{context}"]
+= {SMProductName} version 3.3.7
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator {SMProductVersion}. To see the {ocp-product-title} versions that support {SMProduct} {SMProductVersion}, go to link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]. {SMProductShortName} {SMProductVersion} addresses Common Vulnerabilities and Exposures (CVEs) and includes the following fixed issues.
+
+[id="ossm-fixed-issues-3-3-7_{context}"]
+== Fixed issues
+
+OpenSSL memory allocations visible in tcmalloc heap diagnostics::
+Before this update, OpenSSL memory allocations operated on a separate heap from the intended Envoy `tcmalloc` allocator, bypassing performance optimizations on the TLS hot path and keeping allocations invisible to `tcmalloc` heap dumps and memory profilers. With this release, OpenSSL uses the `tcmalloc` allocator. As a result, OpenSSL benefits from `tcmalloc` optimizations, and its memory usage is fully visible in heap diagnostics for accurate troubleshooting.
++
+link:https://redhat.atlassian.net/browse/OSSM-15244[OSSM-15244]
+
+Namespace administrators can manage Istio resources without cluster-admin privileges::
+Before this update, Istio CRD aggregation `ClusterRoles` were not created when `istiod` was installed through the `pkg/install` library (which is the path used by the Cluster Ingress Operator) rather than the Red Hat Operator Lifecycle Manager (OLM). As a consequence, the admin, edit, and view roles could not access istio.io resources such as `Telemetry`, `VirtualService`, and `AuthorizationPolicy`. Users with these roles received forbidden errors, which forced them to obtain cluster-admin privileges to manage the resources.
++
+With this release, the `pkg/install` library creates the aggregation `ClusterRoles` correctly. As a result, users no longer need cluster-admin access to work with Istio resources.
++
+link:https://redhat.atlassian.net/browse/OSSM-15257[OSSM-15257]
+
+Service mesh sidecar proxies no longer leak memory when closing TLS connections::
+Before this update, a reference count leak in the `SSL_get0_peer_certificates()` OpenSSL compatibility implementation prevented peer X.509 certificate objects from being released when connections closed. This issue occurred when client certificate forwarding (`forward_client_cert_details`) was set to any mode other than `SANITIZE`. As a result, certificate objects accumulated, causing memory usage in service mesh sidecar proxies to grow over time, proportional to the volume of closed TLS connections. Because `APPEND_FORWARD` is the default setting for inbound listeners in mutual TLS (mTLS) environments, nearly all mTLS-enabled sidecar proxies were affected.
++
+This release corrects the reference counting issue for peer certificate objects in `SSL_get0_peer_certificates()`. Certificate objects are properly released when connections close.
++
+link:https://redhat.atlassian.net/browse/OSSM-15075[OSSM-15075]
+
+For supported component versions in {SMProductShortName} {SMProductVersion} (components such as the control plane and `IstioCNI`), see _Service Mesh component versions_.

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -9,6 +9,38 @@
 [role="_abstract"]
 For {SMProduct} 3.3 and each following maintenance release, a table lists the corresponding component versions.
 
+== {SMProduct} 3.3.7 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.3.7
+
+| {SMProduct} `Istio` control plane resource
+| 1.28.10
+
+| {ocp-product-title}
+| 4.18-4.22
+
+| Envoy proxy
+| 1.36.10
+
+| `IstioCNI` resource
+| 1.28.10
+
+| `Ztunnel` resource
+| 1.28.10
+
+| Kiali Operator
+| 2.27.3
+
+| Kiali server
+| 2.22.9
+
+|===
+
 == {SMProduct} 3.3.6 supported versions
 
 [cols="1,1"]

--- a/modules/ossm-supported-platforms.adoc
+++ b/modules/ossm-supported-platforms.adoc
@@ -11,10 +11,10 @@
 The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.18 or later
+* Red Hat OpenShift Container Platform, applicable versions listed on the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] page
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.18 or later
+* Red Hat OpenShift Container Platform, applicable versions listed on the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] page
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 Review new features, compatibility updates, fixed issues, and known issues for {SMProductName} to stay informed about changes across different product versions.
 
+include::modules/ossm-release-notes-3-3-7.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-3-6.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-3-5.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 15560: OSSM 3.4.2& 3.3.7 & 3.2.9 & 3.1.12 & 3.0.15 at ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.3 (No cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-15560

Link to docs preview:
https://119468--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
