### PR TITLE
Fix distro name in "_distro_map.yml" to match the topic map in "serverlesslogic-docs-main" branch

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,5 +1,5 @@
 ---
-openshift-serverless-logic:
+openshift-serverlesslogic:
   name: serverless logic
   author: OpenShift documentation team <openshift-docs@redhat.com>
   site: commercial


### PR DESCRIPTION
The distro key in _distro_map.yml was openshift-serverless-logic, while all 13 sections in _topic_maps/_topic_map.yml declare Distros: openshift-serverlesslogic.

The `serverlesslogic-docs-1.37` and `serverlesslogic-docs-1.38` branches both use **openshift-serverlesslogic** in `_distro_map.yml` and `_topic_map.yml`, so this aligns main with the release branches and with its own topic map.

Verified that all 13 sections now match the distro, where previously none did.
