### PR TITLE
OSDOCS-22097: Documented the External DNS operator expose interval pa…

### DIFF
--- a/modules/nw-external-dns-operator-configuration-parameters.adoc
+++ b/modules/nw-external-dns-operator-configuration-parameters.adoc
@@ -25,11 +25,24 @@ spec:
       credentials:
         name: aws-access-key
 ----
-* `provider.type`: Specifies available options such as AWS, {gcp-short}, Azure, and Infoblox.
+* `provider.type`: Specifies available options such as {aws-short}, {gcp-short}, {azure-short}, and Infoblox.
 * `provider.aws.credentials.name`: Specifies a secret name for your cloud provider.
 
+|`spec.intervalSeconds`
+|Integer value. Specifies the interval in seconds between two consecutive synchronization operations that the ExternalDNS Operator performs.
+If you do not specify a value, the Operator determines a default value, such as `60` seconds, that avoids reaching the rate limit of your cloud provider.
+
+[source,yaml]
+----
+intervalSeconds:
+  format: int32
+  maximum: 3600
+  minimum: 60
+  type: integer
+----
+
 |`zones`
-|Enables you to specify DNS zones by their domains. If you do not specify zones, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
+|Specifies DNS zones by their domains. If you do not specify zones, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
 
 [source,yaml]
 ----
@@ -39,7 +52,7 @@ zones:
 * `<zone_id>`: Specifies the name of DNS zones.
 
 |`domains`
-|Enables you to specify AWS zones by their domains. If you do not specify domains, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
+|Specifies {aws-short} zones by their domains. If you do not specify domains, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
 
 [source,yaml]
 ----

--- a/modules/nw-external-dns-operator-configuration-sync-interval.adoc
+++ b/modules/nw-external-dns-operator-configuration-sync-interval.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-configuration-parameters.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-external-dns-operator-configuration-sync-interval_{context}"]
+= Configuring the External DNS synchronization interval
+
+[role="_abstract"]
+You can configure the `spec.intervalSeconds` field on the ExternalDNS custom resource (CR) to increase the synchronization interval and reduce API load.
+Additionally, you can use this field to decrease the synchronization interval if your environment requires more frequent updates.
+
+By default, the External DNS Operator performs a full synchronization with your DNS provider at a fixed interval. In environments with a large number of  DNS records, such as large Infoblox deployments, this default interval can generate excessive API load against the DNS provider.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster with the External DNS
+Operator installed.
+* You have permissions to edit the ExternalDNS CR.
+
+.Procedure
+
+. Find the ExternalDNS CR for your provider by entering the following command:
++
+[source,terminal]
+----
+$ oc get externaldns
+----
+
+. Edit the target ExternalDNS CR YAML for editing by entering the following command:
++
+[source,terminal]
+----
+$ oc edit externaldns <externaldns_instance_name>
+----
+
+. Add or update the `spec.intervalSeconds` field by specifying an integer value in seconds for the synchronization interval.
+The value must be in the range of `60` to `3600` seconds.
++
+[source,yaml]
+----
+apiVersion: externaldns.olm.openshift.io/v1beta1
+kind: ExternalDNS
+metadata:
+  name: sample-aws
+spec:
+  provider:
+    type: AWS
+  intervalSeconds: 120
+  zones:
+    - "myzoneid"
+----
+** Where the `intervalSeconds` field set to `120` indicates a full synchronization interval of `120` seconds.
+If you do not specify a value, the ExternalDNS Operator sets a default value, such as `60` seconds.
+
+. Save the file and enter the following command to apply the changes:
++
+[source,terminal]
+----
+$ oc apply -f externaldns-sample.yaml
+----
+
+.Verification
+
+* To verify that the CR was successfully updated, enter the following command:
++
+[source,terminal]
+----
+$ oc get externaldns <externaldns_instance_name> -o yaml
+----
+
+* To verify that the Operator applied the new interval to the running pod, enter the following commands:
++
+** Find the operand pod by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-dns-operator
+----
++
+** Check that the container argument for the pod has the `--interval` flag set by entering the following command:
++
+[source,terminal]
+----
+$ oc get pod <operand_pod_name> -n external-dns-operator -o
+  jsonpath='{.spec.containers[0].args}'
+----
++
+Alternatively, you can check the operand log to confirm the new synchronization frequency by entering the following command:
++
+[source,terminal]
+----
+$ oc logs <operand_pod_name> -n external-dns-operator
+----

--- a/networking/networking_operators/external_dns_operator/nw-configuration-parameters.adoc
+++ b/networking/networking_operators/external_dns_operator/nw-configuration-parameters.adoc
@@ -10,3 +10,7 @@ toc::[]
 To customize the behavior of the External DNS Operator, configure the available parameters in the `ExternalDNS` custom resource (CR). By configuraing parameters, you can control how the Operator synchronizes services and routes with your external DNS provider.
 
 include::modules/nw-external-dns-operator-configuration-parameters.adoc[leveloffset=+1]
+
+include::modules/nw-external-dns-operator-configuration-sync-interval.adoc[leveloffset=+2]
+
+


### PR DESCRIPTION
Version(s):
5.0

Issue:
[OSDOCS-22097](https://redhat.atlassian.net/browse/OSDOCS-22097)

Link to docs preview:

* https://119613--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-configuration-parameters.html

- [ ] SME has approved this change (Grzegorz Piotrowski and/or Ryan Fredette).
- [ ] QE has approved this change.

