### PR TITLE
[RELEASE NOTE] OSDOCS-22094: Added a release note for BYO security groups for AWS Net…

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -125,6 +125,12 @@ Detailed information.
 [id="ocp-release-notes-networking_{context}"]
 == Networking
 
+BYO security groups for AWS Network Load Balancers::
++
+The AWS Cloud Controller Manager (CCM) now supports attaching your Bring Your Own (BYO) security groups to Network Load Balancers (NLBs).
+The NLBs must have been created for Kubernetes `Service` resources of type `LoadBalancer`.
++
+For more information, see xref:../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws.adoc#nw-ingress-aws-about-byo-security-groups_configuring-ingress-cluster-traffic-aws[Configuring ingress cluster traffic on AWS].
 
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes


### PR DESCRIPTION
Version(s):
5.0

Issue:
[OSDOCS-21070](https://redhat.atlassian.net/browse/OSDOCS-21070)

Link to docs preview: