### PR TITLE
OSSM_version attribute removed from text

### DIFF
--- a/modules/ossm-release-notes-3-4-1.adoc
+++ b/modules/ossm-release-notes-3-4-1.adoc
@@ -7,9 +7,7 @@
 = {SMProductName} version 3.4.1
 
 [role="_abstract"]
-This release of {SMProductName} is included with the {SMProductName} Operator {SMProductVersion} and is supported on {ocp-product-title} 4.20 and later versions. This release addresses Common Vulnerabilities and Exposures (CVEs).
-
-For supported component versions in {SMProductShortName} {SMProductVersion}, see _Service Mesh component versions_.
+This release of {SMProductName} is included with the {SMProductName} Operator 3.4.1. To see the {ocp-product-title} versions that support {SMProduct} 3.4.1, go to link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]. {SMProductShortName} 3.4.1 addresses Common Vulnerabilities and Exposures (CVEs) and includes the following fixed issue.
 
 [id="ossm-fixed-issues-3-4-1_{context}"]
 == Fixed issues
@@ -18,3 +16,5 @@ Webhook error "failed calling webhook validation.istio.io" no longer occurs::
 After the {SMProductShortName} 3.3.4 upgrade, the `istiod-default-validator` webhook did not point to the control plane if the `Istio` CR used a non-default name with the `IstioRevisionTag` set to `default`. As a consequence, attempts to update Istio networking, security, or telemetry resources failed with the error `failed calling webhook "validation.istio.io"`. Existing mesh traffic continued to function, but you were unable to change the service mesh configuration. With this release, the validating webhook references the correct control plane service. As a result, Istio resource validation succeeds in deployments that use non-default `Istio` CR names.
 +
 link:https://redhat.atlassian.net/browse/OSSM-14646[OSSM-14646]
+
+For supported component versions in {SMProductShortName} 3.4.1, see _Service Mesh component versions_.

--- a/modules/ossm-release-notes-3-4-2.adoc
+++ b/modules/ossm-release-notes-3-4-2.adoc
@@ -7,7 +7,7 @@
 = {SMProductName} version 3.4.2
 
 [role="_abstract"]
-This release of {SMProductName} is included with the {SMProductName} Operator {SMProductVersion}. To see the {ocp-product-title} versions that support {SMProduct} {SMProductVersion}, go to link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]. {SMProductShortName} {SMProductVersion} addresses Common Vulnerabilities and Exposures (CVEs) and includes the following fixed issues.
+This release of {SMProductName} is included with the {SMProductName} Operator 3.4.2. To see the {ocp-product-title} versions that support {SMProduct} 3.4.2, go to link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]. {SMProductShortName} 3.4.2 addresses Common Vulnerabilities and Exposures (CVEs) and includes the following fixed issues.
 
 [id="ossm-fixed-issues-3-4-2_{context}"]
 == Fixed issues
@@ -31,4 +31,4 @@ This release corrects the reference counting issue for peer certificate objects 
 +
 link:https://redhat.atlassian.net/browse/OSSM-15075[OSSM-15075]
 
-For supported component versions in {SMProductShortName} {SMProductVersion} (components such as the control plane and `IstioCNI`), see _Service Mesh component versions_.
+For supported component versions in {SMProductShortName} 3.4.2 (components such as the control plane and `IstioCNI`), see _Service Mesh component versions_.


### PR DESCRIPTION
[OSSM-15982](https://redhat.atlassian.net/browse/OSSM-15982): [DOC] For product versions in release notes, replace attributes with numerical values

In release note module text, I replaced product version attributes with numerical values, so that all maintenance release notes correctly display the applicable versions.

Version(s):
service-mesh-docs-3.4 (No cherry-picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-15982

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

