### PR TITLE
OCPBUGS-115404: Use platform name in extracting infrastructure name warning

### DIFF
--- a/modules/installation-extracting-infraid.adoc
+++ b/modules/installation-extracting-infraid.adoc
@@ -81,7 +81,7 @@ endif::vsphere[]
 
 [WARNING]
 ====
-Do not run the `openshift-install create manifests` command again after creating any {gcp-short} resources. Running the command again generates a new cluster identifier, which will cause errors in existing resources. If you need to regenerate the manifests because you modified the `install-config.yaml` file, delete any {gcp-short} resources you created and re-create them with the new cluster identifier.
+Do not run the `openshift-install create manifests` command again after creating any {cp} resources. Running the command again generates a new cluster identifier, which will cause errors in existing resources. If you need to regenerate the manifests because you modified the `install-config.yaml` file, delete any {cp} resources you created and re-create them with the new cluster identifier.
 ====
 
 .Prerequisites


### PR DESCRIPTION
…arning

The shared module hard-coded {gcp-short}, so the AWS UPI docs warned about Google Cloud resources.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
