### PR TITLE
RHDEVDOCS-7943: Document Argo CD continue parameter sync failure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -233,6 +233,8 @@ Distros: openshift-gitops
 Topics:
 - Name: Auto-reboot during Argo CD sync with machine configurations
   File: auto-reboot-during-argo-cd-sync-with-machine-configurations
+- Name: Argo CD application fails to sync due to expired continue parameter
+  File: argo-cd-continue-parameter-too-old
 ---
 Name: Removing GitOps
 Dir: removing_gitops

--- a/modules/gitops-troubleshooting-continue-parameter-too-old.adoc
+++ b/modules/gitops-troubleshooting-continue-parameter-too-old.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * troubleshooting_gitops_issues/argo-cd-continue-parameter-too-old.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-troubleshooting-continue-parameter-too-old_{context}"]
+= Resolving Argo CD continue parameter sync failures
+
+[role="_abstract"]
+Use this procedure when Argo CD applications fail to sync because the application controller cannot list cluster resources before pagination tokens expire.
+
+== Symptom
+
+Argo CD applications fail to sync and report an error similar to the following message:
+
+[source,terminal]
+----
+failed to list resources: The provided continue parameter is too old to display a consistent list result
+----
+
+You might also see this error in the Argo CD application controller logs when the controller attempts to build or refresh the cluster cache.
+
+This issue is more common on clusters that contain a large number of Kubernetes resources, such as `Secret` or `ConfigMap` objects.
+
+== Cause
+
+The Argo CD application controller lists cluster resources in pages when it builds the cluster cache. If listing all pages takes longer than the Kubernetes API server etcd compaction interval, the `continue` token from an earlier page expires and the list operation fails.
+
+== Solution
+
+Configure the application controller to increase the Kubernetes list page size and the number of pages buffered in memory during cluster cache synchronization.
+
+.Procedure
+. Edit the `ArgoCD` custom resource (CR) for your Argo CD instance and configure the application controller environment variables.
+
++
+For example, to update the default Argo CD instance in the `openshift-gitops` namespace, edit the `openshift-gitops` `ArgoCD` CR:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  controller:
+    env:
+      - name: ARGOCD_CLUSTER_CACHE_LIST_PAGE_SIZE
+        value: "500"
+      - name: ARGOCD_CLUSTER_CACHE_LIST_PAGE_BUFFER_SIZE
+        value: "10"
+----
++
+[NOTE]
+====
+If you manage a different Argo CD instance, replace the `metadata.name` and `metadata.namespace` values with the namespace and name of your instance.
+====
+
+. Wait for the {gitops-title} Operator to reconcile the `ArgoCD` CR and restart the application controller workload.
+
+. Verify that the environment variables are set on the application controller pod:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-gitops -l app.kubernetes.io/name=openshift-gitops-application-controller
+$ oc set env statefulset/openshift-gitops-application-controller -n openshift-gitops --list | grep ARGOCD_CLUSTER_CACHE
+----
+
+. Confirm that affected Argo CD applications can sync successfully and that the error no longer appears in the application controller logs.
+
+== Tuning guidance
+
+* `ARGOCD_CLUSTER_CACHE_LIST_PAGE_SIZE` controls the number of resources returned in each list request. The default value is `500`.
+* `ARGOCD_CLUSTER_CACHE_LIST_PAGE_BUFFER_SIZE` controls how many list pages the application controller buffers in memory while synchronizing the cluster cache. The default value is `1`.
+* Increase these values incrementally until application sync succeeds reliably.
+* Where practical, ensure that `ARGOCD_CLUSTER_CACHE_LIST_PAGE_SIZE` multiplied by `ARGOCD_CLUSTER_CACHE_LIST_PAGE_BUFFER_SIZE` can cover the largest resource count for a single Kubernetes API resource type in the cluster.
+* Higher values can increase memory use on the application controller. Monitor application controller resource consumption after changing these values.

--- a/troubleshooting_gitops_issues/argo-cd-continue-parameter-too-old.adoc
+++ b/troubleshooting_gitops_issues/argo-cd-continue-parameter-too-old.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="argo-cd-continue-parameter-too-old"]
+= Argo CD application fails to sync due to expired continue parameter
+:context: argo-cd-continue-parameter-too-old
+
+toc::[]
+
+[role="_abstract"]
+On large {product-title} clusters, Argo CD can fail to sync applications when the application controller cannot complete cluster cache list operations before Kubernetes API server pagination tokens expire. This topic describes how to identify and resolve the `continue parameter is too old` error in {gitops-title}.
+
+include::modules/gitops-troubleshooting-continue-parameter-too-old.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://access.redhat.com/solutions/7138154[Argo CD Application fails to sync due to "too old" continue parameter]
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/[Argo CD high availability and scalability documentation]


### PR DESCRIPTION
## Summary
- Add a new OpenShift GitOps troubleshooting topic for Argo CD application sync failures that report `continue parameter is too old`.
- Document tuning `ARGOCD_CLUSTER_CACHE_LIST_PAGE_SIZE` and `ARGOCD_CLUSTER_CACHE_LIST_PAGE_BUFFER_SIZE` through the `ArgoCD` CR `spec.controller.env` field.
- Update the GitOps topic map and reference KCS 7138154.

## Jira
https://redhat.atlassian.net/browse/RHDEVDOCS-7943

## Test plan
- [ ] Verify the new topic builds in the Netlify preview
- [ ] Confirm the troubleshooting topic appears under **Troubleshooting issues**
- [ ] Review YAML example and `oc` verification commands for accuracy
- [ ] SME review against KCS 7138154 resolution guidance