### PR TITLE
OSDOCS-20672-RE: Added AWS LB Operator 1.3.3 release notes

### DIFF
--- a/modules/aws-load-balancer-operator-release-notes-1.3-3.adoc
+++ b/modules/aws-load-balancer-operator-release-notes-1.3-3.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="aws-load-balancer-operator-release-notes-1.3-3_{context}"]
+= AWS Load Balancer Operator 1.3.3
+
+[role="_abstract"]
+The AWS Load Balancer Operator 1.3.3 release notes summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability. 
+
+The following advisory is available for the AWS Load Balancer Operator version 1.3.3:
+
+* link:https://access.redhat.com/errata/RHXX-2026:00XX[RHXX-2026:00XX Release of AWS Load Balancer Operator 1.3.z on OperatorHub]
+
+Notable changes::
+
+* This release uses the Kubernetes API version 0.XX.x.
+
+New features::
+
+* The AWS Load Balancer Operator can now run on ARM64 architecture.

--- a/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -12,7 +12,7 @@ The release notes for the AWS Load Balancer (ALB) Operator summarize all new fea
 
 [IMPORTANT]
 ====
-The AWS Load Balancer (ALB) Operator is only supported on the `x86_64` architecture.
+The AWS Load Balancer (ALB) Operator is only supported on the `x86_64` and `arm64` architectures.
 ====
 
 These release notes track the development of the AWS Load Balancer Operator in {product-title}.
@@ -26,6 +26,8 @@ AWS Load Balancer Operator currently does not support AWS GovCloud.
 .Additional resources
 
 * xref:../../../networking/networking_operators/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}]
+
+include::modules/aws-load-balancer-operator-release-notes-1.3-3.adoc[leveloffset=+1]
 
 include::modules/aws-load-balancer-operator-release-notes-1.2-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-22096](https://redhat.atlassian.net/browse/OSDOCS-22096)

Link to docs preview:
* https://119669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html

- [ ] SME has approved this change.
- [ ] QE has approved this change.

