### PR TITLE
OCPBUGS-114001: Add dns-resolver and routes to nodes-config.yaml example

### DIFF
--- a/modules/adding-node-iso-yaml.adoc
+++ b/modules/adding-node-iso-yaml.adoc
@@ -44,6 +44,15 @@ hosts:
            - ip: 192.168.122.2
              prefix-length: 23
          dhcp: false
+   dns-resolver:
+     config:
+       server:
+         - 192.168.122.1
+   routes:
+     config:
+       - destination: 0.0.0.0/0
+         next-hop-address: 192.168.122.1
+         next-hop-interface: eth0
 - hostname: extra-worker-2
   rootDeviceHints:
    deviceName: /dev/sda
@@ -62,6 +71,15 @@ hosts:
            - ip: 192.168.122.3
              prefix-length: 23
          dhcp: false
+   dns-resolver:
+     config:
+       server:
+         - 192.168.122.1
+   routes:
+     config:
+       - destination: 0.0.0.0/0
+         next-hop-address: 192.168.122.1
+         next-hop-interface: eth0
 ----
 
 . Generate the ISO image by running the following command:


### PR DESCRIPTION
### Bug

[OCPBUGS-114001](https://redhat.atlassian.net/browse/OCPBUGS-114001)

### Problem

The example `nodes-config.yaml` file in the **"Adding one or more nodes using a configuration file"** section shows a static IP configuration under `networkConfig`, but omits the `dns-resolver` and `routes` sections.

Without these, a node added with a static IP:
- Cannot resolve DNS names (no `dns-resolver` → no `/etc/resolv.conf` entries)
- Cannot communicate outside its own subnet (no `routes` → no default gateway)

This makes the example incomplete for real-world static networking use and can lead to failed node additions.

### Fix

Added `dns-resolver` and `routes` blocks to the `networkConfig` of **each host** in the example `nodes-config.yaml`, using example values consistent with the existing `192.168.122.0/23` subnet:

```yaml
    dns-resolver:
      config:
        server:
          - 192.168.122.1
    routes:
      config:
        - destination: 0.0.0.0/0
          next-hop-address: 192.168.122.1
          next-hop-interface: eth0
```

### Consistency

This change aligns the `nodes-config.yaml` example with other NMState `networkConfig` examples across the OpenShift documentation that already include `dns-resolver` and `routes`:

- `modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc`
- `modules/ipi-install-preparing-the-bare-metal-node.adoc`

### Version Coverage

| Version | Coverage |
|---------|----------|
| **4.20+** | Primary PR to `main` |
| **4.19** | Cherry-pick via `cherry-pick-enterprise-4.19` |
| **4.18** | Cherry-pick via `cherry-pick-enterprise-4.18` |

> **Note to maintainers:** Please add labels `cherry-pick-enterprise-4.19` and `cherry-pick-enterprise-4.18` for backporting.