### PR TITLE
OCPEDGE-2709: Document TNF metrics and alerts

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -447,6 +447,8 @@ Topics:
       File: install-tnf
     - Name: Operating a degraded two-node OpenShift cluster with fencing
       File: operating-a-degraded-tnf
+    - Name: Monitoring a two-node OpenShift cluster with fencing
+      File: monitoring-two-node-fencing
     - Name: Post-installation troubleshooting and recovery
       File: install-post-tnf
 - Name: Installing on bare metal

--- a/installing/installing_two_node_cluster/installing_tnf/monitoring-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/monitoring-two-node-fencing.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="monitoring-two-node-fencing"]
+= Monitoring a two-node OpenShift cluster with fencing
+include::_attributes/common-attributes.adoc[]
+:context: monitoring-tnf
+
+toc::[]
+
+[role="_abstract"]
+A two-node {product-title} cluster with fencing (TNF) uses Pacemaker to manage cluster membership, fencing, and the `etcd` resource. The cluster exposes this Pacemaker state as Prometheus metrics and ships a set of alerts that fire on TNF-specific failure conditions, such as a node going offline, a fence device becoming unreachable, or the `etcd` resource stopping. Use these metrics and alerts to observe the health of the fencing mechanism and to respond to failures before they compromise the cluster.
+
+include::modules/tnf-monitoring-overview.adoc[leveloffset=+1]
+
+include::modules/tnf-metrics-reference.adoc[leveloffset=+1]
+
+include::modules/tnf-alerts-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/installing_two_node_cluster/installing_tnf/operating-a-degraded-tnf.adoc#operating-a-degraded-tnf[Operating a degraded two-node OpenShift cluster with fencing]
+
+* xref:../../../installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc#installing-post-tnf[Post-installation troubleshooting and recovery]
+
+* xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#accessing-metrics-as-an-administrator[Accessing metrics as an administrator]
+
+* xref:../../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#managing-alerts-as-an-administrator[Managing alerts as an administrator]

--- a/modules/tnf-alerts-reference.adoc
+++ b/modules/tnf-alerts-reference.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_two_node_cluster/installing_tnf/monitoring-two-node-fencing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tnf-alerts-reference_{context}"]
+= TNF alerts reference
+
+[role="_abstract"]
+A two-node {product-title} cluster with fencing (TNF) ships the following alerts in the `tnf-pacemaker.rules` group. `critical` alerts indicate a condition that breaks cluster functionality and requires immediate action. `warning` alerts indicate a degraded state that needs attention while the cluster remains functional. Each alert includes a `runbook_url` annotation that links to detailed investigation and remediation steps.
+
+== Cluster-level alerts
+
+.Cluster-level TNF alerts
+[cols="2,1,2,1", options="header"]
+|===
+| Alert | Severity | Fires when | Runbook
+
+| `TNFNodeCountMismatch`
+| critical
+| The cluster does not have exactly two nodes, for example after a node is added or removed. Restore the cluster to two control plane nodes.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeCountMismatch.md[Runbook]
+
+| `TNFClusterInMaintenance`
+| warning
+| The cluster is in maintenance mode. Expected during planned maintenance; investigate if unexpected.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFClusterInMaintenance.md[Runbook]
+|===
+
+== Node-level alerts
+
+These alerts carry a `node` label that identifies the affected node.
+
+.Node-level TNF alerts
+[cols="2,1,2,1", options="header"]
+|===
+| Alert | Severity | Fires when | Runbook
+
+| `TNFNodeOffline`
+| critical
+| The node is offline because of a node failure, reboot, or network partition. The cluster has lost high-availability redundancy until the node recovers.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeOffline.md[Runbook]
+
+| `TNFNodeFencingUnavailable`
+| critical
+| All fence devices for the node are unhealthy, so the node cannot be fenced. Common causes are an unreachable BMC or invalid credentials. Restore fencing before relying on the cluster for high availability.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeFencingUnavailable.md[Runbook]
+
+| `TNFNodeFencingDegraded`
+| warning
+| Fence device redundancy is lost, but at least one device remains healthy. The node can still be fenced. Repair the failed device.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeFencingDegraded.md[Runbook]
+
+| `TNFNodeUnclean`
+| critical
+| Pacemaker cannot confirm the node state, for example after a fencing, communication, or configuration problem.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeUnclean.md[Runbook]
+
+| `TNFNodeInMaintenance`
+| warning
+| The node is in maintenance mode. Expected during planned maintenance; investigate if unexpected.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeInMaintenance.md[Runbook]
+
+| `TNFNodeStandby`
+| warning
+| The node is in standby mode and is not running resources. Expected during planned maintenance; investigate if unexpected.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeStandby.md[Runbook]
+|===
+
+== Resource-level alerts
+
+These alerts carry a `node` label and a `resource` label, for example `resource="etcd"`.
+
+.Resource-level TNF alerts
+[cols="2,1,2,1", options="header"]
+|===
+| Alert | Severity | Fires when | Runbook
+
+| `TNFResourceStopped`
+| critical
+| A Pacemaker-managed resource, such as `etcd`, is stopped. This can follow a quorum loss or a manual stop.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFResourceStopped.md[Runbook]
+
+| `TNFResourceFailed`
+| critical
+| A resource has failed and cannot start, for example because of a resource agent failure or a configuration error.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFResourceFailed.md[Runbook]
+
+| `TNFResourceUnmanaged`
+| warning
+| A resource is not managed by Pacemaker, typically after a manual unmanage operation. Pacemaker does not recover an unmanaged resource.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFResourceUnmanaged.md[Runbook]
+
+| `TNFResourceDisabled`
+| warning
+| A resource is disabled, typically after a manual disable operation.
+| link:https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFResourceDisabled.md[Runbook]
+|===

--- a/modules/tnf-metrics-reference.adoc
+++ b/modules/tnf-metrics-reference.adoc
@@ -7,7 +7,7 @@
 = TNF metrics reference
 
 [role="_abstract"]
-A two-node {product-title} cluster with fencing (TNF) exposes the following Prometheus gauge metrics. Each gauge reports `1` when the condition is true, which is the healthy state, and `0` when the condition is false. Use these metrics to build queries and dashboards for the Pacemaker and fencing layer of the cluster.
+A two-node {product-title} cluster with fencing (TNF) exposes the following Prometheus gauge metrics, grouped by cluster, node, and resource level. Use these metrics to build queries and dashboards for the Pacemaker and fencing layer of the cluster.
 
 == Cluster-level metrics
 

--- a/modules/tnf-metrics-reference.adoc
+++ b/modules/tnf-metrics-reference.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_two_node_cluster/installing_tnf/monitoring-two-node-fencing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tnf-metrics-reference_{context}"]
+= TNF metrics reference
+
+[role="_abstract"]
+A two-node {product-title} cluster with fencing (TNF) exposes the following Prometheus gauge metrics. Each gauge reports `1` when the condition is true, which is the healthy state, and `0` when the condition is false. Use these metrics to build queries and dashboards for the Pacemaker and fencing layer of the cluster.
+
+== Cluster-level metrics
+
+These metrics describe the cluster as a whole and have no labels.
+
+.Cluster-level TNF metrics
+[cols="1,2", options="header"]
+|===
+| Metric | Description
+
+| `tnf_cluster_healthy`
+| Overall cluster health. `1` when the cluster is healthy.
+
+| `tnf_cluster_in_service`
+| Whether the cluster is in service. `0` indicates the cluster is in maintenance mode.
+
+| `tnf_cluster_node_count_as_expected`
+| Whether the cluster has the expected node count. `1` when exactly two nodes are present.
+|===
+
+== Node-level metrics
+
+These metrics describe an individual node and carry a `node` label set to the node name.
+
+.Node-level TNF metrics
+[cols="1,2", options="header"]
+|===
+| Metric | Description
+
+| `tnf_node_healthy`
+| Overall node health. `1` when the node is healthy.
+
+| `tnf_node_online`
+| Whether the node is online. `0` indicates the node is offline.
+
+| `tnf_node_in_service`
+| Whether the node is in service. `0` indicates the node is in maintenance mode.
+
+| `tnf_node_active`
+| Whether the node is active. `0` indicates the node is in standby mode.
+
+| `tnf_node_ready`
+| Whether the node is ready. `0` indicates the node is pending.
+
+| `tnf_node_clean`
+| Whether the node is in a clean state. `0` indicates Pacemaker cannot confirm the node state.
+
+| `tnf_node_member`
+| Whether the node is a cluster member.
+
+| `tnf_node_fencing_available`
+| Whether at least one fence device for the node is healthy. `0` indicates the node cannot be fenced.
+
+| `tnf_node_fencing_healthy`
+| Whether all fence devices for the node are healthy. `0` indicates reduced fencing redundancy.
+|===
+
+== Resource-level metrics
+
+These metrics describe a Pacemaker-managed resource, such as `etcd`, on a specific node. They carry a `node` label and a `resource` label.
+
+.Resource-level TNF metrics
+[cols="1,2", options="header"]
+|===
+| Metric | Description
+
+| `tnf_resource_healthy`
+| Overall resource health. `1` when the resource is healthy.
+
+| `tnf_resource_in_service`
+| Whether the resource is in service. `0` indicates maintenance mode.
+
+| `tnf_resource_managed`
+| Whether the resource is managed by Pacemaker. `0` indicates the resource was manually unmanaged.
+
+| `tnf_resource_enabled`
+| Whether the resource is enabled. `0` indicates the resource was manually disabled.
+
+| `tnf_resource_operational`
+| Whether the resource is operational. `0` indicates the resource has failed and cannot start.
+
+| `tnf_resource_active`
+| Whether the resource is active.
+
+| `tnf_resource_started`
+| Whether the resource is started. `0` indicates the resource is stopped.
+
+| `tnf_resource_schedulable`
+| Whether the resource can be scheduled.
+|===

--- a/modules/tnf-monitoring-overview.adoc
+++ b/modules/tnf-monitoring-overview.adoc
@@ -9,12 +9,12 @@
 [role="_abstract"]
 In a two-node {product-title} cluster with fencing (TNF), the cluster Etcd Operator watches the Pacemaker cluster state and exposes it as Prometheus metrics. The in-cluster monitoring stack scrapes these metrics and evaluates them against a dedicated set of alerting rules. This gives you the same observability for the Pacemaker and fencing layer that you have for the rest of the cluster.
 
-TNF monitoring covers state that is unique to the two-node topology and is not visible through standard `etcd` metrics:
+TNF monitoring reflects the state of the Pacemaker cluster:
 
-* Cluster membership and expected node count.
-* Node availability, maintenance, and standby state.
+* Pacemaker cluster membership and expected node count. This is not `etcd`'s own raft membership, which fluctuates by design during fencing and recovery.
+* Node availability, maintenance, and standby state. This is distinct from the state of OpenShift nodes.
 * Fence device health for each node.
-* The state of Pacemaker-managed resources, such as `etcd`.
+* The state of Pacemaker-managed resources, such as `etcd`, as reported by the resource agent.
 
 .Metric naming and values
 Every TNF metric name is prefixed with `tnf_` and is grouped by level: `tnf_cluster_*`, `tnf_node_*`, and `tnf_resource_*`. Each metric is a gauge that mirrors a Pacemaker condition:

--- a/modules/tnf-monitoring-overview.adoc
+++ b/modules/tnf-monitoring-overview.adoc
@@ -17,12 +17,7 @@ TNF monitoring reflects the state of the Pacemaker cluster:
 * The state of Pacemaker-managed resources, such as `etcd`, as reported by the resource agent.
 
 .Metric naming and values
-Every TNF metric name is prefixed with `tnf_` and is grouped by level: `tnf_cluster_*`, `tnf_node_*`, and `tnf_resource_*`. Each metric is a gauge that mirrors a Pacemaker condition:
-
-* A value of `1` means the condition is true, which is the healthy state, for example the node is online.
-* A value of `0` means the condition is false, which typically indicates a problem, for example the node is offline.
-
-Node-level metrics carry a `node` label, and resource-level metrics carry both a `node` and a `resource` label. This lets you scope a query or alert to a specific node or resource.
+Every TNF metric name is prefixed with `tnf_` and is grouped by level: `tnf_cluster_*`, `tnf_node_*`, and `tnf_resource_*`. Each metric is a gauge that mirrors a Pacemaker condition, where `1` means the condition is true (the healthy state) and `0` means the condition is false.
 
 .Alerting
 TNF alerts are delivered as part of the cluster Etcd Operator alerting rules, in a `tnf-pacemaker.rules` group that is separate from the standard `etcd` alerts. The alerts fire only on two-node clusters with fencing. Each alert targets a specific leaf condition, such as a node being offline or a fence device being unavailable, so that the firing alert names the actionable problem rather than a generic "cluster unhealthy" rollup.

--- a/modules/tnf-monitoring-overview.adoc
+++ b/modules/tnf-monitoring-overview.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_two_node_cluster/installing_tnf/monitoring-two-node-fencing.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="tnf-monitoring-overview_{context}"]
+= How monitoring works in a two-node cluster with fencing
+
+[role="_abstract"]
+In a two-node {product-title} cluster with fencing (TNF), the cluster Etcd Operator watches the Pacemaker cluster state and exposes it as Prometheus metrics. The in-cluster monitoring stack scrapes these metrics and evaluates them against a dedicated set of alerting rules. This gives you the same observability for the Pacemaker and fencing layer that you have for the rest of the cluster.
+
+TNF monitoring covers state that is unique to the two-node topology and is not visible through standard `etcd` metrics:
+
+* Cluster membership and expected node count.
+* Node availability, maintenance, and standby state.
+* Fence device health for each node.
+* The state of Pacemaker-managed resources, such as `etcd`.
+
+.Metric naming and values
+Every TNF metric name is prefixed with `tnf_` and is grouped by level: `tnf_cluster_*`, `tnf_node_*`, and `tnf_resource_*`. Each metric is a gauge that mirrors a Pacemaker condition:
+
+* A value of `1` means the condition is true, which is the healthy state, for example the node is online.
+* A value of `0` means the condition is false, which typically indicates a problem, for example the node is offline.
+
+Node-level metrics carry a `node` label, and resource-level metrics carry both a `node` and a `resource` label. This lets you scope a query or alert to a specific node or resource.
+
+.Alerting
+TNF alerts are delivered as part of the cluster Etcd Operator alerting rules, in a `tnf-pacemaker.rules` group that is separate from the standard `etcd` alerts. The alerts fire only on two-node clusters with fencing. Each alert targets a specific leaf condition, such as a node being offline or a fence device being unavailable, so that the firing alert names the actionable problem rather than a generic "cluster unhealthy" rollup.
+
+You do not need to configure anything to enable TNF metrics and alerts. They are active automatically on a cluster that uses the two-node with fencing topology.


### PR DESCRIPTION
## Summary
- New assembly `monitoring-two-node-fencing.adoc` under `installing_tnf`, covering monitoring for two-node OpenShift clusters with fencing (TNF)
- Concept module `tnf-monitoring-overview.adoc`: how TNF exposes Pacemaker state as Prometheus metrics and alerts
- Reference module `tnf-metrics-reference.adoc`: cluster/node/resource-level `tnf_*` metrics
- Reference module `tnf-alerts-reference.adoc`: `tnf-pacemaker.rules` alerts with severity and per-alert runbook links (`openshift/runbooks`)
- Registered in `_topic_maps/_topic_map.yml` under "Two-node with Fencing"
- Cross-links to the general monitoring stack docs (`accessing-metrics-as-an-administrator`, `managing-alerts-as-an-administrator`) to avoid duplicating platform-wide monitoring concepts

Jira: https://redhat.atlassian.net/browse/OCPEDGE-2709

## Test plan
- [ ] AsciiBinder build passes for the new assembly and modules
- [ ] Topic map entry renders under Two-node with Fencing nav
- [ ] Runbook links resolve (alerts published as part of OCPEDGE-2707/2710)