### PR TITLE
Fix DPF module errors: DPUDeployment nodeSelector and OVN_MTU jumbo value

### DIFF
--- a/modules/nw-dpf-environment-variables.adoc
+++ b/modules/nw-dpf-environment-variables.adoc
@@ -56,7 +56,7 @@ The values of these variables are used in multiple DPF Operator installation and
 |`v26.4.1-ocp-release-v4.22`
 
 |`OVN_MTU`
-|The MTU value for OVN-Kubernetes overlay networking. Set to `1400` for standard MTU (`NODES_MTU` of 1500) or `8940` for jumbo frames (`NODES_MTU` of 9000). Must be kept consistent with `NODES_MTU`.
+|The MTU value for OVN-Kubernetes overlay networking. Set to `1400` for standard MTU (`NODES_MTU` of 1500) or `8900` for jumbo frames (`NODES_MTU` of 9000). This is `NODES_MTU` minus 100 bytes of Geneve encapsulation overhead. Must be kept consistent with `NODES_MTU`.
 |`1400`
 
 |`BFB_URL`


### PR DESCRIPTION
## Summary

Two content errors in the NVIDIA DPF Operator modules, verified against the DPF automation source-of-truth (rh-ecosystem-edge/openshift-dpf, branch `release-4.22`).

### 1. `DPUDeployment` uses `nodeSelector`, not `dpuNodeSelector`

`modules/nw-dpf-creating-dpudeployment.adoc`

The `dpuSets` entries in a `DPUDeployment` use the field `nodeSelector`. `dpuNodeSelector` is a `DPUSet`-only field; when placed inside a `DPUDeployment` it is silently dropped by the API server, so the selector does not take effect.

- CRD `svc.dpu.nvidia.com_dpudeployments.yaml` allows only `dpuSelector`/`nodeSelector` under `dpuSets`.
- Automation manifest: https://github.com/rh-ecosystem-edge/openshift-dpf/blob/release-4.22/manifests/post-installation/dpudeployment.yaml#L18

### 2. `OVN_MTU` jumbo value should be `8900`, not `8940`

`modules/nw-dpf-environment-variables.adoc`

The OVN-Kubernetes overlay MTU is `NODES_MTU` minus 100 bytes of Geneve encapsulation overhead. For a 9000 jumbo `NODES_MTU` that is **8900**. `8940` is the pod MTU (`NODES_MTU` − 60), a different value.

- Automation: `scripts/post-install.sh` — `ovn_mtu=$((NODES_MTU - 100))`

Both errors are also present in enterprise-4.22 and enterprise-5.0 and should be cherry-picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)