### PR TITLE
[enterprise-4.20] OSDOCS-16997-installing-gcp-shared-vpc# CQA

### DIFF
--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -7,20 +7,37 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on {gcp-first}. In this installation method, the cluster is configured to use a VPC from a different {gcp-short} project. A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IP addresses from that network. For more information about shared VPC, see link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview in the {gcp-short} documentation].
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on {gcp-first}. In this installation method, the cluster is configured to use a VPC from a different {gcp-short} project. A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IP addresses from that network.
 
 The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview]
 
 [id="installation-gcp-shared-vpc-prerequisites_{context}"]
 == Prerequisites
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects in the {gcp-short} documentation].
-* You have a {gcp-short} host project that contains a shared VPC network and that has a configured Cloud Router and Cloud NAT gateway, to ensure that internet access from the VPC is available. For more information, see link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview] and  link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview] (Google documentation).
-* You have a {gcp-short} service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account[required {gcp-short} permissions] in both the host and service projects.
-* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read the documentation on selecting a cluster installation method and preparing it for users. For more information, see "Selecting a cluster installation method and preparing it for users".
+* If you use a firewall, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall for {product-title}".
+* You configured a {gcp-short} project to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see "Configuring a {gcp-short} project".
+* You have a {gcp-short} host project that contains a shared VPC network and that has a configured Cloud Router and Cloud NAT gateway, to ensure that internet access from the VPC is available.
+* You have a {gcp-short} service account that has the required {gcp-short} permissions in both the host and service projects. For more information, see "Required {gcp-short} permissions for shared VPC installations".
+* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. If you do not provide a private hosted zone, the installation program provisions one automatically.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall-module_configuring-firewall[Configuring your firewall for {product-title}]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configuring a {gcp-short} project]
+* link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects]
+* link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview]
+* link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview]
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account[Required {gcp-short} permissions for shared VPC installations]
+* link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
@@ -68,23 +85,13 @@ include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
 // Installing the OpenShift CLI on macOS
 include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
 
-[id="installing-gcp-manual-modes_{context}"]
-== Alternatives to storing administrator-level secrets in the kube-system project
-
-By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
-
-* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#manually-create-iam_installing-gcp-shared-vpc[Manually creating long-term credentials].
-
-* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#installing-gcp-with-short-term-creds_installing-gcp-shared-vpc[Configuring a {gcp-short} cluster to use short-term credentials].
+include::modules/installing-gcp-manual-modes.adoc[leveloffset=+1]
 
 //Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
 
 //Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-=== Configuring a {gcp-short} cluster to use short-term credentials
-
-To install a cluster that is configured to use {gcp-short} Workload Identity, you must configure the CCO utility and create the required {gcp-short} resources for your cluster.
+include::modules/installing-gcp-short-term-creds.adoc[leveloffset=+2]
 
 //Task part 1: Configuring the Cloud Credential Operator utility
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
@@ -108,18 +115,14 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
-
-[id="installation-gcp-shared-vpc-next-steps_{context}"]
-== Next steps
-
-* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customizing your cluster]
+* xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -238,7 +238,7 @@ endif::[]
 = Deploying the cluster
 
 [role="_abstract"]
-To deploy your {product-title} cluster, you can initialize installation by running the `openshift-install create cluster` command from the directory that contains the installation program. The installation program provisions infrastructure and completes cluster setup.
+To deploy your {product-title} cluster, you initialize installation by running the `openshift-install create cluster` command from the directory that contains the installation program. The installation program provisions the required infrastructure and completes the cluster setup.
 
 [IMPORTANT]
 ====
@@ -281,11 +281,8 @@ endif::vsphere[]
 
 .Procedure
 ifdef::gcp[]
-. Remove any existing {gcp-short} credentials that do not use the service account key
-for the {gcp-short} account that you configured for your cluster and that are stored in the
-following locations:
-** The `GOOGLE_CREDENTIALS`, `GOOGLE_CLOUD_KEYFILE_JSON`, or `GCLOUD_KEYFILE_JSON`
-environment variables
+. Remove any existing {gcp-short} credentials that do not use the service account key for the {gcp-short} account that you configured for your cluster and that are stored in the following locations:
+** The `GOOGLE_CREDENTIALS`, `GOOGLE_CLOUD_KEYFILE_JSON`, or `GCLOUD_KEYFILE_JSON` environment variables
 ** The `~/.gcp/osServiceAccount.json` file
 ** The `gcloud cli` default credentials
 endif::gcp[]
@@ -321,15 +318,18 @@ $ ./openshift-install create cluster --dir <installation_directory> \
     --log-level=info
 ----
 +
-** For `<installation_directory>`, specify the
+where:
++
+--
+* `<installation_directory>`: Specifies the
 ifdef::custom-config[]
 location of your customized `./install-config.yaml` file.
 endif::custom-config[]
 ifdef::no-config[]
 directory name to store the files that the installation program creates.
 endif::no-config[]
-** To view different installation details, specify `warn`, `debug`, or
-`error` instead of `info`.
+* `--log-level`: Specifies the log level. To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
+--
 
 ifdef::azure-gov,azure-private[]
 +
@@ -392,14 +392,10 @@ If the installation program cannot locate the `osServicePrincipal.json` configur
 endif::azure[]
 ifdef::gcp[]
 .. Select *gcp* as the platform to target.
-.. If you have not configured the service account key for your {gcp-short} account on
-your host, you must obtain it from {gcp-short} and paste the contents of the file
-or enter the absolute path to the file.
-.. Select the project ID to provision the cluster in. The default value is
-specified by the service account that you configured.
+.. If you have not configured the service account key for your {gcp-short} account on your host, you must obtain it from {gcp-short} and paste the contents of the file or enter the absolute path to the file.
+.. Select the project ID to provision the cluster in. The default value is specified by the service account that you configured.
 .. Select the region to deploy the cluster to.
-.. Select the base domain to deploy the cluster to. The base domain corresponds
-to the public DNS zone that you created for your cluster.
+.. Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
 endif::gcp[]
 ifdef::ibm-cloud[]
 .. test
@@ -458,9 +454,7 @@ link:https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshoot
 ====
 endif::azure[]
 ifdef::gcp[]
-If you provide a name that is longer
-than 6 characters, only the first 6 characters will be used in the infrastructure
-ID that is generated from the cluster name.
+If you provide a name that is longer than 6 characters, only the first 6 characters will be used in the infrastructure ID that is generated from the cluster name.
 endif::gcp[]
 ifndef::openshift-origin[]
 .. Paste the {cluster-manager-url-pull}.
@@ -470,7 +464,6 @@ ifdef::openshift-origin[]
 * If you do not have a {cluster-manager-url-pull}, you can paste the pull secret another private registry.
 * If you do not need the cluster to pull images from a private registry, you can paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret.
 endif::openshift-origin[]
-
 ifdef::azure[]
 +
 [NOTE]
@@ -511,7 +504,8 @@ When the cluster deployment completes successfully:
 Do not delete the installation program or the files that the installation program creates. Both are required to delete the cluster.
 ====
 +
-.Example output
+The following example shows the expected output:
++
 [source,terminal]
 ----
 ...

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -61,18 +61,21 @@ endif::[]
 = Obtaining the installation program
 
 [role="_abstract"]
-Before you install {product-title}, download the installation file on
 ifdef::restricted[]
-the mirror host, so that installation assets exist for deployment in your environment.
+Before you install {product-title}, download the installation file on the mirror host, so that installation assets exist for deployment in your environment.
 endif::restricted[]
 ifndef::restricted[]
-ifdef::ibm-z[ your provisioning machine.]
-ifndef::ibm-z,private[ the host you are using for installation.]
+ifdef::ibm-z[]
+Before you install {product-title}, download the installation file on your provisioning machine, so that installation assets exist for deployment in your environment.
+endif::ibm-z[]
 ifdef::private[]
-a bastion host on your cloud network or a machine that has access to the to the network through a VPN. This ensures that installation assets exist for deployment in your environment.
+Before you install {product-title}, download the installation file on a bastion host on your cloud network or a machine that has access to the network through a VPN. This ensures that installation assets exist for deployment in your environment.
 
 For more information about private cluster installation requirements, see "Private clusters".
 endif::private[]
+ifndef::ibm-z,private[]
+Before you install {product-title}, download the installation file on the host you are using for installation, so that installation assets exist for deployment in your environment.
+endif::ibm-z,private[]
 endif::restricted[]
 //mpytlak: Added "private" in the context of a review for the {ibm-cloud-title} private work. In an effort to keep updates to other platforms separate, I will open a doc story for each platform that supports a private install.
 


### PR DESCRIPTION
Manual cherry-pick of #117807 to enterprise-4.20.

The automated cherry-pick failed with a merge conflict in `installing/installing_gcp/installing-gcp-shared-vpc.adoc`. This branch resolves the conflict manually.

## Conflict resolution

On enterprise-4.20, this assembly diverged from the main base in two ways: it did not include the "Managing your own firewall rules" prerequisite, and its abstract was missing the `[role="_abstract"]` tag.

The resolution applies the CQA breadcrumb and Additional resources treatment while keeping the content release-accurate for enterprise-4.20:

* The abstract role tag, prerequisite breadcrumbs, Additional resources blocks, and the two inline-heading-to-include conversions (`installing-gcp-manual-modes.adoc` and `installing-gcp-short-term-creds.adoc`) are all applied.
* The "Managing your own firewall rules" prerequisite and its matching Additional resources cross-reference are omitted. The `installation-gcp-user-managed-firewall-rules_installing-gcp-account` anchor does not exist on enterprise-4.20, so including these entries would produce a broken cross-reference.

All retained Additional resources cross-references were verified to resolve on enterprise-4.20.

## File count

This PR changes 3 files compared to 5 in the original PR. The two differences are no-ops on enterprise-4.20:

* `modules/installing-gcp-manual-modes.adoc` already exists on this branch with identical content.
* `modules/installing-gcp-short-term-creds.adoc` already exists on this branch with identical content.

The insertion count reconciles exactly: the original PR has 100 insertions. Subtract 43 insertions for the two pre-existing modules and 2 insertions for the dropped firewall-rules prerequisite and cross-reference, then add 1 insertion for the `[role="_abstract"]` tag that enterprise-4.20 was missing, which gives 56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
