### PR TITLE
[enterprise-4.21] Tweaking RN short descriptions to fit 50-300 char limit

### DIFF
--- a/modules/microshift-4-21-0-async.adoc
+++ b/modules/microshift-4-21-0-async.adoc
@@ -7,7 +7,7 @@
 = RHEA-2025:23728 - {microshift-short} 4.21.0 bug fix and enhancement update
 
 [role="_abstract"]
-Issued: 01 February 2026
+Issued: 01 February 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
 
 {product-title} release 4.21.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:23728[RHEA-2025:23728] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481] advisory.
 

--- a/modules/microshift-4-21-11-async.adoc
+++ b/modules/microshift-4-21-11-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-11-async_{context}"]
 = RHBA-2026:8932 - {microshift-short} 4.21.11 known issue update
 
-Issued: 21 April 2026
-
 [role="_abstract"]
+Issued: 21 April 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.11 is now available. Known issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:8932[RHBA-2026:8932] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:8424[RHBA-2026:8424] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-21-16-async.adoc
+++ b/modules/microshift-4-21-16-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-16-async_{context}"]
 = RHBA-2026:18007 - {microshift-short} 4.21.16 fixed issue update
 
-Issued: 19 May 2026
-
 [role="_abstract"]
+Issued: 19 May 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.16 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:18007[RHBA-2026:18007] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:17474[RHSA-2026:17474] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-21-29-async.adoc
+++ b/modules/microshift-4-21-29-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-29-async_{context}"]
 = RHBA-2026:55535 - {microshift-short} 4.21.29 fixed issue update
 
-Issued: 18 August 2026
-
 [role="_abstract"]
+Issued: 18 August 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.29 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:55535[RHBA-2026:55535] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:54602[RHSA-2026:54602] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-21-31-async.adoc
+++ b/modules/microshift-4-21-31-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-31-async_{context}"]
 = RHSA-2026:60668 - {microshift-short} 4.21.31 security update
 
-Issued: 1 September 2026
-
 [role="_abstract"]
+Issued: 1 September 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.31 is now available. Security updates are listed in the link:https://access.redhat.com/errata/RHSA-2026:60668[RHSA-2026:60668] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:60477[RHSA-2026:60477] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-21-32-async.adoc
+++ b/modules/microshift-4-21-32-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-32-async_{context}"]
 = RHBA-2026:63638 - {microshift-short} 4.21.32 fixed issue update
 
-Issued: 8 September 2026
-
 [role="_abstract"]
+Issued: 8 September 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.32 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:63638[RHBA-2026:63638] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63046[RHSA-2026:63046] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-21-7-async.adoc
+++ b/modules/microshift-4-21-7-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-21-7-async_{context}"]
 = RHBA-2026:5339 - {microshift-short} 4.21.7 bug fix and enhancement update
 
-Issued: 24 March 2026
-
 [role="_abstract"]
+Issued: 24 March 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.21.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:5339[RHBA-2026:5339] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:5174[RHSA-2026:5174] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:


### PR DESCRIPTION
4.21

Bulking out release notes shortdesc's to clear the 50 character limit.