### PR TITLE
[RHDEVDOCS-6040] Fix results.yaml indentation so opc can parse the example

### DIFF
--- a/modules/op-prepare-opc-for-results.adoc
+++ b/modules/op-prepare-opc-for-results.adoc
@@ -39,11 +39,11 @@ Save the string that this command outputs.
 address: <tekton_results_route> # <1>
 token: <authentication_token> # <2>
 ssl:
-   roots_file_path: /home/example/cert.pem # <3>
-   server_name_override: tekton-results-api-service.openshift-pipelines.svc.cluster.local # <4>
- service_account:
-   namespace: service_acc_1 <5>
-   name: service_acc_1 <5>
+  roots_file_path: /home/example/cert.pem # <3>
+  server_name_override: tekton-results-api-service.openshift-pipelines.svc.cluster.local # <4>
+service_account:
+  namespace: service_acc_1 <5>
+  name: service_acc_1 <5>
 ----
 <1> The route to the {tekton-results} API. Use the same value as you set for `RESULTS_API`.
 <2> The authentication token that was created by the `oc create token` command. If you provide this token, it overrides the `service_account` setting and `opc` uses this token to authenticate.


### PR DESCRIPTION
Version(s):
- `pipelines-docs-1.14`

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-6040
- Support case: 03800936

Cherry-pick of https://github.com/openshift/openshift-docs/pull/119553 onto `pipelines-docs-1.14`.

The `~/.config/tkn/results.yaml` example had extra leading spaces after `ssl`, which made `service_account` invalid YAML so `opc` could not parse the file. Callout markers from the 1.14 module are preserved.

QE/SME review:
- [ ] QE/SME has approved this change.


Made with [Cursor](https://cursor.com)