### PR TITLE
OSDOCS-20945: Correct Podman docs version and add slirp4netns deprecation note

### DIFF
--- a/modules/configuring-rootless-podman-networking.adoc
+++ b/modules/configuring-rootless-podman-networking.adoc
@@ -11,6 +11,11 @@ To restore rootless Podman networking when the default `pasta` stack fails on {p
 
 You might need to configure rootless Podman networking after upgrading to {op-system-base} 9.5 or Podman 5.0. In these versions, the default networking stack changed from `slirp4netns` to `pasta`. As a result, systems that previously operated without a default route might no longer be able to establish network connectivity and could display the following error:
 
+[NOTE]
+====
+Reverting the default rootless network to `slirp4netns` is deprecated and will be removed in a future version. Use `pasta` as the supported rootless networking backend where possible.
+====
+
 [source,terminal]
 ----
 Error: pasta failed with exit code 1:

--- a/modules/installing-mirroring-creating-registry-prerequisites.adoc
+++ b/modules/installing-mirroring-creating-registry-prerequisites.adoc
@@ -12,7 +12,7 @@ There are several prerequisites that you must meet before you can create a mirro
 The following prerequisites must be met:
 
 * An {product-title} subscription.
-* {op-system-base-full} 8 and 9 with Podman 3.4.2 or later and OpenSSL installed. If you are using Podman 5.7 or later, see "Configuring rootless Podman networking".
+* {op-system-base-full} 8 and 9 with Podman 3.4.2 or later and OpenSSL installed. If you are using Podman 5.0 or later, see "Configuring rootless Podman networking".
 * Fully qualified domain name for the Red{nbsp}Hat Quay service, which must resolve through a DNS server.
 * Key-based SSH connectivity on the target host. SSH keys are automatically generated for local installs. For remote hosts, you must generate your own SSH keys.
 * 2 or more vCPUs.


### PR DESCRIPTION
## Summary
- Fixes incorrect Podman version reference in mirror registry prerequisites (`5.7` → `5.0`)
- Adds deprecation note to the rootless `slirp4netns` networking workaround procedure

Jira: https://redhat.atlassian.net/browse/OSDOCS-20945

## Test plan
- [ ] Verified prerequisites text reads "Podman 5.0 or later"
- [ ] Verified deprecation note renders in "Configuring rootless Podman networking"
- [ ] Confirmed no other unintended doc changes