### PR TITLE
OADP-8193: Add OADP 1.5.8 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,10 +49,10 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.5.7
+:oadp-version: 1.5.8
 :oadp-version-1-3: 1.3.6
 :oadp-version-1-4: 1.4.6
-:oadp-version-1-5: 1.5.7
+:oadp-version-1-5: 1.5.8
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
@@ -16,6 +16,8 @@ The release notes for {oadp-first} 1.5 describe new features and enhancements, d
 For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
+include::modules/oadp-1-5-8-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-5-7-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-5-5-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-5-8-release-notes.adoc
+++ b/modules/oadp-1-5-8-release-notes.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-5-8-release-notes_{context}"]
+= {oadp-short} 1.5.8 release notes
+
+[role="_abstract"]
+{oadp-first} 1.5.8 release notes list new features, resolved issues, and known issues.
+
+The following Red Hat Security Advisory (RHSA) is available for {oadp-short} 1.5.8:
+
+* link:https://access.redhat.com/errata/RHSA-2026:66022[RHSA-2026:66022 - New version of Red{nbsp}Hat OpenShift API for Data Protection]
+
+
+[id="new-features-1-5-8_{context}"]
+== New features
+
+{oadp-short} CLI plugin::
+{oadp-short} includes a `kubectl` command-line interface (CLI) plugin that provides a `kubectl` native interface for managing backups and restores. Before this update, you aliased to the Velero CLI to perform backup operations. Non-cluster administrators had no way to independently manage their own backups, creating a dependency on cluster admins for routine data protection tasks. As a result, admins can run `kubectl oadp` or `oc oadp` commands to create, delete, and retrieve logs for backups and restores. Non-cluster admins can run the `oc oadp nonadmin` command to independently create, delete, and inspect non-admin backups within their permitted namespaces.
++
+link:https://redhat.atlassian.net/browse/OADP-8075[OADP-8075]
+
+
+[id="resolved-issues-1-5-8_{context}"]
+== Resolved issues
+
+Restored pods no longer fail to connect because of retained OVN network annotations::
+Before this update, Velero restored pods with the `k8s.ovn.org/pod-networks` annotation preserved from the source cluster. As a consequence, OVN-Kubernetes skipped allocating new network configurations, resulting in stale IP assignments, subnet mismatches, and lost network connectivity for restored pods. With this release, the `k8s.ovn.org/pod-networks` annotation is automatically stripped during restore operations. As a result, OVN-Kubernetes successfully re-allocates fresh logical ports and IP addresses to restored pods, ensuring proper network connectivity.
++
+link:https://redhat.atlassian.net/browse/OADP-7560[OADP-7560]
+
+DPA reconciliation no longer fails when credentials are defined only in `CloudStorage`::
+Before this update, the `DataProtectionApplication` (DPA) reconciliation required credentials to be explicitly specified in the DPA custom resource (CR) even when the credentials were provided in the `CloudStorage` CR. With this release, the DPA controller inherits credentials, configuration values, and region settings from the referenced `CloudStorage` CR when using `backupLocations.bucket.cloudStorageRef`. If both DPA-level and `CloudStorage`-level values are provided, DPA-level values take precedence. As a result, DPA reconciliation no longer fails due to missing credentials in DPA CR.
++
+link:https://redhat.atlassian.net/browse/OADP-6669[OADP-6669]
+
+Backup hooks are no longer skipped on dynamically injected pods when using `labelSelector`::
+Before this update, Velero evaluated backup hooks by using the backup's top-level label selector. As a consequence, pods dynamically added to a backup by plugins by using `AdditionalItems` were skipped during hook execution if they did not directly match `labelSelector`. This resulted in crash-consistent or potentially corrupt backups. With this release, plugin adjustments ensure that dynamic pod items properly call configured pre- and post-backup hooks regardless of whether the pod itself carries the primary backup label. As a result, dynamically included pods run backup hooks as expected.
++
+link:https://redhat.atlassian.net/browse/OADP-8332[OADP-8332]
+
+{oadp-short} workload pods use dedicated service accounts::
+Before this update, the `oadp-cli-server` workload pods in the `openshift-adp` namespace used the default service account instead of dedicated, workload-specific service accounts. As a consequence, access control validation checks failed during deployment verification. With this release, dedicated and valid service accounts are properly assigned to these workload pods. As a result, all {oadp-short} workload pods comply with access control verification and adhere to cluster security standards.
++
+link:https://redhat.atlassian.net/browse/OADP-8454[OADP-8454]
+
+{oadp-short} CLI server pod uses a dedicated service account with no cross-namespace `RoleBindings`::
+Before this update, the `oadp-cli-server` pod was deployed with an empty or default `serviceAccountName` without properly scoped role bindings. As a consequence, role bindings used by a pod did not reside within the same workload namespace. With this release, the {oadp-short} Operator creates a dedicated `openshift-adp-cli-server` service account with `automountServiceAccountToken: false` and no cross-namespace `RoleBindings`. As a result, the {oadp-short} CLI server pod runs with a correctly scoped, least-privilege service account in the `openshift-adp` namespace.
++
+link:https://redhat.atlassian.net/browse/OADP-8455[OADP-8455]
+
+`NetworkAttachmentDefinitions` are backed up as part of VM backups::
+Before this update, when backing up a virtual machine (VM) with an attached `NetworkAttachmentDefinition` (NAD), the NAD was not included in the backup. With this release, the Velero `kubevirt` plugin includes NADs in the resource graph (`KVGraph`) for VM backups. It also correctly updates the namespace references inside the NAD configuration during alternate-namespace restores. As a result, backing up a VM successfully backs up all attached NADs.
++
+link:https://redhat.atlassian.net/browse/OADP-8462[OADP-8462]
+
+{oadp-short} containers include liveness, readiness, and startup probes::
+Before this update, the {oadp-short} command-line interface (CLI) container did not have configured Kubernetes health probes (liveness, readiness, and startup probes). As a consequence, workloads could not automatically recover from common failures, such as pod, host, or network issues. With this release, the {oadp-short} Operator adds liveness, readiness, and startup probes to the deployed containers. As a result, workloads can use native Kubernetes health-checking mechanisms to self-recover from failures and ensure reliable application traffic routing.
++
+link:https://redhat.atlassian.net/browse/OADP-8486[OADP-8486]
+
+
+[id="known-issues-1-5-8_{context}"]
+== Known issues
+
+`CloudStorage` bucket creation fails on {gcp-short} with WIF authentication::
+When you configure `CloudStorage` on OpenShift clusters on {gcp-short} by using Workload Identity Federation (WIF) authentication, the `CloudStorage` resource fails to detect that a {gcp-short} bucket does not exist. As a consequence, the resource returns a `BucketCheckError` condition and prevents automatic bucket creation.
++
+To work around this problem, use an existing {gcp-short} bucket. As a result, the controller skips bucket creation and proceeds with the existing bucket for backup storage.
++
+link:https://redhat.atlassian.net/browse/OADP-8786[OADP-8786]


### PR DESCRIPTION
Summary of changes: Update attributes and add Release Notes for OADP 1.5.8.

Version(s):
OCP 4.21

Issue:
[OADP-8193](https://redhat.atlassian.net/browse/OADP-8193)

Link to docs preview:
[OADP 1.5.8 release notes](https://119491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.html#oadp-1-5-8-release-notes_oadp-1-5-release-notes)

QE review:
- [x] QE has approved this change.
