### PR TITLE
[TELCODOCS#2936]: Stop documenting unused PreCachingConfig override fields

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="talm-prechache-user-specified-images-preparing-crs_{context}"]
@@ -16,17 +17,20 @@ apiVersion: ran.openshift.io/v1alpha1
 kind: PreCachingConfig
 metadata:
   name: exampleconfig
-  namespace: default <1>
+  namespace: default
 spec:
-[...]
-  spaceRequired: 30Gi <2>
+# ...
+  spaceRequired: 30Gi
   additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1> The `namespace` must be accessible to the hub cluster.
-<2> It is recommended to set the minimum disk space required field to ensure that there is sufficient storage space for the pre-cached images.
++
+where:
+
+`namespace`:: Specifies the namespace for the `PreCachingConfig` CR. The namespace must be accessible to the hub cluster.
+`spaceRequired`:: Specifies the minimum disk space required on the cluster to ensure that there is sufficient storage space for the pre-cached images.
 
 . Create a `ClusterGroupUpgrade` CR with the `preCaching` field set to `true` and specify the `PreCachingConfig` CR created in the previous step:
 +
@@ -78,7 +82,7 @@ All sites are pre-cached concurrently.
 
 .Verification
 
-. Check the pre-caching status on the hub cluster where the `ClusterUpgradeGroup` CR is applied by running the following command:
+. Check the pre-caching status on the hub cluster where the `ClusterGroupUpgrade` CR is applied by running the following command:
 +
 [source,terminal]
 ----
@@ -86,7 +90,10 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-.Example output
+The following example shows the derived pre-caching specification.
+The `platformImage` and `operatorsIndexes` values come from the managed policies, not from `PreCachingConfig` overrides.
++
+
 [source,yaml]
 ----
   precaching:

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
@@ -114,7 +114,8 @@ Example output:
 }
 ----
 +
-Displays the list of identified clusters.
+The output lists the identified clusters.
+The `platformImage` value in `status.precaching.spec` is derived by {cgu-operator} from the `ClusterVersion` object in the managed policies.
 
 . Check the status of the pre-caching job by running the following command on the spoke cluster:
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
@@ -1,17 +1,21 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+// * edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+// * edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="talm-prechache-user-specified-images-concept_{context}"]
 = Pre-caching user-specified images with {cgu-operator} on {sno} clusters
 
-You can pre-cache application-specific workload images on {sno} clusters before upgrading your applications.
+You can pre-cache application-specific workload images on {sno} clusters before updating your applications.
 
 You can specify the configuration options for the pre-caching jobs using the following custom resources (CR):
 
 * `PreCachingConfig` CR
 * `ClusterGroupUpgrade` CR
+
+{cgu-operator} derives the platform image from the `ClusterVersion` object in the managed policies.
+{cgu-operator} derives Operator index images from `CatalogSource` objects that the managed policies reference.
 
 [NOTE]
 ====
@@ -27,27 +31,27 @@ metadata:
   name: exampleconfig
   namespace: exampleconfig-ns
 spec:
-  overrides: <1>
-    platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-    operatorsIndexes:
-      - registry.example.com:5000/custom-redhat-operators:1.0.0
+  overrides:
     operatorsPackagesAndChannels:
       - local-storage-operator: stable
       - ptp-operator: stable
       - sriov-network-operator: stable
-  spaceRequired: 30 Gi <2>
-  excludePrecachePatterns: <3>
+  spaceRequired: 30 Gi
+  excludePrecachePatterns:
     - aws
     - vsphere
-  additionalImages: <4>
+  additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1>  By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
-<2> Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
-<3> Specifies the images to exclude from pre-caching based on image name matching.
-<4> Specifies the list of additional images to pre-cache.
++
+where:
+
+`overrides`:: Specifies Operator packages and channels to pre-cache instead of the values that {cgu-operator} derives from the managed policies. The only supported override is `operatorsPackagesAndChannels`. {cgu-operator} ignores the deprecated `platformImage` and `operatorsIndexes` override fields if they are present.
+`spaceRequired`:: Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
+`excludePrecachePatterns`:: Specifies the images to exclude from pre-caching based on image name matching.
+`additionalImages`:: Specifies the list of additional images to pre-cache.
 
 .Example ClusterGroupUpgrade CR with PreCachingConfig CR reference
 [source,yaml]
@@ -57,11 +61,14 @@ kind: ClusterGroupUpgrade
 metadata:
   name: cgu
 spec:
-  preCaching: true <1>
+  preCaching: true
   preCachingConfigRef:
-    name: exampleconfig <2>
-    namespace: exampleconfig-ns <3>
+    name: exampleconfig
+    namespace: exampleconfig-ns
 ----
-<1> The `preCaching` field set to `true` enables the pre-caching job.
-<2> The `preCachingConfigRef.name` field specifies the `PreCachingConfig` CR that you want to use.
-<3> The `preCachingConfigRef.namespace` specifies the namespace of the `PreCachingConfig` CR that you want to use.
++
+where:
+
+`preCaching`:: Set to `true` to enable the pre-caching job.
+`preCachingConfigRef.name`:: Specifies the `PreCachingConfig` CR that you want to use.
+`preCachingConfigRef.namespace`:: Specifies the namespace of the `PreCachingConfig` CR that you want to use.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2936

Cherry-pick of https://github.com/openshift/openshift-docs/pull/118337 (manual, patch does not apply cleanly).

Link to docs preview:
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.html
- https://118337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/cnf-talm-for-cluster-upgrades.html

QE review:
- [x] QE has approved this change.

Additional information:
Manual cherry-pick of #118337 to enterprise-4.18. Updates TALM precaching docs so they no longer instruct users to set `PreCachingConfig` `overrides.platformImage` and `overrides.operatorsIndexes`. TALM now derives those images from managed policies (`ClusterVersion` and `CatalogSource` objects). The remaining supported override is `operatorsPackagesAndChannels`. Status examples still show the derived `platformImage` and `operatorsIndexes` values and now state that those values come from policies, not from user overrides.

Made with [Cursor](https://cursor.com)