### PR TITLE
Service Mesh_v3.1.12

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.10
+:SMProductVersion: 3.1.12
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.17

--- a/modules/ossm-release-notes-3-1-12.adoc
+++ b/modules/ossm-release-notes-3-1-12.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-12_{context}"]
+= {SMProductName} version 3.1.12
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator {SMProductVersion}. To see the {ocp-product-title} versions that support {SMProduct} {SMProductVersion}, go to link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]. {SMProductShortName} {SMProductVersion} addresses Common Vulnerabilities and Exposures (CVEs) and includes the following fixed issues.
+
+[id="ossm-fixed-issues-3-1-12_{context}"]
+== Fixed issues
+
+OpenSSL memory allocations visible in tcmalloc heap diagnostics::
+Before this update, OpenSSL memory allocations operated on a separate heap from the intended Envoy `tcmalloc` allocator, bypassing performance optimizations on the TLS hot path and keeping allocations invisible to `tcmalloc` heap dumps and memory profilers. With this release, OpenSSL uses the `tcmalloc` allocator. As a result, OpenSSL benefits from `tcmalloc` optimizations, and its memory usage is fully visible in heap diagnostics for accurate troubleshooting.
++
+link:https://redhat.atlassian.net/browse/OSSM-15244[OSSM-15244]
+
+Service mesh sidecar proxies no longer leak memory when closing TLS connections::
+Before this update, a reference count leak in the `SSL_get0_peer_certificates()` OpenSSL compatibility implementation prevented peer X.509 certificate objects from being released when connections closed. This issue occurred when client certificate forwarding (`forward_client_cert_details`) was set to any mode other than `SANITIZE`. As a result, certificate objects accumulated, causing memory usage in service mesh sidecar proxies to grow over time, proportional to the volume of closed TLS connections. Because `APPEND_FORWARD` is the default setting for inbound listeners in mutual TLS (mTLS) environments, nearly all mTLS-enabled sidecar proxies were affected.
++
+This release corrects the reference counting issue for peer certificate objects in `SSL_get0_peer_certificates()`. Certificate objects are properly released when connections close.
++
+link:https://redhat.atlassian.net/browse/OSSM-15075[OSSM-15075]
+
+For supported component versions for {SMProductVersion}, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,37 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.1.12 supported versions.
+
+== {SMProduct} 3.1.12 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.1.12
+
+| {SMProduct} `Istio` control plane resource
+| 1.26.8
+
+| {ocp-product-title}
+| 4.16-4.20
+
+| Envoy proxy
+| 1.34.14
+
+| `IstioCNI` resource
+| 1.26.8
+
+| Kiali Operator
+| 2.27.3
+
+| Kiali server
+| 2.11.16
+
+|===
+
 See the following table for information about {SMProduct} 3.1.11 supported versions.
 
 == {SMProduct} 3.1.11 supported versions

--- a/modules/ossm-supported-platforms.adoc
+++ b/modules/ossm-supported-platforms.adoc
@@ -11,10 +11,10 @@
 The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.16 or later
+* Red Hat OpenShift Container Platform, applicable versions listed on the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] page
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.16 or later
+* Red Hat OpenShift Container Platform, applicable versions listed on the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] page
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-1-12.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-11.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-10.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 15560: OSSM 3.4.2& 3.3.7 & 3.2.9 & 3.1.12 & 3.0.15 at ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.1 (No cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-15560

Link to docs preview:
https://119546--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
