### PR TITLE
OSDOCS-17371: Align LVM Storage default namespace to openshift-lvm-storage

### DIFF
--- a/modules/lvms-about-creating-lvmcluster-cr.adoc
+++ b/modules/lvms-about-creating-lvmcluster-cr.adoc
@@ -13,7 +13,7 @@ You must install {lvms} by using {rh-rhacm} if you want to create an `LVMCluster
 
 [IMPORTANT]
 ====
-You must create the `LVMCluster` CR in the same namespace where you installed the {lvms} Operator, which is `openshift-storage` by default.
+You must create the `LVMCluster` CR in the same namespace where you installed the {lvms} Operator, which is `openshift-lvm-storage` by default.
 ====
 
 After creating the `LVMCluster` CR, {lvms} creates the following system-managed CRs:

--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -54,7 +54,7 @@ metadata:
   namespace: openshift-lvm-storage
 spec:
   targetNamespaces:
-  - openshift-storage
+  - openshift-lvm-storage
 ----
 
 . Create the `OperatorGroup` CR by running the following command:

--- a/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -25,7 +25,7 @@ The default namespace for the {lvms} Operator is `openshift-lvm-storage`.
 . Set the following options on the *Operator Installation* page:
 .. *Update Channel* as *stable-{product-version}*.
 .. *Installation Mode* as *A specific namespace on the cluster*.
-.. *Installed Namespace* as *Operator recommended namespace openshift-storage*.
+.. *Installed Namespace* as *Operator recommended namespace `openshift-lvm-storage`*.
    If the `openshift-lvm-storage` namespace does not exist, it is created during the operator installation.
 .. *Update approval* as *Automatic* or *Manual*.
 +

--- a/modules/lvms-reusing-vg-from-prev-installation.adoc
+++ b/modules/lvms-reusing-vg-from-prev-installation.adoc
@@ -32,7 +32,7 @@ apiVersion: lvm.topolvm.io/v1alpha1
 kind: LVMCluster
 metadata:
   name: my-lvmcluster
-  namespace: openshift-storage
+  namespace: openshift-lvm-storage
 spec:
 # ...
   storage:


### PR DESCRIPTION
Version(s):
main (in-development OpenShift 5.1). Still present in published 4.18-4.22 docs.

Issue:
https://issues.redhat.com/browse/OSDOCS-17371

Link to docs preview:
Affected modules:
- `modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc`
- `modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc`
- `modules/lvms-about-creating-lvmcluster-cr.adoc`
- `modules/lvms-reusing-vg-from-prev-installation.adoc`
Published 4.22 page:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/storage/persistent-storage-using-local-storage

QE review:
- [ ] QE has approved this change.

Additional information:
The LVM Storage Operator default namespace is `openshift-lvm-storage`. Several install and LVMCluster examples still used `openshift-storage`.

Verified still present in OpenShift 4.22:
- Published 4.22 storage docs still mix `openshift-storage` and `openshift-lvm-storage` for the LVM Storage Operator default namespace.