### PR TITLE
OSDOCS#22060: Update the MicroShift RNs for 4.20.37

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -24,6 +24,8 @@ include::modules/microshift-4-20-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-20-asynchronous-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-20-37-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-20-26-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-20-23-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-20-37-dp.adoc
+++ b/modules/microshift-4-20-37-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-20-37-dp_{context}"]
+= RHSA-2026:63637 - {microshift-short} 4.20.37 fixed issue update
+
+[role="_abstract"]
+Issued: 08 September 2026
+
+{product-title} release 4.20.37 is now available, see the link:https://access.redhat.com/errata/RHSA-2026:63637[RHSA-2026:63637] advisory. Release notes for bug fixes are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63103[RHSA-2026:63103] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-20-37-dp-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-22060](https://redhat.atlassian.net/browse/OSDOCS-22060)

Link to docs preview:
[4.20.37](https://119536--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-37-dp_release-notes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
