### PR TITLE
SRVLOGIC-780: Document consuming in-cluster workflows via OpenAPI and service discovery 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -64,6 +64,8 @@ Topics:
   File: serverless-logic-configuring-openAPI-services
 - Name: Configuring OpenAPI services endpoints
   File: serverless-logic-configuring-openAPI-services-endpoints
+- Name: Consuming other workflows in the same cluster
+  File: serverless-logic-consuming-in-cluster-workflows
 ---
 Name: Secure
 Dir: secure

--- a/configure/serverless-logic-configuring-workflow-services.adoc
+++ b/configure/serverless-logic-configuring-workflow-services.adoc
@@ -17,4 +17,6 @@ include::modules/serverless-logic-defining-global-managed-properties.adoc[levelo
 
 include::modules/serverless-logic-service-discovery.adoc[leveloffset=+1]
 
+include::modules/serverless-logic-configuring-service-discovery.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-customizing-podspec-definition.adoc[leveloffset=+1]

--- a/integrate/serverless-logic-configuring-openAPI-services.adoc
+++ b/integrate/serverless-logic-configuring-openAPI-services.adoc
@@ -7,14 +7,25 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The link:https://spec.openapis.org/oas/latest.html[_OpenAPI Specification_] (OAS) defines a standard, programming language-agnostic interface for HTTP APIs. You can understand a service's capabilities without access to the source code, additional documentation, or network traffic inspection. When you define a service by using the OpenAPI, you can understand and interact with it using minimal implementation logic. Just as interface descriptions simplify lower-level programming, the _OpenAPI Specification_ eliminates guesswork in calling a service.
+The link:https://spec.openapis.org/oas/latest.html[_OpenAPI Specification_] (OAS) defines a standard interface for HTTP APIs that does not depend on a programming language. An OpenAPI document describes what a service does and how to call it. You therefore do not need to read the source code of a service, find extra documentation, or inspect network traffic to use that service.
+
+{ServerlessLogicProductName} uses these documents to call REST services from a workflow. You add the OpenAPI document of a service to your workflow project, and then reference the operations of that service from your workflow definition.
+
+include::modules/serverless-logic-microprofile-rest-client-openapi.adoc[leveloffset=+1]
 
 include::modules/serverless-logic-openAPI-function-definition.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-sending-rest-requests-openAPI-specification.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-configuring-endpoint-url-openAPI-services.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-openapi-callbacks.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
 
 * xref:serverless-logic-configuring-openAPI-services-endpoints.adoc#serverless-logic-configuring-openAPI-services-endpoint[Configuring OpenAPI services endpoints]
 * xref:serverless-logic-consuming-in-cluster-workflows.adoc#serverless-logic-consuming-in-cluster-workflows[Consuming other workflows in the same cluster]
+* link:https://spec.openapis.org/oas/latest.html[OpenAPI Specification]
+* link:https://download.eclipse.org/microprofile/microprofile-config-3.0/microprofile-config-spec-3.0.html[MicroProfile Config specification]
+* link:https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html#_support_for_microprofile_config[MicroProfile REST Client specification]

--- a/integrate/serverless-logic-configuring-openAPI-services.adoc
+++ b/integrate/serverless-logic-configuring-openAPI-services.adoc
@@ -12,3 +12,9 @@ The link:https://spec.openapis.org/oas/latest.html[_OpenAPI Specification_] (OAS
 include::modules/serverless-logic-openAPI-function-definition.adoc[leveloffset=+1]
 include::modules/serverless-logic-sending-rest-requests-openAPI-specification.adoc[leveloffset=+1]
 include::modules/serverless-logic-configuring-endpoint-url-openAPI-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:serverless-logic-configuring-openAPI-services-endpoints.adoc#serverless-logic-configuring-openAPI-services-endpoint[Configuring OpenAPI services endpoints]
+* xref:serverless-logic-consuming-in-cluster-workflows.adoc#serverless-logic-consuming-in-cluster-workflows[Consuming other workflows in the same cluster]

--- a/integrate/serverless-logic-consuming-in-cluster-workflows.adoc
+++ b/integrate/serverless-logic-consuming-in-cluster-workflows.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-consuming-in-cluster-workflows"]
+= Consuming other workflows in the same cluster
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-consuming-in-cluster-workflows
+
+toc::[]
+
+[role="_abstract"]
+A workflow that the {ServerlessLogicOperatorName} deploys is an HTTP service that publishes an OpenAPI document describing its own operations. You can use this to compose workflows, where one workflow orchestrates other workflows that run in the same cluster. The calling workflow references the OpenAPI document of the called workflow in a function definition, and Kubernetes service discovery resolves the address of the called workflow when you deploy the calling workflow. This combination keeps each workflow independently deployable and avoids hardcoding cluster addresses in workflow definitions.
+
+include::modules/serverless-logic-in-cluster-workflow-orchestration.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-retrieving-workflow-openapi-document.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-calling-a-workflow-from-a-workflow.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-in-cluster-workflow-consumption-considerations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:serverless-logic-configuring-openAPI-services.adoc#serverless-logic-configuring-openAPI-services[Configuring OpenAPI services]
+* xref:serverless-logic-configuring-openAPI-services-endpoints.adoc#serverless-logic-configuring-openAPI-services-endpoint[Configuring OpenAPI services endpoints]
+* xref:../configure/serverless-logic-configuring-workflow-services.adoc#serverless-logic-configuring-workflow-services[Configuring workflow services]
+* xref:../secure/serverless-logic-authentication-openapi-services.adoc#serverless-logic-authentication-openapi-services[Authentication for OpenAPI services]

--- a/modules/serverless-logic-calling-a-workflow-from-a-workflow.adoc
+++ b/modules/serverless-logic-calling-a-workflow-from-a-workflow.adoc
@@ -7,7 +7,27 @@
 = Calling a workflow from another workflow
 
 [role="_abstract"]
-You can define an OpenAPI function in a calling workflow that starts an instance of a called workflow, and then resolve the address of the called workflow with a service discovery URI. The following procedure uses an `order-processing` workflow that calls an `inventory-check` workflow in the same cluster.
+You can define an OpenAPI function in a calling workflow that starts an instance of a called workflow. A service discovery URI then resolves the address of the called workflow at deployment time.
+
+The following procedure uses an `order-processing` workflow that calls an `inventory-check` workflow in the same cluster. The example uses these values:
+
+.Example values used in this procedure
+[cols="1,1",options="header"]
+|===
+|Item |Value
+
+|Calling workflow
+|`order-processing`
+
+|Called workflow
+|`inventory-check`
+
+|OpenAPI document in the calling project
+|`specs/inventory-check-openapi.yaml`
+
+|REST client configuration key
+|`inventory_check_openapi_yaml`
+|===
 
 .Prerequisites
 
@@ -33,9 +53,9 @@ You can define an OpenAPI function in a calling workflow that starts an instance
 }
 ----
 +
-<1> The `operation` attribute combines the path of the OpenAPI document in the project with the operation identifier that you recorded from that document.
+<1> The `operation` attribute joins two values with a `#` character: the path of the OpenAPI document in the project, and the operation identifier that you recorded from that document.
 
-. Reference the function from a workflow state and map the workflow data to the request:
+. Reference the function from a workflow state, and map the workflow data to the request arguments:
 +
 [source,json]
 ----
@@ -46,8 +66,8 @@ You can define an OpenAPI function in a calling workflow that starts an instance
     {
       "name": "checkInventoryAction",
       "functionRef": {
-        "refName": "checkInventory",
-        "arguments": {
+        "refName": "checkInventory", <1>
+        "arguments": { <2>
           "productId": ".order.productId",
           "quantity": ".order.quantity"
         }
@@ -57,24 +77,27 @@ You can define an OpenAPI function in a calling workflow that starts an instance
   "transition": "ConfirmOrder"
 }
 ----
-
-. Determine the REST client configuration key for the OpenAPI document.
 +
-With the default `FILE_NAME` strategy, {ServerlessLogicProductName} derives the key from the file name of the OpenAPI document and replaces special characters with underscores. The `inventory-check-openapi.yaml` file therefore produces the `inventory_check_openapi_yaml` key.
+<1> The name of the function that you declared in the previous step.
+<2> The request arguments. Use jq expressions to take values from the workflow data.
 
-. In the `application.properties` file of the calling workflow project, set the endpoint URL for that key to a service discovery URI. Enclose the URI in `${}` so that the {ServerlessLogicOperatorName} resolves it during deployment:
+. Find the REST client configuration key for the OpenAPI document.
++
+By default, {ServerlessLogicProductName} uses the `FILE_NAME` strategy. This strategy builds the key from the file name of the OpenAPI document and replaces special characters with underscores. The `inventory-check-openapi.yaml` file therefore gives the `inventory_check_openapi_yaml` key.
+
+. In the `application.properties` file of the calling workflow project, set the endpoint URL for that key to a service discovery URI. Enclose the URI in `${}`:
 +
 [source,properties]
 ----
 quarkus.rest-client.inventory_check_openapi_yaml.url=${kubernetes:services.v1//inventory-check}
 ----
 +
-The empty namespace segment instructs the {ServerlessLogicOperatorName} to look for the `inventory-check` service in the namespace of the calling workflow.
+The empty namespace segment between the two slashes tells the {ServerlessLogicOperatorName} to look for the `inventory-check` service in the namespace of the calling workflow.
 
-. If the called workflow runs in a different namespace, or if it is deployed as a Knative service, adjust the URI accordingly:
+. Optional: If the called workflow runs elsewhere, or runs as a Knative service, adjust the URI:
 +
 --
-* To reference a Kubernetes service in another namespace, add the namespace to the URI:
+* To reference a Kubernetes service in the `warehouse` namespace, add the namespace to the URI:
 +
 [source,properties]
 ----
@@ -89,19 +112,20 @@ quarkus.rest-client.inventory_check_openapi_yaml.url=${knative:warehouse/invento
 ----
 --
 
-. Build the image of the calling workflow and deploy the workflow to the cluster.
+. Build the image of the calling workflow, and then deploy the workflow to the cluster.
 
 .Verification
 
-. Confirm that the {ServerlessLogicOperatorName} resolved the service discovery URI by inspecting the operator-managed properties `ConfigMap` of the calling workflow:
+. Display the operator-managed properties `ConfigMap` of the calling workflow by running the following command:
 +
 [source,terminal]
 ----
 $ oc get configmap order-processing-managed-props -n <namespace> -o yaml
 ----
+
+. Confirm that the {ServerlessLogicOperatorName} replaced the service discovery URI with a resolved endpoint:
 +
-The resolved endpoint is displayed as a plain URL, as shown in the following example output:
-+
+.Example output
 [source,yaml]
 ----
 data:
@@ -109,7 +133,7 @@ data:
     quarkus.rest-client.inventory_check_openapi_yaml.url=http://inventory-check.<namespace>.svc.cluster.local
 ----
 
-. Start an instance of the calling workflow and confirm that the called workflow receives the request by checking the logs of the called workflow:
+. Start an instance of the calling workflow, and then check the logs of the called workflow to confirm that it received the request:
 +
 [source,terminal]
 ----

--- a/modules/serverless-logic-calling-a-workflow-from-a-workflow.adoc
+++ b/modules/serverless-logic-calling-a-workflow-from-a-workflow.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-consuming-in-cluster-workflows.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-calling-a-workflow-from-a-workflow_{context}"]
+= Calling a workflow from another workflow
+
+[role="_abstract"]
+You can define an OpenAPI function in a calling workflow that starts an instance of a called workflow, and then resolve the address of the called workflow with a service discovery URI. The following procedure uses an `order-processing` workflow that calls an `inventory-check` workflow in the same cluster.
+
+.Prerequisites
+
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to an {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have retrieved the OpenAPI document of the called workflow and copied it into the `specs` directory of the calling workflow project.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. In the definition of the calling workflow, declare a function that references the OpenAPI document of the called workflow:
++
+[source,json]
+----
+{
+  "id": "order-processing",
+  "functions": [
+    {
+      "name": "checkInventory",
+      "operation": "specs/inventory-check-openapi.yaml#<start_workflow_operation_id>" <1>
+    }
+  ]
+}
+----
++
+<1> The `operation` attribute combines the path of the OpenAPI document in the project with the operation identifier that you recorded from that document.
+
+. Reference the function from a workflow state and map the workflow data to the request:
++
+[source,json]
+----
+{
+  "name": "CheckInventory",
+  "type": "operation",
+  "actions": [
+    {
+      "name": "checkInventoryAction",
+      "functionRef": {
+        "refName": "checkInventory",
+        "arguments": {
+          "productId": ".order.productId",
+          "quantity": ".order.quantity"
+        }
+      }
+    }
+  ],
+  "transition": "ConfirmOrder"
+}
+----
+
+. Determine the REST client configuration key for the OpenAPI document.
++
+With the default `FILE_NAME` strategy, {ServerlessLogicProductName} derives the key from the file name of the OpenAPI document and replaces special characters with underscores. The `inventory-check-openapi.yaml` file therefore produces the `inventory_check_openapi_yaml` key.
+
+. In the `application.properties` file of the calling workflow project, set the endpoint URL for that key to a service discovery URI. Enclose the URI in `${}` so that the {ServerlessLogicOperatorName} resolves it during deployment:
++
+[source,properties]
+----
+quarkus.rest-client.inventory_check_openapi_yaml.url=${kubernetes:services.v1//inventory-check}
+----
++
+The empty namespace segment instructs the {ServerlessLogicOperatorName} to look for the `inventory-check` service in the namespace of the calling workflow.
+
+. If the called workflow runs in a different namespace, or if it is deployed as a Knative service, adjust the URI accordingly:
++
+--
+* To reference a Kubernetes service in another namespace, add the namespace to the URI:
++
+[source,properties]
+----
+quarkus.rest-client.inventory_check_openapi_yaml.url=${kubernetes:services.v1/warehouse/inventory-check}
+----
+
+* To reference a Knative service, use the `knative` scheme:
++
+[source,properties]
+----
+quarkus.rest-client.inventory_check_openapi_yaml.url=${knative:warehouse/inventory-check}
+----
+--
+
+. Build the image of the calling workflow and deploy the workflow to the cluster.
+
+.Verification
+
+. Confirm that the {ServerlessLogicOperatorName} resolved the service discovery URI by inspecting the operator-managed properties `ConfigMap` of the calling workflow:
++
+[source,terminal]
+----
+$ oc get configmap order-processing-managed-props -n <namespace> -o yaml
+----
++
+The resolved endpoint is displayed as a plain URL, as shown in the following example output:
++
+[source,yaml]
+----
+data:
+  application.properties: |
+    quarkus.rest-client.inventory_check_openapi_yaml.url=http://inventory-check.<namespace>.svc.cluster.local
+----
+
+. Start an instance of the calling workflow and confirm that the called workflow receives the request by checking the logs of the called workflow:
++
+[source,terminal]
+----
+$ oc logs -l app=inventory-check -n <namespace>
+----

--- a/modules/serverless-logic-configuring-endpoint-url-openAPI-services.adoc
+++ b/modules/serverless-logic-configuring-endpoint-url-openAPI-services.adoc
@@ -42,6 +42,18 @@ In this example:
 * Configuration Key: `quarkus.rest-client.subtraction_yaml.url`
 * Environment variable: SUBTRACTION_URL
 * Fallback URL: `\http://myserver.com`
++
+[NOTE]
+====
+If the target service runs in the same cluster as the workflow, you can use the endpoint of its Kubernetes service as the URL. Kubernetes service endpoints use the `\http://<service_name>.<namespace>.svc.cluster.local` format, as shown in the following example:
+
+[source,sh]
+----
+quarkus.rest-client.subtraction_yaml.url=${SUBTRACTION_URL:http://subtraction-service.myapp.svc.cluster.local}
+----
+
+Alternatively, you can use a service discovery URI so that the {ServerlessLogicOperatorName} resolves the endpoint when it deploys the workflow.
+====
 
 . Ensure that the `(SUBTRACTION_URL)` environment variable is set in your system or deployment environment. If the variable is not found, the application uses the fallback URL `(\http://myserver.com)`.
 

--- a/modules/serverless-logic-configuring-service-discovery.adoc
+++ b/modules/serverless-logic-configuring-service-discovery.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * configure/serverless-logic-configuring-workflow-services.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-configuring-service-discovery_{context}"]
+= Configuring service discovery for a workflow service
+
+[role="_abstract"]
+To use Kubernetes service discovery, you set a workflow configuration property to a service discovery URI instead of a fixed URL. The {ServerlessLogicOperatorName} resolves the URI into a network endpoint when it deploys the workflow, so the same workflow image can run in different namespaces and clusters without configuration changes.
+
+.Prerequisites
+
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to an {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* The resource that you want to reference exists in your cluster.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Open the `application.properties` file of your workflow project.
+
+. Set the property that holds the endpoint to a service discovery URI, and enclose the URI in `${}`:
++
+[source,properties]
+----
+quarkus.rest-client.my_service_yaml.url=${kubernetes:services.v1//my-backend-service}
+----
++
+In this example, `my_service_yaml` is the REST client configuration key, and the URI references a Kubernetes service that is named `my-backend-service` in the namespace of the workflow.
+
+. Optional: To reference a Knative service, use either the `knative` shorthand scheme or the full group, version, and kind (GVK) form:
++
+[source,properties]
+----
+quarkus.rest-client.financial_service_yaml.url=${knative:finance/financial-service}
+----
++
+[source,properties]
+----
+quarkus.rest-client.financial_service_yaml.url=${kubernetes:services.v1.serving.knative.dev/finance/financial-service}
+----
+
+. Optional: To select one resource when several resources match, add label query parameters:
++
+[source,properties]
+----
+quarkus.rest-client.backend_yaml.url=${kubernetes:services.v1//backend-service?app=backend&env=production}
+----
+
+. Optional: To select a port when the service exposes more than one port, add the `port` query parameter:
++
+[source,properties]
+----
+quarkus.rest-client.api_service_yaml.url=${kubernetes:services.v1//api-service?port=https}
+----
+
+. Optional: To reference a route, use the `openshift` scheme:
++
+[source,properties]
+----
+quarkus.rest-client.web_service_yaml.url=${openshift:routes.v1.route.openshift.io/web/frontend-route}
+----
+
+. Save the `application.properties` file and deploy the workflow.
+
+.Verification
+
+. Display the operator-managed properties `ConfigMap` of the workflow by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap <workflow_name>-managed-props -n <namespace> -o yaml
+----
+
+. Confirm that the service discovery URI is replaced by a resolved endpoint, as shown in the following example output:
++
+[source,yaml]
+----
+data:
+  application.properties: |
+    quarkus.rest-client.my_service_yaml.url=http://my-backend-service.<namespace>.svc.cluster.local
+----

--- a/modules/serverless-logic-configuring-service-discovery.adoc
+++ b/modules/serverless-logic-configuring-service-discovery.adoc
@@ -73,8 +73,9 @@ quarkus.rest-client.web_service_yaml.url=${openshift:routes.v1.route.openshift.i
 $ oc get configmap <workflow_name>-managed-props -n <namespace> -o yaml
 ----
 
-. Confirm that the service discovery URI is replaced by a resolved endpoint, as shown in the following example output:
+. Confirm that the {ServerlessLogicOperatorName} replaced the service discovery URI with a resolved endpoint:
 +
+.Example output
 [source,yaml]
 ----
 data:

--- a/modules/serverless-logic-in-cluster-workflow-consumption-considerations.adoc
+++ b/modules/serverless-logic-in-cluster-workflow-consumption-considerations.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-consuming-in-cluster-workflows.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-in-cluster-workflow-consumption-considerations_{context}"]
+= Considerations for consuming in-cluster workflows
+
+[role="_abstract"]
+Composing workflows introduces a runtime dependency between two independently deployed services. Review the following considerations before you adopt this pattern.
+
+The OpenAPI document is a build-time dependency:: {ServerlessLogicProductName} generates the REST client of the calling workflow when it builds the workflow image. A change to the API of the called workflow does not reach the calling workflow until you retrieve the updated OpenAPI document and rebuild the calling workflow. Treat the OpenAPI document that you copy into the `specs` directory as a versioned artifact of the calling workflow project.
+
+The service name follows the workflow identifier:: The {ServerlessLogicOperatorName} names the Kubernetes `Service` of a workflow after the `SonataFlow` custom resource (CR), which in turn uses the `id` field of the workflow definition. Changing the identifier of the called workflow, including changing it to introduce a new version, changes the resource name that the service discovery URI must target. Update the URI in the calling workflow whenever you rename or version the called workflow.
+
+Calls are synchronous:: An OpenAPI function call blocks the calling workflow instance until the called workflow responds. This behavior is suitable for short-lived called workflows. If the called workflow is long-running, consider event-based integration or OpenAPI callbacks instead, so that the calling workflow does not hold an open connection for the duration of the called workflow.
+
+Service discovery affects startup time:: Service discovery triggers a scan of the workflow configuration parameters during deployment. If the startup time of the calling workflow is critical, configure a static URL, such as `\http://<called_workflow_id>.<namespace>.svc.cluster.local`, instead of a service discovery URI.
+
+The called workflow must exist when the calling workflow is deployed:: The {ServerlessLogicOperatorName} resolves service discovery URIs during the deployment of the calling workflow. If the referenced resource does not exist at that point, the {ServerlessLogicOperatorName} logs an exception and the endpoint remains unresolved. Deploy the called workflow first, or redeploy the calling workflow after the called workflow becomes available.
+
+Resolved endpoints are managed by the Operator:: The {ServerlessLogicOperatorName} writes the resolved endpoints to an operator-managed properties `ConfigMap`, and it recreates that `ConfigMap` on each reconciliation cycle.
++
+[IMPORTANT]
+====
+Any manual edit to the operator-managed properties `ConfigMap` is overwritten during the next reconciliation cycle. To change a resolved endpoint, change the service discovery URI in the workflow configuration and redeploy the workflow.
+====
+
+Secured called workflows require authentication configuration:: If the called workflow requires authentication, the OpenAPI document of the called workflow declares a security scheme. Configure the corresponding credentials in the calling workflow in the same way that you configure them for any other secured OpenAPI service.

--- a/modules/serverless-logic-in-cluster-workflow-consumption-considerations.adoc
+++ b/modules/serverless-logic-in-cluster-workflow-consumption-considerations.adoc
@@ -7,23 +7,23 @@
 = Considerations for consuming in-cluster workflows
 
 [role="_abstract"]
-Composing workflows introduces a runtime dependency between two independently deployed services. Review the following considerations before you adopt this pattern.
+When one workflow calls another, the two workflows become coupled at run time. Review the following considerations before you adopt this pattern.
 
-The OpenAPI document is a build-time dependency:: {ServerlessLogicProductName} generates the REST client of the calling workflow when it builds the workflow image. A change to the API of the called workflow does not reach the calling workflow until you retrieve the updated OpenAPI document and rebuild the calling workflow. Treat the OpenAPI document that you copy into the `specs` directory as a versioned artifact of the calling workflow project.
+The OpenAPI document is a build-time dependency:: {ServerlessLogicProductName} generates the REST client when it builds the calling workflow image. A change to the API of the called workflow does not reach the calling workflow on its own. You must retrieve the updated OpenAPI document and rebuild the calling workflow. Treat the document in the `specs` directory as a versioned artifact of the calling workflow project.
 
-The service name follows the workflow identifier:: The {ServerlessLogicOperatorName} names the Kubernetes `Service` of a workflow after the `SonataFlow` custom resource (CR), which in turn uses the `id` field of the workflow definition. Changing the identifier of the called workflow, including changing it to introduce a new version, changes the resource name that the service discovery URI must target. Update the URI in the calling workflow whenever you rename or version the called workflow.
+The service name follows the workflow identifier:: The {ServerlessLogicOperatorName} names the Kubernetes `Service` of a workflow after the `SonataFlow` custom resource (CR). That CR takes its name from the `id` field of the workflow definition. If you rename the called workflow, or give a new version a new identifier, the service name changes too. Update the service discovery URI in the calling workflow whenever this happens.
 
-Calls are synchronous:: An OpenAPI function call blocks the calling workflow instance until the called workflow responds. This behavior is suitable for short-lived called workflows. If the called workflow is long-running, consider event-based integration or OpenAPI callbacks instead, so that the calling workflow does not hold an open connection for the duration of the called workflow.
+Calls are synchronous:: An OpenAPI function call blocks the calling workflow instance until the called workflow responds. This behavior suits short-lived called workflows. For a long-running called workflow, use event-based integration or OpenAPI callbacks instead. The calling workflow then does not hold an open connection for the whole run of the called workflow.
 
-Service discovery affects startup time:: Service discovery triggers a scan of the workflow configuration parameters during deployment. If the startup time of the calling workflow is critical, configure a static URL, such as `\http://<called_workflow_id>.<namespace>.svc.cluster.local`, instead of a service discovery URI.
+Service discovery adds startup time:: Service discovery triggers a scan of the workflow configuration parameters during deployment. If startup time is critical, configure a static URL instead, such as `\http://<called_workflow_id>.<namespace>.svc.cluster.local`.
 
-The called workflow must exist when the calling workflow is deployed:: The {ServerlessLogicOperatorName} resolves service discovery URIs during the deployment of the calling workflow. If the referenced resource does not exist at that point, the {ServerlessLogicOperatorName} logs an exception and the endpoint remains unresolved. Deploy the called workflow first, or redeploy the calling workflow after the called workflow becomes available.
+The called workflow must exist first:: The {ServerlessLogicOperatorName} resolves service discovery URIs when it deploys the calling workflow. If the referenced resource does not exist at that point, the {ServerlessLogicOperatorName} logs an exception and the endpoint stays unresolved. Deploy the called workflow first. If you deploy in the other order, redeploy the calling workflow after the called workflow becomes available.
 
-Resolved endpoints are managed by the Operator:: The {ServerlessLogicOperatorName} writes the resolved endpoints to an operator-managed properties `ConfigMap`, and it recreates that `ConfigMap` on each reconciliation cycle.
+The Operator owns the resolved endpoints:: The {ServerlessLogicOperatorName} writes the resolved endpoints to an operator-managed properties `ConfigMap`. It recreates that `ConfigMap` on each reconciliation cycle.
 +
 [IMPORTANT]
 ====
-Any manual edit to the operator-managed properties `ConfigMap` is overwritten during the next reconciliation cycle. To change a resolved endpoint, change the service discovery URI in the workflow configuration and redeploy the workflow.
+The next reconciliation cycle overwrites any manual edit to the operator-managed properties `ConfigMap`. To change a resolved endpoint, edit the service discovery URI in the workflow configuration and redeploy the workflow.
 ====
 
-Secured called workflows require authentication configuration:: If the called workflow requires authentication, the OpenAPI document of the called workflow declares a security scheme. Configure the corresponding credentials in the calling workflow in the same way that you configure them for any other secured OpenAPI service.
+A secured called workflow needs credentials:: If the called workflow requires authentication, its OpenAPI document declares a security scheme. Configure the matching credentials in the calling workflow. Use the same approach that you use for any other secured OpenAPI service.

--- a/modules/serverless-logic-in-cluster-workflow-orchestration.adoc
+++ b/modules/serverless-logic-in-cluster-workflow-orchestration.adoc
@@ -7,15 +7,39 @@
 = Orchestration of in-cluster workflows
 
 [role="_abstract"]
-A workflow that the {ServerlessLogicOperatorName} deploys is an HTTP service, in the same way as any other service in your cluster. Each deployed workflow exposes a REST endpoint that starts a workflow instance, and it publishes an OpenAPI document that describes that endpoint. Because a workflow is both an HTTP client and an HTTP service, you can compose workflows, where a calling workflow orchestrates one or more called workflows that run in the same cluster.
+The {ServerlessLogicOperatorName} deploys each workflow as an HTTP service. Every deployed workflow does two things that make it callable by other workflows:
 
-To consume another workflow, you combine two capabilities that {ServerlessLogicProductName} already provides for external services:
+* It exposes a REST endpoint that starts a workflow instance.
+* It publishes an OpenAPI document that describes that endpoint.
 
-OpenAPI function definitions:: The calling workflow references the OpenAPI document of the called workflow in a function definition, in the same way that it references the OpenAPI document of any other service. {ServerlessLogicProductName} generates a REST client from that document at build time.
+A workflow is therefore both an HTTP client and an HTTP service. You can use this to compose workflows, so that a calling workflow orchestrates one or more called workflows in the same cluster.
 
-Kubernetes service discovery:: Instead of hardcoding the address of the called workflow, the calling workflow configures the REST client URL as a service discovery URI. The {ServerlessLogicOperatorName} resolves the URI into a network endpoint when it deploys the calling workflow.
+== Features that the pattern combines
 
-Keeping these two concerns separate means that the workflow definition describes only _what_ it calls, and the deployment configuration describes _where_ that call goes. As a result, you can promote the same workflow image through different namespaces or clusters without editing the workflow definition.
+To consume another workflow, you combine two features that {ServerlessLogicProductName} already provides for external services:
+
+OpenAPI function definitions:: The calling workflow references the OpenAPI document of the called workflow in a function definition. {ServerlessLogicProductName} generates a REST client from that document when it builds the workflow image.
+
+Kubernetes service discovery:: The calling workflow sets the URL of that REST client to a service discovery URI. The {ServerlessLogicOperatorName} resolves the URI to a network endpoint at deployment time.
+
+This split keeps two concerns separate. The workflow definition describes _what_ the workflow calls. The deployment configuration describes _where_ the call goes. As a result, you can promote the same workflow image to a different namespace or cluster without editing the workflow definition.
+
+== Process overview
+
+When you apply this pattern, the following process takes place:
+
+. You deploy the called workflow. The {ServerlessLogicOperatorName} creates a Kubernetes `Service` for it.
+. You download the OpenAPI document of the called workflow from its `/q/openapi` path.
+. You add the document to the `specs` directory of the calling workflow project.
+. You define an OpenAPI function in the calling workflow that references the document.
+. You set the URL of the generated REST client to a service discovery URI.
+. You build and deploy the calling workflow.
+. The {ServerlessLogicOperatorName} resolves the URI and writes the resolved endpoint to an operator-managed properties `ConfigMap`.
+. At run time, the calling workflow reads the endpoint from that `ConfigMap` and calls the called workflow.
+
+== Elements of the pattern
+
+The following table describes the elements that take part in a workflow-to-workflow call:
 
 .Building blocks of in-cluster workflow orchestration
 [cols="1,2",options="header"]
@@ -23,22 +47,22 @@ Keeping these two concerns separate means that the workflow definition describes
 |Element |Description
 
 |Called workflow endpoint
-|The {ServerlessLogicOperatorName} creates a Kubernetes `Service` for each deployed workflow. The service is named after the `SonataFlow` custom resource (CR), so the workflow is reachable in the cluster at `\http://<workflow_id>.<namespace>`.
+|The {ServerlessLogicOperatorName} creates a Kubernetes `Service` for each deployed workflow. It names the service after the `SonataFlow` custom resource (CR). The workflow is therefore reachable in the cluster at `\http://<workflow_id>.<namespace>`.
 
 |Generated OpenAPI document
-|The called workflow publishes its own OpenAPI document at the `/q/openapi` path. This document contains the operation identifier that the calling workflow references.
+|The called workflow publishes its own OpenAPI document at the `/q/openapi` path. This document has the operation identifier that the calling workflow references.
 
 |OpenAPI function definition
-|The calling workflow declares a function whose `operation` attribute points to the OpenAPI document of the called workflow and to the operation identifier within that document.
+|The calling workflow declares a function. The `operation` attribute of that function points to the OpenAPI document of the called workflow and to an operation identifier in that document.
 
 |REST client configuration key
-|{ServerlessLogicProductName} derives a configuration key for the generated REST client from the OpenAPI document, based on the `kogito.sw.operationIdStrategy` property. You use this key to set the endpoint URL.
+|{ServerlessLogicProductName} derives a configuration key for each generated REST client. The `kogito.sw.operationIdStrategy` property controls how it derives the key. You use this key to set the endpoint URL.
 
 |Service discovery URI
-|The value of the endpoint URL, expressed as a `kubernetes`, `openshift`, or `knative` URI that the {ServerlessLogicOperatorName} resolves during deployment.
+|The value of the endpoint URL. You express it as a `kubernetes`, `openshift`, or `knative` URI that the {ServerlessLogicOperatorName} resolves during deployment.
 |===
 
 [NOTE]
 ====
-{ServerlessLogicProductName} generates REST clients at build time. The OpenAPI document of the called workflow must be part of the calling workflow project before you build the image of the calling workflow. If the API of the called workflow changes, you must retrieve the updated document and rebuild the calling workflow.
+{ServerlessLogicProductName} generates REST clients at build time. The OpenAPI document of the called workflow must be part of the calling workflow project before you build the image of the calling workflow. If the API of the called workflow changes, retrieve the updated document and rebuild the calling workflow.
 ====

--- a/modules/serverless-logic-in-cluster-workflow-orchestration.adoc
+++ b/modules/serverless-logic-in-cluster-workflow-orchestration.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-consuming-in-cluster-workflows.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-in-cluster-workflow-orchestration_{context}"]
+= Orchestration of in-cluster workflows
+
+[role="_abstract"]
+A workflow that the {ServerlessLogicOperatorName} deploys is an HTTP service, in the same way as any other service in your cluster. Each deployed workflow exposes a REST endpoint that starts a workflow instance, and it publishes an OpenAPI document that describes that endpoint. Because a workflow is both an HTTP client and an HTTP service, you can compose workflows, where a calling workflow orchestrates one or more called workflows that run in the same cluster.
+
+To consume another workflow, you combine two capabilities that {ServerlessLogicProductName} already provides for external services:
+
+OpenAPI function definitions:: The calling workflow references the OpenAPI document of the called workflow in a function definition, in the same way that it references the OpenAPI document of any other service. {ServerlessLogicProductName} generates a REST client from that document at build time.
+
+Kubernetes service discovery:: Instead of hardcoding the address of the called workflow, the calling workflow configures the REST client URL as a service discovery URI. The {ServerlessLogicOperatorName} resolves the URI into a network endpoint when it deploys the calling workflow.
+
+Keeping these two concerns separate means that the workflow definition describes only _what_ it calls, and the deployment configuration describes _where_ that call goes. As a result, you can promote the same workflow image through different namespaces or clusters without editing the workflow definition.
+
+.Building blocks of in-cluster workflow orchestration
+[cols="1,2",options="header"]
+|===
+|Element |Description
+
+|Called workflow endpoint
+|The {ServerlessLogicOperatorName} creates a Kubernetes `Service` for each deployed workflow. The service is named after the `SonataFlow` custom resource (CR), so the workflow is reachable in the cluster at `\http://<workflow_id>.<namespace>`.
+
+|Generated OpenAPI document
+|The called workflow publishes its own OpenAPI document at the `/q/openapi` path. This document contains the operation identifier that the calling workflow references.
+
+|OpenAPI function definition
+|The calling workflow declares a function whose `operation` attribute points to the OpenAPI document of the called workflow and to the operation identifier within that document.
+
+|REST client configuration key
+|{ServerlessLogicProductName} derives a configuration key for the generated REST client from the OpenAPI document, based on the `kogito.sw.operationIdStrategy` property. You use this key to set the endpoint URL.
+
+|Service discovery URI
+|The value of the endpoint URL, expressed as a `kubernetes`, `openshift`, or `knative` URI that the {ServerlessLogicOperatorName} resolves during deployment.
+|===
+
+[NOTE]
+====
+{ServerlessLogicProductName} generates REST clients at build time. The OpenAPI document of the called workflow must be part of the calling workflow project before you build the image of the calling workflow. If the API of the called workflow changes, you must retrieve the updated document and rebuild the calling workflow.
+====

--- a/modules/serverless-logic-microprofile-rest-client-openapi.adoc
+++ b/modules/serverless-logic-microprofile-rest-client-openapi.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-configuring-openAPI-services.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-microprofile-rest-client-openapi_{context}"]
+= MicroProfile REST Client for OpenAPI services
+
+[role="_abstract"]
+{ServerlessLogicProductName} uses the MicroProfile REST Client specification to call OpenAPI services from a workflow. This specification defines a type-safe API for REST calls.
+
+When you add an OpenAPI document to a workflow project, {ServerlessLogicProductName} generates a REST client from that document at build time. The client handles the HTTP calls, so your workflow definition holds no HTTP code.
+
+{ServerlessLogicProductName} configures each client through the MicroProfile Config specification. This specification defines a standard way to keep configuration outside the code. As a result, you can change a service endpoint without a change to the workflow definition.
+
+Each generated client has a configuration key. Use the key to set properties for that client, such as its URL:
+
+[source,sh]
+----
+quarkus.rest-client.<configuration_key>.url=http://myserver.com
+----
+
+The `kogito.sw.operationIdStrategy` property sets how {ServerlessLogicProductName} derives the configuration key. Based on the value that you set, the key comes from the file name of the OpenAPI document, the full URI of the document, the workflow and function names, or the title of the document.

--- a/modules/serverless-logic-openapi-callbacks.adoc
+++ b/modules/serverless-logic-openapi-callbacks.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-configuring-openAPI-services.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-openapi-callbacks_{context}"]
+= OpenAPI callbacks for asynchronous service interactions
+
+[role="_abstract"]
+An OpenAPI callback is an asynchronous request that a service sends back to your workflow after it finishes an operation. Use callbacks when a called service takes too long to answer in a single HTTP request, and you do not want the workflow to hold an open connection.
+
+== How an OpenAPI callback works
+
+An OpenAPI callback follows this sequence:
+
+. The workflow starts an asynchronous service call.
+. The workflow supplies a callback URL in the request body.
+. Control returns to the workflow immediately, because the operation is asynchronous.
+. The external service processes the request.
+. The external service calls the callback URL and sends a `CloudEvent`.
+. The workflow receives the `CloudEvent` and resumes.
+
+== Event identification
+
+The workflow must route the incoming `CloudEvent` to the instance that started the call. To make this possible, meet one of the following conditions:
+
+* The external service includes the workflow instance ID in the `CloudEvent` header.
+* You configure event correlation for the workflow.
+
+Each workflow instance has a unique identifier that {ServerlessLogicProductName} generates automatically. This identifier routes the event to the correct instance when several instances run at the same time.
+
+== OpenAPI callbacks compared with callback states
+
+Both mechanisms support fire-and-wait-for-result operations, but they differ in how the external service learns where to send the result.
+
+.Comparison of OpenAPI callbacks and callback states
+[cols="1,1,1",options="header"]
+|===
+|Aspect |OpenAPI callbacks |Callback states
+
+|Where the endpoint comes from
+|The workflow supplies a callback endpoint in the initial request.
+|The external service publishes events on its own, without an endpoint from the workflow.
+
+|How the workflow matches the result
+|The external service sends a `CloudEvent` to the supplied endpoint.
+|The workflow waits for an event that matches its correlation criteria.
+
+|When to use it
+|The external service accepts a callback URL.
+|The external service cannot accept a callback URL.
+|===
+
+Choose between the two based on whether the external service can accept and use a callback URL that the workflow provides.

--- a/modules/serverless-logic-retrieving-workflow-openapi-document.adoc
+++ b/modules/serverless-logic-retrieving-workflow-openapi-document.adoc
@@ -74,7 +74,7 @@ paths:
 
 .Verification
 
-* Confirm that the downloaded file is a valid OpenAPI document and that it contains the operation you want to call by running the following command:
+* Confirm that the downloaded file is a valid OpenAPI document and that it has the operation you want to call, by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-logic-retrieving-workflow-openapi-document.adoc
+++ b/modules/serverless-logic-retrieving-workflow-openapi-document.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * integrate/serverless-logic-consuming-in-cluster-workflows.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-retrieving-workflow-openapi-document_{context}"]
+= Retrieving the OpenAPI document of a deployed workflow
+
+[role="_abstract"]
+Before a calling workflow can consume another workflow, you must add the OpenAPI document of the called workflow to the calling workflow project. Each deployed workflow publishes its OpenAPI document at the `/q/openapi` path, so you can retrieve the document directly from the running workflow.
+
+.Prerequisites
+
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to an {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have deployed the workflow that you want to call, and it is running.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Identify the deployment of the called workflow by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n <namespace>
+----
++
+The {ServerlessLogicOperatorName} names the deployment after the `SonataFlow` CR of the workflow.
+
+. Forward a local port to the workflow container by running the following command:
++
+[source,terminal]
+----
+$ oc port-forward deployment/<called_workflow_id> 8080:8080 -n <namespace>
+----
++
+The workflow container listens on port `8080`, because the {ServerlessLogicOperatorName} enforces `quarkus.http.port=8080` as a managed property.
+
+. In a second terminal, download the OpenAPI document into the `specs` directory of the calling workflow project by running the following command:
++
+[source,terminal]
+----
+$ curl -o <project_application_dir>/specs/<called_workflow_id>-openapi.yaml http://localhost:8080/q/openapi
+----
+
+. Stop the port-forwarding session in the first terminal.
+
+. Open the downloaded file and record the `operationId` value of the operation that starts a workflow instance. The calling workflow uses this identifier in its function definition.
++
+The following example shows the structure of the OpenAPI document that an `inventory-check` workflow publishes:
++
+[source,yaml]
+----
+openapi: 3.0.3
+info:
+  title: inventory-check API
+  version: 1.0.0
+paths:
+  /inventory-check: # <1>
+    post:
+      operationId: <start_workflow_operation_id> # <2>
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InventoryCheckInput'
+      responses:
+        '201':
+          description: Created
+----
++
+<1> The path that starts an instance of the workflow. This path matches the `id` field of the workflow definition.
+<2> The operation identifier that the calling workflow references. Take this value from the document that you downloaded, because it depends on the definition of the called workflow.
+
+.Verification
+
+* Confirm that the downloaded file is a valid OpenAPI document and that it contains the operation you want to call by running the following command:
++
+[source,terminal]
+----
+$ grep operationId <project_application_dir>/specs/<called_workflow_id>-openapi.yaml
+----

--- a/modules/serverless-logic-service-discovery.adoc
+++ b/modules/serverless-logic-service-discovery.adoc
@@ -1,13 +1,19 @@
 // Module included in the following assemblies:
 //
-// * serverless/serverless-logic/serverless-logic-configuring-workflow-services.adoc
+// * configure/serverless-logic-configuring-workflow-services.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="serverless-logic-kubernetes-service-discovery_{context}"]
 = Kubernetes service discovery
 
 [role="_abstract"]
-You can use Kubernetes service discovery to reference Kubernetes resources using a custom URI for HTTP requests. The {ServerlessLogicOperatorName} resolves this URI into a network endpoint (URL) during workflow deployment.
+You can use Kubernetes service discovery to reference Kubernetes resources by using a custom URI for HTTP requests. The {ServerlessLogicOperatorName} resolves this URI into a network endpoint (URL) during workflow deployment. You therefore do not need to hard code a service URL in your workflow configuration.
+
+Service discovery gives you the following advantages:
+
+* The {ServerlessLogicOperatorName} resolves endpoints for you, so there are fewer configuration errors.
+* The same workflow image runs in different namespaces and clusters without configuration changes.
+* Workflows reference standard Kubernetes resources and Knative services in one consistent format.
 
 [NOTE]
 ====
@@ -43,52 +49,64 @@ For Knative Services, you can use a simplified `knative:<namespace>/<service_nam
 --
 The following table lists the supported Kubernetes resources for GVK identifiers:
 
-[cols="1,1", options="header"]
+.Supported Kubernetes resources and GVK identifiers
+[cols="1,1,2", options="header"]
 |===
-| Resource | GVK identifier
+| Resource | GVK identifier | Example URI
 
 | Kubernetes Service
 | `services.v1`
+| `kubernetes:services.v1//my-service`
 
 | Knative Service
 | `services.v1.serving.knative.dev`
+| `knative:my-namespace/my-service`
 
 | Pod
 | `pods.v1`
+| `kubernetes:pods.v1//my-pod`
 
 | Deployment
 | `deployments.v1.apps`
+| `kubernetes:deployments.v1.apps//my-deployment`
 
 | DeploymentConfig
 | `deploymentconfigs.v1.apps.openshift.io`
+| `openshift:deploymentconfigs.v1.apps.openshift.io//my-deployment-config`
 
 | StatefulSet
 | `statefulsets.v1.apps`
+| `kubernetes:statefulsets.v1.apps//my-stateful-set`
 
 | Route
 | `routes.v1.route.openshift.io`
+| `openshift:routes.v1.route.openshift.io//my-route`
 
 | Ingress
 | `ingresses.v1.networking.k8s.io`
+| `kubernetes:ingresses.v1.networking.k8s.io//my-ingress`
 |===
+
+An empty namespace segment, shown as two consecutive slashes, means the namespace of the workflow.
 --
 
 Query parameters::
-Query parameters allow the Operator to filter or select specific resources when multiple matches exist.
+Query parameters allow the Operator to filter or select specific resources when many matches exist.
 +
 --
 The following table lists the supported query parameters:
 
+.Supported query parameters
 [cols="1,2,1", options="header"]
 |===
 |Parameter|Purpose|Example
 
 |label
-|Filter resources when multiple resources match. Supports multiple labels joined with `&`.
+|Filter resources when many resources match. Supports several labels joined with `&`.
 |`label=app=myapp&env=prod`
 
 |port
-|Select a specific port if multiple ports are exposed.
+|Select a specific port if a service exposes more than one port.
 |`port=http`
 |===
 --
@@ -102,13 +120,18 @@ quarkus.rest-client.my_service_yaml.url=${kubernetes:services.v1//my-backend-ser
 
 == Service discovery resolution
 
-The Operator performs Kubernetes service discovery during the deployment of a managed workflow. It scans the associated workflow config map for URIs that match the discovery pattern, parses each URI, queries the Kubernetes API, and writes the resolved endpoints to an operator-managed config map.
+The Operator performs Kubernetes service discovery during the deployment of a managed workflow. The resolution follows these steps:
+
+. The Operator scans the workflow config map for URIs that match the discovery pattern.
+. The Operator parses each URI to identify the target resource.
+. The Operator queries the Kubernetes API for that resource.
+. The Operator writes the resolved endpoints to an operator-managed config map.
 
 The Operator resolves resources differently based on their type:
 
-* *Direct URL resolution*: For `Service`, `KnativeService`, `Ingress`, or `Route` resources, the Operator returns the service URL or host IP. The Operator automatically uses `https` if TLS is detected.
-* *Indirect service resolution*: For `Pod`, `Deployment`, `DeploymentConfig`, or `StatefulSet` resources, the Operator checks for an associated service. If found, the Operator returns the service URL.
-* *Error handling*: If URI parsing fails or the resource does not exist, the Operator logs an exception. If a resource exists but has no associated service, the Operator issues a warning.
+* *Direct URL resolution*: For `Service`, `KnativeService`, `Ingress`, or `Route` resources, the Operator returns the service URL or the host IP address. The Operator uses `https` when the resource enables TLS.
+* *Indirect service resolution*: For `Pod`, `Deployment`, `DeploymentConfig`, or `StatefulSet` resources, the Operator looks for a service that targets the resource. If a service exists, the Operator returns the URL of that service.
+* *Error handling*: If the Operator cannot parse the URI, or the resource does not exist, the Operator logs an exception. If a resource exists but no service targets it, the Operator logs a warning.
 
 [IMPORTANT]
 ====

--- a/modules/serverless-logic-service-discovery.adoc
+++ b/modules/serverless-logic-service-discovery.adoc
@@ -93,6 +93,13 @@ The following table lists the supported query parameters:
 |===
 --
 
+When you use a service discovery URI as the value of a workflow configuration property, you must enclose the URI in `${}`, as shown in the following example:
+
+[source,properties]
+----
+quarkus.rest-client.my_service_yaml.url=${kubernetes:services.v1//my-backend-service}
+----
+
 == Service discovery resolution
 
 The Operator performs Kubernetes service discovery during the deployment of a managed workflow. It scans the associated workflow config map for URIs that match the discovery pattern, parses each URI, queries the Kubernetes API, and writes the resolved endpoints to an operator-managed config map.


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 

- `serverless-docs-1.38`
- `serverless-docs-1.37`

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVLOGIC-780

**Doc previews** 

- https://119679--ocpdocs-pr.netlify.app/openshift-serverlesslogic/latest/configure/serverless-logic-configuring-workflow-services.html#serverless-logic-configuring-service-discovery_serverless-logic-configuring-workflow-services
- https://119679--ocpdocs-pr.netlify.app/openshift-serverlesslogic/latest/integrate/serverless-logic-configuring-openapi-services
- https://119679--ocpdocs-pr.netlify.app/openshift-serverlesslogic/latest/integrate/serverless-logic-consuming-in-cluster-workflows.html

**Reviews:**
- [ ] SME has approved this change
- [ ] QE has approved this change
- [ ] Peer has approved this change