### PR TITLE
GITOPS-11300: Document Argo CD Git request timeout

### DIFF
--- a/argocd_instance/argo-cd-cr-component-properties.adoc
+++ b/argocd_instance/argo-cd-cr-component-properties.adoc
@@ -18,6 +18,9 @@ include::modules/gitops-repo-server-properties.adoc[leveloffset=+1]
 // Configure TLS trust for the repo server
 include::modules/gitops-configure-repo-server-tls-trust.adoc[leveloffset=+2]
 
+// Configuring the Git request timeout for the repo server
+include::modules/gitops-configuring-git-request-timeout.adoc[leveloffset=+2]
+
 // Enabling notifications with an Argo CD instance
 include::modules/gitops-argo-cd-notification.adoc[leveloffset=+1]
 
@@ -51,4 +54,6 @@ include::modules/proc_configuring-annotation-based-tracking-in-multiple-argo-cd-
 * xref:../argocd_instance/setting-up-argocd-instance.adoc#gitops-argo-cd-installation_setting-up-argocd-instance[Installing a user-defined Argo CD instance]
 
 * link:https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#config-management-plugins[Config Management Plugins]
+
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/argocd-cmd-params-cm-yaml/[Argo CD command parameters]
 

--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -67,7 +67,7 @@ a|* `annotations` - List of custom annotations to add to pods deployed by the Op
 
 |`defaultClusterScopedRoleDisabled` |Disables the creation of default cluster roles for a cluster-scoped instance.|`false` |
 
-|`extraConfig`    |Add any supplementary Argo CD settings to the `argocd-cm` config map that cannot be configured directly within the Argo CD custom resource.| _empty_ |
+|`extraConfig`    |Add any supplementary Argo CD settings to the `argocd-cm` config map that cannot be configured directly within the Argo CD custom resource. This field does not update the `argocd-cmd-params-cm` config map.| _empty_ |
 
 |`gaTrackingID`    |Use a Google Analytics tracking ID.| _empty_ |
 

--- a/modules/gitops-configuring-git-request-timeout.adoc
+++ b/modules/gitops-configuring-git-request-timeout.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/argo-cd-cr-component-properties.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-git-request-timeout_{context}"]
+= Configuring the Git request timeout for the repo server
+
+[role="_abstract"]
+You can increase the timeout that the Argo CD repo server uses for Git HTTP operations such as listing refs. The default timeout is `15s`. If a Git provider is slow to respond, applications can fail with a `failed to list refs` error and `Client.Timeout exceeded while awaiting headers`.
+
+Set the `ARGOCD_GIT_REQUEST_TIMEOUT` environment variable on the repo server by using the Argo CD custom resource (CR). The {gitops-title} Operator applies the value to the repo server workload.
+
+[IMPORTANT]
+====
+Do not edit the `argocd-cmd-params-cm` config map directly. The Operator reverts manual changes to that config map.
+
+Do not set `reposerver.git.request.timeout` in `spec.extraConfig`. The `extraConfig` field updates the `argocd-cm` config map only, not `argocd-cmd-params-cm`.
+====
+
+This timeout applies to Git HTTP list-refs requests. It does not control Helm or Kustomize rendering, which uses `spec.repo.execTimeout`. It also does not control Git fetch commands that the repo server runs as subprocesses, which use the `ARGOCD_EXEC_TIMEOUT` environment variable.
+
+.Prerequisites
+
+* You have access to an {OCP} cluster with `cluster-admin` privileges.
+* You have installed the {gitops-title} Operator on your cluster.
+
+.Procedure
+
+. Edit the Argo CD CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit argocd <argocd-instance> -n <namespace>
+----
++
+where:
+
+`<argocd-instance>`:: Specifies the name of the Argo CD instance, for example `openshift-gitops`.
+`<namespace>`:: Specifies the namespace of the Argo CD instance, for example `openshift-gitops`.
+
+. Under `spec.repo.env`, set `ARGOCD_GIT_REQUEST_TIMEOUT` to a duration that is long enough for your Git provider, for example `90s`:
++
+--
+*Example Argo CD CR with an increased Git request timeout:*
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  repo:
+    env:
+      - name: ARGOCD_GIT_REQUEST_TIMEOUT
+        value: "90s"
+----
+--
+
+. Save the CR.
++
+The Operator reconciles the change and restarts the repo server pods.
+
+. Verify that the repo server deployment has the environment variable by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/<argocd-instance>-repo-server -n <namespace> --list | grep ARGOCD_GIT_REQUEST_TIMEOUT
+----
++
+.Example output
+[source,terminal]
+----
+ARGOCD_GIT_REQUEST_TIMEOUT=90s
+----
+
+. Hard refresh any Argo CD `Application` resources that still show a cached list-refs error so that the repo server retries the Git request with the new timeout. In the Argo CD web UI, open the application, click *Refresh*, and select *Hard Refresh*.

--- a/modules/gitops-repo-server-properties.adoc
+++ b/modules/gitops-repo-server-properties.adoc
@@ -14,9 +14,9 @@ The following properties are available for configuring the repo server component
 |Name |Default | Description
 |`annotations` | _empty_ |List of custom annotations to add to pods deployed by the Operator. This field is optional.
 |`autotls` |`""` |Provider to use to set up TLS for the repo-server's gRPC TLS certificate. Currently, only the `openshift` value is acceptable.
-|`env` | _empty_ |The environment to set for the Repo server workloads.
+|`env` | _empty_ |The environment to set for the Repo server workloads. For example, set the `ARGOCD_GIT_REQUEST_TIMEOUT` environment variable to increase the timeout for Git HTTP operations such as listing refs. The default Git request timeout is `15s`.
 |`enabled` | _empty_ |Flag that enables the Repo server during Argo CD installation.
-|`execTimeout` | `180` |Execution timeout in seconds for rendering tools, for example, Helm or Kustomize.
+|`execTimeout` | `180` |Execution timeout in seconds for rendering tools, for example, Helm or Kustomize. This timeout does not apply to Git HTTP list-refs requests.
 |`extraRepoCommandArgs` | `__empty__` | Passes command-line arguments to the Repo server workload. The command-line arguments are added to the list of arguments set by the Operator.
 |`initContainers` | `__empty__` |The number of `init` containers in the Argo CD Application Controller component. This field is optional.
 |`image` | `registry.redhat.io` |The container image for Argo CD Repo server. This property overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.


### PR DESCRIPTION
Summary
- Document how to increase the Argo CD repo-server Git HTTP list-refs timeout (`ARGOCD_GIT_REQUEST_TIMEOUT` via `spec.repo.env`)
- Clarify that `spec.repo.execTimeout` is Helm/Kustomize only and that `spec.extraConfig` does not update `argocd-cmd-params-cm`

Jira
https://issues.redhat.com/browse/GITOPS-11300

Version(s)
- `gitops-docs-1.22` (this PR)
- Please cherry-pick to `gitops-docs-1.21` and `gitops-docs-main`

 Test plan
- [ ] Preview the Argo CD custom resource and component properties assembly
- [ ] Confirm the new Git request timeout procedure is nested under Repo server properties
- [ ] Confirm the YAML example uses `spec.repo.env` / `ARGOCD_GIT_REQUEST_TIMEOUT`
- [ ] Confirm docs warn not to edit `argocd-cmd-params-cm` or put the timeout in `extraConfig`

QE review:
- [ ] QE has approved this change.
