### PR TITLE
OSDOCS-18107: HCM docs CQA Job: Fix Official Product Names are Used in "Intro to OSD" for OSD

### DIFF
--- a/modules/sdpolicy-am-billing.adoc
+++ b/modules/sdpolicy-am-billing.adoc
@@ -6,37 +6,37 @@
 = Billing options
 
 [role="_abstract"]
-Customers have the option to purchase annual subscriptions of {product-title} (OSD) or consume on-demand through cloud marketplaces. Customers can decide to bring their own cloud infrastructure account, referred to as Customer Cloud Subscription (CCS), or deploy in cloud provider accounts owned by Red Hat. The table below provides additional information regarding billing, as well as the corresponding supported deployment options.
+Customers have the option to buy annual subscriptions of {product-title} or consume on-demand through cloud marketplaces. Customers can decide to bring their own cloud infrastructure account, referred to as Customer Cloud Subscription (CCS), or deploy in cloud provider accounts owned by Red Hat. The table below provides additional information regarding billing and the corresponding supported deployment options.
 [cols="2a,3a,3a",options="header"]
 |===
 
-|OSD Subscription-type
+|{product-title} Subscription-type
 |Cloud infrastructure account
 |Billed through
 
 .2+|Annual fixed capacity subscriptions through Red Hat |Red Hat cloud account
 
-|Red Hat for consumption of both OSD subscriptions and cloud infrastructure
+|Red Hat for consumption of both {product-title} subscriptions and cloud infrastructure
 
 |Customer's own cloud account
-|Red Hat for consumption of the OSD subscriptions
+|Red Hat for consumption of the {product-title} subscriptions
 
 Cloud provider for consumption of cloud infrastructure
 
 |On-demand usage-based consumption through {gcp-full} Marketplace
 
 |Customer's own {gcp-full} account
-|{gcp-full} for both cloud infrastructure and Red Hat OSD subscriptions
+|{gcp-full} for both cloud infrastructure and {product-title} subscriptions
 
 |===
 
 [IMPORTANT]
 ====
 
-Customers that use their own cloud infrastructure account, referred to as Customer Cloud Subscription (CSS), are responsible to pre-purchase or provide Reserved Instance (RI) compute instances to ensure lower cloud infrastructure costs.
+Customers that use their own cloud infrastructure account, referred to as Customer Cloud Subscription (CCS), are responsible to pre-purchase or provide Reserved Instance (RI) compute instances to ensure lower cloud infrastructure costs.
 ====
 
-Additional resources can be purchased for an OpenShift Dedicated cluster, including:
+Additional resources can be purchased for an {product-title} cluster, including:
 
 * Additional nodes (can be different types and sizes through the use of machine pools)
 * Middleware (JBoss EAP, JBoss Fuse, and so on) - additional pricing based on specific middleware component


### PR DESCRIPTION
[OSDOCS-18107](https://redhat.atlassian.net/browse/OSDOCS-18107): HCM docs CQA Job: Fix Official Product Names are Used in "Intro to OSD" for OSD

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18107

Link to docs preview:
https://119469--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
