### PR TITLE
OCPBUGS-116718: Added note to  Restoring etcd quorum for high availab…

### DIFF
--- a/modules/dr-restoring-etcd-quorum-ha.adoc
+++ b/modules/dr-restoring-etcd-quorum-ha.adoc
@@ -70,19 +70,24 @@ After a few minutes, the nodes that went down are automatically synchronized wit
 
 . Return to a three-node configuration if any nodes are offline. Repeat the following steps for each node that is offline to delete and re-create them. After the machines are re-created, a new revision is forced and etcd automatically scales up.
 +
-** If you use a user-provisioned bare-metal installation, you can re-create a control plane machine by using the same method that you used to originally create it. For more information, see "Installing a user-provisioned cluster on bare metal".
-+
 [WARNING]
 ====
-Do not delete and re-create the machine for the recovery host.
+For installer-provisioned infrastructure and user-provisioned infrastructure, do not delete and re-create the machine for the recovery host.
 ====
++
+* If you use a user-provisioned bare-metal installation, you can re-create a control plane machine by using the same method that you used to originally create it. 
++
+[IMPORTANT]
+====
+Before starting the newly provisioned node, you must delete the existing node object from the cluster by running the `oc delete node <node_name>` command. Failing to delete the node object before reinstallating the node can cause conflicts and issues during the reinstallation process.
+====
++
+For more information, see "Installing a user-provisioned cluster on bare metal".
 +
 ** If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps:
 +
-[WARNING]
+[IMPORTANT]
 ====
-Do not delete and re-create the machine for the recovery host.
-
 For bare-metal installations on installer-provisioned infrastructure, control plane machines are not re-created. For more information, see "Replacing a bare-metal control plane node".
 ====
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-116718](https://redhat.atlassian.net/browse/OCPBUGS-116718)

Link to docs preview:

* https://119505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.html
* https://119505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.html
* https://119505--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html


- [x] SME has approved this change (Pablo R.).
- [x] QE has approved this change (Sandeep Kundu).

