### PR TITLE
OSDOCS-13021: Warn that extra files in /var/lib/etcd break restore

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -78,6 +78,11 @@ This procedure assumes that you copied the `backup` directory containing the etc
 
 . Use SSH to connect to the recovery host. Restore the cluster from an earlier backup by running the following command:
 +
+[IMPORTANT]
+====
+Before you run `cluster-restore.sh`, ensure that `/var/lib/etcd` on the recovery host contains only the etcd data that the restore script expects, typically the `member` directory. Extra files in `/var/lib/etcd` can cause the restore script to fail. Move any unrelated files out of `/var/lib/etcd` before you start the restore.
+====
++
 [source,terminal]
 ----
 $ sudo -E /usr/local/bin/cluster-restore.sh /home/core/<etcd-backup-directory>


### PR DESCRIPTION
Version(s):
main (in-development OpenShift 5.1). Still present in published 4.18-4.22 docs.

Issue:
https://issues.redhat.com/browse/OSDOCS-13021

Link to docs preview:
Affected module: `modules/dr-restoring-cluster-state.adoc`
Published 4.22 page:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/backup_and_restore/control-plane-backup-and-restore

QE review:
- [ ] QE has approved this change.

Additional information:
Extra files in `/var/lib/etcd` on the recovery host can cause `cluster-restore.sh` to fail. The restore procedure now warns operators to keep only the expected etcd data (typically the `member` directory) before running the script.

Verified still present in OpenShift 4.22:
- Published 4.22 control-plane backup and restore docs do not warn about extra files in `/var/lib/etcd`.