### PR TITLE
OCPBUGS-100116: Added steps as per customer requirement

### DIFF
--- a/modules/installation-replacing-control-plane-nodes.adoc
+++ b/modules/installation-replacing-control-plane-nodes.adoc
@@ -296,11 +296,11 @@ The value of the `STATUS` column in the output of this command must be `Ready` f
 $ oc annotate bmh <bmh_name> -n openshift-machine-api baremetalhost.metal3.io/detached='' --overwrite
 ----
 
-. Rejoin the replacement node to the pacemaker cluster by running the following command:
+. Rejoin the replacement node to the pacemaker cluster by running the following commands:
 +
 [NOTE]
 ====
-Run the following command on the survivor control plane node, not the node being replaced.
+Run the following commands on the survivor control plane node and not on the node being replaced.
 ====
 +
 [source,terminal]
@@ -312,6 +312,73 @@ $ sudo pcs cluster node remove <node_name>
 ----
 $ sudo pcs cluster node add <node_name> addr=<node_ip> --start --enable
 ----
+
+. If the replacement node has a different BMC system UUID than the failed node, update the fencing secret so that STONITH can fence the new node.
++
+The fencing secret contains a Redfish URL in its `address` field. If the replacement node has a new BMC system UUID, the URL still points to the old UUID and STONITH cannot fence the new node.
++
+.. Verify the new BMC system UUID by querying the Redfish API:
++
+[source,terminal]
+----
+$ curl -k https://<bmc_address>/redfish/v1/Systems/ -u <username>:<password>
+----
++
+.Example output
+[source,json]
+----
+{
+  "Members": [
+    {"@odata.id": "/redfish/v1/Systems/<new_uuid>"}
+  ]
+}
+----
++
+The UUID is the last path segment of the `@odata.id` value under `Members`.
+
+.. Update the fencing secret for the replacement node:
++
+[source,terminal]
+----
+$ oc create secret generic fencing-credentials-<node_name> \
+  --namespace openshift-etcd \
+  --from-literal=address='redfish+https://<bmc_address>:<port>/redfish/v1/Systems/<new_uuid>' \
+  --from-literal=username='<username>' \
+  --from-literal=password='<password>' \
+  --from-literal=certificateVerification='<Disabled_or_Enabled>' \
+  --dry-run=client -o yaml | oc apply -f -
+----
++
+where:
+
+* Replace `<node_name>` with the hostname of the replacement node as it appears in `oc get nodes`.
+
+* Replace `<bmc_address>` and `<port>` with the BMC IP address and port.
+
+* Replace `<new_uuid>` with the new BMC system UUID.
+
+* Replace `<username>` and `<password>` with the BMC credentials. 
++
+Use `Disabled` for `certificateVerification` to skip certificate validation (matching `disableCertificateVerification: true` on the BMH object) or `Enabled` if your BMC has a valid TLS certificate.
++
+.. Verify that the secret is updated successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get secret fencing-credentials-<node_name> -n openshift-etcd \
+  -o jsonpath='{.data.address}' | base64 -d
+----
++
+Confirm the output contains the new BMC system UUID.
++
+[NOTE]
+====
+All four keys must be present because the cluster etcd Operator rejects secrets with missing keys.
+
+Do not use the `update-fencing-credentials.sh` script in this step. The script requires a healthy STONITH device, which is unavailable until the fencing setup completes. Only use this script for subsequent rotations after the cluster is fully operational.
+
+Do not update the STONITH resource directly with the command `pcs stonith update`. The cluster etcd Operator manages STONITH configuration and overwrites manual changes.
+====
 
 . Delete stale jobs for the failed node by running the following command:
 +


### PR DESCRIPTION

Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-100116

Link to docs preview:
https://119537--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.html#installation-replacing-control-plane-nodes_install-post-tnf

QE review:
- [x] QE has approved this change.


Additional information:
@fonta-rh has created https://github.com/openshift/openshift-docs/pull/117587 PR in which I made some changes as per vale suggestions.
