### PR TITLE
[enterprise-4.22] Tweaking short descriptions to fit 50-300 char limit

### DIFF
--- a/modules/microshift-4-22-0-async.adoc
+++ b/modules/microshift-4-22-0-async.adoc
@@ -7,7 +7,7 @@
 = RHEA-2026:2640 - {microshift-short} 4.22.0 bug fix and enhancement update
 
 [role="_abstract"]
-Issued: 09 June 2026
+Issued: 09 June 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
 
 {product-title} release 4.22.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2026:2640[RHEA-2026:2640] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:449[RHBA-2026:449] advisory.
 

--- a/modules/microshift-4-22-13-async.adoc
+++ b/modules/microshift-4-22-13-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-22-13-async_{context}"]
 = RHSA-2026:63639 - {microshift-short} 4.22.13 fixed issue update
 
-Issued: 08 September2026
-
 [role="_abstract"]
+Issued: 08 September 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.22.13 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHSA-2026:63639[RHSA-2026:63639] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:63096[RHSA-2026:63096] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-22-3-async.adoc
+++ b/modules/microshift-4-22-3-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-22-3-async_{context}"]
 = RHBA-2026:29956 - {microshift-short} 4.22.3 fixed issue update
 
-Issued: 30 June 2026
-
 [role="_abstract"]
+Issued: 30 June 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.22.3 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:29956[RHBA-2026:29956] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:29797[RHBA-2026:29797] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-22-4-async.adoc
+++ b/modules/microshift-4-22-4-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-22-4-async_{context}"]
 = RHBA-2026:35330 - {microshift-short} 4.22.4 fixed issue update
 
-Issued: 09 July 2026
-
 [role="_abstract"]
+Issued: 09 July 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.22.4 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:35330[RHBA-2026:35330] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:34794[RHSA-2026:34794] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:

--- a/modules/microshift-4-22-7-async.adoc
+++ b/modules/microshift-4-22-7-async.adoc
@@ -6,9 +6,9 @@
 [id="microshift-4-22-7-async_{context}"]
 = RHBA-2026:45112 - {microshift-short} 4.22.7 fixed issue update
 
-Issued: 30 July 2026
-
 [role="_abstract"]
+Issued: 30 July 2026. Review the changes in this {microshift-short} update. Use the advisory links and image lists to see what is fixed and to plan how you apply the update to your deployment.
+
 {product-title} release 4.22.7 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:45112[RHBA-2026:45112] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:44237[RHSA-2026:44237] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:


### PR DESCRIPTION
4.22

Bulking out release notes shortdesc's to clear the 50 character limit.