### PR TITLE
NVIDIA DPF: update v26.4.1 release notes and About for GA

### DIFF
--- a/modules/nw-dpf-creating-hcp-secrets.adoc
+++ b/modules/nw-dpf-creating-hcp-secrets.adoc
@@ -12,7 +12,7 @@ The `DPFHCPProvisioner` resource references these secrets during hosted cluster 
 
 [NOTE]
 ====
-The BlueField {product-title} layer image referenced by `BLUEFIELD_OCP_IMAGE` might require authentication to the Quay or Red{nbsp}Hat registry. Ensure that the pull secret includes credentials for that image registry.
+The BlueField {product-title} layer image that the Operator resolves automatically might require authentication to the Quay or Red{nbsp}Hat registry. Ensure that the pull secret includes credentials for that image registry.
 ====
 
 .Prerequisites

--- a/modules/nw-dpf-hcp-environment-variables.adoc
+++ b/modules/nw-dpf-hcp-environment-variables.adoc
@@ -31,10 +31,6 @@ These environment variables must be set before you create secrets, the `DPUClust
 |The base DNS domain for the hosted cluster.
 |`example.com`
 
-|`BLUEFIELD_OCP_IMAGE`
-|Optional. The BlueField {product-title} layer container image URL. When set, this value is used as `machineOSURL` in the `DPFHCPProvisioner` resource and skips automatic image lookup. If left unset, the Operator resolves the image automatically. This image will be available on registry.redhat.io for GA release.
-|`<GA-BLUEFIELD-OCP-IMAGE>`
-
 |`ETCD_STORAGE_CLASS`
 |The storage class used for etcd persistent volume claims.
 |`lvms-vg1`
@@ -74,7 +70,6 @@ $ export HOSTED_CLUSTER_NAME="dpf-hosted"
 $ export OPENSHIFT_VERSION="4.22.7"
 $ export CLUSTERS_NAMESPACE="clusters"
 $ export BASE_DOMAIN="example.com"
-$ export BLUEFIELD_OCP_IMAGE="<GA-BLUEFIELD-OCP-IMAGE>"
 $ export ETCD_STORAGE_CLASS="lvms-vg1"
 $ export OCP_RELEASE_IMAGE="quay.io/openshift-release-dev/ocp-release:${OPENSHIFT_VERSION}-multi"
 $ export PULL_SECRET_NAME="my-pull-secret"

--- a/modules/nw-dpf-release-notes.adoc
+++ b/modules/nw-dpf-release-notes.adoc
@@ -9,8 +9,8 @@
 [role="_abstract"]
 The NVIDIA DPF Operator on {product-title} has known limitations for uninstall, secrets, MTU, secure boot, multi-DPU hosts, and HBN, unsupported OVN-Kubernetes features, and issues that can affect Grafana and DTS metrics.
 
-[id="dpf-26-4-1-beta-1_{context}"]
-== DPF Operator v26.4.1-beta.1
+[id="dpf-26-4-1_{context}"]
+== DPF Operator v{dpf-version}
 
 *New features and enhancements*
 

--- a/modules/nw-dpf-release-notes.adoc
+++ b/modules/nw-dpf-release-notes.adoc
@@ -54,6 +54,9 @@ Secondary pod interfaces (MultiNetwork) are not supported.
 MTU changes are not supported after deployment::
 You cannot change the MTU value after deployment.
 
+`controlPlaneMTU` and `highSpeedMTU` must use the same value::
+In the `DPFOperatorConfig` custom resource, you must set `controlPlaneMTU` and `highSpeedMTU` to the same value, either `1500` or `9000`.
+
 Secure boot firmware requirement::
 To boot the RHCOS BFB image with secure boot enabled, the DPU firmware must be at version 3.1.0 or later. Use a BFB firmware bundle to upgrade the firmware.
 

--- a/modules/nw-dpf-release-notes.adoc
+++ b/modules/nw-dpf-release-notes.adoc
@@ -37,11 +37,6 @@ Resolved Node Feature Discovery (NFD) compatibility issues for reliable DPU hard
 Networking stability improvements::
 Fixed OVN-Kubernetes integration issues that could cause worker nodes to remain in `NotReady` state.
 
-*Technology Preview features*
-
-:FeatureName: The NVIDIA DPF Operator
-include::snippets/technology-preview.adoc[]
-
 *Known issues and limitations*
 
 Only x86_64 workers are supported::
@@ -105,7 +100,7 @@ After a node reboot or DPU redeployment, the SR-IOV device plugin might publish 
 
 *OVN-Kubernetes feature support*
 
-The following table lists the support and hardware offload status of OVN-Kubernetes features in this Technology Preview.
+The following table lists the support and hardware offload status of OVN-Kubernetes features in this release.
 
 .OVN-Kubernetes feature support and offload status
 [cols="2,1,1",options="header"]

--- a/networking/networking_operators/dpf_operator/about-dpf-operator.adoc
+++ b/networking/networking_operators/dpf_operator/about-dpf-operator.adoc
@@ -12,9 +12,6 @@ The NVIDIA DOCA Platform Framework (DPF) Operator enables hardware-accelerated n
 
 The DPF deployment creates a dual-cluster topology consisting of a management cluster running on x86 servers and a hosted DPU cluster running on BlueField-3 DPUs.
 
-:FeatureName: The NVIDIA DPF Operator
-include::snippets/technology-preview.adoc[]
-
 // Architecture overview
 include::modules/nw-dpf-architecture-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
The DPF Operator is GA on {product-title} 4.22. This updates the published docs to reflect GA:

**Version string**
- Release notes heading and anchor still carried the `-beta.1` suffix after GA (visible in the live URL fragment `dpf-26-4-1-beta-1_dpf-release-notes`). Heading now uses the `{dpf-version}` attribute (`26.4.1`); anchor drops `-beta-1`. No internal xrefs point at the old anchor, so no links break.

**Technology Preview removal (operator is GA)**
- Removed the `Technology Preview features` block and `technology-preview.adoc` snippet include from the release notes.
- Removed the FeatureName + snippet include from the About assembly.
- Reworded the OVN-Kubernetes feature support table intro from "in this Technology Preview" to "in this release".
- Retained the narrower per-feature note that adding a non-DPU worker node is a Technology Preview feature.

**GA content corrections**
- Removed the `BLUEFIELD_OCP_IMAGE` environment variable (table row + export example) and the pre-GA sentence "will be available on registry.redhat.io for GA release". The Operator resolves the BlueField {product-title} layer image automatically, so users do not set it; the pull-secret note was reworded accordingly.
- Added a known limitation: `controlPlaneMTU` and `highSpeedMTU` in the `DPFOperatorConfig` CR must be set to the same value, either `1500` or `9000`.

Verified: all other DPF doc version values (OCP 4.22.7-multi, OVN chart v26.4.1-ocp-release-v4.22, maintenance-operator 0.3.0, HBN 3.4.0, DTS 1.25.5, dpu-worker-config/HCP provisioner 4.22.0, DOCA 3.4.1, BFB firmware + URL) match the GA source of truth. No broken xrefs, includes, snippets, or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)