### PR TITLE
[RHDEVDOCS-6040] Fix results.yaml indentation so opc can parse the example

### DIFF
--- a/modules/op-prepare-opc-for-results.adoc
+++ b/modules/op-prepare-opc-for-results.adoc
@@ -41,11 +41,11 @@ Save the string that this command outputs.
 address: <tekton_results_route>
 token: <authentication_token>
 ssl:
-   roots_file_path: /home/example/cert.pem
-   server_name_override: tekton-results-api-service.openshift-pipelines.svc.cluster.local
- service_account:
-   namespace: service_acc_1
-   name: service_acc_1
+  roots_file_path: /home/example/cert.pem
+  server_name_override: tekton-results-api-service.openshift-pipelines.svc.cluster.local
+service_account:
+  namespace: service_acc_1
+  name: service_acc_1
 ----
 `address`:: The route to the {tekton-results} API. Use the same value as you set for `RESULTS_API`.
 `token`:: The authentication token that the `oc create token` command created. If you give this token, it overrides the `service_account` setting and `opc` uses this token to authenticate.


### PR DESCRIPTION
Version(s):
- `pipelines-docs-1.23`

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-6040
- Support case: 03800936

Cherry-pick of https://github.com/openshift/openshift-docs/pull/119553 onto `pipelines-docs-1.23`.

The `~/.config/tkn/results.yaml` example had extra leading spaces after `ssl`, which made `service_account` invalid YAML so `opc` could not parse the file.

QE/SME review:
- [ ] QE/SME has approved this change.

Made with [Cursor](https://cursor.com)