### PR TITLE
flipping IBM cloud classic attribute include

### DIFF
--- a/installing/installing_ibm_cloud_classic/install-ibm-cloud-prerequisites.adoc
+++ b/installing/installing_ibm_cloud_classic/install-ibm-cloud-prerequisites.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="install-ibm-cloud-prerequisites"]
 = Prerequisites for installing a cluster on {ibm-cloud-bm}
-include::_attributes/common-attributes.adoc[]
 :context: install-ibm-cloud
 
 toc::[]


### PR DESCRIPTION
Version(s): 4.20+

This PR fixes an attribute not rendering correctly in the IBM cloud classic prereqs assembly

QE review: Not required for formatting fix

Preview: [Prerequisites for IBM Cloud (Classic)](https://119749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_classic/install-ibm-cloud-prerequisites)