### PR TITLE
OSDOCS-21007: Remove hardcoded product name from network policy console step

### DIFF
--- a/modules/nw-networkpolicy-create-ocm.adoc
+++ b/modules/nw-networkpolicy-create-ocm.adoc
@@ -21,7 +21,7 @@ To define granular rules describing the ingress or egress network traffic allowe
 
 . From {cluster-manager-url}, click the cluster you want to access.
 
-. Click *Open console* to navigate to the OpenShift web console.
+. Click *Open console* to navigate to the web console.
 
 . Click your identity provider and give your credentials to log in to the cluster.
 


### PR DESCRIPTION
[OSDOCS-21007](https://redhat.atlassian.net/browse/OSDOCS-21007): Remove hardcoded product name from network policy console step- #119748

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-21007

Link to docs preview:
* ROSA HCP: https://119748--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html
* ROSA Classic: https://119748--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/creating-network-policy.html
* OSD: https://119748--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/creating-network-policy.html

QE review:

 QE has approved this change.
Additional information: