### PR TITLE
Tweaking short descriptions to fit 50-300 char limit

### DIFF
--- a/modules/microshift-about-sos-reports.adoc
+++ b/modules/microshift-about-sos-reports.adoc
@@ -7,7 +7,9 @@
 = About sosreport archive
 
 [role="_abstract"]
-You can use an `sosreport` archive to troubleshoot a failing host or problems with {gitops-title}. The `sos` tool combines plugins that help you gather information from different applications. The `sos report` command generates a detailed report that shows all of the enabled plugins and data from the different components and applications in a system.
+You can use an `sosreport` archive to troubleshoot a failing host or problems with {gitops-title}. The `sos` tool combines plugins that help you gather information from different applications.
+
+The `sos report` command generates a detailed report that shows all of the enabled plugins and data from the different components and applications in a system.
 
 A {microshift-short}-specific plugin from sos version 4.5.1 gathers the following data:
 

--- a/modules/microshift-auto-recovery-example-ostree-systems.adoc
+++ b/modules/microshift-auto-recovery-example-ostree-systems.adoc
@@ -7,7 +7,9 @@
 = Use automatic recovery with {op-system-ostree}
 
 [role="_abstract"]
-To use automatic recovery for {product-title} on {op-system-ostree} systems, you can add the auto-recovery systemd service, `10-auto-recovery.conf`, and the `microshift-auto-recovery` script to your blueprint. Use blueprint customizations so the image includes these files and recovery runs automatically.
+To use automatic recovery for {product-title} on {op-system-ostree} systems, you can add the auto-recovery systemd service, `10-auto-recovery.conf`, and the `microshift-auto-recovery` script to your blueprint.
+
+Use blueprint customizations so the image includes these files and recovery runs automatically.
 
 [IMPORTANT]
 ====

--- a/modules/microshift-auto-recovery-example-rpm-systems.adoc
+++ b/modules/microshift-auto-recovery-example-rpm-systems.adoc
@@ -7,7 +7,9 @@
 = Use automatic recovery in RPM systems
 
 [role="_abstract"]
-To use automatic recovery for {product-title} on RPM systems, you can create the `10-auto-recovery.conf` file, the `microshift-auto-recovery.service` unit, and the `microshift-auto-recovery` script. Systemd runs the recovery service when the {product-title} service does not start, and the script restores the latest backup.
+To use automatic recovery for {product-title} on RPM systems, you can create the `10-auto-recovery.conf` file, the `microshift-auto-recovery.service` unit, and the `microshift-auto-recovery` script.
+
+Systemd runs the recovery service when the {product-title} service does not start, and the script restores the latest backup.
 
 As a use case, consider the following example situation in which you want to automate the automatic recovery process for RPM systems that use the systemd service.
 

--- a/modules/microshift-blocking-nodeport-access.adoc
+++ b/modules/microshift-blocking-nodeport-access.adoc
@@ -7,8 +7,7 @@
 = Blocking external access to the NodePort service on a specific host interface
 
 [role="_abstract"]
-OVN-Kubernetes does not restrict the host interface where a `NodePort` service can be accessed from 
-outside a {product-title} node. To block the `NodePort` service on a specific host interface and restrict external access, you can insert a _drop_ rule for the port and IP on a {product-title} node.
+OVN-Kubernetes does not restrict the host interface where a `NodePort` service can be accessed from outside a {product-title} node. To block the `NodePort` service on a specific host interface and restrict external access, you can insert a _drop_ rule for the port and IP on the node.
 
 .Prerequisites
 

--- a/modules/microshift-ca-adding-bundle-ostree.adoc
+++ b/modules/microshift-ca-adding-bundle-ostree.adoc
@@ -7,7 +7,7 @@
 = Add a certificate authority bundle to a blueprint
 
 [role="_abstract"]
-You can include additional certificate authorities (CAs) to be trusted by the operating system when pulling images from an image registry. To add the additional CAs to the {op-system-ostree-first} `rpm-ostree` image, configure them in the blueprint that you use to create the image.
+You can include additional certificate authorities (CAs) to be trusted by the operating system when pulling images from an image registry. To add the CAs to the {op-system-ostree-first} `rpm-ostree` image, configure them in the blueprint that you use to create the image.
 
 [NOTE]
 ====

--- a/modules/microshift-check-journal-logs-updates.adoc
+++ b/modules/microshift-check-journal-logs-updates.adoc
@@ -7,7 +7,7 @@
 = Check journal logs after updates
 
 [role="_abstract"]
-You can use journal logs to help diagnose {microshift-short} update failures. The default configuration of the `systemd` journal service stores data in a volatile directory, which does not persist across restarts. To retain logs across restarts, enable log persistence and set a maximum size limit for journal data.
+You can use journal logs to help diagnose {microshift-short} update failures. By default, the `systemd` journal service stores data in a volatile directory, which does not persist across restarts. To retain logs across restarts, enable log persistence and set a maximum size limit for journal data.
 
 .Procedure
 

--- a/modules/microshift-con-understanding-generic-device-plugin.adoc
+++ b/modules/microshift-con-understanding-generic-device-plugin.adoc
@@ -7,7 +7,9 @@
 = Understand the Generic Device Plugin
 
 [role="_abstract"]
-The Generic Device Plugin in {product-title} is a Kubernetes device plugin that enables pods to access host devices such as serial ports, cameras, and sound cards securely. You can use it for edge and IoT workloads that require direct hardware access without elevated container privileges.
+The Generic Device Plugin in {product-title} is a Kubernetes device plugin that enables pods to access host devices such as serial ports, cameras, and sound cards securely.
+
+You can use it for edge and IoT workloads that require direct hardware access without elevated container privileges.
 
 The GDP integrates with the kubelet to advertise available devices to the node and facilitate their allocation to pods without requiring elevated privileges within the container itself. It is designed to handle devices that are initialized and managed by the operating system and do not require any special initialization procedures or drivers for a pod to use them.
 

--- a/modules/microshift-config-nodeport-limits.adoc
+++ b/modules/microshift-config-nodeport-limits.adoc
@@ -7,7 +7,9 @@
 = Extending the port range for NodePort services
 
 [role="_abstract"]
-The `serviceNodePortRange` setting extends the port range available to NodePort services. This option is useful when specific standard ports under the `30000-32767` range need to be exposed. For example, if your device needs to expose the `1883/tcp` MQ Telemetry Transport (MQTT) port on the network because client devices cannot use a different port.
+The `serviceNodePortRange` setting extends the port range available to NodePort services. This option is useful when specific standard ports under the `30000-32767` range need to be exposed.
+
+For example, if your device needs to expose the `1883/tcp` MQ Telemetry Transport (MQTT) port on the network because client devices cannot use a different port.
 
 [IMPORTANT]
 ====

--- a/modules/microshift-config-yaml-custom.adoc
+++ b/modules/microshift-config-yaml-custom.adoc
@@ -7,7 +7,7 @@
 = Using custom settings
 
 [role="_abstract"]
-To create custom configurations, make a copy of the `config.yaml.default` file that is given in the `/etc/microshift/` directory, renaming it `config.yaml`. Keep this file in the `/etc/microshift/` directory, and then you can change supported settings that override the defaults before starting or restarting {microshift-short}.
+To create custom configurations, make a copy of the `config.yaml.default` file in the `/etc/microshift/` directory, renaming it `config.yaml`. Keep this file in the `/etc/microshift/` directory, and then change supported settings that override the defaults before starting or restarting {microshift-short}.
 
 If you have just a few changes to make to the default settings, consider using configuration drop-in snippets as an alternative method.
 

--- a/modules/microshift-configure-disconnected-networking.adoc
+++ b/modules/microshift-configure-disconnected-networking.adoc
@@ -7,4 +7,6 @@
 = Configure networking for a fully disconnected host
 
 [role="_abstract"]
-When {microshift-short} runs on a host with no external network connectivity, you must configure networking so that the node can resolve container image references and reach cluster-internal services. This includes configuring the OVN-Kubernetes network plugin for disconnected operation and, if needed, reverting network configuration changes.
+When {microshift-short} runs on a host with no external network connectivity, you must configure networking so that the node can resolve container image references and reach cluster-internal services.
+
+This includes configuring the OVN-Kubernetes network plugin for disconnected operation and, if needed, reverting network configuration changes.

--- a/modules/microshift-configure-with-config-file.adoc
+++ b/modules/microshift-configure-with-config-file.adoc
@@ -7,4 +7,6 @@
 = Configure MicroShift with the configuration file
 
 [role="_abstract"]
-{microshift-short} uses a YAML configuration file to control networking, API server behavior, node settings, and other runtime options. You can customize {microshift-short} by editing the default configuration file or by providing configuration snippets that are merged at startup. Understanding the configuration file structure and parameters helps you tailor {microshift-short} to your deployment requirements.
+{microshift-short} uses a YAML configuration file to control networking, API server behavior, node settings, and other runtime options. You can customize {microshift-short} by editing the default configuration file or by providing configuration snippets that are merged at startup.
+
+Understanding the configuration file structure and parameters helps you tailor {microshift-short} to your deployment requirements.

--- a/modules/microshift-exposed-audit-ports-hostnetwork.adoc
+++ b/modules/microshift-exposed-audit-ports-hostnetwork.adoc
@@ -7,7 +7,9 @@
 = hostNetwork
 
 [role="_abstract"]
-When a pod is configured with the `hostNetwork:true` setting, the pod is running in the host network namespace. This configuration can independently open host ports. {microshift-short} component logs cannot be used to track this case, the ports are subject to firewalld rules. If the port opens in firewalld, you can view the port opening in the firewalld debug log.
+When a pod is configured with the `hostNetwork:true` setting, the pod is running in the host network namespace. This configuration can independently open host ports. {microshift-short} component logs cannot be used to track this case, the ports are subject to firewalld rules.
+
+If the port opens in firewalld, you can view the port opening in the firewalld debug log.
 
 .Prerequisites
 

--- a/modules/microshift-firewall-known-issue.adoc
+++ b/modules/microshift-firewall-known-issue.adoc
@@ -7,6 +7,8 @@
 = Known firewall issue
 
 [role="_abstract"]
-To avoid traffic failures after a firewalld reload or restart on {microshift-short}, run firewall commands before you start {op-system-base-full}. If you must run firewall commands later, restart the `ovnkube-master` pod in `openshift-ovn-kubernetes` to restore iptable rules that OVN-Kubernetes manages.
+To avoid traffic failures after a firewalld reload or restart on {microshift-short}, run firewall commands before you start {op-system-base-full}.
+
+If you must run firewall commands later, restart the `ovnkube-master` pod in `openshift-ovn-kubernetes` to restore iptable rules that OVN-Kubernetes manages.
 
 The CNI driver in {microshift-short} makes use of iptable rules for some traffic flows, such as those using the NodePort service. The iptable rules are generated and inserted by the CNI driver, but are deleted when the firewall reloads or restarts. The absence of the iptable rules breaks traffic flows.

--- a/modules/microshift-firewall-req-settings.adoc
+++ b/modules/microshift-firewall-req-settings.adoc
@@ -7,7 +7,9 @@
 = Required firewall settings
 
 [role="_abstract"]
-An IP address range for the node network must be enabled during firewall configuration. You can use the default values or customize the IP address range. If you choose to customize the node network IP address range from the default `10.42.0.0/16` setting, you must also use the same custom range in the firewall configuration.
+An IP address range for the node network must be enabled during firewall configuration. You can use the default values or customize the IP address range.
+
+If you choose to customize the node network IP address range from the default `10.42.0.0/16` setting, you must also use the same custom range in the firewall configuration.
 
 .Firewall IP address settings
 [cols="3",options="header"]

--- a/modules/microshift-firewall-update-for-service.adoc
+++ b/modules/microshift-firewall-update-for-service.adoc
@@ -7,7 +7,9 @@
 = Overview of firewall ports when a service is exposed
 
 [role="_abstract"]
-Firewalld is often active when you run services on {microshift-short}. This can disrupt certain services on {microshift-short} because traffic to the ports might be blocked by the firewall. You must ensure that the necessary firewall ports are open if you want certain services to be accessible from outside the host. 
+Firewalld is often active when you run services on {microshift-short}. This can disrupt certain services on {microshift-short} because traffic to the ports might be blocked by the firewall.
+
+You must ensure that the necessary firewall ports are open if you want certain services to be accessible from outside the host.
 
 There are several options for opening your ports:
 

--- a/modules/microshift-get-node-id.adoc
+++ b/modules/microshift-get-node-id.adoc
@@ -7,4 +7,4 @@
 = Get your node ID
 
 [role="_abstract"]
-The {microshift-short} node ID uniquely identifies your node within the cluster and is used in support cases, licensing, and cluster registration scenarios. You can retrieve the node ID from the `kube-system` namespace either while {microshift-short} is running or from a stopped node by reading the stored namespace data.
+The {microshift-short} node ID uniquely identifies your node within the cluster and is used in support cases, licensing, and cluster registration. You can retrieve the node ID from the `kube-system` namespace either while {microshift-short} is running or from a stopped node by reading the stored namespace data.

--- a/modules/microshift-greenboot-dir-structure.adoc
+++ b/modules/microshift-greenboot-dir-structure.adoc
@@ -7,7 +7,9 @@
 = How greenboot uses directories to run scripts
 
 [role="_abstract"]
-Greenboot uses directory-based framework to execute health check scripts during the system boot process. By organizing your custom scripts into specific directories, you can define the boot validation workflow and determine whether the system successfully applies an update or initiates an automated rollback.
+Greenboot uses directory-based framework to execute health check scripts during the system boot process.
+
+By organizing your custom scripts into specific directories, you can define the boot validation workflow and determine whether the system successfully applies an update or initiates an automated rollback.
 
 Health check scripts run from four `/etc/greenboot` directories. These scripts run in alphabetical order. Keep this in mind when you configure the scripts for your workloads.
 

--- a/modules/microshift-greenboot-included-health-checks.adoc
+++ b/modules/microshift-greenboot-included-health-checks.adoc
@@ -7,7 +7,9 @@
 = Included greenboot health checks
 
 [role="_abstract"]
-By default, {op-system-ostree-first} includes a set of built-in greenboot health checks designed to verify functions, such as network connectivity to update repositories and hardware watchdog status. Health check scripts are available in `/usr/lib/greenboot/check`, a read-only directory in {op-system-ostree-first} {op-system-image} systems.
+By default, {op-system-ostree-first} includes a set of built-in greenboot health checks designed to verify functions, such as network connectivity to update repositories and hardware watchdog status.
+
+Health check scripts are available in `/usr/lib/greenboot/check`, a read-only directory in {op-system-ostree-first} {op-system-image} systems.
 
 The following health checks are included with the `greenboot-default-health-checks` framework.
 

--- a/modules/microshift-greenboot-prerollback-log.adoc
+++ b/modules/microshift-greenboot-prerollback-log.adoc
@@ -8,7 +8,9 @@
 = Accessing prerollback health check output in the system log
 
 [role="_abstract"]
-When a system update fails and greenboot triggers a rollback, it executes prerollback scripts to clean up services and prevent data conflicts. Using the output of the health check scripts, you can verify that the cleanup tasks are completed successfully before the system reboots into the previous deployment.
+When a system update fails and greenboot triggers a rollback, it executes prerollback scripts to clean up services and prevent data conflicts.
+
+Using the output of the health check scripts, you can verify that the cleanup tasks are completed successfully before the system reboots into the previous deployment.
 
 For example, check the results of a pre-rollback script using the following procedure.
 

--- a/modules/microshift-info-collected-telemetry.adoc
+++ b/modules/microshift-info-collected-telemetry.adoc
@@ -7,7 +7,9 @@
 = Information collected by the {microshift-short} Telemetry API
 
 [role="_abstract"]
-The {microshift-short} Telemetry API collects a lightweight set of metrics to assist with remote health monitoring and product improvement. The data payload is minimal, generally under 2KB, and is designed to have very minimal impact on node resources. The collected information is categorized into system configuration, node capacity, and usage metrics.
+The {microshift-short} Telemetry API collects a lightweight set of metrics to assist with remote health monitoring and product improvement. The data payload is minimal, generally under 2KB, and is designed to have very minimal impact on node resources.
+
+The collected information is categorized into system configuration, node capacity, and usage metrics.
 
 The following information is collected by Telemetry:
 

--- a/modules/microshift-ingress-controller-conc.adoc
+++ b/modules/microshift-ingress-controller-conc.adoc
@@ -7,7 +7,9 @@
 = Use ingress control in {microshift-short}
 
 [role="_abstract"]
-When you create your {microshift-short} node, each pod and service running on the node is allocated an IP address. These IP addresses are accessible to other pods and services running nearby by default, but are not accessible to external clients. {microshift-short} uses a minimal implementation of the {OCP} `IngressController` API to enable external access to node services.
+When you create your {microshift-short} node, each pod and service running on the node is allocated an IP address. These IP addresses are accessible to other pods and services running nearby by default, but are not accessible to external clients.
+
+{microshift-short} uses a minimal implementation of the {OCP} `IngressController` API to enable external access to node services.
 
 With more configuration options, you can fine-tune ingress to meet your specific needs. To use enhanced ingress control, update the parameters in the {microshift-short} configuration file and restart the service.
 

--- a/modules/microshift-install-and-configure-oc-cli.adoc
+++ b/modules/microshift-install-and-configure-oc-cli.adoc
@@ -7,4 +7,6 @@
 = Install and configure the oc CLI
 
 [role="_abstract"]
-The `oc` CLI tool is the primary command-line interface for interacting with {microshift-short}. You can install `oc` on Linux, Windows, and macOS, or install it from an RPM package on {op-system-base}. After installation, you configure access by using a kubeconfig file to connect to the {microshift-short} API server, either locally on the node or remotely from another host.
+The `oc` CLI tool is the primary command-line interface for interacting with {microshift-short}. You can install `oc` on Linux, Windows, and macOS, or install it from an RPM package on {op-system-base}.
+
+After installation, you configure access by using a kubeconfig file to connect to the {microshift-short} API server, either locally on the node or remotely from another host.

--- a/modules/microshift-install-optional-rpms.adoc
+++ b/modules/microshift-install-optional-rpms.adoc
@@ -7,4 +7,6 @@
 = Install optional RPM packages
 
 [role="_abstract"]
-After installing {microshift-short}, you can add optional RPM packages to expand your deployment capabilities. Optional packages include networking extensions such as Multus, application lifecycle management with Operator Lifecycle Manager (OLM), GitOps, observability with OpenTelemetry, and AI model serving with {rhoai}. Install only the packages that your deployment requires.
+After installing {microshift-short}, you can add optional RPM packages to expand your deployment capabilities. Install only the packages that your deployment requires.
+
+Optional packages include networking extensions such as Multus, application lifecycle management with Operator Lifecycle Manager (OLM), GitOps, observability with OpenTelemetry, and AI model serving with {rhoai}.

--- a/modules/microshift-install-rhde-steps.adoc
+++ b/modules/microshift-install-rhde-steps.adoc
@@ -7,7 +7,9 @@
 = {op-system-bundle} installation steps
 
 [role="_abstract"]
-Before proceeding with your specific installation method, you must prepare your environment for installation. To ensure a successful deployment, you must follow the general prerequisites such as obtaining your pull secret, planning your storage strategy, and defining your network topology, before you begin.
+Before proceeding with your specific installation method, you must prepare your environment for installation.
+
+To ensure a successful deployment, you must follow the general prerequisites such as obtaining your pull secret, planning your storage strategy, and defining your network topology, before you begin.
 
 For most installation types, you must also take the following steps:
 

--- a/modules/microshift-install-rhel-types.adoc
+++ b/modules/microshift-install-rhel-types.adoc
@@ -7,7 +7,9 @@
 = {op-system-base} installation types
 
 [role="_abstract"]
-{microshift-short} supports multiple installation methods depending on your target edge environment and workload requirements. You can deploy {microshift-short} by using the standard RPM packages on an existing machine or build an immutable, image-based operating system tailored for disconnected or networked edge deployments.
+{microshift-short} supports multiple installation methods depending on your target edge environment and workload requirements.
+
+You can deploy {microshift-short} by using the standard RPM packages on an existing machine or build an immutable, image-based operating system tailored for disconnected or networked edge deployments.
 
 Choose the best {op-system-base-full} installation type based on where you want to run your node and what your applications need to do. For the best results, apply the following principles:
 

--- a/modules/microshift-install-rpms-olm.adoc
+++ b/modules/microshift-install-rpms-olm.adoc
@@ -7,7 +7,9 @@
 = Install the Operator Lifecycle Manager (OLM) from an RPM package
 
 [role="_abstract"]
-When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can install the OLM on your {microshift-short} instance by using an RPM package. OLM helps you install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running in each {microshift-short} node.
+When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can install the OLM on your {microshift-short} instance by using an RPM package.
+
+OLM helps you install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running in each {microshift-short} node.
 
 .Procedure
 

--- a/modules/microshift-install-tools-intro.adoc
+++ b/modules/microshift-install-tools-intro.adoc
@@ -7,6 +7,8 @@
 = {microshift-short} installation tools
 
 [role="_abstract"]
-To use {microshift-short}, you must already have or plan to install a {op-system-base-full} type, such as on bare metal, or as a virtual machine (VM) that you provision. Although each use case has different details, each installation of {op-system-bundle} uses {op-system-base} tools and the {oc-first}.
+To use {microshift-short}, you must already have or plan to install a {op-system-base-full} type, such as on bare metal, or as a virtual machine (VM) that you provision.
+
+Although each use case has different details, each installation of {op-system-bundle} uses {op-system-base} tools and the {oc-first}.
 
 You can use RPMs to install {microshift-short} on an existing {op-system-base} machine. You do not need other tools unless you are also installing an image-based {op-system-base} system or VM at the same time.

--- a/modules/microshift-install-with-kickstart.adoc
+++ b/modules/microshift-install-with-kickstart.adoc
@@ -7,4 +7,6 @@
 = Install with a Kickstart file
 
 [role="_abstract"]
-You can automate the installation of {microshift-short} by using a Kickstart file. Kickstart files let you pre-configure installation parameters so that the installation process runs without manual input. {microshift-short} supports Kickstart-based installations for RPM packages, `rpm-ostree` (RHEL for Edge), and image mode for RHEL (bootc) targets.
+You can automate the installation of {microshift-short} by using a Kickstart file. Kickstart files let you pre-configure installation parameters so that the installation process runs without manual input.
+
+{microshift-short} supports Kickstart-based installations for RPM packages, `rpm-ostree` (RHEL for Edge), and image mode for RHEL (bootc) targets.

--- a/modules/microshift-kubeconfig-overview.adoc
+++ b/modules/microshift-kubeconfig-overview.adoc
@@ -7,7 +7,9 @@
 = Kubeconfig files for configuring node access
 
 [role="_abstract"]
-The two categories of `kubeconfig` files used in {microshift-short} are local access and remote access. Each time {microshift-short} starts, it generates a set of `kubeconfig` files for accessing the API server. These files are created in the `/var/lib/microshift/resources/kubeadmin/` directory by using existing configuration information.
+The two categories of `kubeconfig` files used in {microshift-short} are local access and remote access. Each time {microshift-short} starts, it generates a set of `kubeconfig` files for accessing the API server.
+
+These files are created in the `/var/lib/microshift/resources/kubeadmin/` directory by using existing configuration information.
 
 Each access type requires a different authentication certificate signed by different Certificate Authorities (CAs). The generation of multiple `kubeconfig` files accommodates this need.
 

--- a/modules/microshift-migrate-rhel-edge-to-image-mode.adoc
+++ b/modules/microshift-migrate-rhel-edge-to-image-mode.adoc
@@ -8,4 +8,6 @@
 = Migrate {microshift-short} from {op-system-ostree} to {op-system-image}
 
 [role="_abstract"]
-Starting with {microshift-short} 4.19, you can migrate your {microshift-short} node from {op-system-ostree} to {op-system-image} if the final versions are a supported configuration of {op-system-bundle}. Check compatibilities before beginning a migration. See the {op-system-base} documentation for instructions to migrate your image-based {op-system-base} system.
+Starting with {microshift-short} 4.19, you can migrate your {microshift-short} node from {op-system-ostree} to {op-system-image} if the final versions are a supported configuration of {op-system-bundle}. Check compatibilities before beginning a migration.
+
+See the {op-system-base} documentation for instructions to migrate your image-based {op-system-base} system.

--- a/modules/microshift-migrate-rhel9-to-rhel10.adoc
+++ b/modules/microshift-migrate-rhel9-to-rhel10.adoc
@@ -7,4 +7,6 @@
 = Migrate from RHEL 9 to RHEL 10
 
 [role="_abstract"]
-To migrate {microshift-short} from an existing {op-system-ostree-first} system running {op-system-version} to one running {op-system-version-10}, you must embed {microshift-short} into a new operating system image. This process transitions your deployment from an `rpm-ostree`-based system to an image mode for RHEL (bootc) system, and requires planning for any UID or GID drift that may occur.
+To migrate {microshift-short} from an existing {op-system-ostree-first} system running {op-system-version} to one running {op-system-version-10}, you must embed {microshift-short} into a new operating system image.
+
+This process transitions your deployment from an `rpm-ostree`-based system to an image mode for RHEL (bootc) system, and requires planning for any UID or GID drift that may occur.

--- a/modules/microshift-mirroring-prereqs.adoc
+++ b/modules/microshift-mirroring-prereqs.adoc
@@ -7,7 +7,9 @@
 = Configure mirroring prerequisites
 
 [role="_abstract"]
-You must create a container image registry credentials file that allows the mirroring of images from your internet-connected mirror host to your air-gapped mirror. Follow the instructions in the "Configuring credentials that allow images to be mirrored" link provided in the "Additional resources" section. These instructions guide you to create a `~/.pull-secret-mirror.json` file on the mirror registry host that includes the user credentials for accessing the mirror.
+You must create a container image registry credentials file that allows the mirroring of images from your internet-connected mirror host to your air-gapped mirror.
+
+Follow the instructions in the "Configuring credentials that allow images to be mirrored" link provided in the "Additional resources" section. These instructions guide you to create a `~/.pull-secret-mirror.json` file on the mirror registry host that includes the user credentials for accessing the mirror.
 
 [id="microshift-example-mirror-pull-secret-entry_{context}"]
 == Example mirror registry pull secret entry

--- a/modules/microshift-nw-advertise-address.adoc
+++ b/modules/microshift-nw-advertise-address.adoc
@@ -7,7 +7,9 @@
 = Configure the advertise address network flag
 
 [role="_abstract"]
-The `apiserver.advertiseAddress` flag specifies the IP address on which to advertise the API server to members of the node. This address must be reachable by the node. You can set a custom IP address here, but you must also add the IP address to a host interface. Customizing this parameter preempts {microshift-short} from adding a default IP address to the `br-ex` network interface.
+The `apiserver.advertiseAddress` flag specifies the IP address on which to advertise the API server to members of the node. This address must be reachable by the node. You can set a custom IP address here, but you must also add the IP address to a host interface.
+
+Customizing this parameter preempts {microshift-short} from adding a default IP address to the `br-ex` network interface.
 
 [IMPORTANT]
 ====

--- a/modules/microshift-nw-network-policy-intro.adoc
+++ b/modules/microshift-nw-network-policy-intro.adoc
@@ -7,7 +7,9 @@
 = How network policy works in {microshift-short}
 
 [role="_abstract"]
-In a node that is using the default OVN-Kubernetes Container Network Interface (CNI) plugin for {microshift-short}, network isolation is controlled by both firewalld, which is configured on the host, and by `NetworkPolicy` objects created within {microshift-short}. Simultaneous use of firewalld and `NetworkPolicy` is supported.
+In a node that is using the default OVN-Kubernetes Container Network Interface (CNI) plugin for {microshift-short}, network isolation is controlled by both firewalld, which is configured on the host, and by `NetworkPolicy` objects created within {microshift-short}.
+
+Simultaneous use of firewalld and `NetworkPolicy` is supported.
 
 * Network policies work only within boundaries of OVN-Kubernetes-controlled traffic, so they can apply to every situation except for `hostPort/hostNetwork` enabled pods.
 

--- a/modules/microshift-oc-cli-commands-reference.adoc
+++ b/modules/microshift-oc-cli-commands-reference.adoc
@@ -7,4 +7,6 @@
 = oc CLI commands reference
 
 [role="_abstract"]
-This reference covers the `oc` and `oc adm` commands available for use with {microshift-short}. The `oc` binary provides commands for managing applications, resources, and cluster state. The `oc adm` commands cover cluster administration tasks. {microshift-short} supports a subset of the full {OCP} command set.
+This reference covers the `oc` and `oc adm` commands available for use with {microshift-short}. The `oc` binary provides commands for managing applications, resources, and cluster state. The `oc adm` commands cover cluster administration tasks.
+
+{microshift-short} supports a subset of the full {OCP} command set.

--- a/modules/microshift-oc-mirror-install-catalog-node.adoc
+++ b/modules/microshift-oc-mirror-install-catalog-node.adoc
@@ -7,7 +7,9 @@
 = Install a custom catalog created with the oc-mirror plugin
 
 [role="_abstract"]
-After you mirror your image set to the mirror registry, you must apply the generated `CatalogSource` custom resource (CR) into the node. Operator Lifecycle Manager (OLM) uses the `CatalogSource` CR to retrieve information about the available Operators in the mirror registry. You must then create and apply a subscription CR to subscribe to your custom catalog.
+After you mirror your image set to the mirror registry, you must apply the generated `CatalogSource` custom resource (CR) into the node. Operator Lifecycle Manager (OLM) uses the `CatalogSource` CR to retrieve information about the available Operators in the mirror registry.
+
+You must then create and apply a subscription CR to subscribe to your custom catalog.
 
 .Prerequisites
 

--- a/modules/microshift-proc-configuring-generic-device-plugin.adoc
+++ b/modules/microshift-proc-configuring-generic-device-plugin.adoc
@@ -7,7 +7,7 @@
 = Configure the Generic Device Plugin
 
 [role="_abstract"]
-The Generic Device Plugin (GDP) is disabled by default in {microshift-short}. To expose host devices such as serial ports and cameras to pods in {product-title}, you can enable the Generic Device Plugin and define devices in the `config.yaml` file or create a configuration snippet file such as `/etc/microshift/config.d/10-gdp.yaml`.
+The Generic Device Plugin (GDP) is disabled by default in {microshift-short}. To expose host devices such as serial ports and cameras to pods, you can enable the GDP and define devices in the `config.yaml` file or create a configuration snippet file such as `/etc/microshift/config.d/10-gdp.yaml`.
 
 .Prerequisites
 

--- a/modules/microshift-proc-deploying-applications-with-generic-devices.adoc
+++ b/modules/microshift-proc-deploying-applications-with-generic-devices.adoc
@@ -7,7 +7,9 @@
 = Deploy applications that use generic devices
 
 [role="_abstract"]
-After the Generic Device Plugin (GDP) is configured and enabled in {microshift-short}, you can deploy Kubernetes workloads, such as pods, deployments, or `StatefulSets`, that request access to the host devices that you have exposed. Devices are made available inside the container without requiring the pod to run with elevated privileges.
+After the Generic Device Plugin (GDP) is configured and enabled in {microshift-short}, you can deploy Kubernetes workloads, such as pods, deployments, or `StatefulSets`, that request access to the host devices that you have exposed.
+
+Devices are made available inside the container without requiring the pod to run with elevated privileges.
 
 .Prerequisites
 

--- a/modules/microshift-restoring-data-backups.adoc
+++ b/modules/microshift-restoring-data-backups.adoc
@@ -8,7 +8,9 @@
 = Restore {microshift-short} data backups manually
 
 [role="_abstract"]
-To restore {product-title} data after an update or data loss, you can run `microshift restore` with the full path to the backup. Backups can be restored after updates, or after other system events that remove or damage required data. When you restore a backup, you must use the entire file path.
+To restore {product-title} data after an update or data loss, you can run `microshift restore` with the full path to the backup. Backups can be restored after updates, or after other system events that remove or damage required data.
+
+When you restore a backup, you must use the entire file path.
 
 [NOTE]
 ====

--- a/modules/microshift-storage-backup-volume-snapshots.adoc
+++ b/modules/microshift-storage-backup-volume-snapshots.adoc
@@ -7,7 +7,9 @@
 = Backing up a volume snapshot
 
 [role="_abstract"]
-Snapshots of data from applications running on a {microshift-short} node are created as read-only logical volumes (LVs) located on the same devices as the original data. You must manually mount local volumes before they can be copied as persistent volumes (PVs) and used as backup copies. To use a snapshot of a {microshift-short} storage volume as a backup, find it on the local host and then move it to a secure location.
+Snapshots of data from applications running on a {microshift-short} node are created as read-only logical volumes (LVs) located on the same devices as the original data. You must manually mount local volumes before they can be copied as persistent volumes (PVs) and used as backup copies.
+
+To use a snapshot of a {microshift-short} storage volume as a backup, find it on the local host and then move it to a secure location.
 
 .Prerequisites
 

--- a/modules/microshift-storage-persistent-storage-overview.adoc
+++ b/modules/microshift-storage-persistent-storage-overview.adoc
@@ -8,7 +8,9 @@
 = Persistent storage overview
 
 [role="_abstract"]
-Stateful applications deployed in containers require persistent storage. {microshift-short} uses a pre-provisioned storage framework called persistent volumes (PV) to allow node administrators to provision persistent storage. The data inside these volumes can exist beyond the lifecycle of an individual pod. Developers can use persistent volume claims (PVCs) to request storage requirements.
+Stateful applications deployed in containers require persistent storage. {microshift-short} uses a pre-provisioned storage framework called persistent volumes (PV) to allow node administrators to provision persistent storage.
+
+The data inside these volumes can exist beyond the lifecycle of an individual pod. Developers can use persistent volume claims (PVCs) to request storage requirements.
 
 ifndef::microshift[]
 Managing storage is a distinct problem from managing compute resources. {product-title} uses the Kubernetes persistent volume (PV) framework to allow cluster administrators to provision persistent storage for a cluster. Developers can use persistent volume claims (PVCs) to request PV resources without having specific knowledge of the underlying storage infrastructure.

--- a/modules/microshift-tls-config-con.adoc
+++ b/modules/microshift-tls-config-con.adoc
@@ -7,7 +7,9 @@
 = Use TLS with {microshift-short}
 
 [role="_abstract"]
-Transport layer security (TLS) profiles provide a way for servers to regulate which ciphers a client can use when connecting to the server. Using TLS helps to ensure that {microshift-short} applications use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms. You can use either the TLS 1.2 or TLS 1.3 security profiles with {microshift-short}.
+Transport layer security (TLS) profiles provide a way for servers to regulate which ciphers a client can use when connecting to the server. Using TLS helps to ensure that {microshift-short} applications use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
+
+You can use either the TLS 1.2 or TLS 1.3 security profiles with {microshift-short}.
 
 {microshift-short} API server cipher suites apply automatically to the following internal control plane components:
 

--- a/modules/microshift-understand-lvms-storage.adoc
+++ b/modules/microshift-understand-lvms-storage.adoc
@@ -7,4 +7,6 @@
 = Understand LVMS storage
 
 [role="_abstract"]
-{microshift-short} uses the Logical Volume Manager Storage (LVMS) plugin to provide dynamic, persistent storage for workloads. LVMS provisions local storage on the device and manages storage classes, device classes, and thin volumes. Understanding how LVMS works and what resources it manages helps you plan and configure storage for your {microshift-short} deployments.
+{microshift-short} uses the Logical Volume Manager Storage (LVMS) plugin to provide dynamic, persistent storage for workloads. LVMS provisions local storage on the device and manages storage classes, device classes, and thin volumes.
+
+Understanding how LVMS works and what resources it manages helps you plan and configure storage for your {microshift-short} deployments.

--- a/modules/microshift-update-kubernetes-storage.adoc
+++ b/modules/microshift-update-kubernetes-storage.adoc
@@ -7,7 +7,9 @@
 = Update existing Kubernetes storage objects
 
 [role="_abstract"]
-When you update {microshift-short} to a new version, existing stored Kubernetes objects may need to be migrated to their latest API storage version. The storage version migration process updates the stored representation of resources to match the API version expected by the new release, ensuring that your cluster remains fully operational after the update.
+When you update {microshift-short} to a new version, existing stored Kubernetes objects may need to be migrated to their latest API storage version.
+
+The storage version migration process updates the stored representation of resources to match the API version expected by the new release, ensuring that your cluster remains fully operational after the update.
 
 To update existing objects to their latest version without recreating them, use storage version migration in {microshift-short}. By creating a StorageVersionMigration custom resource (CR), you request the Kube Storage Version Migrator embedded controller to handle the transition automatically.
 

--- a/modules/microshift-use-ephemeral-storage.adoc
+++ b/modules/microshift-use-ephemeral-storage.adoc
@@ -7,4 +7,6 @@
 = Use ephemeral storage
 
 [role="_abstract"]
-{microshift-short} supports ephemeral storage for workloads that require temporary, pod-local data storage. Ephemeral storage is tied to the lifecycle of the pod and is automatically released when the pod terminates. You can configure ephemeral storage limits and use generic ephemeral volumes backed by LVMS for workloads that need more flexible temporary storage.
+{microshift-short} supports ephemeral storage for workloads that require temporary, pod-local data storage. Ephemeral storage is tied to the lifecycle of the pod and is automatically released when the pod terminates.
+
+You can configure ephemeral storage limits and use generic ephemeral volumes backed by LVMS for workloads that need more flexible temporary storage.

--- a/modules/microshift-use-sos-reports.adoc
+++ b/modules/microshift-use-sos-reports.adoc
@@ -7,4 +7,6 @@
 = Use sos reports
 
 [role="_abstract"]
-The `sos` tool collects diagnostic information from a {microshift-short} node, including logs, configuration files, and system state. You can generate an sos report and share it with Red Hat Support to help diagnose problems. {microshift-short} provides a dedicated sos plugin that gathers {microshift-short}-specific data alongside standard system information.
+The `sos` tool collects diagnostic information from a {microshift-short} node, including logs, configuration files, and system state. You can generate an sos report and share it with Red Hat Support to help diagnose problems.
+
+{microshift-short} provides a dedicated sos plugin that gathers {microshift-short}-specific data alongside standard system information.

--- a/modules/microshift-work-with-volume-snapshots.adoc
+++ b/modules/microshift-work-with-volume-snapshots.adoc
@@ -7,4 +7,6 @@
 = Work with volume snapshots
 
 [role="_abstract"]
-Volume snapshots on {microshift-short} let you capture the state of a persistent volume at a point in time. You can use snapshots to back up application data, restore volumes to a previous state, and clone volumes for testing or migration. {microshift-short} uses LVMS-backed CSI snapshot support to create and manage volume snapshot resources.
+Volume snapshots on {microshift-short} let you capture the state of a persistent volume at a point in time. You can use snapshots to back up application data, restore volumes to a previous state, and clone volumes for testing or migration.
+
+{microshift-short} uses LVMS-backed CSI snapshot support to create and manage volume snapshot resources.

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -17,7 +17,7 @@ endif::[]
 = Delete a {name} policy using the CLI
 
 [role="_abstract"]
-You can delete a {name} policy in a namespace.
+You can delete a {name} policy in a namespace by using the CLI.
 
 ifndef::multi[]
 [NOTE]

--- a/modules/pvc-storage-class.adoc
+++ b/modules/pvc-storage-class.adoc
@@ -8,7 +8,9 @@
 = Storage classes
 
 [role="_abstract"]
-To request specific storage capabilities, define the `StorageClass` name in the `storageClassName` attribute of your `PersistentVolumeClaim` (PVC). This setting ensures the claim binds only to matching `PersistentVolumes` (PVs) or triggers dynamic provisioning if the cluster administrator has configured on-demand creation.
+To request specific storage capabilities, define the `StorageClass` name in the `storageClassName` attribute of your `PersistentVolumeClaim` (PVC).
+
+This setting ensures the claim binds only to matching `PersistentVolumes` (PVs) or triggers dynamic provisioning if the cluster administrator has configured on-demand creation.
 
 ifndef::microshift,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.20+

What changed:

- 42 files — pure sentence relocation, zero wording change. Claude moved the trailing sentence(s) out of the abstract into a new paragraph directly below it. Verified programmatically: the added and removed word sequences are byte-identical, only the paragraph break moved.
- 7 files — minimal wording edits, where relocating would have stripped the actual point of the topic out of the short description:
  - microshift-blocking-nodeport-access — on a {product-title} node → on the node (already named in the prior sentence)
  - microshift-ca-adding-bundle-ostree — dropped a redundant second additional
  - microshift-check-journal-logs-updates — The default configuration of the systemd journal service → By default, the systemd journal service
  - microshift-config-yaml-custom — dropped that is given, you can
  - microshift-get-node-id — dropped trailing scenarios
  - microshift-proc-configuring-generic-device-plugin — dropped in {product-title}, used the already-defined GDP acronym
  - microshift-install-optional-rpms — moved the middle sentence down (the package list); moving the last sentence alone still left it at 313
- 1 file too short — nw-networkpolicy-delete-cli: 47 → 64 chars by appending by using the CLI (matches the module title and the -cli filename). Checked both {name} values it's included under: 64 (network) and 70 (multi-network).

