### PR TITLE
Fix typo accomodate → accommodate in virt-expanding-vm-disks abstract

### DIFF
--- a/virt/managing_vms/virtual_disks/virt-expanding-vm-disks.adoc
+++ b/virt/managing_vms/virtual_disks/virt-expanding-vm-disks.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Expand the  persistent volume claim (PVC) of your virtual machine disk to accomodate growing data requirements. If your storage provider does not support volume expansion, you can expand the available virtual storage of a VM by adding blank data volumes.
+Expand the persistent volume claim (PVC) of your virtual machine disk to accommodate growing data requirements. If your storage provider does not support volume expansion, you can expand the available virtual storage of a VM by adding blank data volumes.
 
 You cannot reduce the size of a VM disk.
 


### PR DESCRIPTION
## Summary

Fix spelling error and extra space in the abstract for *Expand virtual machine disks*.

- `accomodate` → `accommodate`
- `Expand the  persistent` → `Expand the persistent`

## Related

- https://redhat.atlassian.net/browse/CNV-96922

## Test plan

- [ ] Verify abstract renders correctly in docs preview
- [ ] Confirm no other occurrences of `accomodate` in this assembly directory

