### PR TITLE
OCPBUGS-55694: Clarify vSphere static IP IPPool vs IPAddressClaim usage

### DIFF
--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -13,6 +13,13 @@ You can use a machine set to scale machines with configured static IP addresses.
 
 After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.
 
+[NOTE]
+====
+Do not confuse the installer-created `IPPool` resource used for machine static IP addresses with the `IPPool` resource from Whereabouts or Multus. The Whereabouts and Multus `IPPool` objects apply only to pod networking and cannot satisfy machine `IPAddressClaim` resources.
+
+When you install a cluster with static IP addresses, the installer can create an `IPPool` in the `openshift-machine-api` namespace. You can reference that pool from a machine set by using `addressesFromPools`, even if you do not run a separate IPAM controller. Use a third-party IPAM controller only when you need a different pool or external IPAM integration.
+====
+
 [IMPORTANT]
 ====
 Your organization might use numerous types of IP address management (IPAM) services. If you want to enable a particular IPAM service on {product-title}, you might need to manually create the `IPAddressClaim` resource in a YAML definition and then bind a static IP address to this resource by entering the following command in your `oc` CLI:

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -155,9 +155,11 @@ where:
 By default, the external controller automatically scans any resources in the machine set for recognizable address pool types. When the external controller finds `kind: IPPool` defined in the `IPAddress` resource, the controller binds any static IP addresses to the `IPAddressClaim` resource.
 ====
 
-. Update the `IPAddressClaim` status with a reference to the `IPAddress` resource:
+. Optional: If your IPAM controller does not automatically bind the `IPAddress` to the `IPAddressClaim`, update the `IPAddressClaim` status with a reference to the `IPAddress` resource:
 +
 [source, terminal]
 ----
 $ oc --type=merge patch IPAddressClaim cluster-dev-9n5wg-worker-0-m7529-claim-0-0 -p='{"status":{"addressRef": {"name": "cluster-dev-9n5wg-worker-0-m7529-ipaddress-0-0"}}}' -n openshift-machine-api --subresource=status
 ----
++
+This manual status update is required when you use the default installer-created `IPPool` and no IPAM controller performs the association.


### PR DESCRIPTION
Version(s):
main (in-development OpenShift 5.1). Still present in published 4.18-4.22 docs.

Issue:
https://issues.redhat.com/browse/OCPBUGS-55694

Link to docs preview:
Affected modules:
- `modules/nodes-vsphere-machine-set-concept-static-ip.adoc`
- `modules/nodes-vsphere-machine-set-scaling-static-ip.adoc`
Published 4.22 page:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/postinstallation_configuration/post-install-node-tasks

QE review:
- [ ] QE has approved this change.

Additional information:
The vSphere static IP scaling docs mention IPAddressClaims without explaining that the installer-created IPPool is different from Whereabouts/Multus IPPool objects. The manual IPAddressClaim status patch is required for the default installer IPPool when no IPAM controller does the association, so that step is now marked Optional with that note.

Verified still present in OpenShift 4.22:
- Published 4.22 post-installation node tasks still omit the installer IPPool vs Whereabouts distinction and still present the status patch as a required step.