### PR TITLE
Fix stale/missing OTel docs: deprecated type names, kafka topic, k8sattributes fields

### DIFF
--- a/modules/otel-collector-config-options.adoc
+++ b/modules/otel-collector-config-options.adoc
@@ -75,7 +75,7 @@ The Operator uses the following parameters to define the OpenTelemetry Collector
 
 |processors:
 |Processors run through the received data before it is exported. By default, no processors are enabled.
-|`batch`, `memory_limiter`, `resourcedetection`, `attributes`, `span`, `k8sattributes`, `filter`, `routing`
+|`batch`, `memory_limiter`, `resource_detection`, `attributes`, `span`, `k8s_attributes`, `filter`, `routing`
 |None
 
 |exporters:
@@ -85,7 +85,7 @@ The Operator uses the following parameters to define the OpenTelemetry Collector
 
 |connectors:
 |Connectors join pairs of pipelines by consuming data as end-of-pipeline exporters and emitting data as start-of-pipeline receivers. Connectors can be used to summarize, replicate, or route consumed data.
-|`spanmetrics`
+|`span_metrics`
 |None
 
 |extensions:

--- a/modules/otel-connectors-span-metrics-connector.adoc
+++ b/modules/otel-connectors-span-metrics-connector.adoc
@@ -16,16 +16,22 @@ The following `OpenTelemetryCollector` custom resource configures the Span Metri
 # ...
   config:
     connectors:
-      spanmetrics:
+      span_metrics:
         metrics_flush_interval: 15s
     service:
       pipelines:
         traces:
-          exporters: [spanmetrics]
+          exporters: [span_metrics]
         metrics:
-          receivers: [spanmetrics]
+          receivers: [span_metrics]
 # ...
 ----
+
+[NOTE]
+====
+The connector type `span_metrics` was previously named `spanmetrics`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `span_metrics` in new configurations.
+====
+
 where:
 
 `metrics_flush_interval`:: Defines the flush interval of the generated metrics. Defaults to `15s`.

--- a/modules/otel-exporters-load-balancing-exporter.adoc
+++ b/modules/otel-exporters-load-balancing-exporter.adoc
@@ -20,7 +20,7 @@ The following `OpenTelemetryCollector` custom resource configures the Load Balan
 # ...
   config:
     exporters:
-      loadbalancing:
+      load_balancing:
         routing_key: "service"
         protocol:
           otlp:
@@ -39,6 +39,12 @@ The following `OpenTelemetryCollector` custom resource configures the Load Balan
               - 16317
 # ...
 ----
+
+[NOTE]
+====
+The exporter type `load_balancing` was previously named `loadbalancing`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `load_balancing` in new configurations.
+====
+
 where:
 
 `routing_key`:: Determines how telemetry is distributed to Collector instances. Available values are: `service` for routes by service name, `traceID` for routes by trace ID, `metric` for routes by metric name, `resource` for routes by resource attributes for metrics, `streamID` for routes by datapoint stream ID for metrics, and `attributes` for routes by specified attribute values. When you use `attributes`, you must also specify the `routing_attributes` field, which lists the attributes to use.

--- a/modules/otel-exporters-prometheus-remote-write-exporter.adoc
+++ b/modules/otel-exporters-prometheus-remote-write-exporter.adoc
@@ -16,7 +16,7 @@ The following `OpenTelemetryCollector` custom resource configures the Prometheus
 # ...
   config:
     exporters:
-      prometheusremotewrite:
+      prometheus_remote_write:
         endpoint: "https://my-prometheus:7900/api/v1/push"
         tls:
           ca_file: ca.pem
@@ -34,9 +34,15 @@ The following `OpenTelemetryCollector` custom resource configures the Prometheus
     service:
       pipelines:
         metrics:
-          exporters: [prometheusremotewrite]
+          exporters: [prometheus_remote_write]
 # ...
 ----
+
+[NOTE]
+====
+The exporter type `prometheus_remote_write` was previously named `prometheusremotewrite`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `prometheus_remote_write` in new configurations.
+====
+
 where:
 
 `endpoint`:: Endpoint for sending the metrics.

--- a/modules/otel-extensions-k8sleaderelector-extension.adoc
+++ b/modules/otel-extensions-k8sleaderelector-extension.adoc
@@ -46,7 +46,7 @@ The following `OpenTelemetryCollector` custom resource configures the Kubernetes
       k8s_cluster:
         k8s_leader_elector: k8s_leader_elector
         collection_interval: 30s
-      k8sobjects:
+      k8s_objects:
         k8s_leader_elector: k8s_leader_elector
         objects:
           - name: pods
@@ -71,7 +71,7 @@ The following `OpenTelemetryCollector` custom resource configures the Kubernetes
           processors: [batch]
           exporters: [otlp]
         logs:
-          receivers: [k8sobjects, k8s_events]
+          receivers: [k8s_objects, k8s_events]
           processors: [batch]
           exporters: [otlp]
 # ...

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -53,7 +53,7 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP Expor
           authenticator: googleclientauth
 
     processors:
-      metricstarttime:
+      metric_start_time:
         strategy: subtract_initial_point
 
       resource/gcp_project_id:
@@ -62,7 +62,7 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP Expor
           value: <project_id>
           key: gcp.project_id
 
-      k8sattributes: {}
+      k8s_attributes: {}
 
       transform/collision:
         metric_statements:
@@ -85,7 +85,7 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP Expor
       extensions: [googleclientauth]
       pipelines:
         metrics:
-          processors: [k8sattributes, resource/gcp_project_id, transform/collision, metricstarttime]
+          processors: [k8s_attributes, resource/gcp_project_id, transform/collision, metric_start_time]
           exporters: [otlp_http]
 # ...
 ----

--- a/modules/otel-forwarding-logs-to-lokistack.adoc
+++ b/modules/otel-forwarding-logs-to-lokistack.adoc
@@ -99,7 +99,7 @@ spec:
           grpc: {}
           http: {}
     processors:
-      k8sattributes: {}
+      k8s_attributes: {}
       resource:
         attributes:
           - key:  kubernetes.namespace_name
@@ -134,7 +134,7 @@ spec:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [k8sattributes, transform, resource]
+          processors: [k8s_attributes, transform, resource]
           exporters: [otlp_http/logs]
         logs/test:
           receivers: [otlp]

--- a/modules/otel-forwarding-traces.adoc
+++ b/modules/otel-forwarding-traces.adoc
@@ -105,12 +105,12 @@ spec:
       zipkin: {}
     processors:
       batch: {}
-      k8sattributes: {}
+      k8s_attributes: {}
       memory_limiter:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
     exporters:
       otlp_grpc/traces:
@@ -121,7 +121,7 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
+          processors: [memory_limiter, k8s_attributes, resource_detection, batch]
           exporters: [otlp_grpc/traces]
 ----
 where:

--- a/modules/otel-migrating-from-jaeger-with-sidecars.adoc
+++ b/modules/otel-migrating-from-jaeger-with-sidecars.adoc
@@ -41,7 +41,7 @@ spec:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
         timeout: 2s
     exporters:
@@ -53,7 +53,7 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger]
-          processors: [memory_limiter, resourcedetection, batch]
+          processors: [memory_limiter, resource_detection, batch]
           exporters: [otlp_grpc/traces]
 ----
 where:

--- a/modules/otel-migrating-from-jaeger-without-sidecars.adoc
+++ b/modules/otel-migrating-from-jaeger-without-sidecars.adoc
@@ -104,12 +104,12 @@ spec:
           thrift_http: {}
     processors:
       batch: {}
-      k8sattributes: {}
+      k8s_attributes: {}
       memory_limiter:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
     exporters:
       otlp_grpc/traces:
@@ -120,7 +120,7 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger]
-          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
+          processors: [memory_limiter, k8s_attributes, resource_detection, batch]
           exporters: [otlp_grpc/traces]
 ----
 

--- a/modules/otel-processors-cumulative-to-delta-processor.adoc
+++ b/modules/otel-processors-cumulative-to-delta-processor.adoc
@@ -26,7 +26,7 @@ The following `OpenTelemetryCollector` custom resource example configures the Cu
 mode: sidecar
 config:
   processors:
-    cumulativetodelta:
+    cumulative_to_delta:
       include:
         match_type: strict
         metrics:
@@ -38,6 +38,12 @@ config:
         - "<regular_expression_for_metric_names>"
 # ...
 ----
+
+[NOTE]
+====
+The processor type `cumulative_to_delta` was previously named `cumulativetodelta`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `cumulative_to_delta` in new configurations.
+====
+
 where:
 
 `mode`:: To tie the Collector's lifecycle to the metric source, you can run the Collector as a sidecar to the application that emits the cumulative temporality metrics.

--- a/modules/otel-processors-kubernetes-attributes-processor.adoc
+++ b/modules/otel-processors-kubernetes-attributes-processor.adoc
@@ -43,13 +43,45 @@ spec:
           fieldPath: spec.nodeName
   config:
     processors:
-         k8sattributes:
+         k8s_attributes:
              filter:
                  namespace:
                  node_from_env_var: KUBE_NODE_NAME
+             extract:
+                 metadata:
+                     - k8s.pod.name
+                     - k8s.namespace.name
+                     - k8s.deployment.name
+                 labels:
+                     - tag_name: app.label.component
+                       key: app.kubernetes.io/component
+                 annotations:
+                     - tag_name: git.sha
+                       key: git_sha
+                 otel_annotations: false
+             pod_association:
+                 - sources:
+                     - from: resource_attribute
+                       name: k8s.pod.ip
+                     - from: connection
+             passthrough: false
+             exclude:
+                 pods:
+                     - name: jaeger-agent
+                     - name: jaeger-collector
 
 # ...
 ----
+
+[NOTE]
+====
+The processor type `k8s_attributes` was previously named `k8sattributes`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `k8s_attributes` in new configurations.
+====
+
 where:
 
 `filter`:: Optional: Filters resource objects cached for metadata extraction, reducing API requests and memory usage.
+`extract`:: Optional: Specifies which Kubernetes metadata to extract and add as resource attributes. `metadata` accepts a list of supported field names (for example `k8s.pod.name`, `k8s.namespace.name`, `k8s.deployment.name`). `labels` and `annotations` each accept a list of extraction rules (`key` or `key_regex`, an optional `tag_name`, and an optional `from` source, default `pod`) to pull specific pod labels or annotations into resource attributes. `otel_annotations` extracts all pod annotations prefixed `resource.opentelemetry.io` when set to `true`. If omitted, a default set of common fields is extracted.
+`pod_association`:: Optional: A list of association rules used to correlate incoming telemetry with the originating pod. Each entry's `sources` is an ordered list of `from` (`connection` or `resource_attribute`) and, for `resource_attribute`, a `name` identifying the attribute to match on (for example `k8s.pod.ip`). Required for non-trivial deployments where the default connection-based association isn't sufficient, such as when telemetry is proxied or the source pod IP isn't the connecting IP.
+`passthrough`:: Optional: Disables the processor's own metadata extraction and only annotates telemetry with the source pod's IP address, deferring actual tagging to a downstream instance of this processor. Useful in agent-plus-gateway deployments. The default is `false`.
+`exclude`:: Optional: A list of pod names, under `pods`, to exclude from metadata tagging.

--- a/modules/otel-processors-metricstarttime-processor.adoc
+++ b/modules/otel-processors-metricstarttime-processor.adoc
@@ -25,12 +25,18 @@ The following `OpenTelemetryCollector` custom resource configures the Metric Sta
 # ...
 config:
     processors:
-      metricstarttime:
+      metric_start_time:
         strategy: start_time_metric
         gc_interval: 10m
         start_time_metric_regex:
 # ...
 ----
+
+[NOTE]
+====
+The processor type `metric_start_time` was previously named `metricstarttime`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `metric_start_time` in new configurations.
+====
+
 where:
 
 `strategy`:: Defines the strategy for setting start times. Valid values are `true_reset_point`, `subtract_initial_point`, and `start_time_metric`. The default value is `true_reset_point`.

--- a/modules/otel-processors-resource-detection-processor.adoc
+++ b/modules/otel-processors-resource-detection-processor.adoc
@@ -38,15 +38,15 @@ The following `OpenTelemetryCollector` custom resource configures the Resource D
 # ...
   config:
     processors:
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
         override: true
     service:
       pipelines:
         traces:
-          processors: [resourcedetection]
+          processors: [resource_detection]
         metrics:
-          processors: [resourcedetection]
+          processors: [resource_detection]
 # ...
 ----
 
@@ -57,12 +57,18 @@ The following `OpenTelemetryCollector` custom resource configures the Resource D
 # ...
   config:
     processors:
-      resourcedetection/env:
+      resource_detection/env:
         detectors: [env]
         timeout: 2s
         override: false
 # ...
 ----
+
+[NOTE]
+====
+The processor type `resource_detection` was previously named `resourcedetection`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `resource_detection` in new configurations.
+====
+
 where:
 
 `detectors`:: Specifies which detector to use. In this example, the environment detector is specified.

--- a/modules/otel-receivers-filelog-receiver.adoc
+++ b/modules/otel-receivers-filelog-receiver.adoc
@@ -16,7 +16,7 @@ The following `OpenTelemetryCollector` custom resource configures the Filelog Re
 # ...
   config:
     receivers:
-      filelog:
+      file_log:
         include: [ /simple.log ]
         operators:
           - type: regex_parser
@@ -28,6 +28,12 @@ The following `OpenTelemetryCollector` custom resource configures the Filelog Re
               parse_from: attributes.sev
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `file_log` was previously named `filelog`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `file_log` in new configurations.
+====
+
 where:
 
 `include`:: List of file glob patterns that match the file paths to be read.
@@ -76,7 +82,7 @@ spec:
   mode: daemonset
   config:
     receivers:
-      filelog:
+      file_log:
         include:
         - "/var/log/pods/*/*/*.log"
         exclude:
@@ -94,7 +100,7 @@ spec:
     service:
       pipelines:
         logs:
-          receivers: [filelog]
+          receivers: [file_log]
           exporters: [debug]
   securityContext:
     runAsUser: 0
@@ -148,7 +154,7 @@ spec:
     mountPath: /var/log/app
   config:
     receivers:
-      filelog:
+      file_log:
         include:
         - /var/log/app/*.log
         operators:
@@ -164,10 +170,16 @@ spec:
     service:
       pipelines:
         logs:
-          receivers: [filelog]
+          receivers: [file_log]
           processors: []
           exporters: [debug]
 ----
+
+[NOTE]
+====
+The receiver type `file_log` was previously named `filelog`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `file_log` in new configurations.
+====
+
 where:
 
 `volumeMounts`:: Defines the volume mount that the sidecar Collector uses to access the target log files. This volume must match the volume name defined in the application deployment.

--- a/modules/otel-receivers-hostmetrics-receiver.adoc
+++ b/modules/otel-receivers-hostmetrics-receiver.adoc
@@ -71,7 +71,7 @@ spec:
       name: host
   config:
     receivers:
-      hostmetrics:
+      host_metrics:
         collection_interval: 10s
         initial_delay: 1s
         root_path: /
@@ -82,9 +82,15 @@ spec:
     service:
       pipelines:
         metrics:
-          receivers: [hostmetrics]
+          receivers: [host_metrics]
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `host_metrics` was previously named `hostmetrics`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `host_metrics` in new configurations.
+====
+
 where:
 
 `collection_interval`:: Sets the time interval for host metrics collection. If omitted, the default value is `+1m+`.

--- a/modules/otel-receivers-k8sobjectsreceiver-receiver.adoc
+++ b/modules/otel-receivers-k8sobjectsreceiver-receiver.adoc
@@ -75,7 +75,7 @@ spec:
   mode: deployment
   config:
     receivers:
-      k8sobjects:
+      k8s_objects:
         auth_type: serviceAccount
         objects:
           - name: pods
@@ -91,10 +91,16 @@ spec:
     service:
       pipelines:
         logs:
-          receivers: [k8sobjects]
+          receivers: [k8s_objects]
           exporters: [debug]
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `k8s_objects` was previously named `k8sobjects`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `k8s_objects` in new configurations.
+====
+
 where:
 
 `name`:: Resource name that this receiver observes: for example, `pods`, `deployments`, or `events`.

--- a/modules/otel-receivers-kafka-receiver.adoc
+++ b/modules/otel-receivers-kafka-receiver.adoc
@@ -19,12 +19,14 @@ The following `OpenTelemetryCollector` custom resource configures the Kafka Rece
       kafka:
         brokers: ["localhost:9092"]
         protocol_version: 2.0.0
-        topic: otlp_spans
         logs:
+          topics: ["otlp_logs"]
           encoding: raw
         metrics:
+          topics: ["otlp_metrics"]
           encoding: otlp_proto
         traces:
+          topics: ["otlp_spans"]
           encoding: otlp_proto
         auth:
           plain_text:
@@ -50,7 +52,8 @@ where:
 
 `brokers`:: List of Kafka brokers. The default is `+localhost:9092+`.
 `protocol_version`:: Kafka protocol version. For example, `+2.0.0+`. This is a required field.
-`topic`:: Name of the Kafka topic to read from. The default is `+otlp_spans+`.
+`topics`:: Names of the Kafka topics to read from, configured per signal type under `logs`, `metrics`, and `traces`. The default is `+otlp_logs+` for logs, `+otlp_metrics+` for metrics, and `+otlp_spans+` for traces.
+`exclude_topics`:: Optional: Names of Kafka topics to exclude, configured per signal type alongside `topics`.
 `plain_text`:: Plain text authentication configuration. If omitted, plain text authentication is disabled.
 `tls`:: Client-side TLS configuration. Defines paths to the TLS certificates. If omitted, TLS authentication is disabled.
 `insecure`:: Disables TLS on the client connection when set to `true`. This setting is ignored if a CA file is also configured. The default is `false`.

--- a/modules/otel-receivers-kubeletstats-receiver.adoc
+++ b/modules/otel-receivers-kubeletstats-receiver.adoc
@@ -16,7 +16,7 @@ The following `OpenTelemetryCollector` custom resource configures the Kubelet St
 # ...
   config:
     receivers:
-      kubeletstats:
+      kubelet_stats:
         collection_interval: 20s
         auth_type: "serviceAccount"
         endpoint: "https://${env:K8S_NODE_NAME}:10250"
@@ -24,7 +24,7 @@ The following `OpenTelemetryCollector` custom resource configures the Kubelet St
     service:
       pipelines:
         metrics:
-          receivers: [kubeletstats]
+          receivers: [kubelet_stats]
   env:
     - name: K8S_NODE_NAME
       valueFrom:
@@ -32,6 +32,12 @@ The following `OpenTelemetryCollector` custom resource configures the Kubelet St
           fieldPath: spec.nodeName
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `kubelet_stats` was previously named `kubeletstats`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `kubelet_stats` in new configurations.
+====
+
 where:
 
 `name`:: Sets the `K8S_NODE_NAME` to authenticate to the API.

--- a/modules/otel-receivers-otlpjsonfile-receiver.adoc
+++ b/modules/otel-receivers-otlpjsonfile-receiver.adoc
@@ -21,7 +21,7 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP JSON 
 # ...
   config:
     receivers:
-      otlpjsonfile:
+      otlp_json_file:
         include:
           - "/var/log/*.log"
         exclude:
@@ -29,9 +29,15 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP JSON 
     service:
       pipelines:
         traces:
-          receivers: [otlpjsonfile]
+          receivers: [otlp_json_file]
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `otlp_json_file` was previously named `otlpjsonfile`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `otlp_json_file` in new configurations.
+====
+
 where:
 
 `include`:: Lists file path glob patterns to watch.

--- a/modules/otel-receivers-prometheus-remote-write-receiver.adoc
+++ b/modules/otel-receivers-prometheus-remote-write-receiver.adoc
@@ -19,15 +19,21 @@ The following `OpenTelemetryCollector` custom resource configures the Prometheus
 # ...
   config:
     receivers:
-      prometheusremotewrite:
+      prometheus_remote_write:
         endpoint: 0.0.0.0:9090
     # ...
     service:
       pipelines:
         metrics:
-          receivers: [prometheusremotewrite]
+          receivers: [prometheus_remote_write]
 # ...
 ----
+
+[NOTE]
+====
+The receiver type `prometheus_remote_write` was previously named `prometheusremotewrite`. The old name still works as a deprecated alias, but it will be removed in a future release. Use `prometheus_remote_write` in new configurations.
+====
+
 where:
 
 `endpoint`:: Endpoint where the receiver listens for Prometheus Remote Write requests.

--- a/modules/otel-receiving-telemetry-from-multiple-clusters.adoc
+++ b/modules/otel-receiving-telemetry-from-multiple-clusters.adoc
@@ -201,12 +201,12 @@ spec:
       zipkin: {}
     processors:
       batch: {}
-      k8sattributes: {}
+      k8s_attributes: {}
       memory_limiter:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
     exporters:
       otlp_http:
@@ -220,7 +220,7 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
+          processors: [memory_limiter, k8s_attributes, resource_detection, batch]
           exporters: [otlp_http]
   volumes:
     - name: otel-certs

--- a/modules/otel-send-traces-and-metrics-to-otel-collector-with-sidecar.adoc
+++ b/modules/otel-send-traces-and-metrics-to-otel-collector-with-sidecar.adoc
@@ -46,7 +46,7 @@ metadata:
   namespace: observability
 ----
 
-. Grant the permissions to the service account for the `k8sattributes` and `resourcedetection` processors.
+. Grant the permissions to the service account for the `k8s_attributes` and `resource_detection` processors.
 +
 [source,yaml]
 ----
@@ -98,7 +98,7 @@ spec:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
         timeout: 2s
     exporters:
@@ -110,7 +110,7 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resourcedetection, batch]
+          processors: [memory_limiter, resource_detection, batch]
           exporters: [otlp_grpc/traces]
 ----
 where:

--- a/modules/otel-send-traces-and-metrics-to-otel-collector-without-sidecar.adoc
+++ b/modules/otel-send-traces-and-metrics-to-otel-collector-without-sidecar.adoc
@@ -44,7 +44,7 @@ metadata:
   namespace: observability
 ----
 
-. Grant the permissions to the service account for the `k8sattributes` and `resourcedetection` processors.
+. Grant the permissions to the service account for the `k8s_attributes` and `resource_detection` processors.
 +
 [source,yaml]
 ----
@@ -99,12 +99,12 @@ spec:
       zipkin: {}
     processors:
       batch: {}
-      k8sattributes: {}
+      k8s_attributes: {}
       memory_limiter:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      resourcedetection:
+      resource_detection:
         detectors: [openshift]
     exporters:
       otlp_grpc/traces:
@@ -115,7 +115,7 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
+          processors: [memory_limiter, k8s_attributes, resource_detection, batch]
           exporters: [otlp_grpc/traces]
 ----
 where:


### PR DESCRIPTION
Automated remediation from the otel-regression-detection report (reports/regression-remediation-2026-09-08.md).

Addresses:
- HIGH-13: at least 13 upstream OpenTelemetry component types were renamed to canonical snake_case (e.g. `hostmetrics` -> `host_metrics`), keeping the old camelCase name only as a deprecated alias. Updated every affected `.adoc` example — the 12 reference module pages plus several scenario/tutorial docs found by grepping the full repo — to the canonical name, and added a deprecation note to each reference page.
- HIGH-14: the Kafka receiver doc's top-level `topic: otlp_spans` field doesn't exist in the current schema; topic selection is per-signal via `logs.topics`/`metrics.topics`/`traces.topics`. Fixed the example and field reference.
- HIGH-16: documented `extract`, `pod_association`, `passthrough`, and `exclude` for the Kubernetes Attributes Processor, previously undocumented entirely despite being the primary way to select metadata and correlate telemetry to pods.

Field names, descriptions, and defaults verified against opentelemetry-collector-contrib config.go/metadata.yaml sources, not just the report's description text.

Generated by otel-regression-remediation.