### PR TITLE
Document undocumented k8sattributes and resourcedetection processor fields

### DIFF
--- a/modules/otel-processors-kubernetes-attributes-processor.adoc
+++ b/modules/otel-processors-kubernetes-attributes-processor.adoc
@@ -53,3 +53,7 @@ spec:
 where:
 
 `filter`:: Optional: Filters resource objects cached for metadata extraction, reducing API requests and memory usage.
+`wait_for_metadata`:: Optional: Specifies whether the processor waits for the Kubernetes metadata to be synced when starting. The default value is `false`.
+`wait_for_metadata_timeout`:: Optional: Specifies the maximum time the processor waits for the Kubernetes metadata to be synced. The default value is `10s`.
+`watch_sync_period`:: Optional: Specifies the resync period for the Kubernetes informers. The default value is `5m`.
+`pod_delete_grace_period`:: Optional: Specifies the duration to wait before deleting a pod from the cache after receiving a delete event. The default value is `120s`.

--- a/modules/otel-processors-resource-detection-processor.adoc
+++ b/modules/otel-processors-resource-detection-processor.adoc
@@ -66,3 +66,4 @@ The following `OpenTelemetryCollector` custom resource configures the Resource D
 where:
 
 `detectors`:: Specifies which detector to use. In this example, the environment detector is specified.
+`refresh_interval`:: Optional: Specifies the interval at which the configured detectors re-run to refresh the detected resource attributes. The default value is `0`, which disables periodic refresh and runs detection only once at startup.


### PR DESCRIPTION
Automated remediation from the otel-regression-detection report (reports/regression-remediation-2026-09-08.md).

Addresses:
- LOW-1: Documents `wait_for_metadata`, `wait_for_metadata_timeout`, `watch_sync_period`, and `pod_delete_grace_period` for the Kubernetes Attributes Processor.
- LOW-3: Documents `refresh_interval` for the Resource Detection Processor.

Field names, descriptions, and defaults were verified against `processor/k8sattributesprocessor/config.go` and `processor/resourcedetectionprocessor/config.go` in opentelemetry-collector-contrib.

Generated by otel-regression-remediation.