### PR TITLE
CORS-4674: GCP 5.0 permissions

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -111,6 +111,7 @@ The following permissions are required for creating compute resources:
 * `compute.disks.get`
 * `compute.disks.list`
 * `compute.disks.setLabels`
+* `compute.diskTypes.get`
 * `compute.instanceGroups.create`
 * `compute.instanceGroups.delete`
 * `compute.instanceGroups.get`
@@ -147,6 +148,7 @@ The following permissions are required for creating health check resources:
 * `compute.healthChecks.create`
 * `compute.healthChecks.get`
 * `compute.healthChecks.list`
+* `compute.healthChecks.update`
 * `compute.healthChecks.useReadOnly`
 * `compute.httpHealthChecks.create`
 * `compute.httpHealthChecks.get`
@@ -154,6 +156,7 @@ The following permissions are required for creating health check resources:
 * `compute.httpHealthChecks.useReadOnly`
 * `compute.regionHealthChecks.create`
 * `compute.regionHealthChecks.get`
+* `compute.regionHealthChecks.update`
 * `compute.regionHealthChecks.useReadOnly`
 
 


### PR DESCRIPTION
[CORS-4674](https://redhat.atlassian.net/browse/CORS-4674)

Version(s): 5.0+

This PR adds new permissions for GCP installs.

QE review:
- [x] QE has approved this change.

Preview:  [Required Google Cloud permissions for installer-provisioned infrastructure](https://119744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp_installing-gcp-account)