### PR TITLE
OSDOCS-22030-1:Add 4.22.13 z-stream release notes

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -300,6 +300,14 @@ For more information, see xref:../machine_configuration/index.html#checking-mco-
 [id="ocp-release-notes-machine-management_{context}"]
 == Machine management
 
+Bare-metal nodes on {vmw-full} clusters is generally available::
++
+You can add bare-metal compute machines to an existing {product-title} cluster on {vmw-short}. With this capability, you can migrate workloads to physical hardware without reinstalling the cluster.
++
+Bare-metal nodes on {vmw-short} clusters was introduced in {product-title} 4.21 with Technology Preview status. Beginning in {product-title} 4.22.13, it is now generally available.
++
+For more information, see xref:../machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc#adding-bare-metal-compute-vsphere-user-infra[Adding bare-metal compute machines to a vSphere cluster].
+
 {aws-short} Dedicated Host support (Technology Preview)::
 +
 You can now place compute machines on {aws-first} Dedicated Hosts. Dedicated Hosts are physical servers that are fully dedicated to your use. With Dedicated Hosts, you can use your existing per-socket, per-core, or per-VM software licenses and comply with corporate policies that require physical CPU assignment.
@@ -623,6 +631,16 @@ With this update, you can collect diagnostic data by using custom images in the 
 
 [id="ocp-release-notes-storage_{context}"]
 == Storage
+
+Adding bare-metals nodes on {vmw-full} is generally available::
++
+{product-title} 4.21 added the ability to add bare-metal nodes to an {product-title} cluster on {vmw-short} as a Technology Preview feature. Beginning in {product-title} 4.22.13, this feature is generally available.
++
+However, if you add bare-metal nodes, you must remove the {vmw-short} Container Storage Interface (CSI) Driver, otherwise the cluster is marked as degraded.
++
+For information about how to add bare-metal nodes, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-adding-bm-nodes_persistent-storage-csi-vsphere[Adding bare-metal nodes].
++
+For information about how to remove the {vmw-short} CSI Driver, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-disable-storage-overview_persistent-storage-csi-vsphere[Disabling and enabling storage on vSphere].
 
 New VolumeSnapshotClass csi-gce-pd-vsc-images is generally available::
 By default, you cannot restore more than six volumes per snapshot per hour. So in Kubevirt environments, you normally cannot create more than six VMs per hour from a "golden image" (templates saved as snapshots).

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -306,7 +306,7 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |Bare-metal nodes on {vmw-full} clusters
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |{aws-full} Dedicated Host support
 |Not Available

--- a/modules/zstream-4-22-13.adoc
+++ b/modules/zstream-4-22-13.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-13_{context}"]
+= RHSA-2026:63096 - {product-title} {product-version}.13 bug fix and security update
+
+Issued: 08 September 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.13 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:63096[RHSA-2026:63096] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:63091[RHSA-2026:63091] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.13 --pullspecs
+----
+
+[id="zstream-4-22-13-enhancements_{context}"]
+== Enhancements
+
+* In {product-title} release 4.22.13 and later, you can add bare-metal compute machines to an existing {product-title} cluster on {vmw-short}. With this capability, you can migrate workloads to physical hardware without reinstalling the cluster. Previously, that bare-metal compute machines feature was listed as a Technology Preview feature. The feature is now generally available for {product-title} release 4.22.13 and later.
+
+[id="zstream-4-22-13-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `IngressNodeFirewall` custom resource (CR) could not apply rules on sub-interfaces with dotted names because the Berkeley Packet Filter (BPF) file system did not allow dots (".") in the filenames. With this release, the dots in the interface names are replaced by a placeholder before writing to the BPF file system. As a result, the `IngressNodeFirewall` CR can apply rules on the sub-interfaces. (link:https://redhat.atlassian.net/browse/OCPBUGS-86993[OCPBUGS-86993])
+
+* Before this update, the Bare Metal Operator (BMO) `getChecksum()` function accepted non-empty checksums for Oracle Cloud Infrastructure (OCI) images. As a consequence, OCI image provisioning failed. With this release, a check in the `getChecksum()` function rejects non-empty user-provided checksums for OCI images. As a result, OCI image provisioning does not fail. (link:https://redhat.atlassian.net/browse/OCPBUGS-90570[OCPBUGS-90570])
+
+* Before this update, detaching and re-attaching a bare-metal host (BMH) using the Redfish Virtual Media driver did not set the `bootMACAddress` parameter. As a consequence, host provisioning failed because port records for the network interface controllers (NICs) were not re-created for the host. With this release, port records are recreated on-demand using the information from the inventory, that is, the HardwareData schema resources. As a result, re-attached hosts are successfully provisioned. (link:https://redhat.atlassian.net/browse/OCPBUGS-99420[OCPBUGS-99420])
+
+* Before this update, when the bare-metal host (BMH) `spec.online` parameter was set to `False`, the Bare Metal Operator (BMO) forced Ironic to issue a power off command to the node at the end of inspection, after the ramdisk had been ejected. As a consequence, the node OS lost access to the boot media during shutdown, and filesystem corruption errors were visible on the BMH console. With this release, the node is powered off after inspection, while cleaning up the ramdisk, before ejecting Redfish virtual media. As a result, the host does not lose access to the boot media. (link:https://redhat.atlassian.net/browse/OCPBUGS-112341[OCPBUGS-112341])
+
+* Before this update, the `GetMarketplaceImage` function for the installation program experienced timeout issues because the function used a deprecated SDK that lacked a retry mechanism. As a consequence, the marketplace image fetch failed, which terminated the installation. With this release, the timeout for retrieving marketplace images is increased  from 30 seconds to five minutes because the `GetMarketplaceImage` function now uses the new Azure SDK to retry requests. As a result, timeout issues do not cause installation failure.(link:https://redhat.atlassian.net/browse/OCPBUGS-112471[OCPBUGS-112471])
+
+* Before this update, the Node Tuning Operator reconciliation used the rate-limited work queue for all event enqueues. As a consequence, node-tuning configuration was delayed for cluster notes greater than 100. With this release, the Node Tuning Operator reconciliation loop uses the rate-limited work queue only for failures instead of all event enqueues. As a result, node-tuning configuration for cluster nodes greater than 100 is not delayed. (link:https://redhat.atlassian.net/browse/OCPBUGS-112554[OCPBUG-112554])
+
+* Before this update, the short description for the `info` command in the Performance Profile Creator (PPC) tool was not updated after the cluster inspection was moved. As a consequence, inconsistencies between the parent help and the info help occurred when you ran the PPC tool. With this release, the short description for the `info` command in the PPC tool is updated to match the current CLI. As a result, the help inconsistencies do not occur when you run the tool. (link:https://redhat.atlassian.net/browse/OCPBUGS-113579[OCPBUGS-113579])
+
+* Before this update, the Machine Config Controller `EventRecorder` was initialized with the MCO-specific client set scheme, which did not include core Kubernetes types such as `Node`. As a consequence, drain failure events were silently dropped when a node drain failed, for example, due to a blocking `PodDisruptionBudget` parameter. When a node drain failed, the expected warning events, such as the `DrainThresholdExceeded` event, were not emitted. This issue made drain failures more difficult to diagnose and observe. With this release, the `EventRecorder` scheme is updated to include the core Kubernetes types, which ensures that drain failure events are correctly recorded against `Node` objects. As a result, drain failure events are correctly emitted, which improves observability for node drain issues. (link:https://redhat.atlassian.net/browse/OCPBUGS-114392[OCPBUG-114392])
+
+[id="zstream-4-22-13-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -13,7 +13,6 @@ Red{nbsp}Hat {product-title} provides developers and IT organizations with a hyb
 
 Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
-
 // About this release
 include::modules/rn-ocp-about-this-release.adoc[leveloffset=+1]
 
@@ -46,6 +45,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
+
+// 4.22.12 RNs and updating
+include::modules/zstream-4-22-13.adoc[leveloffset=+2]
 
 // 4.22.12 RNs and updating
 include::modules/zstream-4-22-12.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-22030

Link to docs preview:
Updates to the Machine management sections: https://119626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-machine-management_release-notes and https://119626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-machine-management-tech-preview_release-notes

Update to the Storage section: 
https://119626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-storage_release-notes

Updates to the 4.22.13 RN file: https://119626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-13_release-notes

QE review:
N/A

Additional information:

Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/795
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
Errata: RHSA-2026:63096/ RHSA-2026:63091
