### PR TITLE
MULTIARCH-6291: MTO 1.3.4 RNs

### DIFF
--- a/modules/multi-arch-tuning-operator-release-notes-1-3-4.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-3-4.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-3-4_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.3.4
+
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.3.4 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
+Issued: 8 September 2026
+
+[id="multi-arch-tuning-operator-1-3-4-enhancements_{context}"]
+== Enhancements
+
+* MTO has been updated to use `go` version 1.26.7.
+
+[id="multi-arch-tuning-operator-1-3-4-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, deleting a `ClusterPodPlacementConfig` object immediately after creation could leave the object stuck with a deletion timestamp and finalizer, and operand resources could remain. With this update, the Operator reads the current object state so deletion is processed correctly. link:https://redhat.atlassian.net/browse/MULTIARCH-6269[(MULTIARCH-6269)]
+
+* Previously, the enoexec-event-daemon DaemonSet could fail to start because its ServiceAccount image pull secret was not yet available. With this update, the Operator waits until the ServiceAccount pull secret is provisioned before creating the DaemonSet. link:https://redhat.atlassian.net/browse/MULTIARCH-6270[(MULTIARCH-6270)]
+
+* Previously, OLM CSV lifecycle cycling could prevent the Operator from reaching a stable installed state and block `ClusterPodPlacementConfig` finalizer processing. With this update, the Operator converges after installation and can process `ClusterPodPlacementConfig` deletion. link:https://redhat.atlassian.net/browse/MULTIARCH-6271[(MULTIARCH-6271)]
+
+[id="multi-arch-tuning-operator-1-3-4-security-fixes_{context}"]
+== Security fixes
+
+* Previously, the Operator and pod placement controller ServiceAccounts had cluster-wide permission to read Secrets. With this update, Secret access is limited to the permissions required for image inspection. link:https://redhat.atlassian.net/browse/MULTIARCH-6187[(MULTIARCH-6187)]
+
+* Previously, the Operator ServiceAccount could create, update, or delete any `MutatingWebhookConfiguration`. With this update, update, patch, and delete permissions are restricted to the webhook configuration that the Operator manages. link:https://redhat.atlassian.net/browse/MULTIARCH-6188[(MULTIARCH-6188)]
+
+* Previously, the Operator ServiceAccount had unscoped write access to `ClusterRoles`, `ClusterRoleBindings`, `Roles`, and `RoleBindings`. With this update, those write permissions are restricted to the operand resources that the Operator manages. link:https://redhat.atlassian.net/browse/MULTIARCH-6189[(MULTIARCH-6189)]
+
+* Previously, the `pod-placement-controller` used hostPath mounts that could create directories on the node. With this update, the `/etc/containers/` hostPath mount requires the directory to already exist and does not create it. link:https://redhat.atlassian.net/browse/MULTIARCH-6191[(MULTIARCH-6191)]
+
+* Previously, the image-architecture cache used a hash that was not collision-resistant. With this update, the cache key uses a collision-resistant hash. link:https://redhat.atlassian.net/browse/MULTIARCH-6193[(MULTIARCH-6193)]
+
+* Previously, architecture strings and error messages from container registries were written to pod labels, annotations, and events without validation. With this update, architecture values are validated against supported architectures, and error messages are truncated before they are written to pod metadata. link:https://redhat.atlassian.net/browse/MULTIARCH-6194[(MULTIARCH-6194)]
+
+[id="multi-arch-tuning-operator-1-3-4-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/cve-2026-33818[CVE-2026-33818]
+
+* link:https://access.redhat.com/security/cve/cve-2026-56853[CVE-2026-56853]
+
+* link:https://access.redhat.com/security/cve/cve-2026-56860[CVE-2026-56860]
+
+* link:https://access.redhat.com/security/cve/cve-2026-56862[CVE-2026-56862]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -15,6 +15,8 @@ The Multiarch Tuning Operator (MTO) optimizes workload management within multi-a
 
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]
 
+include::modules/multi-arch-tuning-operator-release-notes-1-3-4.adoc[leveloffset=+1]
+
 include::modules/multi-arch-tuning-operator-release-notes-1-3-3.adoc[leveloffset=+1]
 
 include::modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc[leveloffset=+1]


### PR DESCRIPTION
[MULTIARCH-6291](https://redhat.atlassian.net/browse/MULTIARCH-6291)

Version(s): 4.22+

This PR adds the release notes for the 1.3.4 release of the multiarch tuning operator.

QE review:
- [x] QE has approved this change.

Preview: [Release notes for the Multiarch Tuning Operator 1.3.4](https://119543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html#multi-arch-tuning-operator-release-notes-1-3-4_multi-arch-tuning-operator-release-notes)
