### PR TITLE
OCPBUGS-56258: Replace deprecated oc sa get-token with oc create token

### DIFF
--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -25,7 +25,7 @@ When using a service account as an OAuth client:
 +
 [source,terminal]
 ----
-$ oc sa get-token <service_account_name>
+$ oc create token <service_account_name>
 ----
 
 * To get `WWW-Authenticate` challenges, set an


### PR DESCRIPTION
Version(s):
main (in-development OpenShift 5.1). Still present in published 4.17-4.22 docs.

Issue:
https://issues.redhat.com/browse/OCPBUGS-56258

Link to docs preview:
Preview is generated after an org member comments /ok-to-test.
Affected module: `modules/service-accounts-as-oauth-clients.adoc`
Published 4.22 page (still shows the deprecated command):
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/using-service-accounts-as-oauth-client

QE review:
- [ ] QE has approved this change.

Additional information:
The service-accounts-as-OAuth-clients topic currently tells users to run:

```
$ oc sa get-token <service_account_name>
```

That command is deprecated. The replacement is:

```
$ oc create token <service_account_name>
```

Verified still present in OpenShift 4.22:
- Published 4.22 docs still show `$ oc sa get-token <service_account_name>` on the OAuth client page above.
- Reproduced on OCP 4.22.7: `oc sa get-token` prints a deprecation warning (`Use oc create token instead`) and fails without a service account name; `oc create token` works and returns a token.

This PR is a one-line docs change so the procedure matches current `oc` behavior.