### PR TITLE
OSDOCS#22077: Update the MicroShift RNs for 4.21.32

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-32-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-31-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-29-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-32-async.adoc
+++ b/modules/microshift-4-21-32-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-32-async_{context}"]
+= RHBA-2026:63638 - {microshift-short} 4.21.32 fixed issue update
+
+Issued: 8 September 2026
+
+[role="_abstract"]
+{product-title} release 4.21.32 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:63638[RHBA-2026:63638] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63046[RHSA-2026:63046] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-21-32-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-22077

Link to docs preview:
[4.21.32](https://119528--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-32-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- Draft: MicroShift RPM advisory RHBA-2026:63638 is assigned in Brew but not yet published on access.redhat.com.
- OCP images advisory: https://access.redhat.com/errata/RHSA-2026:63046
- OCP packages advisory: https://access.redhat.com/errata/RHBA-2026:63040
- OCP extras advisory: https://access.redhat.com/errata/RHSA-2026:63048
- Microshift-bootc (stage): https://access.stage.redhat.com/errata/RHBA-2026:120677
- OCP shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/793
- Microshift-bootc shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/802
- Advisory-only: no documentable MicroShift OCPBUGS bullets.


Made with [Cursor](https://cursor.com)