### PR TITLE
OCPBUGS-122280: Document mirror registry version support and lifecycle policy

### DIFF
--- a/modules/mirror-registry-introduction.adoc
+++ b/modules/mirror-registry-introduction.adoc
@@ -15,6 +15,13 @@ The _mirror registry for Red{nbsp}Hat OpenShift_ provides a pre-determined netwo
 
 Use of the _mirror registry for Red{nbsp}Hat OpenShift_ is optional if another container registry is already available in the install environment.
 
+[id="mirror-registry-version-support_{context}"]
+== Version support and lifecycle
+
+Red{nbsp}Hat publishes a link:https://access.redhat.com/support/policy/updates/openshift/mirror-registry[life cycle policy] for the _mirror registry for Red{nbsp}Hat OpenShift_. Only the latest released version of the _mirror registry for Red{nbsp}Hat OpenShift_ is supported at any point in time. When a new major or minor version becomes generally available, the previous version reaches end of life and no longer receives errata or maintenance updates.
+
+The release notes in this documentation describe changes in each version. For supported version dates and life cycle phases, see the link:https://access.redhat.com/support/policy/updates/openshift/mirror-registry[life cycle policy for the mirror registry for Red{nbsp}Hat OpenShift].
+
 [id="mirror-registry-limitations_{context}"]
 == Mirror registry for Red Hat OpenShift limitations
 


### PR DESCRIPTION
## Summary

- Adds a **Version support and lifecycle** section to `modules/mirror-registry-introduction.adoc`
- Documents that only the latest released version of the mirror registry for Red Hat OpenShift is supported
- Links to the published [life cycle policy](https://access.redhat.com/support/policy/updates/openshift/mirror-registry) for version dates and support phases

Addresses the documentation gap described in [KCS 7083311](https://access.redhat.com/solutions/7083311): release notes exist but the product documentation did not explain the support period or lifecycle for each version.

**Jira:** https://redhat.atlassian.net/browse/OCPBUGS-122280

## Test plan

- [ ] Verify AsciiDoc renders correctly in the disconnected install / mirror registry documentation assembly
- [ ] Confirm life cycle policy link resolves correctly