### PR TITLE
NVIDIA DPF: add deploy: true to Maintenance Operator config

### DIFF
--- a/modules/nw-dpf-installing-maintenance-operator.adoc
+++ b/modules/nw-dpf-installing-maintenance-operator.adoc
@@ -23,6 +23,7 @@ You install this operator by using Helm.
 [source,yaml]
 ----
 operatorConfig:
+  deploy: true
   maxParallelOperations: 60%
 operator:
   affinity:


### PR DESCRIPTION
## Summary

The NVIDIA Maintenance Operator installation module (`modules/nw-dpf-installing-maintenance-operator.adoc`) uses chart version `0.3.0`, but the documented `operatorConfig` is missing the `deploy: true` field.

In chart 0.3.0, the operator only creates the config object when `operatorConfig.deploy` is `true`. Without it, the `maxParallelOperations: 60%` setting is silently ignored and DPU provisioning runs one node at a time instead of in parallel.

## Change

```yaml
operatorConfig:
  deploy: true          # added
  maxParallelOperations: 60%
```

This aligns the docs with the automation values in `rh-ecosystem-edge/openshift-dpf` (release-4.22), which already set `operatorConfig.deploy: true`.

Follow-up to #119476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)