### PR TITLE
OSDOCS-22064: Add 4.22.12 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-12.adoc
+++ b/modules/zstream-4-22-12.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-12_{context}"]
+= RHSA-2026:60441 - {product-title} {product-version}.12 bug fix and security update
+
+Issued: 01 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.12 is now available. The list of bug fixes and enhancements that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:60441[RHSA-2026:60441] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:60439[RHBA-2026:60439] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.12 --pullspecs
+----
+
+[id="zstream-4-22-12-enhancements_{context}"]
+== Enhancements
+
+* You can now pin the HAProxy version to `2.8` by using the new `haproxyVersion` field from the `IngressResource` API, before upgrading {product-title} cluster to 4.23 or 5.0. If you do not pin the HAProxy version, it is upgraded to version `3.2`. (link:https://issues.redhat.com/browse/OCPBUGS-105168[OCPBUGS-105168])
+
+[id="zstream-4-22-12-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the machine controller in the Hosted Cluster Config Operator (HCCO) included non-routable ovn-kubernetes routes in the node network configuration. As a consequence, it caused networking conflicts and routing issues. With this release, non-routable routes are filtered out during configuration. As a result, networking conflicts are resolved. (link:https://issues.redhat.com/browse/OCPBUGS-98328[OCPBUGS-98328])
+
+* Before this update, by default, the Vertical Pod Autoscaler (VPA) Operator required a control plane node for running workloads. As a consequence, it caused issues in single-node deployments. With this release, the Operator is updated to support deployment without control plane node requirements. As a result, the VPA Operator now functions correctly in single-node configurations. (link:https://issues.redhat.com/browse/OCPBUGS-98604[OCPBUGS-98604])
+
+* Before this update, socket connections triggered multiple state synchronization, leading to excessive socket connection reconciliation. As a consequence, it caused unnecessary API calls and reduced performance. With this release, the reconciliation logic is updated to synchronize only on meaningful state changes. As a result, API calls are reduced and performance is improved. (link:https://issues.redhat.com/browse/OCPBUGS-105877[OCPBUGS-105877])
+
+* Before this update, the console required cloud credentials during Operator initialization. As a consequence, installation failed when credentials were not immediately available. With this release, the initialization process is updated to defer credential requirements. As a result, installation succeeds without requiring immediate cloud credentials. (link:https://issues.redhat.com/browse/OCPBUGS-111417[OCPBUGS-111417])
+
+
+
+
+
+[id="zstream-4-22-12-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -47,6 +47,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.12 RNs and updating
+include::modules/zstream-4-22-12.adoc[leveloffset=+2]
+
 // 4.22.11 RNs and updating
 include::modules/zstream-4-22-11.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version
4.22

Issue
https://redhat.atlassian.net/browse/OSDOCS-22064

Link to docs preview
https://119497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-12_release-notes

QE review:
N/A

Additional information

- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/770
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
- Errata: RHSA-2026:60441 (Security - Important) / RHBA-2026:60439 (RPM packages)
