### PR TITLE
OSDOCS Add additional resources heading to 'Additional CRI-O storage locations' assembly

### DIFF
--- a/nodes/nodes/nodes-nodes-additional-crio-storage.adoc
+++ b/nodes/nodes/nodes-nodes-additional-crio-storage.adoc
@@ -22,6 +22,8 @@ include::modules/nodes-nodes-additional-crio-storage-configuring.adoc[leveloffse
 
 include::modules/nodes-nodes-additional-crio-storage-troubleshooting.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * link:https://github.com/containerd/stargz-snapshotter[Stargz Store plugin]


### PR DESCRIPTION
I noticed when creating the https://github.com/openshift/openshift-docs/pull/118494 PR that the `Additional resources` section didn't have the proper role and ID tags. I added them there. @skopacz1 correctly suggesting using a separate PR to add to all branches.