### PR TITLE
OSDOCS 19535 & 19533: [ROSA] CQA for  Install Docs

### DIFF
--- a/modules/rosa-hcp-prerequisites.adoc
+++ b/modules/rosa-hcp-prerequisites.adoc
@@ -12,7 +12,7 @@
 = {product-title} prerequisites
 
 [role="_abstract"]
-Before you can create a {product-title} cluster,  you must complete the following prerequisites. Use each link to find detailed instructions for completing that specific prerequisite:
+Before you can create a {product-title} cluster, you must complete several prerequisites, such as configuring a virtual private cloud (VPC) and creating the required account-wide IAM roles and resources.
 
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index#mos-checklist-vpc-post-install_rosa-cloud-expert-prereq-checklist[Configure a virtual private cloud (VPC)]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index#rosa-sts-creating-account-wide-sts-roles-and-policies_prepare-role-resources[Create account-wide roles]

--- a/modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc
@@ -10,7 +10,7 @@
 :icons: font
 
 [role="_abstract"]
-Use the `--external-auth-providers-enabled` flag in the ROSA CLI to create a cluster that uses an external authentication service.
+Use the `--external-auth-providers-enabled` flag in the {rosa-cli-first} to create a cluster that uses an external authentication service.
 
 [NOTE]
 ====

--- a/modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
@@ -9,11 +9,11 @@
 :icons: font
 
 [role="_abstract"]
-After you have created a {product-title} cluster with the enabled option for external authentication providers, you must create a provider using the ROSA CLI.
+After you have created a {product-title} cluster with the enabled option for external authentication providers, you must create a provider by using the {rosa-cli-first}.
 
 [NOTE]
 ====
-Similar to the `rosa create|delete|list idp[s]` command in the ROSA CLI, you cannot edit an existing identity provider that you created using `rosa create external-auth-provider`. Instead, you must delete the external authentication provider and create a new one.
+Similar to the `rosa create|delete|list idp[s]` command in the {rosa-cli}, you cannot edit an existing identity provider that you created using `rosa create external-auth-provider`. Instead, you must delete the external authentication provider and create a new one.
 ====
 
 .Procedure

--- a/modules/rosa-sts-cluster-terraform-execute.adoc
+++ b/modules/rosa-sts-cluster-terraform-execute.adoc
@@ -28,7 +28,7 @@ include::snippets/terraform-modification-disclaimer.adoc[]
 $ terraform init
 ----
 
-. *Optional*: Verify that the Terraform you copied is correct by running the following command:
+. Optional: Verify that the Terraform you copied is correct by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-cluster-terraform-setup.adoc
+++ b/modules/rosa-sts-cluster-terraform-setup.adoc
@@ -15,10 +15,10 @@ endif::[]
 = Preparing your environment for Terraform
 
 [role="_abstract"]
-Before you can create your {product-title} cluster by using Terraform, you need to export your link:https://console.redhat.com/openshift/token[offline {cluster-manager-first} token].
+Before you can create your {product-title} cluster by using Terraform, you must export your offline {cluster-manager-first} token to grant Terraform permission to access your account.
 
 .Procedure
-. *Optional*: Because the Terraform files get created in your current directory during this procedure, you can create a new directory to store these files and navigate into it by running the following command:
+. Optional: Because the Terraform files get created in your current directory during this procedure, you can create a new directory to store these files and navigate into it by running the following command:
 +
 [source,terminal]
 ----

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -13,12 +13,7 @@ While the built-in OpenShift OAuth server supports integration with a variety of
 
 [IMPORTANT]
 ====
-You cannot upgrade or convert existing {rosa-classic-title} clusters to {hcp} architecture. You must create a new {product-title} cluster. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster.
-====
-
-[NOTE]
-====
-{product-title} clusters only support {sts-first} authentication.
+You cannot upgrade or convert existing {rosa-classic-title} clusters to {hcp} architecture. You must create a new {product-title} cluster. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster. The {product-title} clusters only support {sts-first} authentication.
 ====
 
 include::modules/rosa-hcp-prerequisites.adoc[leveloffset=+1]
@@ -50,7 +45,7 @@ include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-delete-c
 * xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly[OIDC configuration]
 * xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-operator-config_rosa-hcp-sts-creating-a-cluster-quickly[Operator roles]
 * xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes]
-* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-hcp-aws-prereqs[AWS prerequisites for ROSA with STS]
+* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-hcp-prereqs[AWS prerequisites for ROSA with STS]
 * link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers (AWS documentation)]
 * xref:../support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc#rosa-troubleshooting-installations-hcp[Troubleshooting {product-title} cluster installations]
 * xref:../support/getting-support.adoc#getting-support[Getting support for {product-title}]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-sts-creating-a-cluster-quickly"]
-= Creating {product-title} clusters using the default options
+= Creating {product-title} clusters by using the default options
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-quickly
 
@@ -11,12 +11,7 @@ You can create a {product-title} cluster quickly by using the default options an
 
 [IMPORTANT]
 ====
-You cannot upgrade or convert existing {rosa-classic-title} clusters to {hcp} architecture. You must create a new {product-title} cluster.
-====
-
-[NOTE]
-====
-{product-title} clusters only support AWS IAM Security Token Service (STS) authentication.
+You cannot upgrade or convert existing {rosa-classic-title} clusters to {hcp} architecture. You must create a new {product-title} cluster. The {product-title} clusters only support AWS IAM Security Token Service (STS) authentication.
 ====
 
 include::modules/consideration-regarding-auto-creation-mode.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+ 

Issue:

- https://redhat.atlassian.net/browse/OSDOCS-19535
- https://redhat.atlassian.net/browse/OSDOCS-19533 

Link to docs preview:

- https://119538--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html
- https://119538--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.html
- https://119538--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html
- https://119538--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
