### PR TITLE
OBSDOCS-3597: Replace Prometheus Exporter's add_metric_suffixes field with translation_strategy field

### DIFF
--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -49,7 +49,7 @@ spec:
     exporters:
       prometheus:
         endpoint: 0.0.0.0:8889
-        add_metric_suffixes: false
+        translation_strategy: "UnderscoreEscapingWithoutSuffixes"
         resource_to_telemetry_conversion:
           enabled: true
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): standalone-distributed-tracing-docs-main, standalone-distributed-tracing-docs-3.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3597
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://119485--ocpdocs-pr.netlify.app/openshift-distributed-tracing/latest/configuring/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-spanmetrics_distr-tracing-tempo-configuring
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
