### PR TITLE
OSDOCS-22130 RODOO 1.0.4 release notes

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,6 +14,20 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+[id="run-once-duration-override-operator-release-notes-1-0-4_{context}"]
+== {run-once-operator} 1.0.4
+
+Issued: 9 September 2026
+
+The following advisory is available for the {run-once-operator} 1.0.4:
+
+* link:https://access.redhat.com/errata/RHBA-2026:65922[RHBA-2026:65922]
+
+[id="run-once-duration-override-operator-1-0-4-new-features_{context}"]
+=== New features and enhancements
+
+* This release rebuilds the base image for the {run-once-operator} to improve its image grade.
+
 [id="run-once-duration-override-operator-release-notes-1-0-3"]
 == {run-once-operator} 1.0.3
 


### PR DESCRIPTION

Version(s): 4.13, 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-22130
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://119693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- [X] QE has approved this change. (SME acting as QE)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
