### PR TITLE
[OSDOCS-20189]: Changed table headers in the deprecated and removed tables file for 5.0

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -8,11 +8,11 @@
 .Images deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |Cluster Samples Operator
 |Deprecated
-|Deprecated
+|
 |
 |====
 
@@ -23,52 +23,52 @@
 .Installation deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |`--cloud` parameter for `oc adm release extract`
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |CoreDNS wildcard queries for the `cluster.local` domain
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`compute.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`controlPlane.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`platform.aws.preserveBootstrapIgnition` parameter for {aws-first}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Installing a cluster on {aws-short} with compute nodes in {aws-short} Outposts
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Adding kernel modules to nodes with kvc
 |General Availability
-|General Availability
 |Deprecated
+|
 
 |Installing a cluster using Fujitsu iRMC drivers on bare-metal machines
-|General Availability
 |Deprecated
 |Deprecated
+|
 |====
 
 [id="ocp-release-note-machine-manage-dep-rem_{context}"]
@@ -77,17 +77,17 @@
 .Machine management deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |Confidential Computing with AMD Secure Encrypted Virtualization for {gcp-first}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Managing bare-metal machines using Fujitsu iRMC drivers
-|General Availability
 |Deprecated
 |Deprecated
+|
 |====
 
 [id="ocp-release-note-networking-dep-rem_{context}"]
@@ -96,11 +96,11 @@
 .Networking deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |iptables
 |Deprecated
-|Deprecated
+|
 |
 |====
 
@@ -111,32 +111,32 @@
 .Node deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |`ImageContentSourcePolicy` (ICSP) objects
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Kubernetes topology label `failure-domain.beta.kubernetes.io/zone`
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Kubernetes topology label `failure-domain.beta.kubernetes.io/region`
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Dynamic Accelerator Slicer (DAS) Operator
 |Technology Preview
-|Technology Preview
 |Removed
+|
 
 |runC container runtime
 |General Availability
-|General Availability
 |Deprecated
+|
 |====
 
 
@@ -146,23 +146,23 @@
 .OpenShift CLI (oc) deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |oc-mirror plugin v1
 |Deprecated
-|Deprecated
+|
 |
 
 
 |Docker v2 registries
 |Deprecated
-|Deprecated
+|
 |
 
 |`oc adm release mirror` command
 |General Availability
-|General Availability
 |Deprecated
+|
 |====
 
 
@@ -174,18 +174,18 @@
 .Operator lifecycle and development deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |Red Hat Marketplace
 |Deprecated
-|Deprecated
 |Removed
+|
 
 // Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====
 
 [id="ocp-release-note-rhcos-dep-rem_{context}"]
@@ -194,12 +194,7 @@
 .{op-system} deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
-
-|WebAssembly (WASM) extension
-|Removed
-|Removed
-|Removed
+|Feature |4.21 |4.22 |5.0
 |====
 
 //[id="ocp-hardware-an-driver-dep-rem_{context}"]
@@ -236,11 +231,11 @@
 .Web console deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |`useModal` hook for dynamic plugin SDK
 |Deprecated
-|Deprecated
+|
 |
 |====
 
@@ -251,10 +246,10 @@
 .Workloads deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.20 |4.21 |4.22
+|Feature |4.21 |4.22 |5.0
 
 |`DeploymentConfig` objects
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====


### PR DESCRIPTION
Version(s):
5.0

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20189

Link to docs preview:
https://119689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-deprecated-removed-tables_release-notes


QE review:
N/A

