### PR TITLE
PR for SRVLOGIC-976: Add a section about explaining the workflow id naming and versioning recommended practices and limitations in the OSL product docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -20,6 +20,8 @@ Distros: openshift-serverlesslogic
 Topics:
 - Name: Creating and running workflows with the Knative Workflow plugin
   File: serverless-logic-creating-managing-workflows
+- Name: Workflow identifiers and versioning
+  File: serverless-logic-workflow-identifiers-versioning
 ---
 Name: Install
 Dir: install

--- a/get-started/serverless-logic-workflow-identifiers-versioning.adoc
+++ b/get-started/serverless-logic-workflow-identifiers-versioning.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-workflow-identifiers-versioning"]
+= Workflow identifiers and versioning
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-workflow-identifiers-versioning
+
+toc::[]
+
+[role="_abstract"]
+Every {ServerlessLogicProductName} workflow is identified by the value of the `id` field in its workflow definition. This identifier must follow a specific naming standard, and it must remain consistent across all the configurations. Understanding how {ServerlessLogicProductName} handles workflow identifiers and versions helps you to name your workflows correctly and to plan how your workflows evolve.
+
+include::modules/serverless-logic-workflow-identifier-requirements.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-workflow-identifier-consistency.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-workflow-versioning-limitations.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-workflow-versioning-recommendations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:serverless-logic-creating-managing-workflows.adoc#serverless-logic-creating-managing-workflows[Creating and running workflows with Knative Workflow plugin]
+* xref:../deploy/serverless-logic-deploying-workflows.adoc#serverless-logic-deploying-workflows[Deployment options and deploying workflows]

--- a/modules/serverless-logic-workflow-identifier-consistency.adoc
+++ b/modules/serverless-logic-workflow-identifier-consistency.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-workflow-identifier-consistency_{context}"]
+= Workflow identifier consistency across configurations
+
+[role="_abstract"]
+You must use the same workflow identifier and version in every configuration that refers to a workflow.
+Consistency is especially important when you deploy a workflow by using the GitOps profile. The workflow definition that the `SonataFlow` custom resource (CR) specifies must be consistent with the workflow files that the container image embeds. Differences between these definitions can lead to unexpected deployment or runtime failures.
+
+The following example shows a workflow definition that declares an identifier and a version:
+
+.Example workflow definition
+[source,yaml]
+----
+id: hello-world
+version: "1.0"
+specVersion: 0.8.0
+name: Hello World
+description: An example workflow that says Hello World
+start: HelloWorld
+# The remainder of the workflow definition is omitted
+----
+
+The following table describes the fields that identify a workflow:
+
+.Workflow definition fields
+[cols="1,2",options="header"]
+|===
+|Field
+|Description
+
+|`id`
+|The workflow identifier. The value must be a valid RFC 1123 DNS label.
+
+|`version`
+|The version of the workflow. Enclose the value in quotation marks so that the YAML parser interprets it as a string rather than as a number.
+
+|`specVersion`
+|The version of the CNCF Serverless Workflow specification that the workflow definition uses. {ServerlessLogicProductName} supports version `0.8.0`.
+
+|`name`
+|Optional: A human-readable name for the workflow.
+
+|`description`
+|Optional: A description of the workflow.
+
+|===
+
+When you deploy this workflow by using the GitOps profile, the `SonataFlow` CR must carry the same identifier and version, as shown in the following example:
+
+.Example `SonataFlow` CR that uses the GitOps profile
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: hello-world
+  annotations:
+    sonataflow.org/name: Hello World
+    sonataflow.org/description: An example workflow that says Hello World
+    sonataflow.org/version: "1.0"
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      image: "quay.io/my-workflows/hello-world:1.0"
+  flow:
+    start: HelloWorld
+    # The remainder of the workflow definition is omitted
+----
+
+The following table maps each field of the `SonataFlow` CR to the corresponding field of the workflow definition:
+
+.Mapping between the `SonataFlow` CR and the workflow definition
+[cols="1,2",options="header"]
+|===
+|`SonataFlow` CR field
+|Description
+
+|`metadata.name`
+|Must match the `id` field of the workflow definition.
+
+|`metadata.annotations.sonataflow.org/version`
+|Must match the `version` field of the workflow definition. Enclose the value in quotation marks, because {ocp-product-title} requires annotation values to be strings.
+
+|`metadata.annotations.sonataflow.org/name`
+|Use this annotation to configure the optional human-readable workflow name that the `sw.yaml` or `sw.json` file of the workflow declares, if any.
+
+|`metadata.annotations.sonataflow.org/description`
+|Use this annotation to configure the optional human-readable workflow description that the `sw.yaml` or `sw.json` file of the workflow declares, if any.
+
+|`apiVersion`
+|Determines the version of the CNCF Serverless Workflow specification that the {ServerlessLogicOperatorName} applies. The `sonataflow.org/v1alpha08` value corresponds to specification version `0.8.0`.
+
+|===

--- a/modules/serverless-logic-workflow-identifier-requirements.adoc
+++ b/modules/serverless-logic-workflow-identifier-requirements.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-workflow-identifier-requirements_{context}"]
+= Workflow identifier naming requirements
+
+[role="_abstract"]
+Every workflow that you author for {ServerlessLogicProductName} declares an identifier in the `id` field of the workflow definition. You must then use the same identifier to name the corresponding `SonataFlow` custom resource (CR). The {ServerlessLogicOperatorName} in turn uses the name of the `SonataFlow` CR to name the {ocp-product-title} resources that it creates for the workflow, such as the deployment, the service, and the config maps. Because these resources inherit the identifier, the `id` value must be a valid RFC 1123 DNS label.
+
+A valid workflow identifier meets the following requirements:
+
+* Contains only lowercase alphanumeric characters (`a-z` and `0-9`) and hyphens (`-`)
+* Starts with a lowercase letter or a digit
+* Ends with a lowercase letter or a digit
+* Contains no more than 63 characters
+
+The following identifiers are valid:
+
+* `order-processing`
+* `invoice123`
+* `customer-onboarding-flow`
+* `flow-01`
+
+The following table lists identifiers that are not valid and the reason each identifier is rejected:
+
+.Examples of invalid workflow identifiers
+[cols="1,2",options="header"]
+|===
+|Identifier
+|Reason
+
+|`OrderProcessing`
+|Uppercase characters are not permitted.
+
+|`order_processing`
+|Underscores are not permitted.
+
+|`-orderflow`
+|An identifier cannot start with a hyphen.
+
+|`orderflow-`
+|An identifier cannot end with a hyphen.
+
+|===
+
+If the identifier does not conform to these requirements, {ocp-product-title} rejects the resource names that are derived from it, and the workflow deployment fails.
+
+[NOTE]
+====
+The `id` field identifies the workflow to the platform and is not intended to be a display name. To provide a human-readable title and summary for a workflow, use the optional `name` and `description` fields instead.
+====

--- a/modules/serverless-logic-workflow-versioning-limitations.adoc
+++ b/modules/serverless-logic-workflow-versioning-limitations.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-workflow-versioning-limitations_{context}"]
+= Workflow identifier and versioning limitations
+
+[role="_abstract"]
+Before you plan how to name and version your workflows, review the following limitations and considerations.
+
+Workflow identifiers must be unique::
+{ServerlessLogicProductName} does not support running more than one version of a workflow that shares the same `id` value. The platform resolves a workflow by its identifier alone and does not take the `version` field into account.
++
+[IMPORTANT]
+====
+Deploying multiple workflows that have the same `id` value and different `version` values is not supported and causes unexpected behavior, such as workflow instances being routed to the wrong workflow definition.
+====
+
+Identifiers are constrained by resource naming rules::
+You use the workflow identifier as the name of the `SonataFlow` custom resource (CR), and the {ServerlessLogicOperatorName} derives the names of the {ocp-product-title} resources from that name. As a result, the identifier is limited to 63 characters and to the character set that RFC 1123 DNS labels allow. Keep identifiers short so that the generated resource names remain readable.
+
+The `version` field does not change platform behavior::
+The `version` field and the `sonataflow.org/version` annotation are metadata. They record which iteration of a workflow you deployed, but they do not cause the platform to maintain separate versions of a workflow.
+
+Existing instances remain with the workflow that started them::
+Because each version of a workflow requires its own identifier, a new version is a separate deployment. Instances that started on the earlier workflow continue to run under the earlier identifier. Plan how those instances complete before you remove the earlier workflow.

--- a/modules/serverless-logic-workflow-versioning-recommendations.adoc
+++ b/modules/serverless-logic-workflow-versioning-recommendations.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-workflow-versioning-recommendations_{context}"]
+= Recommended practices for versioning workflows
+
+[role="_abstract"]
+{ServerlessLogicProductName} does not support more than one version of a workflow that shares the same `id` value. Therefore, whenever you change a workflow, create a new version of that workflow. A new version requires a new `id` value and a new `version` value. Apply a consistent naming convention so that the relationship between the versions remains clear.
+
+[IMPORTANT]
+====
+Do not change the definition of a workflow that you already deployed. Instances of that workflow can still be running, the platform can hold persisted data for those instances, and the deployed image contains the compiled form of the earlier definition. A change in place can therefore cause unexpected behavior.
+====
+
+Red Hat recommends that you append a version suffix to the base name of the workflow, as shown in the following examples.
+
+.Example workflow definition for version 1.0
+[source,yaml]
+----
+id: hello-world-v1
+version: "1.0"
+specVersion: 0.8.0
+name: Hello World V1
+description: First version of the Hello World workflow
+start: HelloWorld
+# The remainder of the workflow definition is omitted
+----
+
+.Example workflow definition for version 2.0
+[source,yaml]
+----
+id: hello-world-v2
+version: "2.0"
+specVersion: 0.8.0
+name: Hello World V2
+description: Second version of the Hello World workflow
+start: HelloWorld
+# The remainder of the workflow definition is omitted
+----
+
+When you apply this convention, consider the following practices:
+
+* Create a new version for every change that you make to a workflow definition. This practice applies to a corrective change in the same way as it applies to a change to the workflow data model or to the sequence of states.
+* Keep the `version` field aligned with the suffix in the identifier so that the two values do not contradict each other.
+* Retain the same base name across versions, for example `hello-world`, so that you can identify related workflows.
+* Keep the base name short enough that later suffixes do not push the identifier beyond the 63-character limit.
+* Create a new set of configurations for the new `id` and `version` pair instead of changing the existing configurations. Such configurations include the `SonataFlow` custom resource (CR) and the container image of the workflow. Point any client that must use the new version to the new endpoint, because the workflow identifier determines the endpoint of the workflow.
+* Remove a superseded workflow only after its remaining instances have completed.


### PR DESCRIPTION
**You can cherry-pick to the following branches:** 

- `serverless-docs-1.38`
- `serverless-docs-1.37`

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVLOGIC-976

**Changes & preview:** 
Added a [Workflow identifiers and versioning](https://119661--ocpdocs-pr.netlify.app/openshift-serverlesslogic/latest/get-started/serverless-logic-workflow-identifiers-versioning.html) section under the **Get started** directory.

**Reviews:**
- [ ] SME has approved this change
- [ ] QE has approved this change
- [ ] Peer has approved this change