### PR TITLE
OSDOCS-17437: Document nodeStatusMaxImages for KubeVirt hosted workers

### DIFF
--- a/modules/hcp-kubeconf-nodepool.adoc
+++ b/modules/hcp-kubeconf-nodepool.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 To reference your kubelet configuration in node pools, you add the kubelet configuration in a config map and then apply the config map in the `NodePool` resource.
 
+[NOTE]
+====
+On hosted clusters that use the {VirtProductName} provider, kubelet reports a maximum of 50 images per node by default (`nodeStatusMaxImages: 50`). If a worker node has more than 50 images, the truncated image list can prevent the `imageLocality` scheduler plugin from scoring nodes correctly and can cause imbalanced pod scheduling.
+
+To disable the limit, set `nodeStatusMaxImages` to `-1` in the kubelet configuration that you add to the config map.
+====
+
 .Procedure
 
 . Add the kubelet configuration inside of a config map in the management cluster by entering the following information:
@@ -29,6 +36,7 @@ data:
       name: <kubeletconfig_name>
     spec:
       kubeletConfig:
+        nodeStatusMaxImages: -1
         registerWithTaints:
         - key: "example.sh/unregistered"
           value: "true"


### PR DESCRIPTION
Version(s):
main (in-development OpenShift 5.1). Still present in published 4.18-4.22 docs.

Issue:
https://issues.redhat.com/browse/OSDOCS-17437

Link to docs preview:
Affected module: `modules/hcp-kubeconf-nodepool.adoc`
Published 4.22 page:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes/hcp-machine-config

QE review:
- [ ] QE has approved this change.

Additional information:
Hosted clusters on OpenShift Virtualization default kubelet `nodeStatusMaxImages` to 50. When a worker has more than 50 images, the truncated image list can break imageLocality scoring. Docs now note this and show `nodeStatusMaxImages: -1` in the kubelet ConfigMap example.

Verified still present in OpenShift 4.22:
- Published 4.22 hosted control planes kubelet configuration topic does not mention `nodeStatusMaxImages`.