### PR TITLE
OBSDOCS-3597: Breaking change RN for Prometheus Exporter's translation_strategy field

### DIFF
--- a/modules/otel-exporters-prometheus-exporter.adoc
+++ b/modules/otel-exporters-prometheus-exporter.adoc
@@ -34,7 +34,7 @@ The following `OpenTelemetryCollector` custom resource configures the Prometheus
         resource_to_telemetry_conversion:
           enabled: true
         metric_expiration: 180m
-        add_metric_suffixes: false
+        translation_strategy: "UnderscoreEscapingWithoutSuffixes"
     service:
       pipelines:
         metrics:
@@ -55,7 +55,7 @@ where:
 `enable_open_metrics`:: If `true`, metrics are exported by using the OpenMetrics format. Exemplars are only exported in the OpenMetrics format and only for histogram and monotonic sum metrics such as `counter`. Disabled by default.
 `resource_to_telemetry_conversion`:: If `enabled` is `true`, all the resource attributes are converted to metric labels. Disabled by default.
 `metric_expiration`:: Defines how long metrics are exposed without updates. The default is `5m`.
-`add_metric_suffixes`:: Adds the metrics types and units suffixes. Must be disabled if the monitor tab in the Jaeger console is enabled. The default is `true`.
+`translation_strategy`:: Controls translation of OTLP metric and attribute names into Prometheus metric and label names. When you set `UnderscoreEscapingWithoutSuffixes`, special characters in metric names are escaped to underscores (`_`), and suffixes are not included.
 
 [NOTE]
 ====

--- a/modules/otel-rn-3.11.0.adoc
+++ b/modules/otel-rn-3.11.0.adoc
@@ -22,6 +22,14 @@ This update introduces high availability support for the {OTelOperator} webhooks
 +
 link:https://redhat.atlassian.net/browse/TRACING-6157[TRACING-6157]
 
+Breaking change in Prometheus Exporter configuration::
+With this update, the `add_metric_suffixes` field of the Prometheus Exporter configuration in the `OpenTelemetryCollector` custom resource is removed. To manage metric name suffixes, use the `translation_strategy` field instead.
++
+[WARNING]
+====
+If you do not explicitly set the `translation_strategy: "UnderscoreEscapingWithoutSuffixes"` value in your configuration, it defaults to the `UnderscoreEscapingWithSuffixes` value.
+====
+
 ////
 General availability of Collector components::
 These components, available as a Technology Preview before this update, are fully supported from version 3.11.0:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): standalone-otel-docs-main, standalone-otel-docs-3.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3597
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://119481--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-exporters.html#otel-exporters-prometheus-exporter_otel-collector-exporters
https://119481--ocpdocs-pr.netlify.app/openshift-otel/latest/release-notes/otel-rn.html#otel-rn-3-11-0_otel-rn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
