### PR TITLE
OSDOCS-22090: Use .crt extension for LLM trusted CA configmap key

### DIFF
--- a/modules/ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm.adoc
+++ b/modules/ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm.adoc
@@ -21,7 +21,7 @@ If the LLM provider you are using requires a trusted-ca certificate to authentic
 +
 [source,terminal]
 ----
-$ oc create configmap trusted-certs --from-file=caCertFileName --namespace openshift-lightspeed
+$ oc create configmap trusted-certs --from-file=caCertFileName.crt --namespace openshift-lightspeed
 ----
 +
 This command returns an output similar to the following example:


### PR DESCRIPTION
 ### Description

  This PR resolves an issue in the OpenShift Lightspeed (OLS) LLM trusted CA configuration documentation.

  The current documented command for creating the custom CA ConfigMap uses the key name `caCertFileName` without
  any file extension. However, the OLS cert-consolidation script only merges CA certificates ending in `.crt` or
  `.pem` into the consolidated bundle (`/etc/certs/cert-bundle/ols.pem`). Consequently, the custom CA is skipped,
  resulting in Python `httpx` connection and SSL verification failures (`SSL: CERTIFICATE_VERIFY_FAILED`) when
  OLS attempts to connect to the LLM.

  This PR updates the ConfigMap creation instruction to use a `.crt` extension for the certificate key
  (specifically, `--from-file=ca-bundle.crt=...`), ensuring that the certificate is successfully consolidated and
  trusted.

  ### Jira Ticket
  
  * **Jira Link**: [OSDOCS-22090](https://redhat.atlassian.net/browse/OSDOCS-22090)

  ### Related Support Case

  * **Case Link**: [04531024](https://access.redhat.com/support/cases/#/case/04531024)

  ### Affected Documentation

  * **Docs Link**: [Configuring Red Hat OpenShift Lightspeed with a trusted CA certificate for the 
  LLM](https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0/html-single/configure/index#ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm_ols-configuring-openshift-lightspeed)