### PR TITLE
OSDOCS#22016: MicroShift and RHEL 10.2 support - GA

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -7,6 +7,7 @@
 :imagesdir: images
 :OCP: OpenShift Container Platform
 :ocp-version: 4.22
+:ocp-version-5: 5.0
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :ai-first: artificial intelligence (AI)
 //OpenShift Kubernetes Engine
@@ -19,7 +20,9 @@
 :gitops: GitOps
 :product-registry: OpenShift image registry
 :product-version: 4.22
+:product-version-5: 5.0
 :rhel-major: rhel-9
+:rhel-major-10: rhel-10
 :rhoai-full: Red{nbsp}Hat OpenShift AI
 :rhoai: RHOAI
 :op-system-base-full: Red{nbsp}Hat Enterprise Linux (RHEL)
@@ -30,13 +33,16 @@
 :op-system-rtk: real-time kernel
 :op-system-image: image mode for RHEL
 :op-system-version: 9.8
+:op-system-version-10: 10.2
 :op-system-version-major: 9
+:op-system-version-major-10: 10
 :op-system-version-10: 10.2
 :op-system-version-major-10: 10
 :op-system-bundle: Red{nbsp}Hat Device Edge
 :ovms: OpenVINO Model Server
 :ov: OVMS
 :rpm-repo-version: rhocp-4.22
+:rpm-repo-version-5: rhocp-5.0
 :rhde-version: 4
 :VirtProductName: OpenShift Virtualization
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift

--- a/maps/jobs/migrate-rhel9-to-rhel10.adoc
+++ b/maps/jobs/migrate-rhel9-to-rhel10.adoc
@@ -8,6 +8,10 @@
 // (migrate-rhel-edge-to-image-mode); confirm whether this job is still needed.
 include::modules/microshift-migrate-rhel9-to-rhel10.adoc[leveloffset=+0,chunk="to-content"]
 
+include::modules/microshift-update-rhel9-to-rhel10-rpm.adoc[leveloffset=+1,toc="no"]
+
+include::modules/microshift-update-rhel9-to-rhel10-bootc.adoc[leveloffset=+1,toc="no"]
+
 include::modules/microshift-update-edge-to-image.adoc[leveloffset=+1,toc="no"]
 
 include::modules/microshift-updates-edge-to-image-uid-drift.adoc[leveloffset=+2,toc="no"]

--- a/microshift_install_get_ready/microshift-install-get-ready.adoc
+++ b/microshift_install_get_ready/microshift-install-get-ready.adoc
@@ -11,6 +11,10 @@ To use {op-system-bundle} to compute at the edge, plan your {op-system-base-full
 
 include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
 
+include::modules/microshift-rhel-support-overview.adoc[leveloffset=+1]
+
+include::modules/microshift-plan-rhel-deployment.adoc[leveloffset=+1]
+
 include::modules/microshift-install-rhde-compat-table.adoc[leveloffset=+1]
 
 include::modules/microshift-rhde-compatibility-table.adoc[leveloffset=+2]

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -28,7 +28,8 @@ include::modules/microshift-standalone-rhel-updates.adoc[leveloffset=+1]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10[Red Hat Enterprise Linux 10]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9[Red Hat Enterprise Linux 9]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL 9]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel-10_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL 10]
 
 include::modules/microshift-simultaneous-microshift-rhel-updates.adoc[leveloffset=+1]
 

--- a/microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
+++ b/microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
@@ -7,7 +7,14 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-To migrate {microshift-short} from an existing {op-system-ostree-first} system, you must embed {microshift-short} on a new operating system image to ensure a successful transition.
+To upgrade a {microshift-short} node from {op-system-base} {op-system-version} to {op-system-version-10}, you must update both {microshift-short} and the operating system at the same time to a supported configuration.
+
+
+include::modules/microshift-migrate-rhel9-to-rhel10.adoc[leveloffset=+1]
+
+include::modules/microshift-update-rhel9-to-rhel10-rpm.adoc[leveloffset=+1]
+
+include::modules/microshift-update-rhel9-to-rhel10-bootc.adoc[leveloffset=+1]
 
 include::modules/microshift-update-edge-to-image.adoc[leveloffset=+1]
 

--- a/modules/microshift-ingress-controller-create-cert-secret.adoc
+++ b/modules/microshift-ingress-controller-create-cert-secret.adoc
@@ -30,6 +30,11 @@ To configure application-level certificates for a Kubernetes Ingress object by u
 This procedure only applies to the default ingress router certificate, `ingress.certificateSecret`.
 ====
 
+[NOTE]
+====
+This procedure applies only to the default ingress router certificate, `ingress.certificateSecret`.
+====
+
 .Procedure
 
 . Create a secret that contains the wildcard certificate chain and key:

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -11,8 +11,8 @@ Build your {op-system-base-full} that contains {microshift-short} as a bootable 
 
 .Prerequisites
 
-* A {op-system-base} {op-system-version} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images and running containers.
-* You logged into the {op-system-base} {op-system-version} host by using the user credentials that have `sudo` permissions.
+* A {op-system-base} {op-system-version-10} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images and running containers.
+* You logged into the {op-system-base} {op-system-version-10} host by using the user credentials that have `sudo` permissions.
 * The `rhocp` and `fast-datapath` repositories are accessible in the host subscription. The repositories do not necessarily need to be enabled on the host.
 * You have a remote registry such as link:https://quay.io[{quay}] for storing and accessing bootc images.
 * You used the `dnf install -y container-tools` command to install the `container-tools` meta-package on the host. The meta-package contains all container tools, such as Podman, Buildah, and Skopeo for additional support and troubleshooting. These tools are required for obtaining assistance from Red{nbsp}Hat Support when you are building and installing the image.
@@ -24,12 +24,12 @@ Build your {op-system-base-full} that contains {microshift-short} as a bootable 
 .Example Containerfile for {op-system-base} image mode
 [source,text,subs="attributes+"]
 ----
-FROM registry.redhat.io/rhel{op-system-version-major}/rhel-bootc:{op-system-version}
+FROM registry.redhat.io/rhel{op-system-version-major-10}/rhel-bootc:{op-system-version-10}
 
-ARG USHIFT_VER={product-version}
+ARG USHIFT_VER={product-version-5}
 RUN dnf config-manager \
-        --set-enabled rhocp-${USHIFT_VER}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
-        --set-enabled fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
+        --set-enabled rhocp-${USHIFT_VER}-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms \
+        --set-enabled fast-datapath-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms
 RUN dnf install -y firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all
@@ -89,7 +89,7 @@ Replace `_<redhat_user_password>_` with your password.
 +
 [source,terminal,subs="attributes+"]
 ----
-$ IMAGE_NAME=microshift-{product-version}-bootc
+$ IMAGE_NAME=microshift-{product-version-5}-bootc
 ----
 
 . Create a local bootc image by running the following image build command:
@@ -105,7 +105,7 @@ $ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
 ====
 How secrets are used during the image build:
 
-* The podman `--authfile` argument is required to pull the base `rhel-bootc:{op-system-version}` image from the `registry.redhat.io` registry.
+* The podman `--authfile` argument is required to pull the base `rhel-bootc:{op-system-version-10}` image from the `registry.redhat.io` registry.
 * The build `USER_PASSWD` argument is used to set a password for the `redhat` user.
 ====
 
@@ -122,5 +122,5 @@ $ sudo podman images "${IMAGE_NAME}"
 [source,text,subs="attributes+"]
 ----
 REPOSITORY                       TAG         IMAGE ID      CREATED        SIZE
-localhost/microshift-{product-version}-bootc  latest      193425283c00  2 minutes ago  2.31 GB
+localhost/microshift-{product-version-5}-bootc  latest      193425283c00  2 minutes ago  2.31 GB
 ----

--- a/modules/microshift-migrate-rhel9-to-rhel10.adoc
+++ b/modules/microshift-migrate-rhel9-to-rhel10.adoc
@@ -1,12 +1,20 @@
 // Module included in the following assemblies:
 //
-// * maps/microshift/jobs/migrate-rhel9-to-rhel10.adoc
+// * microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
+// * maps/jobs/migrate-rhel9-to-rhel10.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-migrate-rhel9-to-rhel10_{context}"]
-= Migrate from RHEL 9 to RHEL 10
+= Update paths from {op-system-base} {op-system-version} to {op-system-version-10}
 
 [role="_abstract"]
-To migrate {microshift-short} from an existing {op-system-ostree-first} system running {op-system-version} to one running {op-system-version-10}, you must embed {microshift-short} into a new operating system image.
+To upgrade a {microshift-short} node from {op-system-base} {op-system-version} to {op-system-version-10}, you must update both {microshift-short} and the operating system at the same time to a supported configuration. Use the procedure that matches your installation type.
 
-This process transitions your deployment from an `rpm-ostree`-based system to an image mode for RHEL (bootc) system, and requires planning for any UID or GID drift that may occur.
+* On a package-based {op-system-base} host, enable the {op-system-base} {op-system-version-10} and matching {microshift-short} `rhocp` repositories, then update both in one maintenance window. This path is not a `bootc switch`.
+* On an {op-system-image} host, build a new {op-system-base} {op-system-version-10} image that already contains the target {microshift-short} version, then switch the node to that image.
+* On a {op-system-ostree-first} host, you cannot stay on `rpm-ostree` for {op-system-base} {op-system-version-major-10}. Embed {microshift-short} in a new {op-system-image} image. Plan for UID and GID drift because {op-system-ostree} and {op-system-image} are not derived from the same parent image.
+
+[IMPORTANT]
+====
+Upgrading only {op-system-base} or only {microshift-short} can result in an unsupported configuration. Check the {op-system-bundle} release compatibility matrix before you begin.
+====

--- a/modules/microshift-plan-rhel-deployment.adoc
+++ b/modules/microshift-plan-rhel-deployment.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * microshift_install_get_ready/microshift-install-get-ready.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-plan-rhel-deployment_{context}"]
+= Planning your {microshift-short} deployment
+
+[role="_abstract"]
+Before you install {microshift-short}, choose a supported {op-system-base-full} version, CPU architecture, and installation type. {microshift-short} networking and storage settings are the same on {op-system-base} {op-system-version} and {op-system-version-10}. The operating system major version changes which repositories, image-build tools, and update path you use.
+
+[id="microshift-plan-rhel-version_{context}"]
+== Choosing a {op-system-base} version
+
+Choose {op-system-base} {op-system-version} or {op-system-base} {op-system-version-10} for a new {microshift-short} {product-version-5} installation. Check the "{op-system-bundle} release compatibility matrix" for the pairing you plan to run.
+
+* Choose {op-system-base} {op-system-version} if your hardware supports only the x86-64-v2 microarchitecture level, or if you must keep an existing {op-system-ostree} deployment.
+* Choose {op-system-base} {op-system-version-10} if your hardware meets the {op-system-base} {op-system-version-major-10} requirements and you want a {op-system-base} {op-system-version-major-10} lifecycle.
+
+[id="microshift-plan-rhel-architecture_{context}"]
+== Choosing a CPU architecture
+
+{microshift-short} supports the x86_64 and aarch64 architectures on both {op-system-base} {op-system-version} and {op-system-base} {op-system-version-10}.
+
+* x86_64 hosts must meet the microarchitecture level of the {op-system-base} major version you select. {op-system-base} {op-system-version-major-10} requires x86-64-v3. Hosts that support only x86-64-v2 must use {op-system-base} {op-system-version-major}.
+* Build image-based systems on a host that uses the same CPU architecture as the target device.
+
+[id="microshift-plan-rhel-install-type_{context}"]
+== Choosing an installation type
+
+Select the installation type that matches your operating system and how you manage devices:
+
+* RPM, or package-based, installation is supported on {op-system-base} {op-system-version} and {op-system-base} {op-system-version-10}. Use this type on an existing machine when you want to install {microshift-short} with `dnf`.
+* {op-system-image} is supported on {op-system-base} {op-system-version} and {op-system-base} {op-system-version-10}. Use this type to build and deploy an immutable bootc image. New image-based installations on {op-system-base} {op-system-version-major-10} must use {op-system-image}.
+* {op-system-ostree} is supported on {op-system-base} {op-system-version-major} only. You cannot stay on `rpm-ostree` for {op-system-base} {op-system-version-major-10}. If you plan to move those nodes to {op-system-base} {op-system-version-10}, plan a migration to {op-system-image}.
+
+[id="microshift-plan-rhel-network-storage_{context}"]
+== Planning networking and storage
+
+Plan networking and storage before installation. These {microshift-short} choices apply on both {op-system-base} majors:
+
+* Decide whether you need single-stack or dual-stack networking, a firewall, and routes to the node or to your applications.
+* If your workloads need persistent volumes, prepare an LVM volume group with enough capacity, or disable the {microshift-short} storage plugin if you do not need it.
+
+The {op-system-base} major version changes how you obtain and update those capabilities:
+
+* Package-based nodes use `rhocp` and `fast-datapath` repositories for {op-system-base} {op-system-version-major} or {op-system-base} {op-system-version-major-10}. Enable the repositories that match the {op-system-base} major version of the host.
+* Image-based nodes on {op-system-base} {op-system-version-major} can use {op-system-ostree} image builder. Image-based nodes on {op-system-base} {op-system-version-major-10} use bootc image builds instead of `rpm-ostree` image builder workflows.
+
+For more information, see "{op-system-base} installation types" and the "{op-system-bundle} release compatibility matrix".

--- a/modules/microshift-rhde-compatibility-table.adoc
+++ b/modules/microshift-rhde-compatibility-table.adoc
@@ -25,20 +25,20 @@ Be sure to check the support status of a release on the product lifecycle page.
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
 ^|10.2
-^|4.22
-^|4.22.0{nbsp}&#8594;{nbsp}4.22.z (Technology Preview)
+^|5.0
+^|5.0.0{nbsp}&#8594;{nbsp}5.0.z (General Availability)
 
 ^|9.8
 ^|4.22
-^|4.22.0{nbsp}&#8594;{nbsp}4.22.z, 4.22 on {op-system-base} 9.8{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
+^|4.22.0{nbsp}&#8594;{nbsp}4.22.z, 4.22 on {op-system-base} 9.8{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (General Availability)
 
 ^|9.6
 ^|4.21
-^|4.21.0{nbsp}&#8594;{nbsp}4.21.z, 4.21{nbsp}&#8594;{nbsp}4.22, 4.21{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 9.8, 4.21{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
+^|4.21.0{nbsp}&#8594;{nbsp}4.21.z, 4.21{nbsp}&#8594;{nbsp}4.22, 4.21{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 9.8, 4.21{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (General Availability)
 
 ^|9.6
 ^|4.20
-^|4.20.0{nbsp}&#8594;{nbsp}4.20.z, 4.20{nbsp}&#8594;{nbsp}4.21, 4.20{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
+^|4.20.0{nbsp}&#8594;{nbsp}4.20.z, 4.20{nbsp}&#8594;{nbsp}4.21, 4.20{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 10.2 (General Availability)
 
 ^|9.6
 ^|4.19

--- a/modules/microshift-rhel-support-overview.adoc
+++ b/modules/microshift-rhel-support-overview.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * microshift_install_get_ready/microshift-install-get-ready.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-rhel-support-overview_{context}"]
+= Understanding {microshift-short} on {op-system-base}
+
+[role="_abstract"]
+{microshift-short} {product-version-5} supports new installations on {op-system-base-full} {op-system-version} and {op-system-base} {op-system-version-10} for the x86_64 and aarch64 architectures. Pair {microshift-short} only with a supported {op-system-base} version.
+
+* You can install {microshift-short} {product-version-5} on {op-system-base} {op-system-version} or {op-system-base} {op-system-version-10}.
+* Earlier {microshift-short} releases keep the {op-system-base} pairings that were supported when those releases shipped. Do not install an older {microshift-short} version on a newer {op-system-base} version unless that pairing is listed as supported.
+* Hosts that support only the x86-64-v2 microarchitecture level cannot run {op-system-base} {op-system-version-major-10}. Those hosts must remain on a supported {op-system-base} {op-system-version-major} configuration.
+
+For the supported {microshift-short} and {op-system-base} combinations, see the "{op-system-bundle} release compatibility matrix".

--- a/modules/microshift-standalone-rhel-updates.adoc
+++ b/modules/microshift-standalone-rhel-updates.adoc
@@ -8,3 +8,8 @@
 
 [role="_abstract"]
 You can update to any {op-system-base} type without updating {microshift-short} if the two final versions in your {op-system-bundle} are compatible. Check compatibilities before beginning an update. Use the {op-system-base} documentation specific to your use case.
+
+[IMPORTANT]
+====
+You must update {op-system-base} and {microshift-short} if you are updating from {op-system-base} {op-system-version} to {op-system-base} {op-system-version-10} version. Do not update {op-system-base} without updating {microshift-short} at the same time.
+====

--- a/modules/microshift-update-rhel9-to-rhel10-bootc.adoc
+++ b/modules/microshift-update-rhel9-to-rhel10-bootc.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-update-rhel9-to-rhel10-bootc_{context}"]
+= Upgrade {microshift-short} from {op-system-version} to {op-system-version-10} by using {op-system-image}
+
+[role="_abstract"]
+On an {op-system-image} host, you must build a new {op-system-base} {op-system-version-10} bootc image that already contains the target {microshift-short} version, then switch the node to that image. Do not update the operating system without including the compatible {microshift-short} version in the same image.
+
+.Prerequisites
+
+* The version of {microshift-short} you have is compatible with the version you are preparing to use.
+* Your current {op-system-base} {op-system-version} and {microshift-short} pairing is listed as supported in the {op-system-bundle} release compatibility matrix.
+* The target {op-system-base} {op-system-version-10} and {microshift-short} pairing is listed as supported in the {op-system-bundle} release compatibility matrix.
+* You have a build host and a remote registry for creating and storing bootc images.
+* You have root user access to the {microshift-short} node.
+* You have completed a system backup.
+
+.Procedure
+
+. Build a {op-system-base} {op-system-version-10} bootc image that includes the target {microshift-short} version. The Containerfile must use the following base image:
++
+[source,text,subs="attributes+"]
+----
+FROM registry.redhat.io/rhel{op-system-version-major-10}/rhel-bootc:{op-system-version-10}
+----
++
+For the complete image-build steps, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-build-image_microshift-install-bootc-image[Build the bootc image].
+
+. Publish the image to your remote registry. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-bootc-publish-image_microshift-install-bootc-image[Publish the bootc image to the remote registry].
+
+. On the running {microshift-short} node, switch to the new image by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ sudo bootc switch _<registry>/<repository>:<tag>_
+----
++
+Replace `_<registry>/<repository>:<tag>_` with the location of the {op-system-base} {op-system-version-10} image that contains the target {microshift-short} version.
+
+. Reboot the host to start the new image by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl reboot
+----
+
+.Verification
+
+. Check that the node booted the {op-system-base} {op-system-version-10} image by running the following command:
++
+[source,terminal]
+----
+$ sudo bootc status
+----
+
+. Check if the health checks exited with a successful boot by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl status greenboot-healthcheck
+----

--- a/modules/microshift-update-rhel9-to-rhel10-rpm.adoc
+++ b/modules/microshift-update-rhel9-to-rhel10-rpm.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-update-rhel9-to-rhel10-rpm_{context}"]
+= Upgrade {microshift-short} from {op-system-version} to {op-system-version-10} by using RPMs
+
+[role="_abstract"]
+On a package-based {op-system-base-full} host, you must update {microshift-short} and the operating system together from a supported {op-system-version} configuration to a supported {op-system-version-10} configuration. This path uses RPM repositories. Do not use the `bootc switch` command.
+
+include::snippets/microshift-unsupported-config-warn.adoc[]
+
+[IMPORTANT]
+====
+Do not run `dnf update` to move the host to {op-system-base} {op-system-version-10} while {microshift-short} remains on the previous `rhocp` repositories. That command does not switch {microshift-short} to the {op-system-base} {op-system-version-major-10} repositories and can result in an unsupported configuration.
+====
+
+[NOTE]
+====
+You cannot downgrade {microshift-short} with this process. Downgrades are not supported.
+====
+
+.Prerequisites
+
+* The version of {microshift-short} you have is compatible with the version you are preparing to use.
+* Your current {op-system-base} {op-system-version} and {microshift-short} pairing is listed as supported in the {op-system-bundle} release compatibility matrix.
+* The target {op-system-base} {op-system-version-10} and {microshift-short} pairing is listed as supported in the {op-system-bundle} release compatibility matrix.
+* You have root user access to the host.
+* You have completed a system backup.
+
+.Procedure
+
+. Disable the previous {microshift-short} repositories by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo subscription-manager repos \
+    --disable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
+    --disable fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
+----
+
+. Enable the {microshift-short} repositories for {op-system-base} {op-system-version-major-10} by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo subscription-manager repos \
+    --enable rhocp-{ocp-version-5}-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms \
+    --enable fast-datapath-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms
+----
+
+. Follow the {op-system-base} documentation to upgrade the host operating system from {op-system-version} to {op-system-version-10} in the same maintenance window. See the following link:
++
+link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major-10}/html/upgrading_from_rhel_9_to_rhel_10/index[Upgrading from RHEL 9 to RHEL 10]
+
+. On the upgraded host, lock the operating system version by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo subscription-manager release --set={op-system-version-10}
+----
+
+. Update the {microshift-short} RPMs by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf update -y microshift
+----
+
+. Reboot the host to apply updates by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl reboot
+----
+
+.Verification
+
+. Check that the host is running {op-system-base} {op-system-version-10} by running the following command:
++
+[source,terminal]
+----
+$ cat /etc/os-release
+----
+
+. Check if the health checks exited with a successful boot by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl status greenboot-healthcheck
+----
+
+. Check the health check logs by running the following command:
++
+[source,terminal]
+----
+$ sudo journalctl -u greenboot-healthcheck
+----

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -7,7 +7,7 @@
 = Apply minor-version updates with RPMs
 
 [role="_abstract"]
-Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.18 to 4.20.
+Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.22 to 5.0.
 
 include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
 
@@ -30,8 +30,8 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
-    --enable fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
+    --enable rhocp-{ocp-version-5}-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms \
+    --enable fast-datapath-for-rhel-{op-system-version-major-10}-$(uname -m)-rpms
 ----
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:
@@ -39,15 +39,15 @@ $ sudo subscription-manager repos \
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhel-{op-system-version-major}-for-$(uname -m)-appstream-eus-rpms \
-    --enable rhel-{op-system-version-major}-for-$(uname -m)-baseos-eus-rpms
+    --enable rhel-{op-system-version-major-10}-for-$(uname -m)-appstream-eus-rpms \
+    --enable rhel-{op-system-version-major-10}-for-$(uname -m)-baseos-eus-rpms
 ----
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager release --set={op-system-version}
+$ sudo subscription-manager release --set={op-system-version-10}
 ----
 
 . Update the {microshift-short} RPMs by running the following command:


### PR DESCRIPTION
Version(s):
5.0

Issue:
[OSDOCS-22016](https://redhat.atlassian.net/browse/OSDOCS-22016)

Link to docs previews:

- [MicroShift RHDE compatibility table](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-rhde-compatibility-table_microshift-install-get-ready)
- [Getting ready to install MicroShift](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready)
- [Update options for Red Hat Device Edge](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options)
- [Upgrading the host operating system from 9.8 to 10.2](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rhel9-to-rhel-10)
- [Create a secret for the ingress controller certificateSecret](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-ingress-controller#microshift-ingress-controller-create-cert-secret_microshift-ingress-controller)
- [Build the bootc image](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image)
- [Upgrade paths from RHEL 9.8 to 10.2](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rhel9-to-rhel-10#microshift-migrate-rhel9-to-rhel10_microshift-update-rhel9-to-rhel-10)
- [Planning your MicroShift deployment](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-plan-rhel-deployment_microshift-install-get-ready)
- [Red Hat Device Edge release compatibility matrix](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-rhde-compatibility-table_microshift-install-get-ready)
- [Understanding MicroShift on RHEL](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-rhel-support-overview_microshift-install-get-ready)
- [Standalone RHEL updates](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options#microshift-standalone-rhel-updates_microshift-update-options)
- [Upgrade MicroShift from 9.8 to 10.2 by using image mode for RHEL](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rhel9-to-rhel-10#microshift-update-rhel9-to-rhel10-bootc_microshift-update-rhel9-to-rhel-10)
- [Upgrade MicroShift from 9.8 to 10.2 by using RPMs](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rhel9-to-rhel-10#microshift-update-rhel9-to-rhel10-rpm_microshift-update-rhel9-to-rhel-10)
- [Apply minor-version updates with RPMs](https://119552--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually#microshift-updating-rpms_microshift-update-rpms-manually)

QE review:
- [ ] QE has approved this change.


Additional information:

