### PR TITLE
CNV-95767: Add release note for deprecated IBM Operator

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -195,6 +195,11 @@ The `HotplugVolume` feature gate, which allows you to add storage without restar
 +
 link:https://issues.redhat.com/browse/CNV-73301[CNV-73301]
 
+The {FusionSAN} Operator is deprecated::
+The {FusionSAN} Operator is deprecated and will be removed in a future release. For new deployments, configure {IBMFusionFirst} in Fusion Data Foundation as an external system.
++
+For more information, see link:https://www.ibm.com/docs/en/fusion-software/2.13.x?topic=san-deploying-fusion-access[Deploying IBM Fusion Access for SAN].
+
 [id="virt-4-22-removed_{context}"]
 == Removed features
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-95767

Link to docs preview:
https://119529--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-deprecated_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
