### PR TITLE
OSDOCS-21993: OCP 5 updates

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -878,6 +878,8 @@ Topics:
 - Name: Performing a cluster update
   Dir: updating_a_cluster
   Topics:
+  - Name: Updating a cluster to OpenShift Container Platform 5.0
+    File: update-ocp-5
   - Name: Updating a cluster using the CLI
     File: updating-cluster-cli
   - Name: Updating a cluster using the web console

--- a/updating/updating_a_cluster/update-ocp-5.adoc
+++ b/updating/updating_a_cluster/update-ocp-5.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="updating-ocp-5"]
+= Updating a cluster to {product-title} 5.0
+include::_attributes/common-attributes.adoc[]
+:context: updating-ocp-5
+
+toc::[]
+
+[role="_abstract"]
+You can update your cluster to {product-title} 5.0 using any of the methods available for minor version updates.
+
+Updating an {product-title} cluster from a 4.x release to version 5.0 is an in-place update.
+The process is functionally identical to a minor version update, such as updating from 4.16 to 4.17, and does not require a cluster rebuild or manual data migration.
+
+Updates to version 5.0 are available on the `stable-5.0` and `candidate-5.0` channels.
+
+[IMPORTANT]
+====
+For production clusters, you must subscribe to a `stable-\*`, `eus-*`, or `fast-*` channel.
+====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster by using the web console]
+* xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]


### PR DESCRIPTION
[OSDOCS-21993](https://redhat.atlassian.net/browse/OSDOCS-21993)

Version(s): 5.0+

This PR adds an assembly about updates to OCP 5.0

QE review:
- [x] QE has approved this change.

Preview: [Updating a cluster to OpenShift Container Platform 5](https://119691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/update-ocp-5)