### PR TITLE
OSDOCS-22091: Fix olfconfig placeholder typo in trusted CA procedure

### DIFF
--- a/modules/ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm.adoc
+++ b/modules/ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm.adoc
@@ -66,5 +66,5 @@ spec:
 +
 [source,terminal]
 ----
-$ oc apply -f <olfconfig_cr_filename> 
+$ oc apply -f <olsconfig_cr_filename>
 ----


### PR DESCRIPTION
## Summary
- Fix placeholder typo `olfconfig_cr_filename` → `olsconfig_cr_filename` in the OpenShift Lightspeed 1.0 trusted CA certificate procedure.
- Aligns the CLI example with the `olsconfig` naming used elsewhere in the guide and operator docs.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-22091

## Affected documentation
- **Product:** Red Hat OpenShift Lightspeed 1.0
- **Guide:** Configure
- **Module:** `modules/ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm.adoc`
- **Published URL:** https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0/html-single/configure/index#ols-configuring-lightspeed-with-a-trusted-ca-certificate-for-the-llm_ols-configuring-openshift-lightspeed

## Test plan
- [x] Verified only the placeholder text changes in the trusted CA apply command
- [ ] Docs build/review as needed by the OpenShift docs team

