### PR TITLE
OBSDOCS-3896: Add Logging 6.6.1 z-stream release notes

### DIFF
--- a/modules/logging-release-notes-6-6-1-cves.adoc
+++ b/modules/logging-release-notes-6-6-1-cves.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-1-cves_{context}"]
+= CVEs
+
+[role="_abstract"]
+The following CVEs are included in this release of {LoggingProductName}.
+
+* https://access.redhat.com/security/cve/cve-2026-15792[CVE-2026-15792]
+* https://access.redhat.com/security/cve/cve-2026-17106[CVE-2026-17106]
+* https://access.redhat.com/security/cve/cve-2026-18140[CVE-2026-18140]
+* https://access.redhat.com/security/cve/cve-2026-29181[CVE-2026-29181]
+* https://access.redhat.com/security/cve/cve-2026-33818[CVE-2026-33818]
+* https://access.redhat.com/security/cve/cve-2026-35469[CVE-2026-35469]
+* https://access.redhat.com/security/cve/cve-2026-39828[CVE-2026-39828]
+* https://access.redhat.com/security/cve/cve-2026-39830[CVE-2026-39830]
+* https://access.redhat.com/security/cve/cve-2026-39831[CVE-2026-39831]
+* https://access.redhat.com/security/cve/cve-2026-39832[CVE-2026-39832]
+* https://access.redhat.com/security/cve/cve-2026-39835[CVE-2026-39835]
+* https://access.redhat.com/security/cve/cve-2026-41178[CVE-2026-41178]
+* https://access.redhat.com/security/cve/cve-2026-42508[CVE-2026-42508]
+* https://access.redhat.com/security/cve/cve-2026-46595[CVE-2026-46595]
+* https://access.redhat.com/security/cve/cve-2026-46597[CVE-2026-46597]
+* https://access.redhat.com/security/cve/cve-2026-46604[CVE-2026-46604]
+* https://access.redhat.com/security/cve/cve-2026-56852[CVE-2026-56852]
+* https://access.redhat.com/security/cve/cve-2026-56853[CVE-2026-56853]
+* https://access.redhat.com/security/cve/cve-2026-56858[CVE-2026-56858]
+* https://access.redhat.com/security/cve/cve-2026-56859[CVE-2026-56859]
+* https://access.redhat.com/security/cve/cve-2026-56860[CVE-2026-56860]
+* https://access.redhat.com/security/cve/cve-2026-56862[CVE-2026-56862]
+* https://access.redhat.com/security/cve/cve-2026-75593[CVE-2026-75593]

--- a/modules/logging-release-notes-6-6-1-enhancement.adoc
+++ b/modules/logging-release-notes-6-6-1-enhancement.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-1-enhancement_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release of {LoggingProductName} includes the following new features and enhancements.
+
+LokiStack gateway support for BYO and external authentication::
+With this release, the LokiStack gateway supports clusters configured with BYO or external authentication. In environments where the native OpenShift OAuth server has been removed, the Loki Operator no longer attempts to auto-discover OAuth endpoints that are not present. This eliminates repeated error messages in the gateway logs and allows Loki to function correctly with external identity providers. (link:https://issues.redhat.com/browse/LOG-8139[LOG-8139])

--- a/modules/logging-release-notes-6-6-1-fixed-issues.adoc
+++ b/modules/logging-release-notes-6-6-1-fixed-issues.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-1-fixed-issues_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following issues were resolved in this release of {LoggingProductName}.
+
+* Previously, LokiStack gateway OIDC authentication failed with `x509: certificate signed by unknown authority` errors when the `issuerCA` ConfigMap contained multiple CA certificates in a single PEM bundle. Only the first certificate in the bundle was loaded, causing JWKS fetch requests to fail. With this release, all certificates in the PEM bundle are loaded, allowing successful OIDC token validation. (link:https://issues.redhat.com/browse/LOG-8727[LOG-8727])
+
+* Previously, when `ClusterLogForwarder` was configured with `AtLeastOnce` delivery mode, one or more collector pods could fail to start with the error `error occurred when building buffer: failed to decoded record: InvalidProtobufPayload`. With this release, the disk buffer initialization correctly handles existing data, and collector pods start successfully. (link:https://issues.redhat.com/browse/LOG-9386[LOG-9386])
+
+* Previously, setting `omitManagedFields: true` in a `kubeAPIAudit` filter within `ClusterLogForwarder` did not take effect when using the Vector collector. The `metadata.managedFields` field was not removed from log events, which could cause log payloads to exceed output size limits and be silently dropped. With this release, `omitManagedFields: true` is correctly applied, removing managed fields from log events as configured. (link:https://issues.redhat.com/browse/LOG-9388[LOG-9388])
+
+* Previously, when a pod was deleted while Vector was collecting its logs, Vector could fail with `function call error for "match_any" ... expected string, got null` errors. These errors disrupted the Vector processing pipeline and could trigger the `ClusterLogForwarderRuntimeConfigurationMissingUnmatched` alert. With this release, Vector handles missing pod metadata gracefully and the pipeline continues operating when pod annotations are unavailable. (link:https://issues.redhat.com/browse/LOG-9677[LOG-9677])
+
+* Previously, Vector could fail with an `os error 24: Too many open files` error under high log collection load, causing log forwarding to stop. With this release, Vector handles file descriptors more efficiently, preventing this error. (link:https://issues.redhat.com/browse/LOG-9829[LOG-9829])
+
+* Previously, Vector stopped forwarding logs over UDP when a syslog server went through a failover event. Forwarding did not resume automatically and required a manual restart. With this release, Vector automatically resumes log forwarding over UDP after a syslog server failover. (link:https://issues.redhat.com/browse/LOG-10077[LOG-10077])
+
+* Previously, a spurious `can't abort infallible function` warning was logged when `payload_key` was configured in Logging 6.6. With this release, the erroneous warning is no longer generated when `payload_key` is used. (link:https://issues.redhat.com/browse/LOG-10078[LOG-10078])
+
+* Previously, setting `ClusterLogForwarder.spec.outputs.syslog.severity: informational` generated numerous warning messages in Logging 6.6. With this release, the `informational` severity value no longer produces spurious warnings. (link:https://issues.redhat.com/browse/LOG-10079[LOG-10079])
+
+* Previously, syslog forwarding incorrectly added empty `KubernetesMinimal` prefixes to audit and journald log messages after upgrading from Logging 6.2 to Logging 6.6. With this release, empty prefixes are no longer added to audit and journald messages. (link:https://issues.redhat.com/browse/LOG-10080[LOG-10080])

--- a/modules/logging-release-notes-6-6-1.adoc
+++ b/modules/logging-release-notes-6-6-1.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-1_{context}"]
+= Logging 6.6.1
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:66521[RHSA-2026:66521].

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -10,6 +10,14 @@ toc::[]
 [role="_abstract"]
 This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
 
+include::modules/logging-release-notes-6-6-1.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-6-1-enhancement.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-6-1-fixed-issues.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-6-1-cves.adoc[leveloffset=+2]
+
 include::modules/logging-release-notes-6-6-0.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-6-0-enhancement.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds release notes for OpenShift Logging 6.6.1 z-stream release
- Includes 1 enhancement, 9 bug fixes, and 23 distinct CVEs
- Uses errata placeholder pending actual errata number

## Changes
- Created `modules/logging-release-notes-6-6-1.adoc` (main module)
- Created `modules/logging-release-notes-6-6-1-enhancement.adoc` (enhancements)
- Created `modules/logging-release-notes-6-6-1-fixed-issues.adoc` (bug fixes)
- Created `modules/logging-release-notes-6-6-1-cves.adoc` (CVEs)
- Updated `release_notes/logging-release-notes.adoc` to include new modules as first entry

## Enhancements
- [LOG-8139](https://redhat.atlassian.net/browse/LOG-8139): LokiStack gateway support for BYO and external authentication

## Bug Fixes
- [LOG-8727](https://redhat.atlassian.net/browse/LOG-8727): LokiStack gateway OIDC fails with multiple certs in issuerCA PEM bundle
- [LOG-9386](https://redhat.atlassian.net/browse/LOG-9386): Collector pods fail to start with buffer build error in AtLeastOnce mode
- [LOG-9388](https://redhat.atlassian.net/browse/LOG-9388): omitManagedFields not honoured by Vector, causing silent log drops
- [LOG-9677](https://redhat.atlassian.net/browse/LOG-9677): Vector match_any null error when pod is deleted mid-collection
- [LOG-9829](https://redhat.atlassian.net/browse/LOG-9829): Vector too many open files (os error 24)
- [LOG-10077](https://redhat.atlassian.net/browse/LOG-10077): Vector stops forwarding logs over UDP after syslog server failover
- [LOG-10078](https://redhat.atlassian.net/browse/LOG-10078): Spurious "can't abort infallible function" warning with payload_key
- [LOG-10079](https://redhat.atlassian.net/browse/LOG-10079): Syslog severity informational generates spurious warnings
- [LOG-10080](https://redhat.atlassian.net/browse/LOG-10080): Syslog forwarding adds empty KubernetesMinimal prefixes after upgrade

## CVEs Included (23 distinct)
- CVE-2026-15792, CVE-2026-17106, CVE-2026-18140, CVE-2026-29181, CVE-2026-33818
- CVE-2026-35469, CVE-2026-39828, CVE-2026-39830, CVE-2026-39831, CVE-2026-39832
- CVE-2026-39835, CVE-2026-41178, CVE-2026-42508, CVE-2026-46595, CVE-2026-46597
- CVE-2026-46604, CVE-2026-56852, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859
- CVE-2026-56860, CVE-2026-56862, CVE-2026-75593

Note: CVE-2026-41178 appeared in two JIRA tickets and is listed once.

## Follow-up
The errata placeholder (`RHSA-2026:66521` — already updated) needs confirmation once the advisory is finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)