### PR TITLE
[OCPBUGS#120844]: Align OCP prerequisites with OSSM 3.3 supported platforms

### DIFF
--- a/modules/ossm-deploying-bookinfo-application.adoc
+++ b/modules/ossm-deploying-bookinfo-application.adoc
@@ -10,7 +10,7 @@
 
 .Prerequisites
 
-* You have deployed a cluster on {ocp-product-title} 4.15 or later.
+* You have deployed a cluster on {ocp-product-title} 4.18 or later.
 
 * You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 

--- a/modules/ossm-installing-cert-manager.adoc
+++ b/modules/ossm-installing-cert-manager.adoc
@@ -14,7 +14,7 @@ Integrate the cert-manager Operator with {SMProduct} by deploying the `istio-csr
 
 * You have installed the {cert-manager-operator} version 1.18.0 or later.
 
-* You have logged in to {ocp-product-title} 4.14 or later.
+* You have logged in to {ocp-product-title} 4.18 or later.
 
 * You have installed the {SMProduct} Operator.
 

--- a/modules/ossm-installing-operator.adoc
+++ b/modules/ossm-installing-operator.adoc
@@ -15,7 +15,7 @@ For clusters without {SMProduct} instances, install the {SMProductShortName} Ope
 
 .Prerequisites
 
-* You have deployed a cluster on {ocp-product-title} 4.14 or later.
+* You have deployed a cluster on {ocp-product-title} 4.18 or later.
 
 * You have logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
 


### PR DESCRIPTION
## What changed

- Updated OCP version prerequisite in `modules/ossm-installing-operator.adoc` (section 2.2, Installing the Operator) from **4.14 or later** to **4.18 or later**.
- Updated OCP version prerequisite in `modules/ossm-deploying-bookinfo-application.adoc` (section 2.5.1, Deploying the Bookinfo application) from **4.15 or later** to **4.18 or later**.
- Updated OCP version prerequisite in `modules/ossm-installing-cert-manager.adoc` (section 6.1.1, cert-manager integration) from **4.14 or later** to **4.18 or later**.

## Why

The Installing guide prerequisites for sections 2.2, 2.5.1, and 6.1.1 incorrectly stated OCP 4.14 or 4.15 as the minimum supported version. This conflicts with:

- Section 1.1 (Supported platforms), which requires OCP **4.18 or later**
- OSSM 3.3.3 release notes, which state support on OCP **4.18 and later**

Readers following the install procedures may assume an unsupported OCP version is valid for OSSM 3.3.
