### PR TITLE
Document undocumented reliability/tuning fields for OTLP, Kafka, tail-sampling

### DIFF
--- a/modules/otel-exporters-otlp-grpc-exporter.adoc
+++ b/modules/otel-exporters-otlp-grpc-exporter.adoc
@@ -30,6 +30,20 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP gRPC 
           max_version: "1.3"
         headers:
           X-Scope-OrgID: "dev"
+        compression: gzip
+        keepalive:
+          time: 10s
+          timeout: 10s
+        timeout: 10s
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 1000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 5m
     service:
       pipelines:
         traces:
@@ -49,3 +63,15 @@ where:
 `min_version`:: Sets the minimum supported TLS protocol version. This parameter is optional. The default is `1.2`.
 `max_version`:: Sets the maximum supported TLS protocol version. This parameter is optional. The default is `1.3`.
 `headers`:: Headers are sent for every request performed during an established connection.
+`compression`:: Optional: Compression type to use for outgoing requests. Supported values include `gzip`, `zstd`, and `snappy`. If omitted, compression is disabled.
+`keepalive`:: Optional: gRPC keepalive parameters. `time` sets the interval between keepalive pings and `timeout` sets how long to wait for a ping response before considering the connection dead. Both default to `10s`.
+`read_buffer_size`:: Optional: gRPC read buffer size for the client connection.
+`write_buffer_size`:: Optional: gRPC write buffer size for the client connection.
+`wait_for_ready`:: Optional: When set to `true`, the client waits for the connection to be ready before sending data instead of failing fast. The default is `false`.
+`user_agent`:: Optional: Overrides the default user agent header sent on gRPC requests.
+`balancer_name`:: Optional: Sets the gRPC client-side load balancing policy. The default is `pick_first`.
+`authority`:: Optional: Overrides the `:authority` pseudo-header used in gRPC requests.
+`auth`:: Optional: Authenticator configuration for outgoing requests, referencing an authentication extension configured elsewhere in the collector.
+`timeout`:: Optional: Timeout for every attempt to send data to the backend. A value of `0` means no timeout. The default is `10s`.
+`sending_queue`:: Optional: Configures request queuing so that data is buffered and retried instead of dropped on transient failures. Enabled by default with `num_consumers: 10` and `queue_size: 1000`. Set `storage` to a `file_storage` extension name to persist the queue to disk.
+`retry_on_failure`:: Optional: Configures exponential-backoff retry for failed requests. Enabled by default with `initial_interval: 5s`, `max_interval: 30s`, and `max_elapsed_time: 5m`. Set `enabled: false` to disable retries.

--- a/modules/otel-processors-tail-sampling-processor.adoc
+++ b/modules/otel-processors-tail-sampling-processor.adoc
@@ -178,6 +178,25 @@ where:
 
 `rate_limiting`:: Provided `35` value is an example.
 
+* The following policy samples traces by the rate of bytes processed per second:
++
+[source,yaml]
+----
+# ...
+      policies:
+        [
+          {
+            name: <bytes_limiting_policy>,
+            type: bytes_limiting,
+            bytes_limiting: {bytes_per_second: 1000000}
+          },
+        ]
+# ...
+----
+where:
+
+`bytes_limiting`:: Provided `1000000` value is an example. Optional: `burst_capacity` sets the maximum burst size in bytes; if omitted, it defaults to twice the `bytes_per_second` value.
+
 * The following policy samples traces by the minimum and maximum number of spans inclusively:
 +
 [source,yaml]

--- a/modules/otel-receivers-kafka-receiver.adoc
+++ b/modules/otel-receivers-kafka-receiver.adoc
@@ -20,6 +20,18 @@ The following `OpenTelemetryCollector` custom resource configures the Kafka Rece
         brokers: ["localhost:9092"]
         protocol_version: 2.0.0
         topic: otlp_spans
+        group_id: otel-collector
+        initial_offset: latest
+        autocommit:
+          enable: true
+          interval: 1s
+        message_marking:
+          after: true
+          on_error: false
+        partition_processing:
+          independent: false
+        header_extraction:
+          extract_headers: false
         logs:
           encoding: raw
         metrics:
@@ -51,6 +63,12 @@ where:
 `brokers`:: List of Kafka brokers. The default is `+localhost:9092+`.
 `protocol_version`:: Kafka protocol version. For example, `+2.0.0+`. This is a required field.
 `topic`:: Name of the Kafka topic to read from. The default is `+otlp_spans+`.
+`group_id`:: The consumer group ID to use for this receiver. The default is `+otel-collector+`.
+`initial_offset`:: Where to start consuming from when no committed offset exists. Valid values are `latest` and `earliest`. The default is `+latest+`.
+`autocommit`:: Optional: Controls automatic committing of consumed offsets back to the broker. `enable` defaults to `+true+`, and `interval` (how often to commit) defaults to `+1s+`.
+`message_marking`:: Optional: Controls when a Kafka message is marked as consumed. `after` marks the message after it's been processed by the pipeline instead of on receipt (default `+false+`). `on_error` also marks a message as consumed when processing it returns an error (default `+false+`); only effective when `after` is `+true+`.
+`partition_processing`:: Optional: `independent` processes each partition's messages independently instead of sequentially. The default is `+false+`.
+`header_extraction`:: Optional: `extract_headers` copies Kafka message headers into the resulting telemetry as attributes, restricted to the header names listed in `headers`. The default is `+false+`.
 `plain_text`:: Plain text authentication configuration. If omitted, plain text authentication is disabled.
 `tls`:: Client-side TLS configuration. Defines paths to the TLS certificates. If omitted, TLS authentication is disabled.
 `insecure`:: Disables TLS on the client connection when set to `true`. This setting is ignored if a CA file is also configured. The default is `false`.

--- a/modules/otel-receivers-otlp-receiver.adoc
+++ b/modules/otel-receivers-otlp-receiver.adoc
@@ -29,9 +29,15 @@ The following `OpenTelemetryCollector` custom resource configures the OTLP Recei
               reload_interval: 1h
               min_version: "1.2"
               max_version: "1.3"
+            max_recv_msg_size_mib: 4
+            max_concurrent_streams: 100
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
             tls: {}
+            traces_url_path: /v1/traces
+            metrics_url_path: /v1/metrics
+            logs_url_path: /v1/logs
 
     service:
       pipelines:
@@ -51,3 +57,11 @@ where:
 `min_version`:: Sets the minimum supported TLS protocol version. This parameter is optional. The default is `1.2`.
 `max_version`:: Sets the maximum supported TLS protocol version. This parameter is optional. The default is `1.3`.
 `endpoint`:: OTLP HTTP endpoint. The default value is `+0.0.0.0:4318+`.
+`max_recv_msg_size_mib`:: Optional: Maximum size, in MiB, of a gRPC message the receiver accepts. If omitted, the gRPC default of `+4+` MiB is used.
+`max_concurrent_streams`:: Optional: Maximum number of concurrent gRPC streams. If omitted, there is no limit.
+`include_metadata`:: Optional: When set to `true`, propagates client-provided gRPC request metadata (headers) into the request context so downstream processors and exporters can access it. The default is `false`.
+`traces_url_path`:: Optional: URL path to receive traces on for the HTTP protocol. The default is `+/v1/traces+`.
+`metrics_url_path`:: Optional: URL path to receive metrics on for the HTTP protocol. The default is `+/v1/metrics+`.
+`logs_url_path`:: Optional: URL path to receive logs on for the HTTP protocol. The default is `+/v1/logs+`.
+
+The gRPC and HTTP protocols also support additional advanced, optional settings not shown in the preceding example: `keepalive` (server-side gRPC keepalive enforcement and connection-age limits), `read_buffer_size` and `write_buffer_size` (gRPC transport buffer tuning), and `auth` (references an authentication extension to require on incoming requests).


### PR DESCRIPTION
Automated remediation from the otel-regression-detection report (reports/regression-remediation-2026-09-08.md).

Addresses:
- MED-18: OTLP gRPC exporter doc omitted `timeout`, `sending_queue`, and `retry_on_failure` — the standard queuing/retry/backoff mechanism relied on for reliable delivery.
- LOW-8: OTLP gRPC exporter doc omitted additional `configgrpc.ClientConfig` fields (`compression`, `keepalive`, `auth`, and others).
- MED-19: Kafka receiver doc omitted consumer-group and partition-processing tuning (`group_id`, `initial_offset`, `autocommit`, `message_marking`, `partition_processing`, `header_extraction`).
- LOW-7: OTLP receiver doc omitted per-signal HTTP URL path overrides (`traces_url_path`, `metrics_url_path`, `logs_url_path`) and gRPC server tuning (`max_recv_msg_size_mib`, `max_concurrent_streams`, `include_metadata`).
- LOW-9: Tail Sampling Processor doc only documented the `rate_limiting` policy type; added the `bytes_limiting` policy following the same example convention.

Field names, descriptions, and defaults verified against opentelemetry-collector/opentelemetry-collector-contrib config.go sources, not just the report's description text.

Generated by otel-regression-remediation.