### PR TITLE
OSDOCS-22058: Restored the content of modules/enable-gateway-api-ingr…

### DIFF
--- a/modules/enable-gateway-api-ingress-operator.adoc
+++ b/modules/enable-gateway-api-ingress-operator.adoc
@@ -50,6 +50,196 @@ $ oc create -f openshift-default.yaml
 ----
 gatewayclass.gateway.networking.k8s.io/openshift-default created
 ----
++
+During the creation of the `GatewayClass` resource, the Ingress Operator installs a lightweight version of {SMProductName}, an Istio custom resource, and a new deployment in the `openshift-ingress` namespace.
++
+.. Optional: Verify that the new deployment, `istiod-openshift-gateway`, is ready and available:
++
+[source,terminal]
+----
+$ oc get deployment -n openshift-ingress
+----
++
+.Example output
+[source,terminal]
+----
+NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+istiod-openshift-gateway   1/1     1            1           55s
+router-default             2/2     2            2           6h4m
+----
+
+. Create a secret by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress create secret tls gwapi-wildcard --cert=wildcard.crt --key=wildcard.key
+----
+
+. Get the domain of the Ingress Operator by running the following command:
++
+[source,terminal]
+----
+$ DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
+----
+
+. Create a `Gateway` object:
++
+.. Create a YAML file, `example-gateway.yaml`, that contains the following information:
++
+.Example Gateway CR
+[source,yaml]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: openshift-ingress
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+  - name: https
+    hostname: "*.gwapi.${DOMAIN}"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: gwapi-wildcard
+    allowedRoutes:
+      namespaces:
+        from: All
+----
++
+where:
++
+`metadata.namespace`:: The `Gateway` object must be created in the `openshift-ingress` namespace.
+`gatewayClassName`:: The `Gateway` object must reference the name of the previously created `GatewayClass` object.
+`listeners.name`:: The HTTPS listener listens for HTTPS requests that match a subdomain of the cluster domain. You use this listener to configure ingress to your applications by using Gateway API `HTTPRoute` resources.
+`listeners.hostname`::  The hostname must be a subdomain of the Ingress Operator domain. If you use a domain, the listener tries to serve all traffic in that domain.
+`tls.name`:: The name of the previously created secret.
++
+.. Apply the resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f example-gateway.yaml
+----
++
+.. Optional: When you create a `Gateway` object, {SMProductName} automatically provisions a deployment and service with the same name. Verify this by running the following commands:
++
+*** To verify the deployment, run the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n openshift-ingress example-gateway-openshift-default
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
+example-gateway-openshift-default    1/1     1            1           25s
+----
++
+[NOTE]
+====
+The difference between high available and non-high-available topologies is the minimum number of replicas: at least two gateway instances on high available clusters, which can scale out to ten replicas, and only one gateway instance on the cluster that does not use a high available topology. 
+====
++
+*** To verify the service, run the following command:
++
+[source,terminal]
+----
+$ oc get service -n openshift-ingress example-gateway-openshift-default
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                TYPE           CLUSTER-IP   EXTERNAL-IP         PORT(S)      AGE
+example-gateway-openshift-default   LoadBalancer   10.1.2.3     <external_ipname>   <port_info>  47s
+----
++
+.. Optional: The Ingress Operator automatically creates a `DNSRecord` CR using the hostname from the listeners, and adds the label `gateway.networking.k8s.io/gateway-name=example-gateway`. Verify the status of the DNS record by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress get dnsrecord -l gateway.networking.k8s.io/gateway-name=example-gateway -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+kind: DNSRecord
+  ...
+status:
+  ...
+  zones:
+  - conditions:
+    - message: The DNS provider succeeded in ensuring the record
+      reason: ProviderSuccess
+      status: "True"
+      type: Published
+    dnsZone:
+      tags:
+        ...
+  - conditions:
+    - message: The DNS provider succeeded in ensuring the record
+      reason: ProviderSuccess
+      status: "True"
+      type: Published
+    dnsZone:
+      id: ...
+----
++
+[NOTE]
+====
+For {gcp-first} installations, you can use a custom DNS solution. You must manually create a DNS record for any Gateways in Gateway API. For more information, see "Enabling a user-managed DNS" and "Provisioning your own DNS records".
+====
+
+. Create an `HTTPRoute` resource that directs requests to your already-created namespace and application called `example-app/example-app`:
++
+.. Create a YAML file, `example-route.yaml`, that contains the following information:
++
+.Example HTTPRoute CR
+[source,yaml]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: example-app-ns
+spec:
+  parentRefs:
+  - name: example-gateway
+    namespace: openshift-ingress
+  hostnames: ["example.gwapi.${DOMAIN}"]
+  rules:
+  - backendRefs:
+    - name: example-app
+      port: 8443
+----
++
+where:
++
+`metadata.namespace`:: The namespace you are deploying your application.
+`spec.parentRefs`:: This field must point to the `Gateway` object you previously configured.
+`spec.hostnames`:: The hostname must match the one specified in the `Gateway` object. In this case, the listeners use a wildcard hostname.
+`rules.backendRefs`:: This field specifies the backend references that point to your service.
+`rules.name`:: The name of the `Service` for your application.
++
+.. Apply the resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f example-route.yaml
+----
++
+.Example output
+[source,terminal]
+----
+httproute.gateway.networking.k8s.io/example-route created
+----
 
 .Verification
 
@@ -84,4 +274,4 @@ status:
 # ...
 ----
 +
-Inspect the `status.conditions` block in the output. A healthy `GatewayClass` CR reports a status of `True` for the `Accepted`, `ControllerInstalled`, and `CRDsReady` conditions. 
+Inspect the `status.conditions` block in the output. A healthy `GatewayClass` CR reports a status of `True` for the `Accepted`, `ControllerInstalled`, and `CRDsReady` conditions.


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[OSDOCS-22058](https://redhat.atlassian.net/browse/OSDOCS-22058)

Link to docs preview:

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Add back in [nw-gateway-api-verifying-infrastructure-status](https://github.com/openshift/openshift-docs/pull/112062/changes#diff-8e4cc6229f581f41c2f2c59caa9ed4574324eaffbe54092f8a60a8b28888573c) and [nw-ingress-gateway-api-troubleshooting-degraded](modules/nw-ingress-gateway-api-troubleshooting-degraded.adoc)

* https://github.com/openshift/openshift-docs/pull/110739