### PR TITLE
OSDOCS#20667: MicroShift-Link to ProdSec CryptoBOM info 

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -146,6 +146,8 @@ Topics:
   Topics:
   - Name: Using custom certificate authorities
     File: microshift-custom-ca
+  - Name: Understanding Cryptography Bill of Materials for MicroShift  
+    File: microshift-cryptobom-ref
   - Name: Configuring TLS security profiles
     File: microshift-tls-config
   - Name: Configuring audit logging policies

--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -146,8 +146,8 @@ Topics:
   Topics:
   - Name: Using custom certificate authorities
     File: microshift-custom-ca
-  - Name: Understanding Cryptography Bill of Materials for MicroShift  
-    File: microshift-cryptobom-ref
+  - Name: Understanding Cryptography Bill of Materials for MicroShift
+    File: microshift-cryptobom
   - Name: Configuring TLS security profiles
     File: microshift-tls-config
   - Name: Configuring audit logging policies

--- a/microshift_configuring/microshift_auth_security/microshift-cryptobom.adoc
+++ b/microshift_configuring/microshift_auth_security/microshift-cryptobom.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-cryptobom"]
+= Understanding Cryptography Bill of Materials for MicroShift
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-cryptobom
+
+toc::[]
+
+[role="_abstract"]
+Use the Cryptography Bill of Materials (CryptoBOM) to review the cryptographic components in a {microshift-short} release and to support security audits and compliance verification.
+
+include::modules/microshift-cryptobom-ref.adoc[leveloffset=+1]
+
+// [id="Additional-resources_cryptobom"]
+// .Additional resources
+
+// * link:https://(canonical Prod Sec CrytoBOM URL)[Title of link]
+

--- a/modules/microshift-cryptobom-ref.adoc
+++ b/modules/microshift-cryptobom-ref.adoc
@@ -7,4 +7,4 @@
 = Cryptography Bill of Materials
 
 [role="_abstract"]
-A Cryptography Bill of Materials (CryptoBOM) is an inventory of the cryptographic components that a {microshift-short} release uses, including algorithms, ciphers, protocols, libraries, and related key material. Use the CryptoBOM to see the cryptographic posture of a specific release so that you can complete security audits and verify compliance with your organization's policies. The CryptoBOM documents are shipped in that specificrelease. It does not replace FIPS configuration or TLS security profiles.
+A Cryptography Bill of Materials (CryptoBOM) is an inventory of the cryptographic components that a {microshift-short} release uses, including algorithms, ciphers, protocols, libraries, and related key material. Use the CryptoBOM to see the cryptographic posture of a specific release so that you can complete security audits and verify compliance with your organization's policies. The CryptoBOM documents are shipped in the release. It does not replace FIPS configuration or TLS security profiles.

--- a/modules/microshift-cryptobom-ref.adoc
+++ b/modules/microshift-cryptobom-ref.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift_auth_security/microshift_cryptobom-ref.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-understand_{context}"]
+= Cryptography Bill of Materials
+
+[role="_abstract"]
+A Cryptography Bill of Materials (CryptoBOM) is an inventory of the cryptographic components that a {microshift-short} release uses, including algorithms, ciphers, protocols, libraries, and related key material. Use the CryptoBOM to see the cryptographic posture of a specific release so that you can complete security audits and verify compliance with your organization's policies. The CryptoBOM documents are shipped in that specificrelease. It does not replace FIPS configuration or TLS security profiles.


### PR DESCRIPTION
Version(s):
 main  (5.0+)

Issue:
[OSDOCS-20667](https://redhat.atlassian.net/browse/OSDOCS-20667)

Link to docs preview:
[Understanding cryptography Bill of Materials for MicroShift](https://119761--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_auth_security/microshift-cryptobom.html)

QE review:
- [ ] QE has approved this change.

Additional information:

