### PR TITLE
CNV-95197: Comment out File Restore Operator from topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5216,8 +5216,8 @@ Topics:
     File: virt-recovering-individual-files-from-vm-backups
   - Name: Use virtual machine file restore
     File: virt-using-vm-file-restore
-  - Name: File Restore Operator
-    File: virt-file-restore-operator
+#  - Name: File Restore Operator
+#    File: virt-file-restore-operator
   - Name: Disaster recovery
     File: virt-disaster-recovery
 #  - Name: Collecting OKD Virtualization data for community report


### PR DESCRIPTION
Version(s):
main (backport to 5.0 will follow)

Issue:
https://redhat.atlassian.net/browse/CNV-95197

Link to docs preview:


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


Additional information:
Commented out File Restore Operator documentation from the topic map as the parent epic was retargeted from v5.0 to v5.1. The module and assembly files remain in place and can be uncommented when the feature is ready to be published.
